### PR TITLE
Fix draw bearing

### DIFF
--- a/firmware/application/ui/ui_geomap.cpp
+++ b/firmware/application/ui/ui_geomap.cpp
@@ -169,8 +169,9 @@ void GeoMap::paint(Painter& painter) {
 		display.fill_rectangle({ r.center() - Point(16, 1), { 32, 2 } }, Color::red());
 		display.fill_rectangle({ r.center() - Point(1, 16), { 2, 32 } }, Color::red());
 	} else {
-		draw_bearing({ 120, 32 + 144 }, angle_, 10, Color::red());
-		painter.draw_string({ 120 - ((int)tag_.length() * 8 / 2), 32 + 144 - 32 }, style(), tag_);
+		//coordinates could probably be calculted off screen_rect()?
+		draw_bearing({ 120, 16 + 48 + 128 }, angle_, 10, Color::red());
+		painter.draw_string({ 120 - ((int)tag_.length() * 8 / 2), 16 + 48 + 128 - 32 }, style(), tag_);
 	}
 }
 

--- a/firmware/application/ui/ui_geomap.cpp
+++ b/firmware/application/ui/ui_geomap.cpp
@@ -169,9 +169,9 @@ void GeoMap::paint(Painter& painter) {
 		display.fill_rectangle({ r.center() - Point(16, 1), { 32, 2 } }, Color::red());
 		display.fill_rectangle({ r.center() - Point(1, 16), { 2, 32 } }, Color::red());
 	} else {
-		//coordinates could probably be calculted off screen_rect()?
-		draw_bearing({ 120, 16 + 48 + 128 }, angle_, 10, Color::red());
-		painter.draw_string({ 120 - ((int)tag_.length() * 8 / 2), 16 + 48 + 128 - 32 }, style(), tag_);
+		draw_bearing(r.center(), angle_, 10, Color::red());
+		//center tag above bearing
+		painter.draw_string(r.center() - Point(((int)tag_.length() * 8 / 2), 2 * 16), style(), tag_);
 	}
 }
 

--- a/firmware/common/ui.cpp
+++ b/firmware/common/ui.cpp
@@ -91,7 +91,9 @@ Rect& Rect::operator-=(const Point& p) {
 }
 
 Point polar_to_point(float angle, uint32_t distance) {
-	return Point(sin_f32(DEG_TO_RAD(angle) + (pi / 2)) * distance, -sin_f32(DEG_TO_RAD(angle)) * distance);
+	//polar to compass with y negated for screen drawing
+	return Point(sin_f32(DEG_TO_RAD(-angle) + pi) * distance, 
+	             sin_f32(DEG_TO_RAD(-angle) - (pi / 2)) * distance); 
 }
 
 } /* namespace ui */


### PR DESCRIPTION
This should fix the triangle location for AIS and ADSB being slightly north of centered. Triangle rotation now also reflects compass heading (0 -> north, 90-> east, etc.)