### PR TITLE
New Antenna length Calculator

### DIFF
--- a/firmware/application/apps/ui_whipcalc.hpp
+++ b/firmware/application/apps/ui_whipcalc.hpp
@@ -28,6 +28,7 @@
 #include "ui_receiver.hpp"
 #include "ui_navigation.hpp"
 #include "string_format.hpp"
+#include <vector>
 
 namespace ui {
 
@@ -43,50 +44,67 @@ private:
 	const double speed_of_light_mps = 299792458.0;		// m/s
 	const double speed_of_light_fps = 983571087.90472;	// feet/s
 	
-	const std::string frac_str[4] = { "", "1/4 ", "1/2 ", "3/4 " };
+	const std::string frac_str[4] = { "", " 1/4", " 1/2", " 3/4" };
+
+ 	struct antenna_entry {
+ 		std::string label { };
+ 		std::vector <uint16_t> elements { };
+ 	};
+
+ 	std::vector<antenna_entry> antenna_db { };
 	
 	double get_decimals(double num, int16_t mult, bool round = false);
 	void update_result();
+
+	uint16_t string_to_number(std::string);
+ 	void txtline_process(std::string&);
+ 	void antenna_Default();
 	
 	Labels labels {
+		{ { 5 * 8, 1 * 16 }, "Loaded:", Color::light_grey() },
 		{ { 2 * 8, 2 * 16 }, "Frequency:", Color::light_grey() },
-		{ { 2 * 8, 3 * 16 }, "Type:", Color::light_grey() }
+		{ { 7 * 8, 3 * 16 }, "Wave:", Color::light_grey() },
+ 		{ { 5 * 8, 4 * 16 }, "Metric:", Color::light_grey() },
+ 		{ { 3 * 8, 5 * 16 }, "Imperial:", Color::light_grey() }
 	};
+
+	Text antennas_on_memory {
+ 		{ 13 * 8, 1 * 16, 2 * 16, 16 },
+ 	};
 
 	FrequencyField field_frequency {
 		{ 13 * 8, 2 * 16 },
 	};
 
 	OptionsField options_type {
-		{ 8 * 8, 3 * 16 },
-		12,
+		{ 13 * 8, 3 * 16 },
+ 		7,
 		{
-			{ "Full wave", 8 },
-			{ "Half wave", 4 },
-			{ "Quarter wave", 2 },
-			{ "3/4 wave", 6 },
-			{ "1/8 wave", 1 },
-			{ "3/8 wave", 3 },
-			{ "5/8 wave", 5 },
-			{ "7/8 wave", 7 }
+			{ "Full", 8 },
+ 			{ "Half", 4 },
+ 			{ "Quarter", 2 },
+ 			{ "3/4", 6 },
+ 			{ "1/8", 1 },
+ 			{ "3/8", 3 },
+ 			{ "5/8", 5 },
+ 			{ "7/8", 7 }
 		}
 	};
 	
 	Text text_result_metric {
-		{ 3 * 8, 5 * 16, 10 * 16, 16 },
+		{ 13 * 8, 4 * 16, 10 * 16, 16 },
 		"-"
 	};
 	Text text_result_imperial {
-		{ 2 * 8, 6 * 16, 10 * 16, 16 },
+		{ 13 * 8, 5 * 16, 10 * 16, 16 },
 		"-"
 	};
-	Text text_result_ant500 {
-		{ 2 * 8, 8 * 16, 26 * 16, 16 },
-		"-"
-	};
+	Console console {
+ 		{ 0, 7 * 16, 240, 144 }		//Allows to show up to 8 antennas
+ 	};
 	
 	Button button_exit {
-		{ 72, 264, 96, 32 },
+		{ 72, 17 * 16, 96, 32 },
 		"Exit"
 	};
 };

--- a/firmware/common/ui_widget.cpp
+++ b/firmware/common/ui_widget.cpp
@@ -595,7 +595,10 @@ void Console::write(std::string message) {
 					pen_color = s.foreground;
 				escape = false;
 			} else {
-				if (c == '\n') {
+				if (c=='\f') {	//Add FORM FEED (clear screen)
+ 					clear();
+ 					buffer.clear();
+ 				} else if (c == '\n') {
 					crlf();
 				} else if (c == '\x1B') {
 					escape = true;

--- a/sdcard/WHIPCALC/ANTENNAS.TXT
+++ b/sdcard/WHIPCALC/ANTENNAS.TXT
@@ -1,0 +1,4 @@
+#<antenna label> <elements length in mm, separated by a space>
+ANT700 95 134 175 206 230 245
+ANT500 185 315 450 586 724 862
+CHEAPO 118 183 253 326 399 476


### PR DESCRIPTION
It reads the antennas definition from a txt file:

WHIPCALC/ANTENNAS.TXT

Inside the textfile you place each antenna you own with the following sintaxis:

<antenna label> <elements length in mm, separated by a space>

For example:

ANT500 185 315 450 586 724 862

Input the required frequency, adjust the wave type (full / half / quarter, etc.) and the calculator will return the antenna length (metric and imperial) while also calculating how much you need to expand the fitting antennas you got defined on the txt.

It may return up to 8 matching antennas, which is more than enough (normally you will have 2, perhaps 3 telescopic antennas around for your portapack)

If by any chance your antennas txt got more than 8 antennas, and more than 8 matches the length of the freq / wave you want, it will only show the first 8 matching antennas and will warn you at the bottom that there are even more results (hidden).

All calculations now are rounded into the best integer, considering first decimal, so precision is double than the original antenna calculator app.

ALSO: I added a tiny bit of extra functionality to the CONSOLE widget:

When writing some text inside a console widget (big text area), It already recognized the \n inside the string and jumped into a new line.

Now It also recognizes \f (what would be Feed form) and will clear the screen and start on a new slate). 