### PR TITLE
Fixed bug in datetime

### DIFF
--- a/firmware/application/string_format.cpp
+++ b/firmware/application/string_format.cpp
@@ -171,7 +171,7 @@ std::string to_string_datetime(const rtc::RTC& value, const TimeFormat format) {
 	}
 	
 	string += to_string_dec_uint(value.hour(), 2, '0') + ":" +
-	string += to_string_dec_uint(value.minute(), 2, '0');
+				to_string_dec_uint(value.minute(), 2, '0');
 	
 	if ((format == YMDHMS) || (format == HMS))
 		string += ":" + to_string_dec_uint(value.second(), 2, '0');


### PR DESCRIPTION
As shown in https://github.com/eried/portapack-mayhem/issues/88 ...

Tiny bug but probably responsible for badly forming datetime in several apps, as it is used in ACARS, POCSAG and ADSB_TX (and of course AIS RX)