### PR TITLE
Speaker enable / disable for Portapack H1 and more

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,0 @@
-## Fork of the unofficial HAVOC
-
-I own a chinese flavored H1 Portapack. This particular fork is finetuned for this model, although it works perfectly OK (AFAIK) on H2 models.
-
-This repository is my coding "buffer" before pulling requests into eried/portapack-mayhem repository, which represents at this time and date one of the main efforts (if not the only one) to keep fixing and further developing the HAVOC version, now re-bautized into "MAYHEM"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ## Fork of the unofficial HAVOC
 
-I own a chinese flavored H1 Portapack. This particular fork is finetuned for H1 models, although it works perfectly OK (AFAIK) on H2 models.
+I own a chinese flavored H1 Portapack. This particular fork is finetuned for this model, although it works perfectly OK (AFAIK) on H2 models.
 
-This repository is my coding "buffer" before pulling requests into eried/portapack-mayhem repository, which represents at this time and date one of the main efforts to keep fixing and further developing the HAVOC version, now re-bautized into "MAYHEM"
+This repository is my coding "buffer" before pulling requests into eried/portapack-mayhem repository, which represents at this time and date one of the main efforts (if not the only one) to keep fixing and further developing the HAVOC version, now re-bautized into "MAYHEM"

--- a/README.md
+++ b/README.md
@@ -1,25 +1,5 @@
 ## Fork of the unofficial HAVOC
 
-Keeping the latest release files and all features I found, and possible my own features in the future, around here. Check Releases
+I own a chinese flavored H1 Portapack. This particular fork is finetuned for H1 models, although it works perfectly OK (AFAIK) on H2 models.
 
