### PR TITLE
Fix MicTX gain when using decimal values

### DIFF
--- a/firmware/baseband/proc_mictx.hpp
+++ b/firmware/baseband/proc_mictx.hpp
@@ -51,7 +51,8 @@ private:
 	ToneGen tone_gen { };
 	ToneGen beep_gen { };
 	
-	uint32_t divider { }, audio_gain { };
+	uint32_t divider { };
+	float audio_gain { };
 	uint64_t power_acc { 0 };
 	uint32_t power_acc_count { 0 };
 	bool play_beep { false };


### PR DESCRIPTION
The MicTX gain was being cast to a uint which forced decimal values like 0.5 to 0 or 1.5 to 1. 

Closes #100 