### PR TITLE
Scanner app - Load custom frequency files

### DIFF
--- a/firmware/application/apps/ui_scanner.cpp
+++ b/firmware/application/apps/ui_scanner.cpp
@@ -335,7 +335,8 @@ ScannerView::ScannerView(
 
 	button_add.on_select = [this](Button&) {  //frequency_list[current_index]
 		File scanner_file;
-		auto result = scanner_file.open("FREQMAN/SCANNER.TXT");	//First search if freq is already in txt
+		std::string freq_file_path = "FREQMAN/" + loaded_file_name + ".TXT";
+		auto result = scanner_file.open(freq_file_path);	//First search if freq is already in txt
 		if (!result.is_valid()) {
 			std::string frequency_to_add = "f=" 
 				+ to_string_dec_uint(frequency_list[current_index] / 1000) 
@@ -363,12 +364,12 @@ ScannerView::ScannerView(
 				big_display.set(frequency_list[current_index]);		//After showing an error
 			}
 			else {
-				auto result = scanner_file.append("FREQMAN/SCANNER.TXT"); //Second: append if it is not there
+				auto result = scanner_file.append(freq_file_path); //Second: append if it is not there
 				scanner_file.write_line(frequency_to_add + ",d=ADD FQ");
 			}
 		} else
 		{
-			nav_.display_modal("Error", "Cannot open SCANNER.TXT\nfor appending freq.");
+			nav_.display_modal("Error", "Cannot open " + loaded_file_name + ".TXT\nfor appending freq.");
 			big_display.set(frequency_list[current_index]);		//After showing an error
 		}
 	};
@@ -385,6 +386,8 @@ ScannerView::ScannerView(
 }
 
 void ScannerView::frequency_file_load(std::string file_name, bool stop_all_before) {
+
+	loaded_file_name = file_name; // keep loaded filename in memory
 
 	// stop everything running now if required
 	if (stop_all_before) {

--- a/firmware/application/apps/ui_scanner.cpp
+++ b/firmware/application/apps/ui_scanner.cpp
@@ -226,7 +226,6 @@ ScannerView::ScannerView(
 				// get the filename without txt extension so we can use load_freqman_file fcn
 				std::string str_file_name = new_file_path.stem().string();
 				frequency_file_load(str_file_name, true);
-				nav_.display_modal("LOAD FREQ FILE", "Successfully loaded:\n" + str_file_name + ".TXT");
 			} else {
 				nav_.display_modal("LOAD ERROR", "A valid file from\nFREQMAN directory is\nrequired.");
 			}

--- a/firmware/application/apps/ui_scanner.cpp
+++ b/firmware/application/apps/ui_scanner.cpp
@@ -387,8 +387,6 @@ ScannerView::ScannerView(
 
 void ScannerView::frequency_file_load(std::string file_name, bool stop_all_before) {
 
-	loaded_file_name = file_name; // keep loaded filename in memory
-
 	// stop everything running now if required
 	if (stop_all_before) {
 		scan_thread->stop();
@@ -398,6 +396,7 @@ void ScannerView::frequency_file_load(std::string file_name, bool stop_all_befor
 	}
 
 	if ( load_freqman_file(file_name, database)  ) {
+		loaded_file_name = file_name; // keep loaded filename in memory
 		for(auto& entry : database) {									// READ LINE PER LINE
 			if (frequency_list.size() < MAX_DB_ENTRY) {					//We got space!
 				if (entry.type == RANGE)  {								//RANGE	
@@ -435,6 +434,7 @@ void ScannerView::frequency_file_load(std::string file_name, bool stop_all_befor
 	} 
 	else 
 	{
+		loaded_file_name = 'SCANNER'; // back to the default frequency file
 		desc_cycle.set(" NO " + file_name + ".TXT FILE ..." );
 	}
 	audio::output::stop();

--- a/firmware/application/apps/ui_scanner.hpp
+++ b/firmware/application/apps/ui_scanner.hpp
@@ -126,6 +126,7 @@ private:
 	void scan_pause();
 	void scan_resume();
 	void user_resume();
+	void frequency_file_load(std::string file_name, bool stop_all_before = false);
 
 	void on_statistics_update(const ChannelStatistics& statistics);
 	void on_headphone_volume_changed(int32_t v);
@@ -276,6 +277,11 @@ private:
 	Button button_add {
 		{ 168, (15 * 16) - 4, 72, 28 },
 		"ADD FQ"
+	};
+
+	Button button_load {
+		{ 24 * 8, 3 * 16 - 8, 6 * 8, 22 },
+		"Load"
 	};
 
 	Button button_remove {

--- a/firmware/application/apps/ui_scanner.hpp
+++ b/firmware/application/apps/ui_scanner.hpp
@@ -138,6 +138,7 @@ private:
 	uint32_t wait { 0 };
 	size_t	def_step { 0 };
 	freqman_db database { };
+	std::string loaded_file_name;
 	uint32_t current_index { 0 };
 	bool userpause { false };
 	


### PR DESCRIPTION
Added a new button with the logic behind to load frequencies from a user-defined list.

- Syntax is the same as the default `SCANNER.TXT` file (`f=FREQUENCY_MHZ,d=DESCRIPTION_TEXT`)
- User frequency files must be placed in the `FREQMAN` folder on the SD card
- When opening the app, `SCANNER.TXT` frequencies are loaded (but replaced by the user's ones when the load button is clicked)
- All other features are working as before

**Modified Scanner UI:**

![image](https://user-images.githubusercontent.com/12009083/93110115-2d6f3e00-f6b5-11ea-8b7e-1db4c721b7b8.png)

When clicking the save button, the new frequency will be added (if not already inside) at the end of the last used frequency file, for example here:

![image](https://user-images.githubusercontent.com/12009083/93111590-221d1200-f6b7-11ea-97a8-791b8cdb3065.png)



