### PR TITLE
Revert into use of spaces for padding freq

### DIFF
--- a/firmware/application/apps/ui_scanner.cpp
+++ b/firmware/application/apps/ui_scanner.cpp
@@ -277,9 +277,9 @@ ScannerView::ScannerView(
 		def_step = step_mode.selected_index_value();		//Use def_step from manual selector
 
 		description_list.push_back(
-			"M:" + to_string_short_freq(frequency_range.min) + " >"
-	 		+ to_string_short_freq(frequency_range.max) + " S:" 
-	 		+ to_string_short_freq(def_step)
+			"M" + to_string_short_freq(frequency_range.min) + ">"
+	 		+ to_string_short_freq(frequency_range.max) + "S" 
+	 		+ to_string_short_freq(def_step).erase(0,1) //euquiq: lame kludge to reduce spacing in step freq
 		);
 
 		rf::Frequency frequency = frequency_range.min;
@@ -375,9 +375,10 @@ ScannerView::ScannerView(
 					case AIRBAND:def_step= 8330;  	break ;
 					}
 					frequency_list.push_back(entry.frequency_a);		//Store starting freq and description
-					description_list.push_back("R:" + to_string_short_freq(entry.frequency_a)
-						+ " >" + to_string_short_freq(entry.frequency_b)
-						+ " S:" + to_string_short_freq(def_step));
+					description_list.push_back("R" + to_string_short_freq(entry.frequency_a)
+						+ ">" + to_string_short_freq(entry.frequency_b)
+						+ " S" + to_string_short_freq(def_step).erase(0,1) //euquiq: lame kludge to reduce spacing in step freq
+						);
 					while (frequency_list.size() < MAX_DB_ENTRY && entry.frequency_a <= entry.frequency_b) { //add the rest of the range
 						entry.frequency_a+=def_step;
 						frequency_list.push_back(entry.frequency_a);
@@ -485,6 +486,7 @@ size_t ScannerView::change_mode(uint8_t new_mod) { //Before this, do a scan_thre
 		bw.emplace_back("DSB", 0);
 		bw.emplace_back("USB", 0);
 		bw.emplace_back("LSB", 0);
+		bw.emplace_back("CW ", 0);
 		field_bw.set_options(bw);
 
 		baseband::run_image(portapack::spi_flash::image_tag_am_audio);

--- a/firmware/application/string_format.cpp
+++ b/firmware/application/string_format.cpp
@@ -113,8 +113,7 @@ std::string to_string_dec_int(
 }
 
 std::string to_string_short_freq(const uint64_t f) {
-	//was...		 to_string_dec_int(f / 1000000,4)
-	auto final_str = to_string_dec_int(f / 1000000) + "." + to_string_dec_int((f / 100) % 10000, 4, '0');
+	auto final_str = to_string_dec_int(f / 1000000,4) + "." + to_string_dec_int((f / 100) % 10000, 4, '0');
 	return final_str;
 }
 


### PR DESCRIPTION
This patch addresses the issue detected in: https://github.com/eried/portapack-mayhem/issues/159

This patch will revert the behavior of the function to_string_short_freq

into using spaces on the left of the integer part of the frequency (as it did originally).

When upgrading the scanner app, I did change the behavior of this function eliminating those spaces, so I could gain some characters-worth of space inside the scanner,  but I failed to detect that it introduced some lack of padding on the rx->audio app.

Now, it is back as before, and I also did update the scanner so it can cope with the "extra spaces" this function now adds (again).