### PR TITLE
Fix aprs tx app

### DIFF
--- a/firmware/application/apps/ui_aprs_tx.hpp
+++ b/firmware/application/apps/ui_aprs_tx.hpp
@@ -82,6 +82,7 @@ private:
 		6,
 		SymField::SYMFIELD_ALPHANUM
 	};
+	
 	NumberField num_ssid_dest {
 		{ 19 * 8, 2 * 16 },
 		2,

--- a/firmware/application/protocols/aprs.cpp
+++ b/firmware/application/protocols/aprs.cpp
@@ -38,9 +38,9 @@ void make_aprs_frame(const char * src_address, const uint32_t src_ssid,
 	char address[14] = { 0 };
 	
 	memcpy(&address[0], dest_address, 6);
-	address[6] = (dest_ssid & 15) << 1;
+	address[6] = (dest_ssid & 15);
 	memcpy(&address[7], src_address, 6);
-	address[13] = (src_ssid & 15) << 1;
+	address[13] = (src_ssid & 15);
 	
 	frame.make_ui_frame(address, 0x03, protocol_id_t::NO_LAYER3, payload);
 }

--- a/firmware/application/protocols/aprs.cpp
+++ b/firmware/application/protocols/aprs.cpp
@@ -38,9 +38,13 @@ void make_aprs_frame(const char * src_address, const uint32_t src_ssid,
 	char address[14] = { 0 };
 	
 	memcpy(&address[0], dest_address, 6);
-	address[6] = (dest_ssid & 15);
 	memcpy(&address[7], src_address, 6);
-	address[13] = (src_ssid & 15);
+	//euquiq: According to ax.25 doc section 2.2.13.x.x and 2.4.1.2
+	// SSID need bits 5.6 set, so later when shifted it will end up being 011xxxx0 (xxxx = SSID number)
+	// Notice that if need to signal usage of AX.25 V2.0, (dest_ssid | 112); (MSb will need to be set at the end)
+	address[6] = (dest_ssid | 48); 
+	address[13] = (src_ssid | 48);
+
 	
 	frame.make_ui_frame(address, 0x03, protocol_id_t::NO_LAYER3, payload);
 }

--- a/firmware/application/protocols/ax25.cpp
+++ b/firmware/application/protocols/ax25.cpp
@@ -51,32 +51,37 @@ void AX25Frame::NRZI_add_bit(const uint32_t bit) {
 	}
 }
 
-void AX25Frame::add_byte(uint8_t byte, bool is_flag, bool is_data) {
-	uint32_t bit;
-	
+void AX25Frame::add_byte(uint8_t byte, bool is_flag, bool is_data)
+{
+	bool bit;
+
 	if (is_data)
 		crc_ccitt.process_byte(byte);
-	
-	for (uint32_t i = 0; i < 8; i++) {
+
+	for (uint32_t i = 0; i < 8; i++)
+	{
 		bit = (byte >> i) & 1;
-		
+
+		NRZI_add_bit(bit);
+
 		if (bit)
+		{
 			ones_counter++;
+			if ((ones_counter == 5) && (!is_flag))
+			{
+				NRZI_add_bit(0);
+				ones_counter = 0;
+			}
+		}
 		else
 			ones_counter = 0;
-		
-		if ((ones_counter == 6) && (!is_flag)) {
-			NRZI_add_bit(0);
-			ones_counter = 0;
-		}
-		
-		NRZI_add_bit(bit);
 	}
 }
 
-void AX25Frame::flush() {
+void AX25Frame::flush()
+{
 	if (bit_counter)
-		*bb_data_ptr = current_byte << (7 - bit_counter);
+		*bb_data_ptr = current_byte << (8 - bit_counter); //euquiq: This was 7 but there are 8 bits
 };
 
 void AX25Frame::add_flag() {

--- a/firmware/application/ui_navigation.cpp
+++ b/firmware/application/ui_navigation.cpp
@@ -464,7 +464,7 @@ TransmittersMenuView::TransmittersMenuView(NavigationView& nav) {
 	add_items({
 		//{ "..",				ui::Color::light_grey(),&bitmap_icon_previous,	[&nav](){ nav.pop(); } },
 		{ "ADS-B [S]",		ui::Color::yellow(), 	&bitmap_icon_adsb,		[&nav](){ nav.push<ADSBTxView>(); } },
-		{ "APRS", 			ui::Color::orange(),	&bitmap_icon_aprs,		[&nav](){ nav.push<APRSTXView>(); } },
+		{ "APRS", 			ui::Color::green(),		&bitmap_icon_aprs,		[&nav](){ nav.push<APRSTXView>(); } },
 		{ "BHT Xy/EP", 		ui::Color::green(), 	&bitmap_icon_bht,		[&nav](){ nav.push<BHTView>(); } },
 		{ "GPS Sim",		ui::Color::yellow(),	&bitmap_icon_gps_sim,		[&nav](){ nav.push<GpsSimAppView>(); } },
 		{ "Jammer", 		ui::Color::yellow(),	&bitmap_icon_jammer,	[&nav](){ nav.push<JammerView>(); } },


### PR DESCRIPTION
On the APRS side, most notably, SSID numbers where shifted left twice, instead of once, and bits 5,6 where not properly set.

On AX.25 side, the bit stuffing part of the encoder was not placing the zero bit on the right place.

Finally, I changed APRS icon from ORANGE to GREEN, since even this may be a simple app, now seems to work as intended.