### PR TITLE
Customisable OOK processor properties with De Bruijn

### DIFF
--- a/firmware/application/apps/ui_bht_tx.cpp
+++ b/firmware/application/apps/ui_bht_tx.cpp
@@ -78,6 +78,8 @@ void BHTView::start_tx() {
 		baseband::set_ook_data(
 			bitstream_length,
 			EPAR_BIT_DURATION,
+			0,
+			encoder_defs[ENCODER_UM3750].sin_carrier_step,
 			EPAR_REPEAT_COUNT,
 			encoder_defs[ENCODER_UM3750].pause_symbols
 		);

--- a/firmware/application/apps/ui_encoders.cpp
+++ b/firmware/application/apps/ui_encoders.cpp
@@ -109,10 +109,17 @@ uint32_t EncodersView::samples_per_bit() {
 	return OOK_SAMPLERATE / ((field_clk.value() * 1000) / encoder_def->clk_per_fragment);
 }
 
+uint16_t EncodersView::repeat_skip_bits_count() {
+	return encoder_def->skip_repeat_bits ? strlen(encoder_def->sync) : 0;
+}
+
+uint16_t EncodersView::sin_carrier_step() {
+	return encoder_def->sin_carrier_step;
+}
+
 uint32_t EncodersView::pause_symbols() {
 	return encoder_def->pause_symbols;
 }
-
 
 void EncodersView::focus() {
 	options_enctype.set_selected_index(0);
@@ -256,6 +263,8 @@ void EncodersView::update_progress() {
 		baseband::set_ook_data(
 			bitstream_length,
 			samples_per_bit(),
+			repeat_skip_bits_count(),
+			sin_carrier_step(),
 			afsk_repeats,
 			pause_symbols());
 	}

--- a/firmware/application/apps/ui_encoders.hpp
+++ b/firmware/application/apps/ui_encoders.hpp
@@ -60,6 +60,8 @@ private:
 	};
 
 	uint32_t samples_per_bit();
+	uint16_t repeat_skip_bits_count();
+	uint16_t sin_carrier_step();
 	uint32_t pause_symbols();
 	void generate_frame(bool is_debruijn, uint32_t debruijn_bits);
 	

--- a/firmware/application/apps/ui_keyfob.cpp
+++ b/firmware/application/apps/ui_keyfob.cpp
@@ -192,6 +192,8 @@ void KeyfobView::start_tx() {
 	baseband::set_ook_data(
 		bitstream_length,
 		subaru_samples_per_bit,
+		0,
+		8,	// 70 kHz carrier frequency, not sure what it was before, to be defined
 		repeats,
 		200		// Pause symbols
 	);

--- a/firmware/application/apps/ui_touchtunes.cpp
+++ b/firmware/application/apps/ui_touchtunes.cpp
@@ -122,6 +122,8 @@ void TouchTunesView::start_tx(const uint32_t button_index) {
 	baseband::set_ook_data(
 		bitstream_length,
 		OOK_SAMPLERATE / 1766,	// 560us
+		0,
+		8,	// 70 kHz carrier frequency, not sure what the TouchTunes carrier freq was before. To be defined.
 		TOUCHTUNES_REPEATS,
 		100						// Pause
 	);

--- a/firmware/application/baseband_api.cpp
+++ b/firmware/application/baseband_api.cpp
@@ -202,11 +202,13 @@ void set_pitch_rssi(int32_t avg, bool enabled) {
 	send_message(&message);	
 }
 
-void set_ook_data(const uint32_t stream_length, const uint32_t samples_per_bit, const uint8_t repeat,
-					const uint32_t pause_symbols) {
+void set_ook_data(const uint32_t stream_length, const uint32_t samples_per_bit, uint16_t repeat_skip_bits,
+					const uint8_t sin_carrier_step, const uint8_t repeat, const uint32_t pause_symbols) {
 	const OOKConfigureMessage message {
 		stream_length,
 		samples_per_bit,
+		repeat_skip_bits,
+		sin_carrier_step,
 		repeat,
 		pause_symbols
 	};

--- a/firmware/application/baseband_api.hpp
+++ b/firmware/application/baseband_api.hpp
@@ -73,8 +73,8 @@ void set_btle(const uint32_t baudrate, const uint32_t word_length, const uint32_
 
 void set_nrf(const uint32_t baudrate, const uint32_t word_length, const uint32_t trigger_value, const bool trigger_word);
 
-void set_ook_data(const uint32_t stream_length, const uint32_t samples_per_bit, const uint8_t repeat,
-					const uint32_t pause_symbols);
+void set_ook_data(const uint32_t stream_length, const uint32_t samples_per_bit, uint16_t repeat_skip_bits,
+					const uint8_t sin_carrier_step, const uint8_t repeat, const uint32_t pause_symbols);
 void set_fsk_data(const uint32_t stream_length, const uint32_t samples_per_bit, const uint32_t shift,
 					const uint32_t progress_notice);
 void set_pocsag(const pocsag::BitRate bitrate, bool phase);

--- a/firmware/application/protocols/encoders.hpp
+++ b/firmware/application/protocols/encoders.hpp
@@ -29,10 +29,10 @@
 
 namespace encoders {
 	
-	#define ENC_TYPES_COUNT 14
-	#define OOK_SAMPLERATE	2280000U
+	#define ENC_TYPES_COUNT 	16
+	#define OOK_SAMPLERATE		2280000U
 	
-	#define ENCODER_UM3750	8
+	#define ENCODER_UM3750		10
 	
 	size_t make_bitstream(std::string& fragments);
 	void bitstream_append(size_t& bitstream_length, uint32_t bit_count, uint32_t bits);
@@ -54,6 +54,30 @@ namespace encoders {
 
 	// Warning ! If this is changed, make sure that ENCODER_UM3750 is still valid !
 	constexpr encoder_def_t encoder_defs[ENC_TYPES_COUNT] = {
+		// Test OOK Doorbell
+		{
+			"Doorbel",
+			"01", "01",
+			228, 57,
+			{ "1000", "1110" },
+			24,	"AAAAAAAAAAAAAAAAAAAAAAAA",
+			"",
+			141260, 32, // repeat=32
+			32
+		},
+
+		// Test OOK Garage Door
+		{
+			"OH200DC",
+			"01", "01",
+			920, 115,
+			{ "10000000", "11110000" },
+			8,	"AAAAAAAA",
+			"",
+			285000, 8, // repeat=230, looks like 8 is still working
+			70
+		},
+
 		// PT2260-R2
 		{
 			"2260-R2",

--- a/firmware/application/protocols/encoders.hpp
+++ b/firmware/application/protocols/encoders.hpp
@@ -31,6 +31,7 @@ namespace encoders {
 	
 	#define ENC_TYPES_COUNT 	16
 	#define OOK_SAMPLERATE		2280000U
+	#define OOK_DEFAULT_STEP 	8	// 70 kHz carrier frequency
 	
 	#define ENCODER_UM3750		10
 	
@@ -50,6 +51,8 @@ namespace encoders {
 		uint32_t default_speed;					// Default encoder clk frequency (often set by shitty resistor)
 		uint8_t repeat_min;						// Minimum repeat count
 		uint16_t pause_symbols;					// Length of pause between repeats in symbols
+		bool skip_repeat_bits;					// Should we skip the sync/header bits once the first frame has been sent?
+		uint8_t sin_carrier_step;				// The sin table step for the carrier frequency, step = 256 / (2.28 MHz / fc), where 4 <= step < 256
 	};
 
 	// Warning ! If this is changed, make sure that ENCODER_UM3750 is still valid !
@@ -63,7 +66,8 @@ namespace encoders {
 			24,	"AAAAAAAAAAAAAAAAAAAAAAAA",
 			"",
 			141260, 32, // repeat=32
-			32
+			32, false,
+			21 // fc = 164 kHz
 		},
 
 		// Test OOK Garage Door
@@ -75,7 +79,8 @@ namespace encoders {
 			8,	"AAAAAAAA",
 			"",
 			285000, 8, // repeat=230, looks like 8 is still working
-			70
+			70, false,
+			6 // fc = ~50 kHz
 		},
 
 		// PT2260-R2
@@ -87,7 +92,8 @@ namespace encoders {
 			12,	"AAAAAAAAAADDS",
 			"10000000000000000000000000000000",
 			150000,	2,
-			0
+			0, false,
+			OOK_DEFAULT_STEP
 		},
 		
 		// PT2260-R4
@@ -99,7 +105,8 @@ namespace encoders {
 			12,	"AAAAAAAADDDDS",
 			"10000000000000000000000000000000",
 			150000,	2,
-			0
+			0, false,
+			OOK_DEFAULT_STEP
 		},
 		
 		// PT2262
@@ -111,7 +118,8 @@ namespace encoders {
 			12,	"AAAAAAAAAAAAS",
 			"10000000000000000000000000000000",
 			20000,	4,
-			0
+			0, false,
+			OOK_DEFAULT_STEP
 		},
 		
 		// 16-bit ?
@@ -123,7 +131,9 @@ namespace encoders {
 			16,	"AAAAAAAAAAAAAAAAS",
 			"100000000000000000000",
 			25000,	50,
-			0	// ?
+			0,	// ?
+			false,
+			OOK_DEFAULT_STEP
 		},
 		
 		// RT1527
@@ -135,7 +145,9 @@ namespace encoders {
 			24,	"SAAAAAAAAAAAAAAAAAAAADDDD",
 			"10000000000000000000000000000000",
 			100000,	4,
-			10	// ?
+			10,	// ?
+			false,
+			OOK_DEFAULT_STEP
 		},
 		
 		// HK526E
@@ -147,7 +159,9 @@ namespace encoders {
 			12,	"AAAAAAAAAAAA",
 			"",
 			20000, 4,
-			10	// ?
+			10,	// ?
+			false,
+			OOK_DEFAULT_STEP
 		},
 		
 		// HT12E
@@ -159,7 +173,9 @@ namespace encoders {
 			12,	"SAAAAAAAADDDD",
 			"0000000000000000000000000000000000001",
 			3000, 4,
-			10	// ?
+			10,	// ?
+			false,
+			OOK_DEFAULT_STEP
 		},
 			
 		// VD5026 13 bits ?
@@ -171,7 +187,9 @@ namespace encoders {
 			12,	"SAAAAAAAAAAAA",
 			"000000000000000000000000000000000000000000000001",		// ?
 			100000,	4,
-			10	// ?
+			10,	// ?
+			false,
+			OOK_DEFAULT_STEP
 		},
 		
 		// UM3750
@@ -183,7 +201,9 @@ namespace encoders {
 			12,	"SAAAAAAAAAAAA",
 			"001",
 			100000,	4,
-			(3 * 12) - 6	// Compensates for pause delay bug in proc_ook
+			(3 * 12) - 6,	// Compensates for pause delay bug in proc_ook
+			false,
+			OOK_DEFAULT_STEP
 		},
 		
 		// UM3758
@@ -195,7 +215,9 @@ namespace encoders {
 			18,	"SAAAAAAAAAADDDDDDDD",
 			"1",
 			160000,	4,
-			10	// ?
+			10,	// ?
+			false,
+			OOK_DEFAULT_STEP
 		},
 		
 		// BA5104
@@ -207,7 +229,9 @@ namespace encoders {
 			9,	"SDDAAAAAAA",
 			"",
 			455000,	4,
-			10	// ?
+			10,	// ?
+			false,
+			OOK_DEFAULT_STEP
 		},
 			
 		// MC145026
@@ -219,7 +243,8 @@ namespace encoders {
 			9,	"SAAAAADDDD",
 			"000000000000000000",
 			455000,	2,
-			2
+			2, false,
+			OOK_DEFAULT_STEP
 		},
 		
 		// HT6*** TODO: Add individual variations
@@ -231,7 +256,9 @@ namespace encoders {
 			18,	"SAAAAAAAAAAAADDDDDD",
 			"0000000000000000000000000000000000001011001011001",
 			80000,	3,
-			10	// ?
+			10,	// ?
+			false,
+			OOK_DEFAULT_STEP
 		},
 		
 		// TC9148
@@ -243,7 +270,9 @@ namespace encoders {
 			12,	"AAAAAAAAAAAA",
 			"",
 			455000,	3,
-			10	// ?
+			10,	// ?
+			false,
+			OOK_DEFAULT_STEP
 		}
 	};
 

--- a/firmware/baseband/proc_ook.hpp
+++ b/firmware/baseband/proc_ook.hpp
@@ -38,6 +38,8 @@ private:
 	BasebandThread baseband_thread { 2280000, this, NORMALPRIO + 20, baseband::Direction::Transmit };
 	
 	uint32_t samples_per_bit { 0 };
+	uint16_t repeat_skip_bits { 0 };
+	uint8_t sin_carrier_step { 0 };
 	uint8_t repeat { 0 };
 	uint32_t length { 0 };
 	uint32_t pause { 0 };

--- a/firmware/common/message.hpp
+++ b/firmware/common/message.hpp
@@ -934,10 +934,14 @@ public:
 	constexpr OOKConfigureMessage(
 		const uint32_t stream_length,
 		const uint32_t samples_per_bit,
+		const uint16_t repeat_skip_bits,
+		const uint8_t sin_carrier_step,
 		const uint8_t repeat,
 		const uint32_t pause_symbols
 	) : Message { ID::OOKConfigure },
 		stream_length(stream_length),
+		repeat_skip_bits(repeat_skip_bits),
+		sin_carrier_step(sin_carrier_step),
 		samples_per_bit(samples_per_bit),
 		repeat(repeat),
 		pause_symbols(pause_symbols)
@@ -946,6 +950,8 @@ public:
 
 	const uint32_t stream_length;
 	const uint32_t samples_per_bit;
+	const uint16_t repeat_skip_bits;
+	const uint8_t sin_carrier_step;
 	const uint8_t repeat;
 	const uint32_t pause_symbols;
 };


### PR DESCRIPTION
Compared with https://github.com/eried/portapack-mayhem/pull/203, this adds the ability to set each encoder's modulation frequency (OOK bursts frequency) through `sin_carrier_step`. @euquiq De Bruijn work is also included.

## OOK burst frequency

`sin_carrier_step` formula is simple:

- `OOKProcessor` baseband frequency is set to *2.28 MHz*
- The `sine_table_i8` table that defines a whole sinus cycle is *256 bytes* long

This gives us:

```c
sin_carrier_step = 256 / (2280000 / fc) // where fc is the OOK burst frequency
```

Previously, this was fixed to *~9 Hz*. Now, the burst frequency can be set from *1.1 MHz* down to *9 kHz*. Obviously, the sinus signal quality decreases as the burst frequency increases.

Right now, the calculation must be done before we set a new encoder's frequency, but later, I'll add a C++ macro to so we just have to insert the burst frequency without having to use a calculator :)

By default, the OOK burst frequency is set to *70 kHz* through the `OOK_DEFAULT_STEP` definition.

**Note:** The user **@flicker-rate**, thanks to him, reported that this mod increase the HackRF range for his setup (*+3dB*). This has to be tested with other receivers as it can be a side effect.

## OOK Sync symbols and repetition 

This also adds a boolean property `skip_repeat_bits` to skip the header (`sync`) symbols after the first frame has been sent when the repeat count is above `1`, as seen with some alarm receivers.