### PR TITLE
Hide temporary & OS system files from category files list

### DIFF
--- a/firmware/application/freqman.cpp
+++ b/firmware/application/freqman.cpp
@@ -30,6 +30,11 @@ std::vector<std::string> get_freqman_files() {
 	
 	for (auto file : files) {
 		file_list.emplace_back(file.stem().string());
+		std::string file_name = file.stem().string();
+		// don't propose tmp / hidden files in freqman's list
+		if (file_name.length() && file_name[0] != '.') {
+			file_list.emplace_back(file_name);
+		}
 	}
 	
 	return file_list;

--- a/firmware/application/freqman.cpp
+++ b/firmware/application/freqman.cpp
@@ -29,7 +29,6 @@ std::vector<std::string> get_freqman_files() {
 	auto files = scan_root_files(u"FREQMAN", u"*.TXT");
 	
 	for (auto file : files) {
-		file_list.emplace_back(file.stem().string());
 		std::string file_name = file.stem().string();
 		// don't propose tmp / hidden files in freqman's list
 		if (file_name.length() && file_name[0] != '.') {


### PR DESCRIPTION
Temporary / hidden / system files and directories starting with `.` character are not shown anymore when then `get_freqman_files()` function is called (from the *Load frequency* view)

![image](https://user-images.githubusercontent.com/12009083/92962895-ee04df80-f471-11ea-9e8d-74719955bdbf.png)

Same goal as https://github.com/eried/portapack-mayhem/pull/182 pull request