### PR TITLE
Nicer debug -> temperature graph

### DIFF
--- a/firmware/application/apps/ui_debug.cpp
+++ b/firmware/application/apps/ui_debug.cpp
@@ -121,7 +121,7 @@ void TemperatureWidget::paint(Painter& painter) {
 }
 
 TemperatureWidget::temperature_t TemperatureWidget::temperature(const sample_t sensor_value) const {
-	return -45 + sensor_value * 5;
+	return -35 + sensor_value * 4;  //max2837 datasheet temp 25ºC has sensor value: 15
 }
 
 std::string TemperatureWidget::temperature_str(const temperature_t temperature) const {

--- a/firmware/application/apps/ui_debug.hpp
+++ b/firmware/application/apps/ui_debug.hpp
@@ -101,10 +101,10 @@ private:
 
 	std::string temperature_str(const temperature_t temperature) const;
 
-	static constexpr temperature_t display_temp_min = 0;
+	static constexpr temperature_t display_temp_min = -10;  //Accomodate negative values, present in cold startup cases
 	static constexpr temperature_t display_temp_scale = 3;
 	static constexpr int bar_width = 1;
-	static constexpr int temp_len = 3;
+	static constexpr int temp_len = 4; //Now scale shows up to 4 chars ("-10C")
 };
 
 class TemperatureView : public View {


### PR DESCRIPTION
Lowered the scale -10 ºC so it accomodates less than zero temperatures, present sometimes when cold starting the system.

Added  one more char for temperature label length (which now has to show i.e. "-10C").

Adjusted the max2837 sensor value -> ºC temp result, by normalizing the conversion to correctly display the standard 25ºC, mentioned in Datasheet.