### PR TITLE
Remove hard-coded rf_amp on.

### DIFF
--- a/firmware/application/apps/ui_siggen.cpp
+++ b/firmware/application/apps/ui_siggen.cpp
@@ -52,7 +52,7 @@ void SigGenView::update_tone() {
 
 void SigGenView::start_tx() {
 	transmitter_model.set_sampling_rate(1536000);
-	transmitter_model.set_rf_amp(true);
+//	transmitter_model.set_rf_amp(true);
 	transmitter_model.set_baseband_bandwidth(1750000);
 	transmitter_model.enable();
 	


### PR DESCRIPTION
Removed hard-coded turning rf_amp on when enabling transmitting in Signal Gen.
It will be handled by TransmitterView.