### PR TITLE
Radiosonde-CRC-checkbox

### DIFF
--- a/firmware/application/apps/ui_sonde.hpp
+++ b/firmware/application/apps/ui_sonde.hpp
@@ -67,6 +67,7 @@ private:
 	std::unique_ptr<SondeLogger> logger { };
 	uint32_t target_frequency_ { 402700000 };
 	bool logging { false };
+	bool use_crc { false };
 	sonde::GPS_data gps_info;
 	std::string sonde_id;
 	
@@ -101,6 +102,12 @@ private:
 		"Log"
 	};
 	
+	Checkbox check_crc {
+		{ 22 * 8, 5 * 16 },
+		3,
+		"CRC"
+	};
+	
 	Text text_signature {
 		{ 10 * 8, 2 * 16, 10 * 8, 16 },
 		"..."
@@ -115,12 +122,12 @@ private:
 	};
 	
 	GeoPos geopos {
-		{ 0, 6 * 16 },
+		{ 0, 7 * 16 },
 		GeoPos::alt_unit::METERS
 	};
 	
 	Button button_see_map {
-		{ 8 * 8, 10 * 16, 14 * 8, 3 * 16 },
+		{ 8 * 8, 11 * 16, 14 * 8, 3 * 16 },
 		"See on map"
 	};
 

--- a/firmware/common/sonde_packet.hpp
+++ b/firmware/common/sonde_packet.hpp
@@ -91,6 +91,8 @@ private:
 
 	using packetReader = FieldReader<baseband::Packet, BitRemapByteReverse>; //baseband::Packet instead of BiphaseMDecoder
 	bool crc_ok_M10() const;
+	bool crc_ok_RS41() const;
+	bool crc16rs41(uint32_t field_start) const;
 };
 
 } /* namespace sonde */


### PR DESCRIPTION
Added CRC calculation for Vaisala radiosondes.

Added a Checkbox on APP for turning ON / OFF CRC. When CRC on, malformed packets are ignored.

Connected existing CRC function for METEOMAN sondes, using the same "CRC" checkbox logic.