### PR TITLE
Fixes SSID value error on APX TX

### DIFF
--- a/firmware/application/apps/ui_aprs_tx.hpp
+++ b/firmware/application/apps/ui_aprs_tx.hpp
@@ -82,6 +82,7 @@ private:
 		6,
 		SymField::SYMFIELD_ALPHANUM
 	};
+	
 	NumberField num_ssid_dest {
 		{ 19 * 8, 2 * 16 },
 		2,

--- a/firmware/application/protocols/aprs.cpp
+++ b/firmware/application/protocols/aprs.cpp
@@ -38,9 +38,9 @@ void make_aprs_frame(const char * src_address, const uint32_t src_ssid,
 	char address[14] = { 0 };
 	
 	memcpy(&address[0], dest_address, 6);
-	address[6] = (dest_ssid & 15) << 1;
+	address[6] = (dest_ssid & 15);
 	memcpy(&address[7], src_address, 6);
-	address[13] = (src_ssid & 15) << 1;
+	address[13] = (src_ssid & 15);
 	
 	frame.make_ui_frame(address, 0x03, protocol_id_t::NO_LAYER3, payload);
 }


### PR DESCRIPTION
SOURCE and DESTINATION SSID Values where left bit-shifted upon being entered by the user, so resulting SSID values being transmitted ended up as a different number.  

