### PR TITLE
Bigger cursor tick on spectrum waterfall

### DIFF
--- a/firmware/application/ui/ui_spectrum.cpp
+++ b/firmware/application/ui/ui_spectrum.cpp
@@ -120,8 +120,8 @@ void FrequencyScale::paint(Painter& painter) {
 	
 	if (_blink) {
 		const Rect r_cursor {
-			120 + cursor_position, r.bottom() - filter_band_height,
-			2, filter_band_height
+			118 + cursor_position, r.bottom() - filter_band_height,
+			5, filter_band_height
 		};
 		painter.fill_rectangle(
 			r_cursor,


### PR DESCRIPTION
I changed width in pixels of the "fine-tune cursor" from 2 to 5 , and then re-centered the cursor, from 120 to 118 to accomodate the shift in width.

I was inspired by this old ISSUE on Havoc's repository, where at the end @furrtek commented the need to make the red tick bigger in the future (but forgot / was swamped with other ehnancements / issues):

https://github.com/furrtek/portapack-havoc/issues/172