### PR TITLE
Added TX Gain control & code simplification

### DIFF
--- a/firmware/application/apps/ui_mictx.cpp
+++ b/firmware/application/apps/ui_mictx.cpp
@@ -140,11 +140,13 @@ void MicTXView::rxaudio(bool is_on) {
 		baseband::shutdown();
 		baseband::run_image(portapack::spi_flash::image_tag_mic_tx);
 		audio::input::start();
-		transmitter_model.enable();		
+//		transmitter_model.enable();		
 		portapack::pin_i2s0_rx_sda.mode(3);
-		transmitting = false;
+//		transmitting = false;
 		configure_baseband();
-		transmitter_model.disable();
+//		transmitter_model.disable();
+		transmitter_model.set_tx_gain(transmitter_model.tx_gain());
+		transmitter_model.set_rf_amp(transmitter_model.rf_amp());
 	}
 }
 
@@ -172,6 +174,8 @@ MicTXView::MicTXView(
 		&field_va_attack,
 		&field_va_decay,
 		&field_bw,
+		&field_rfgain,
+		&field_rfamp,
 		&field_frequency,
 		&options_tone_key,
 		&check_rogerbeep,
@@ -213,6 +217,17 @@ MicTXView::MicTXView(
 	};
 	field_bw.set_value(10);
 	
+	field_rfgain.on_change = [this](int32_t v) {
+		transmitter_model.set_tx_gain(v);
+	};
+	field_rfgain.set_value(transmitter_model.tx_gain());
+	
+	field_rfamp.on_change = [this](int32_t v) {
+		transmitter_model.set_rf_amp((bool)v);
+	};
+	field_rfamp.set_value(transmitter_model.rf_amp() ? 14 : 0);
+	
+	
 	check_va.on_select = [this](Checkbox&, bool v) {
 		va_enabled = v;
 		text_ptt.hidden(v);			//hide / show PTT text
@@ -241,7 +256,7 @@ MicTXView::MicTXView(
 	field_va_decay.set_value(1000);
 
 	check_rxactive.on_select = [this](Checkbox&, bool v) {
-		//vumeter.set_value(0);	//Start with a clean vumeter
+//		vumeter.set_value(0);	//Start with a clean vumeter
 		rx_enabled = v;
 		check_va.hidden(v); 	//Hide or show voice activation
 		rxaudio(v);				//Activate-Deactivate audio rx accordingly

--- a/firmware/application/apps/ui_mictx.hpp
+++ b/firmware/application/apps/ui_mictx.hpp
@@ -88,10 +88,12 @@ private:
 		{ { 3 * 8, 1 * 8 }, "MIC. GAIN:", Color::light_grey() },
 		{ { 3 * 8, 3 * 8 }, "FREQUENCY:", Color::light_grey() },
 		{ { 3 * 8, 5 * 8 }, "BANDWIDTH:   kHz", Color::light_grey() },
-		{ { 7 * 8, 11 * 8 }, "LEVEL:   /255", Color::light_grey() },
-		{ { 6 * 8, 13 * 8 }, "ATTACK:   ms", Color::light_grey() },
-		{ { 7 * 8, 15 * 8 }, "DECAY:    ms", Color::light_grey() },
-		{ { 4 * 8, 18 * 8 }, "TONE KEY:", Color::light_grey() },
+		{ { 3 * 8, 7 * 8 }, "RFGAIN:", Color::light_grey() },
+		{ {13 * 8, 7 * 8 }, "Amp:", Color::light_grey() },
+		{ { 7 * 8, 12 * 8 }, "LEVEL:   /255", Color::light_grey() },
+		{ { 6 * 8, 14 * 8 }, "ATTACK:   ms", Color::light_grey() },
+		{ { 7 * 8, 16 * 8 }, "DECAY:    ms", Color::light_grey() },
+		{ { 4 * 8, ( 19 * 8 ) - 2 }, "TONE KEY:", Color::light_grey() },
 		{ { 9 * 8, 30 * 8 }, "VOL:", Color::light_grey() },
 		{ { 5 * 8, 32 * 8 }, "SQUELCH:", Color::light_grey() }
 	};
@@ -124,29 +126,44 @@ private:
 		' '
 	};
 	
+	NumberField field_rfgain {
+		{ 10 * 8, 7 * 8 },
+		2,
+		{ 0, 47 },
+		1,
+		' '
+	};
+	NumberField field_rfamp {
+		{ 17 * 8, 7 * 8 },
+		2,
+		{ 0, 14 },
+		14,
+		' '
+	};
+	
 	Checkbox check_va {
-		{ 3 * 8, (9 * 8) - 4 },
+		{ 3 * 8, (10 * 8) - 4 },
 		7,
 		"Voice activation",
 		false
 	};
 	
 	NumberField field_va_level {
-		{ 13 * 8, 11 * 8 },
+		{ 13 * 8, 12 * 8 },
 		3,
 		{ 0, 255 },
 		2,
 		' '
 	};
 	NumberField field_va_attack {
-		{ 13 * 8, 13 * 8 },
+		{ 13 * 8, 14 * 8 },
 		3,
 		{ 0, 999 },
 		20,
 		' '
 	};
 	NumberField field_va_decay {
-		{ 13 * 8, 15 * 8 },
+		{ 13 * 8, 16 * 8 },
 		4,
 		{ 0, 9999 },
 		100,
@@ -154,7 +171,7 @@ private:
 	};
 	
 	OptionsField options_tone_key {
-		{ 10 * 8, 20 * 8 },
+		{ 10 * 8, ( 21 * 8 ) - 2 },
 		23,
 		{ }
 	};

--- a/firmware/application/radio.cpp
+++ b/firmware/application/radio.cpp
@@ -157,14 +157,13 @@ bool set_tuning_frequency(const rf::Frequency frequency) {
 
 void set_rf_amp(const bool rf_amp) {
 	rf_path.set_rf_amp(rf_amp);
-	/*
+	
 	if (direction == rf::Direction::Transmit) {
 		if (rf_amp)
 			led_tx.on();
 		else
 			led_tx.off();
 	}
-	*/
 }
 
 void set_lna_gain(const int_fast8_t db) {


### PR DESCRIPTION
A bug that enabling audio RX resets the TX gain (perhaps because that changing to receiving mode modifies some registers)  inspired me to add this gain control.
Commented out some steps which don't require for the VU meter to work again.
Moved some widgets for gain control.