-[![paypal](https://www.paypalobjects.com/en_US/i/btn/btn_donateCC_LG.gif)](https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=CBPQA4HRRPJQ6&source=url)
-
-I only have this [Portapack H2+HackRF+battery](https://s.click.aliexpress.com/e/_dSMPvNo), so that's the version I'll be using for testing the releases before I post them here. BTW, if you have the same H2 (I know... I know it is a *dirty* clone) you could print my case:
-[![Case](docs/images/h2_front.jpg)](https://www.thingiverse.com/thing:4260973)
-
-<details>
-  <summary>More details about the H2 case</summary>
-  
-[STL files](https://www.thingiverse.com/thing:4260973)
-
-  
-</details>
-
-<details>
-  <summary>Printed magnetic cover for the H2 case</summary>
-  
-[![Cover](docs/images/h2_cover.jpg)](https://www.thingiverse.com/thing:4278961)
-  
-[STL files](https://www.thingiverse.com/thing:4278961)
-  
-</details>
+This repository is my coding "buffer" before pulling requests into eried/portapack-mayhem repository, which represents at this time and date one of the main efforts to keep fixing and further developing the HAVOC version, now re-bautized into "MAYHEM"

--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+ I own a chinese flavored H1 Portapack. This particular fork is finetuned for this model, although it works perfectly OK (AFAIK) on H2 models.
+
+ This repository is my coding "buffer" before pulling requests into eried/portapack-mayhem repository, which represents at this time and date one of the main efforts (if not the only one) to keep fixing and further developing the HAVOC version, now re-bautized into "MAYHEM"

--- a/firmware/application/apps/ui_debug.cpp
+++ b/firmware/application/apps/ui_debug.cpp
@@ -321,25 +321,27 @@ void DebugControlsView::focus() {
 /* DebugPeripheralsMenuView **********************************************/
 
 DebugPeripheralsMenuView::DebugPeripheralsMenuView(NavigationView& nav) {
+		if (portapack::persistent_memory::config_backbutton()) add_items({
+		{ "..",				ui::Color::light_grey(),&bitmap_icon_previous,	[&nav](){ nav.pop(); } },
+		});
 	add_items({
-		{ "RFFC5072",    ui::Color::white(),	nullptr,	[&nav](){ nav.push<RegistersView>(
+		{ "RFFC5072",    ui::Color::dark_cyan(),	nullptr,	[&nav](){ nav.push<RegistersView>(
 			"RFFC5072", RegistersWidgetConfig { 31, 16 },
 			[](const size_t register_number) { return radio::debug::first_if::register_read(register_number); }
 		); } },
-		{ "MAX2837",     ui::Color::white(),	nullptr,	[&nav](){ nav.push<RegistersView>(
+		{ "MAX2837",     ui::Color::dark_cyan(),	nullptr,	[&nav](){ nav.push<RegistersView>(
 			"MAX2837", RegistersWidgetConfig { 32, 10 },
 			[](const size_t register_number) { return radio::debug::second_if::register_read(register_number); }
 		); } },
-		{ "Si5351C",     ui::Color::white(),	nullptr,	[&nav](){ nav.push<RegistersView>(
+		{ "Si5351C",     ui::Color::dark_cyan(),	nullptr,	[&nav](){ nav.push<RegistersView>(
 			"Si5351C", RegistersWidgetConfig { 96, 8 },
 			[](const size_t register_number) { return portapack::clock_generator.read_register(register_number); }
 		); } },
-		{ audio::debug::codec_name(), ui::Color::white(),	nullptr,	[&nav](){ nav.push<RegistersView>(
+		{ audio::debug::codec_name(), ui::Color::dark_cyan(),	nullptr,	[&nav](){ nav.push<RegistersView>(
 			audio::debug::codec_name(), RegistersWidgetConfig { audio::debug::reg_count(), audio::debug::reg_bits() },
 			[](const size_t register_number) { return audio::debug::reg_read(register_number); }
 		); } },
 	});
-	on_left = [&nav](){ nav.pop(); };
 }
 
 /* DebugMenuView *********************************************************/
@@ -349,12 +351,12 @@ DebugMenuView::DebugMenuView(NavigationView& nav) {
 		{ "..",				ui::Color::light_grey(),&bitmap_icon_previous,	[&nav](){ nav.pop(); } },
 		});
 	add_items({
-		{ "Memory", 		ui::Color::white(),	&bitmap_icon_soundboard,	[&nav](){ nav.push<DebugMemoryView>(); } },
+		{ "Memory", 		ui::Color::dark_cyan(),	&bitmap_icon_soundboard,	[&nav](){ nav.push<DebugMemoryView>(); } },
 		//{ "Radio State",	ui::Color::white(),	nullptr,	[&nav](){ nav.push<NotImplementedView>(); } },
-		{ "SD Card",		ui::Color::white(),	&bitmap_icon_file,	[&nav](){ nav.push<SDCardDebugView>(); } },
-		{ "Peripherals",	ui::Color::white(),	&bitmap_icon_debug,	[&nav](){ nav.push<DebugPeripheralsMenuView>(); } },
-		{ "Temperature",	ui::Color::white(),	&bitmap_icon_transmit,	[&nav](){ nav.push<TemperatureView>(); } },
-		{ "Controls",		ui::Color::white(),	&bitmap_icon_utilities,	[&nav](){ nav.push<DebugControlsView>(); } },
+		{ "SD Card",		ui::Color::dark_cyan(),	&bitmap_icon_file,	[&nav](){ nav.push<SDCardDebugView>(); } },
+		{ "Peripherals",	ui::Color::dark_cyan(),	&bitmap_icon_debug,	[&nav](){ nav.push<DebugPeripheralsMenuView>(); } },
+		{ "Temperature",	ui::Color::dark_cyan(),	&bitmap_icon_transmit,	[&nav](){ nav.push<TemperatureView>(); } },
+		{ "Controls",		ui::Color::dark_cyan(),	&bitmap_icon_utilities,	[&nav](){ nav.push<DebugControlsView>(); } },
 	});
 	set_max_rows(2); // allow wider buttons
 }

--- a/firmware/application/apps/ui_debug.hpp
+++ b/firmware/application/apps/ui_debug.hpp
@@ -287,7 +287,7 @@ private:
 	};
 };*/
 
-class DebugPeripheralsMenuView : public MenuView {
+class DebugPeripheralsMenuView : public BtnGridView {
 public:
 	DebugPeripheralsMenuView(NavigationView& nav);
 };

--- a/firmware/application/audio.cpp
+++ b/firmware/application/audio.cpp
@@ -26,6 +26,7 @@
 using portapack::clock_manager;
 
 #include "portapack_hal.hpp"
+#include "portapack_persistent_memory.hpp"
 
 #include "i2s.hpp"
 using namespace lpc43xx;
@@ -146,12 +147,24 @@ void stop() {
 void mute() {
 	i2s::i2s0::tx_mute();
 	audio_codec->headphone_disable();
+	//audio_codec->speaker_disable();
 }
 
 void unmute() {
 	i2s::i2s0::tx_unmute();
 	audio_codec->headphone_enable();
+	//audio_codec->speaker_enable();
 }
+
+void speaker_mute() {
+ 	i2s::i2s0::tx_mute();
+ 	audio_codec->speaker_disable();
+ }
+
+ void speaker_unmute() {
+ 	i2s::i2s0::tx_unmute();
+ 	audio_codec->speaker_enable();
+ }
 
 } /* namespace output */
 

--- a/firmware/application/audio.hpp
+++ b/firmware/application/audio.hpp
@@ -46,6 +46,9 @@ public:
 	virtual volume_range_t headphone_gain_range() const = 0;
 	virtual void set_headphone_volume(const volume_t volume) = 0;
 
+	virtual void speaker_enable() = 0;
+ 	virtual void speaker_disable() = 0;
+
 	virtual void microphone_enable() = 0;
 	virtual void microphone_disable() = 0;
 
@@ -61,6 +64,9 @@ void stop();
 
 void mute();
 void unmute();
+
+void speaker_mute();
+ void speaker_unmute();
 
 } /* namespace output */
 
@@ -78,6 +84,14 @@ volume_range_t volume_range();
 void set_volume(const volume_t volume);
 
 } /* namespace headphone */
+
+namespace speaker {
+
+volume_range_t volume_range();
+
+void set_volume(const volume_t volume);
+
+} /* namespace speaker */
 
 namespace debug {
 

--- a/firmware/application/portapack.cpp
+++ b/firmware/application/portapack.cpp
@@ -93,6 +93,19 @@ bool get_antenna_bias() {
 	return antenna_bias;
 }
 
+bool speaker_mode { false };
+ void set_speaker_mode(const bool v) {
+ 	speaker_mode = v;
+ 	if (speaker_mode)
+ 	{
+ 		audio::output::speaker_unmute();
+ 	}
+ 	else
+ 	{
+ 		audio::output::speaker_mute();
+ 	}
+ }
+
 static constexpr uint32_t systick_count(const uint32_t clock_source_f) {
 	return clock_source_f / CH_FREQUENCY;
 }

--- a/firmware/application/portapack.hpp
+++ b/firmware/application/portapack.hpp
@@ -42,6 +42,9 @@ extern portapack::IO io;
 
 extern lcd::ILI9341 display;
 
+extern bool speaker_mode;
+void set_speaker_mode(const bool v);
+
 extern I2C i2c0;
 extern SPI ssp1;
 

--- a/firmware/application/ui_navigation.cpp
+++ b/firmware/application/ui_navigation.cpp
@@ -106,6 +106,7 @@ SystemStatusView::SystemStatusView(
 		&backdrop,
 		&button_back,
 		&title,
+		&button_speaker,
 		&button_stealth,
 		//&button_textentry,
 		&button_camera,
@@ -115,6 +116,11 @@ SystemStatusView::SystemStatusView(
 		&sd_card_status_view,
 	});
 	
+	if (portapack::persistent_memory::config_speaker()) 
+		button_speaker.hidden(false);
+	else
+		button_speaker.hidden(true);
+
 	button_back.id = -1;	// Special ID used by FocusManager
 	title.set_style(&style_systemstatus);
 	
@@ -132,6 +138,10 @@ SystemStatusView::SystemStatusView(
 		if (this->on_back)
 			this->on_back();
 	};
+
+	button_speaker.on_select = [this](ImageButton&) {
+ 		this->on_speaker();
+ 	};
 	
 	button_stealth.on_select = [this](ImageButton&) {
 		this->on_stealth();
@@ -156,6 +166,13 @@ SystemStatusView::SystemStatusView(
 }
 
 void SystemStatusView::refresh() {
+	if (portapack::persistent_memory::config_speaker()) {
+		button_speaker.set_foreground(Color::light_grey());
+		button_speaker.hidden(false);
+	}		
+	else {
+		button_speaker.hidden(true);
+	}
 	if (portapack::get_antenna_bias()) {
 		button_bias_tee.set_bitmap(&bitmap_icon_biast_on);
 		button_bias_tee.set_foreground(ui::Color::yellow());
@@ -187,6 +204,21 @@ void SystemStatusView::set_title(const std::string new_value) {
 		title.set(new_value);
 	}
 }
+
+void SystemStatusView::on_speaker() {
+ 	if (!portapack::speaker_mode) 
+ 	{
+ 		portapack::set_speaker_mode(true);
+ 		button_speaker.set_foreground(Color::green());
+ 	}
+ 	else
+ 	{
+ 		portapack::set_speaker_mode(false);
+ 		button_speaker.set_foreground(Color::light_grey());
+ 	}
+
+ }
+
 
 void SystemStatusView::on_stealth() {
 	bool mode = not portapack::persistent_memory::stealth_mode();

--- a/firmware/application/ui_navigation.hpp
+++ b/firmware/application/ui_navigation.hpp
@@ -126,9 +126,16 @@ private:
 	};
 
 	Text title {
-		{ 20, 0, 16 * 8, 1 * 16 },
+		{ 20, 0, 14 * 8, 1 * 16 },
 		default_title,
 	};
+
+	ImageButton button_speaker {
+ 		{ 17 * 8, 0, 2 * 8, 1 * 16 },
+ 		&bitmap_icon_speaker,
+ 		Color::light_grey(),
+ 		Color::dark_grey()
+ 	};
 	
 	ImageButton button_stealth {
 		{ 19 * 8, 0, 2 * 8, 1 * 16 },
@@ -176,6 +183,7 @@ private:
 		{ 28 * 8, 0 * 16,  2 * 8, 1 * 16 }
 	};
 
+	void on_speaker();
 	void on_stealth();
 	void on_bias_tee();
 	//void on_textentry();

--- a/firmware/common/wm8731.hpp
+++ b/firmware/common/wm8731.hpp
@@ -341,6 +341,10 @@ public:
 		headphone_mute();
 	}
 
+	void speaker_enable() {};
+ 	void speaker_disable() {};
+
+
 	void microphone_enable() override {
 		// TODO: Implement
 	}


### PR DESCRIPTION
DEBUG MENU: All icons are dark cyan now, so they can be seen while moving through the menu

SPEAKER PRESENT: Now, on options -> UI when you mark the speaker checkbox, the speaker icon will be present in the top bar, allowing you to turn on / off the speaker output on your H1.

DEBUG MENU: PERIPHERALS now is it also a button based menu.

Note to @eried : The h2 does not have an installed speaker by default, does it ? (ask because I don't know, since I got an H1)

On the status bar on top of the screen you get the "speaker" icon (Even if there is no speaker) ? 

If so, then the new setting in OPTIONS -> UI which enables / disables the speaker icon might be of use for H2 too. 

On the other hand, the ".." back buttons, given the small screen that the H1 has (the h2 has a bigger screen, it seems ?) at least for me and my rather stocky fingers, is a must. 