### PR TITLE
Speaker icon sync with headphones

### DIFF
--- a/firmware/application/apps/analog_audio_app.cpp
+++ b/firmware/application/apps/analog_audio_app.cpp
@@ -338,7 +338,8 @@ void AnalogAudioView::update_modulation(const ReceiverModel::Mode modulation) {
 	record_view.set_sampling_rate(sampling_rate);
 
 	if( !is_wideband_spectrum_mode ) {
-		audio::output::unmute();
+		//audio::output::unmute();
+		portapack::set_speaker_mode(portapack::speaker_mode); //Now depends on speaker mode
 	}
 }
 

--- a/firmware/application/apps/ui_scanner.cpp
+++ b/firmware/application/apps/ui_scanner.cpp
@@ -174,7 +174,7 @@ ScannerView::ScannerView(
 	
 	audio::output::start();
 	
-	audio::output::mute();
+	//audio::output::mute(); //No need for this
 	baseband::run_image(portapack::spi_flash::image_tag_nfm_audio);
 	receiver_model.set_modulation(ReceiverModel::Mode::NarrowbandFMAudio);
 	receiver_model.set_sampling_rate(3072000);
@@ -182,7 +182,7 @@ ScannerView::ScannerView(
 	receiver_model.enable();
 	receiver_model.set_squelch_level(0);
 	receiver_model.set_nbfm_configuration(field_bw.selected_index());
-	audio::output::unmute();
+	//audio::output::unmute(); //No need for this
 	
 	// TODO: Scanning thread here
 	scan_thread = std::make_unique<ScannerThread>(frequency_list);

--- a/firmware/application/audio.cpp
+++ b/firmware/application/audio.cpp
@@ -141,7 +141,11 @@ void start() {
 }
 
 void stop() {
-	mute();
+	//mute();  //Now it depends on speaker mode
+	if (portapack::speaker_mode)
+ 		speaker_mute();
+ 	else
+ 		mute();   //Mute headphones
 	i2s::i2s0::tx_stop();
 }
 

--- a/firmware/application/audio.cpp
+++ b/firmware/application/audio.cpp
@@ -136,7 +136,8 @@ namespace output {
 
 void start() {
 	i2s::i2s0::tx_start();
-	unmute();
+	//unmute();
+	portapack::set_speaker_mode(portapack::speaker_mode); //Now depends on speaker mode
 }
 
 void stop() {

--- a/firmware/application/portapack.cpp
+++ b/firmware/application/portapack.cpp
@@ -97,9 +97,15 @@ bool speaker_mode { false };
  void set_speaker_mode(const bool v) {
  	speaker_mode = v;
  	if (speaker_mode)
+	{
+	 	audio::output::mute();   //Mute headphones
  		audio::output::speaker_unmute();
+	}
  	else
+	 {
  		audio::output::speaker_mute();
+		audio::output::unmute(); //Unmute headphones
+	 }
  }
 
 static constexpr uint32_t systick_count(const uint32_t clock_source_f) {


### PR DESCRIPTION
This address the issue: https://github.com/eried/portapack-mayhem/issues/82

Speaker icon now behaves naturally: When the speaker amp is off (muted speaker), the headphones amp is on, and viceversa.

From now on, whenever a future app needs to turn audio output ON, it will depend on the speaker mode. For example:

Before, you just did audio::output::unmute(); to activate audio output.

Now, you do: portapack::set_speaker_mode(portapack::speaker_mode);

Which will take into account (if present) the speaker mode, **and either unmute the headphones, or the speaker**.

If the user has no Speaker Icon active on the Status-bar (as may be the case with H2 users), it will always unmute the headphones.

This new approach has the added benefit of not turning on two amps at the same time (the headphones AND speaker) inside the AK4951 audio codec IC.