### PR TITLE
GPS SIMULATOR EXIT ON PLAY FIX

### DIFF
--- a/firmware/application/apps/gps_sim_app.cpp
+++ b/firmware/application/apps/gps_sim_app.cpp
@@ -234,6 +234,8 @@ GpsSimAppView::~GpsSimAppView() {
 void GpsSimAppView::on_hide() {
 	// TODO: Terrible kludge because widget system doesn't notify Waterfall that
 	// it's being shown or hidden.
+	if( is_active() )
+		stop(false);
 	waterfall.on_hide();
 	View::on_hide();
 }


### PR DESCRIPTION
Now, if you exit the GPS SIMULATOR while transmitting, it will properly stop the radio and won't crash, exiting as expected.

Fixes https://github.com/eried/portapack-mayhem/issues/52