### PR TITLE
python-pip not available in repositories

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -14,8 +14,13 @@ COPY ./ /havocsrc
 
 #Fetch dependencies from APT
 RUN apt-get update && \
-	apt-get install -y tar wget dfu-util cmake python python-pip && \
+	apt-get install -y tar wget dfu-util cmake python curl && \
 	apt-get -qy autoremove
+
+#Install pip from PyPa
+RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
+	python get-pip.py
+
 #Fetch additional dependencies from Python 2.x pip
 RUN pip install pyyaml
 

--- a/dockerfile
+++ b/dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update && \
 	apt-get install -y tar wget dfu-util cmake python curl && \
 	apt-get -qy autoremove
 
-#Install pip from PyPa
+#Install current pip from PyPa
 RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
 	python get-pip.py
 

--- a/dockerfile-nogit
+++ b/dockerfile-nogit
@@ -11,8 +11,12 @@ WORKDIR /havoc/firmware
 
 # Fetch dependencies from APT
 RUN apt-get update && \
-	apt-get install -y git tar wget dfu-util cmake python3 python-pip ccache && \
+	apt-get install -y git tar wget dfu-util cmake python3 ccache curl && \
 	apt-get -qy autoremove
+
+#Install pip from PyPa
+RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
+	python get-pip.py
 
 RUN pip install pyyaml
 

--- a/dockerfile-nogit
+++ b/dockerfile-nogit
@@ -14,10 +14,11 @@ RUN apt-get update && \
 	apt-get install -y git tar wget dfu-util cmake python3 ccache curl && \
 	apt-get -qy autoremove
 
-#Install pip from PyPa
+#Install current pip from PyPa
 RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
 	python get-pip.py
 
+#Fetch additional dependencies from Python 3.x pip
 RUN pip install pyyaml
 
 # Grab the GNU ARM toolchain from arm.com

--- a/dockerfile-nogit
+++ b/dockerfile-nogit
@@ -16,7 +16,7 @@ RUN apt-get update && \
 
 #Install current pip from PyPa
 RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
-	python get-pip.py
+	python3 get-pip.py
 
 #Fetch additional dependencies from Python 3.x pip
 RUN pip install pyyaml


### PR DESCRIPTION
Hi, 

I've fixed the installation of pip within the dockerfiles,
the install now happens manually with the current pip version from PyPa. Curl must be available as well. 

Best,
Y