### PR TITLE
fixes file renaming on subdir

### DIFF
--- a/firmware/application/apps/ui_fileman.cpp
+++ b/firmware/application/apps/ui_fileman.cpp
@@ -249,7 +249,11 @@ FileLoadView::FileLoadView(
 
 void FileManagerView::on_rename(NavigationView& nav) {
 	text_prompt(nav, name_buffer, max_filename_length, [this](std::string& buffer) {
-		rename_file(get_selected_path(), buffer);
+		std::string destination_path = current_path.string();
+		if (destination_path.back() != '/')
+			destination_path += '/';
+		destination_path = destination_path + buffer;
+		rename_file(get_selected_path(), destination_path);
 		load_directory_contents(current_path);
 		refresh_list();
 	});


### PR DESCRIPTION
Fixes https://github.com/eried/portapack-mayhem/issues/115

The file rename function needs to be called with full_path/old_name  and full_path/new_name.

Instead, it was called with full_path/old_name and new_name ... thus the renamed file ended on the root dir (path not preserved).