### PR TITLE
Latest-ook-app-with-fixes

### DIFF
--- a/firmware/application/apps/ui_encoders.cpp
+++ b/firmware/application/apps/ui_encoders.cpp
@@ -24,71 +24,13 @@
 
 #include "baseband_api.hpp"
 #include "string_format.hpp"
+//#include "file.hpp"
 
 using namespace portapack;
 
 namespace ui {
 
-EncodersConfigView::EncodersConfigView(
-	NavigationView&, Rect parent_rect
-) {
-	using option_t = std::pair<std::string, int32_t>;
-	std::vector<option_t> enc_options;
-	size_t i;
-	
-	set_parent_rect(parent_rect);
-	hidden(true);
-	
-	// Default encoder def
-	encoder_def = &encoder_defs[0];
-	
-	add_children({
-		&labels,
-		&options_enctype,
-		&field_clk,
-		&field_frameduration,
-		&symfield_word,
-		&text_format,
-		&waveform
-	});
-
-	// Load encoder types in option field
-	for (i = 0; i < ENC_TYPES_COUNT; i++)
-		enc_options.emplace_back(std::make_pair(encoder_defs[i].name, i));
-	
-	options_enctype.on_change = [this](size_t index, int32_t) {
-		on_type_change(index);
-	};
-	
-	options_enctype.set_options(enc_options);
-	options_enctype.set_selected_index(0);
-	
-	symfield_word.on_change = [this]() {
-		generate_frame();
-	};
-	
-	// Selecting input clock changes symbol and word duration
-	field_clk.on_change = [this](int32_t value) {
-		// value is in kHz, new_value is in us
-		int32_t new_value = (encoder_def->clk_per_symbol * 1000000) / (value * 1000);
-		if (new_value != field_frameduration.value())
-			field_frameduration.set_value(new_value * encoder_def->word_length, false);
-	};
-	
-	// Selecting word duration changes input clock and symbol duration
-	field_frameduration.on_change = [this](int32_t value) {
-		// value is in us, new_value is in kHz
-		int32_t new_value = (value * 1000) / (encoder_def->word_length * encoder_def->clk_per_symbol);
-		if (new_value != field_clk.value())
-			field_clk.set_value(1000000 / new_value, false);
-	};
-}
-
-void EncodersConfigView::focus() {
-	options_enctype.focus();
-}
-
-void EncodersConfigView::on_type_change(size_t index) {
+void EncodersView::on_type_change(size_t index) {
 	std::string format_string = "";
 	size_t word_length;
 	char symbol_type;
@@ -117,15 +59,10 @@ void EncodersConfigView::on_type_change(size_t index) {
 	
 	text_format.set(format_string);
 
-	generate_frame();
+	generate_frame(false, 0);
 }
 
-void EncodersConfigView::on_show() {
-	options_enctype.set_selected_index(0);
-	on_type_change(0);
-}
-
-void EncodersConfigView::draw_waveform() {
+void EncodersView::draw_waveform() {
 	size_t length = frame_fragments.length();
 
 	for (size_t n = 0; n < length; n++)
@@ -135,71 +72,53 @@ void EncodersConfigView::draw_waveform() {
 	waveform.set_dirty();
 }
 
-void EncodersConfigView::generate_frame() {
-	size_t i = 0;
-	
+void EncodersView::generate_frame(bool is_debruijn, uint32_t debruijn_bits) {
+	uint8_t i = 0;
+	uint8_t pos = bits_per_packet; //Only need the De Bruijn populated positions inside bits_per_packet (0 based!);
+	char * word_ptr = (char*)encoder_def->word_format;
+
 	frame_fragments.clear();
-	
-	for (auto c : encoder_def->word_format) {
-		if (c == 'S')
+
+	while (*word_ptr) {
+
+		if (*word_ptr == 'S')
 			frame_fragments += encoder_def->sync;
+		else if (*word_ptr == 'D')
+			frame_fragments += encoder_def->bit_format[symfield_word.get_sym(i++)]; //Get_sym brings the index of the char chosen in the symfield, so 0, 1 or eventually 2
 		else
-			frame_fragments += encoder_def->bit_format[symfield_word.get_sym(i++)];
+		{
+			if (!is_debruijn) //single tx
+				frame_fragments += encoder_def->bit_format[symfield_word.get_sym(i++)]; //Get the address from user's configured symfield
+			else 			
+			{	//De BRuijn!
+				if ( debruijn_bits & (1 << pos) ) //if ( debruijn_bits & (1 << (31 - pos)) )
+				 	frame_fragments += encoder_def->bit_format[1];
+				else
+					frame_fragments += encoder_def->bit_format[0];
+
+				pos--;
+				i++; //Even while grabbing this address bit from debruijn, must move forward on the symfield, in case there is a 'D' further ahead
+			}	
+		}
+		word_ptr++;
 	}
-	
+
 	draw_waveform();
 }
 
-uint8_t EncodersConfigView::repeat_min() {
-	return encoder_def->repeat_min;
-}
-
-uint32_t EncodersConfigView::samples_per_bit() {
+uint32_t EncodersView::samples_per_bit() {
 	return OOK_SAMPLERATE / ((field_clk.value() * 1000) / encoder_def->clk_per_fragment);
 }
 
-uint32_t EncodersConfigView::pause_symbols() {
+uint32_t EncodersView::pause_symbols() {
 	return encoder_def->pause_symbols;
 }
 
-void EncodersScanView::focus() {
-	field_debug.focus();
-}
-
-EncodersScanView::EncodersScanView(
-	NavigationView&, Rect parent_rect
-) {
-	set_parent_rect(parent_rect);
-	hidden(true);
-	
-	add_children({
-		&labels,
-		&field_debug,
-		&text_debug,
-		&text_length
-	});
-	
-	// DEBUG
-	field_debug.on_change = [this](int32_t value) {
-		uint32_t l;
-		size_t length;
-		
-		de_bruijn debruijn_seq;
-		length = debruijn_seq.init(value);
-		
-		l = 1;
-		l <<= value;
-		l--;
-		if (l > 25)
-			l = 25;
-		text_debug.set(to_string_bin(debruijn_seq.compute(l), 25));
-		
-		text_length.set(to_string_dec_uint(length));
-	};
-}
 
 void EncodersView::focus() {
-	tab_view.focus();
+	options_enctype.set_selected_index(0);
+	on_type_change(0);
+	options_enctype.focus();
 }
 
 EncodersView::~EncodersView() {
@@ -208,148 +127,255 @@ EncodersView::~EncodersView() {
 }
 
 void EncodersView::update_progress() {
-	std::string str_buffer;
-	
-	// text_status.set("            ");
-	
-	if (tx_mode == SINGLE) {
-		str_buffer = to_string_dec_uint(repeat_index) + "/" + to_string_dec_uint(repeat_min);
-		text_status.set(str_buffer);
-		progressbar.set_value(repeat_index);
-		
-	/*} else if (tx_mode == SCAN) {
-		strcpy(str, to_string_dec_uint(repeat_index).c_str());
-		strcat(str, "/");
-		strcat(str, to_string_dec_uint(portapack::persistent_memory::afsk_repeats()).c_str());
-		strcat(str, " ");
-		strcat(str, to_string_dec_uint(scan_index + 1).c_str());
-		strcat(str, "/");
-		strcat(str, to_string_dec_uint(scan_count).c_str());
-		text_status.set(str);
-		progress.set_value(scan_progress);*/
-	} else {
-		text_status.set("Ready");
-		progressbar.set_value(0);
-	}
-}
+	text_status.set("            "); //euquiq: it was commented
 
-void EncodersView::on_tx_progress(const uint32_t progress, const bool done) {
-	//char str[16];
-	
-	if (!done) {
-		// Repeating...
-		repeat_index = progress + 1;
-		
-		/*if (tx_mode == SCAN) {
-			scan_progress++;
-			update_progress();
-		} else {*/
-			update_progress();
-		//}
-	} else {
-		// Done transmitting
-		/*if ((tx_mode == SCAN) && (scan_index < (scan_count - 1))) {
-			transmitter_model.disable();
-			if (abort_scan) {
-				// Kill scan process
-				strcpy(str, "Abort @");
-				strcat(str, rgsb);
-				text_status.set(str);
-				progress.set_value(0);
-				tx_mode = IDLE;
-				abort_scan = false;
-				button_scan.set_style(&style_val);
-				button_scan.set_text("SCAN");
-			} else {
-				// Next address
-				scan_index++;
-				strcpy(rgsb, &scan_list[options_scanlist.selected_index()].addresses[scan_index * 5]);
+	if (tx_mode == SINGLE) {
+			text_status.set(to_string_dec_uint(repeat_index) + "/" + to_string_dec_uint(afsk_repeats));
+			progressbar.set_value(repeat_index);
+		}
+		else if (tx_mode == SCAN)
+		{
+			text_status.set(
+				to_string_dec_uint(repeat_index) + "/" +
+				to_string_dec_uint(afsk_repeats) + " " +
+				to_string_dec_uint(scan_progress) + "/" +
+				to_string_dec_uint(scan_count)
+			);
+			progressbar.set_value(scan_progress);
+		}
+		else
+		{
+			text_status.set("Ready");
+			progressbar.set_value(0);
+		}
+	}
+
+	void EncodersView::on_tx_progress(const uint32_t progress, const bool done)
+	{
+		if (!done)
+		{ // Repeating...
+			repeat_index = progress + 1;
+
+			if (tx_mode == SCAN)
+			{
 				scan_progress++;
-				repeat_index = 1;
 				update_progress();
+			}
+			else
+			{
+				update_progress();
+			}
+		}
+		else
+		{	// Done transmitting
+			if ((tx_mode == SCAN) && (scan_progress < scan_count))
+			{
+				transmitter_model.disable();
+				if (abort_scan)
+				{	// Kill scan process	
+					strcpy(str, "Abort");
+					text_status.set(str);
+					progressbar.set_value(0);
+					tx_mode = IDLE;
+					abort_scan = false;
+					button_scan.set_text("DE BRUIJN TX");
+				}
+				else
+				{
+					// Next address
+					scan_index += bits_per_packet; //Bit index on the debruijn sequence
+					scan_progress++;
+					repeat_index = 1;
+					update_progress();
+					start_tx(true);
+				}
+			}
+			else
+			{
+				transmitter_model.disable();
+				tx_mode = IDLE;
+				text_status.set("Done");
+				progressbar.set_value(0);
+				button_scan.set_text("DE BRUIJN TX"); //again ... if finished scan
+				tx_view.set_transmitting(false);
+			}
+		}
+	}
+
+	void EncodersView::start_tx(const bool scan)
+	{
+		(void)scan;
+		size_t bitstream_length = 0;
+
+		//repeat_min = repeat_min();
+		uint32_t debruijn_bits;
+
+		if (scan)
+		{
+			if (tx_mode != SCAN)
+			{ 
+				scan_index = 0; //Scanning, number of bits in debruijn sequence
+				bits_per_packet = 0; //Determine the A (Addresses) bit quantity
+				for (uint8_t c=0; c < encoder_def->word_length; c++)
+					if (encoder_def->word_format[c] == 'A') //Address bit found
+						bits_per_packet++;
+
+				uint32_t debruijn_total = debruijn_seq.init(bits_per_packet);
+				scan_count = (debruijn_total / bits_per_packet)  + 1 ; //get total number of packets to tx, plus one, be sure of sending whatever is left from division
+
+				scan_progress = 1;
+				repeat_index = 1;
+				afsk_repeats = 1; // on scanning send just one time each code //encoder_def->repeat_min;
+				tx_mode = SCAN;
+				progressbar.set_max(scan_count * afsk_repeats); 
+			}
+
+			debruijn_bits = debruijn_seq.compute(scan_index); //bits sequence for this step
+
+			//Save this debruijn bits on a logfile
+ 			// File log_file;
+			// std::string file_path = "DEBRUIJN.TXT";
+			// auto result = log_file.append(file_path); 
+			// if (!result.is_valid()) {
+
+			// 	//log_file.write_line(to_string_bin(debruijn_bits,32)); 	//First present the raw 32 bits coming back from debruijn algo.
+
+ 			// 	int16_t pos = bits_per_packet; //Only need the De Bruijn populated positions inside bits_per_packet (0 based!);
+			// 	std::string debruijn_txt;
+			// 	debruijn_txt.reserve(pos);
+			// 	do {
+					
+			// 		if ( debruijn_bits & (1 << (pos)) )
+			// 			debruijn_txt += "1";
+			// 		else
+			// 			debruijn_txt += "0";
+				
+			// 	pos--;
+			// 	} while (pos > 0);
+
+			// 	log_file.write_line(debruijn_txt);		//Log the actual bits which will be used. 
+			// }
+
+			update_progress();
+			generate_frame(true, debruijn_bits);
+		}
+		else
+		{
+			tx_mode = SINGLE;
+			repeat_index = 1;
+			afsk_repeats = encoder_def->repeat_min; 
+			progressbar.set_max(afsk_repeats);
+			update_progress();
+			generate_frame(false, 0);
+		}
+
+		bitstream_length = make_bitstream(frame_fragments);
+
+		transmitter_model.set_sampling_rate(OOK_SAMPLERATE);
+		transmitter_model.set_rf_amp(true);
+		transmitter_model.set_baseband_bandwidth(1750000);
+		transmitter_model.enable();
+
+		baseband::set_ook_data(
+			bitstream_length,
+			samples_per_bit(),
+			afsk_repeats,
+			pause_symbols());
+	}
+
+	EncodersView::EncodersView(
+		NavigationView & nav) : nav_{nav}
+	{
+		baseband::run_image(portapack::spi_flash::image_tag_ook);
+
+		using option_t = std::pair<std::string, int32_t>;
+		std::vector<option_t> enc_options;
+		size_t i;
+		
+		encoder_def = &encoder_defs[0]; // Default encoder def
+
+		add_children({	
+						&labels,
+						&options_enctype,
+						&field_clk,
+						&field_frameduration,
+						&symfield_word,
+						&text_format,
+						&waveform,
+						&text_status,
+						&button_scan,
+						&progressbar,
+						&tx_view
+					});
+
+		// Load encoder types in option field
+		for (i = 0; i < ENC_TYPES_COUNT; i++)
+			enc_options.emplace_back(std::make_pair(encoder_defs[i].name, i));
+		
+		options_enctype.on_change = [this](size_t index, int32_t) {
+			on_type_change(index);
+		};
+		
+		options_enctype.set_options(enc_options);
+		options_enctype.set_selected_index(0);
+		
+		symfield_word.on_change = [this]() {
+			generate_frame(false, 0);
+		};
+		
+		// Selecting input clock changes symbol and word duration
+		field_clk.on_change = [this](int32_t value) {
+			// value is in kHz, new_value is in us
+			int32_t new_value = (encoder_def->clk_per_symbol * 1000000) / (value * 1000);
+			if (new_value != field_frameduration.value())
+				field_frameduration.set_value(new_value * encoder_def->word_length, false);
+		};
+		
+		// Selecting word duration changes input clock and symbol duration
+		field_frameduration.on_change = [this](int32_t value) {
+			// value is in us, new_value is in kHz
+			int32_t new_value = (value * 1000) / (encoder_def->word_length * encoder_def->clk_per_symbol);
+			if (new_value != field_clk.value())
+				field_clk.set_value(1000000 / new_value, false);
+		};
+
+		tx_view.on_edit_frequency = [this, &nav]() {
+			auto new_view = nav.push<FrequencyKeypadView>(transmitter_model.tuning_frequency());
+			new_view->on_changed = [this](rf::Frequency f) {
+				transmitter_model.set_tuning_frequency(f);
+			};
+		};
+
+		tx_view.on_start = [this]() {
+			tx_view.set_transmitting(true);
+			start_tx(false);
+		};
+
+		tx_view.on_stop = [this]() {
+			tx_view.set_transmitting(false);
+			if (tx_mode == SCAN)
+			{ //Also stop ongoing scan!
+				abort_scan = true;
+				button_scan.set_text("DE BRUIJN TX");
+			}
+		};
+
+		button_scan.on_select = [this](Button &) {
+			if (tx_mode != SCAN)
+			{
+				button_scan.set_text("ABORT");
+
+				// std::string file_path = "DEBRUIJN.TXT";
+				// delete_file(file_path); //Start with an empty logfile for debruijn
+
+				tx_view.set_transmitting(true);
 				start_tx(true);
 			}
-		} else {*/
-			transmitter_model.disable();
-			tx_mode = IDLE;
-			text_status.set("Done");
-			progressbar.set_value(0);
-			tx_view.set_transmitting(false);
-		//}
-	}
-}
-
-void EncodersView::start_tx(const bool scan) {
-	(void)scan;
-	size_t bitstream_length = 0;
-	
-	repeat_min = view_config.repeat_min();
-	
-	/*if (scan) {
-		if (tx_mode != SCAN) {
-			scan_index = 0;
-			scan_count = scan_list[options_scanlist.selected_index()].count;
-			scan_progress = 1;
-			repeat_index = 1;
-			tx_mode = SCAN;
-			strcpy(rgsb, &scan_list[options_scanlist.selected_index()].addresses[0]);
-			progress.set_max(scan_count * afsk_repeats);
-			update_progress();
-		}
-	} else {*/
-		tx_mode = SINGLE;
-		repeat_index = 1;
-		progressbar.set_max(repeat_min);
-		update_progress();
-	//}
-	
-	view_config.generate_frame();
-	
-	bitstream_length = make_bitstream(view_config.frame_fragments);
-
-	transmitter_model.set_sampling_rate(OOK_SAMPLERATE);
-	transmitter_model.set_rf_amp(true);
-	transmitter_model.set_baseband_bandwidth(1750000);
-	transmitter_model.enable();
-	
-	baseband::set_ook_data(
-		bitstream_length,
-		view_config.samples_per_bit(),
-		repeat_min,
-		view_config.pause_symbols()
-	);
-}
-
-EncodersView::EncodersView(
-	NavigationView& nav
-) : nav_ { nav }
-{
-	baseband::run_image(portapack::spi_flash::image_tag_ook);
-
-	add_children({
-		&tab_view,
-		&view_config,
-		&view_scan,
-		&text_status,
-		&progressbar,
-		&tx_view
-	});
-	
-	tx_view.on_edit_frequency = [this, &nav]() {
-		auto new_view = nav.push<FrequencyKeypadView>(transmitter_model.tuning_frequency());
-		new_view->on_changed = [this](rf::Frequency f) {
-			transmitter_model.set_tuning_frequency(f);
+			else
+			{
+				abort_scan=true;
+				tx_view.set_transmitting(false);
+			}
 		};
-	};
-	
-	tx_view.on_start = [this]() {
-		tx_view.set_transmitting(true);
-		start_tx(false);
-	};
-	
-	tx_view.on_stop = [this]() {
-		tx_view.set_transmitting(false);
-	};
-}
-
+	}
 } /* namespace ui */

--- a/firmware/application/apps/ui_encoders.hpp
+++ b/firmware/application/apps/ui_encoders.hpp
@@ -21,7 +21,6 @@
  */
 
 #include "ui.hpp"
-#include "ui_tabview.hpp"
 #include "ui_transmitter.hpp"
 #include "transmitter_model.hpp"
 #include "encoders.hpp"
@@ -31,131 +30,18 @@ using namespace encoders;
 
 namespace ui {
 
-class EncodersConfigView : public View {
-public:
-	EncodersConfigView(NavigationView& nav, Rect parent_rect);
-	
-	EncodersConfigView(const EncodersConfigView&) = delete;
-	EncodersConfigView(EncodersConfigView&&) = delete;
-	EncodersConfigView& operator=(const EncodersConfigView&) = delete;
-	EncodersConfigView& operator=(EncodersConfigView&&) = delete;
-	
-	void focus() override;
-	void on_show() override;
-	
-	uint8_t repeat_min();
-	uint32_t samples_per_bit();
-	uint32_t pause_symbols();
-	void generate_frame();
-	
-	std::string frame_fragments = "0";
-
-private:
-	//bool abort_scan = false;
-	//uint8_t scan_count;
-	//double scan_progress;
-	//unsigned int scan_index;
-	int16_t waveform_buffer[550];
-	const encoder_def_t * encoder_def { };
-	//uint8_t enc_type = 0;
-
-	void draw_waveform();
-	void on_bitfield();
-	void on_type_change(size_t index);
-	
-	Labels labels {
-		{ { 1 * 8, 0 }, "Type:", Color::light_grey() },
-		{ { 16 * 8, 0 }, "Clk:", Color::light_grey() },
-		{ { 24 * 8, 0 }, "kHz", Color::light_grey() },
-		{ { 14 * 8, 2 * 8 }, "Frame:", Color::light_grey() },
-		{ { 26 * 8, 2 * 8 }, "us", Color::light_grey() },
-		{ { 2 * 8, 4 * 8 }, "Symbols:", Color::light_grey() },
-		{ { 1 * 8, 11 * 8 }, "Waveform:", Color::light_grey() }
-	};
-
-	OptionsField options_enctype {		// Options are loaded at runtime
-		{ 6 * 8, 0 },
-		7,
-		{
-		}
-	};
-
-	NumberField field_clk {
-		{ 21 * 8, 0 },
-		3,
-		{ 1, 500 },
-		1,
-		' '
-	};
-
-	NumberField field_frameduration {
-		{ 21 * 8, 2 * 8 },
-		5,
-		{ 300, 99999 },
-		100,
-		' '
-	};
-	
-	SymField symfield_word {
-		{ 2 * 8, 6 * 8 },
-		20,
-		SymField::SYMFIELD_DEF
-	};
-	
-	Text text_format {
-		{ 2 * 8, 8 * 8, 24 * 8, 16 },
-		""
-	};
-	
-	Waveform waveform {
-		{ 0, 14 * 8, 240, 32 },
-		waveform_buffer,
-		0,
-		0,
-		true,
-		Color::yellow()
-	};
-};
-
-
-class EncodersScanView : public View {
-public:
-	EncodersScanView(NavigationView& nav, Rect parent_rect);
-	
-	void focus() override;
-
-private:
-	Labels labels {
-		{ { 1 * 8, 1 * 8 }, "Coming soon...", Color::light_grey() }
-	};
-	
-	// DEBUG
-	NumberField field_debug {
-		{ 1 * 8, 6 * 8 },
-		2,
-		{ 3, 16 },
-		1,
-		' '
-	};
-	
-	// DEBUG
-	Text text_debug {
-		{ 1 * 8, 8 * 8, 24 * 8, 16 },
-		""
-	};
-	
-	// DEBUG
-	Text text_length {
-		{ 1 * 8, 10 * 8, 24 * 8, 16 },
-		""
-	};
-};
-
 class EncodersView : public View {
 public:
 	EncodersView(NavigationView& nav);
 	~EncodersView();
 	
+	EncodersView(NavigationView& nav, Rect parent_rect);
+	
+	EncodersView(const EncodersView&) = delete;
+	EncodersView(EncodersView&&) = delete;
+	EncodersView& operator=(const EncodersView&) = delete;
+	EncodersView& operator=(EncodersView&&) = delete;
+
 	void focus() override;
 	
 	std::string title() const override { return "OOK transmit"; };
@@ -168,39 +54,99 @@ private:
 		SINGLE,
 		SCAN
 	};
+
+	uint32_t samples_per_bit();
+	uint32_t pause_symbols();
+	void generate_frame(bool is_debruijn, uint32_t debruijn_bits);
+	
+	std::string frame_fragments = "0";
+	const encoder_def_t * encoder_def { };
+	uint8_t bits_per_packet; 	//Euquiq: the number of bits needed from de_bruijn, depends on the encoder's needs
 	
 	tx_modes tx_mode = IDLE;
 	uint8_t repeat_index { 0 };
-	uint8_t repeat_min { 0 };
+	uint32_t scan_count;
+	uint32_t scan_index;
+	double scan_progress;
+	bool abort_scan = false;
+	char str[16];
+
+	uint8_t afsk_repeats;
+	de_bruijn debruijn_seq;
 	
 	void update_progress();
 	void start_tx(const bool scan);
 	void on_tx_progress(const uint32_t progress, const bool done);
+
+	int16_t waveform_buffer[550];
 	
-	/*const Style style_address {
-		.font = font::fixed_8x16,
-		.background = Color::black(),
-		.foreground = Color::red(),
+	uint8_t enc_type = 0;
+
+	void draw_waveform();
+	void on_bitfield();
+	void on_type_change(size_t index);
+
+	Labels labels {
+		{ { 1 * 8, 1 * 8}, "Type:", Color::light_grey() },
+		{ { 16 * 8, 1 * 8}, "Clk:", Color::light_grey() },
+		{ { 24 * 8, 1 * 8}, "kHz", Color::light_grey() },
+		{ { 14 * 8, 3 * 8 }, "Frame:", Color::light_grey() },
+		{ { 26 * 8, 3 * 8 }, "us", Color::light_grey() },
+		{ { 2 * 8, 5 * 8 }, "Symbols:", Color::light_grey() },
+		{ { 1 * 8, 13 * 8 }, "Waveform:", Color::light_grey() }
 	};
-	const Style style_data {
-		.font = font::fixed_8x16,
-		.background = Color::black(),
-		.foreground = Color::blue(),
-	};*/
-	
-	Rect view_rect = { 0, 4 * 8, 240, 168 };
-	
-	EncodersConfigView view_config { nav_, view_rect };
-	EncodersScanView view_scan { nav_, view_rect };
-	
-	TabView tab_view {
-		{ "Config", Color::cyan(), &view_config },
-		{ "Scan", Color::green(), &view_scan },
+
+	OptionsField options_enctype {		// Options are loaded at runtime
+		{ 6 * 8, 1 * 8 },
+		9,
+		{
+		}
 	};
+
+	NumberField field_clk {
+		{ 21 * 8, 1 * 8 },
+		3,
+		{ 1, 500 },
+		1,
+		' '
+	};
+
+	NumberField field_frameduration {
+		{ 21 * 8, 3 * 8 },
+		5,
+		{ 300, 99999 },
+		100,
+		' '
+	};
+	
+	SymField symfield_word {
+		{ 2 * 8, 7 * 8 },
+		20,
+		SymField::SYMFIELD_DEF
+	};
+	
+	Text text_format {
+		{ 2 * 8, 9 * 8, 24 * 8, 16 },
+		""
+	};
+	
+	Waveform waveform {
+		{ 0, 15 * 8, 240, 32 },
+		waveform_buffer,
+		0,
+		0,
+		true,
+		Color::yellow()
+	};	
 
 	Text text_status {
 		{ 2 * 8, 13 * 16, 128, 16 },
 		"Ready"
+	};
+
+	Button button_scan {
+		{ 8 * 8, 11 * 16, 120, 28 },
+		"DE BRUIJN TX"
 	};
 	
 	ProgressBar progressbar {


### PR DESCRIPTION
This OOK app includes several fixes, including a nasty bug fix which developer @rascafr noticed, involving the use of auto: on certain type of vars and loops. We also got rid of the "tabbed" screen, since the "SCAN" tab was intended for testing purposes (or whatever) but in practice, the De Bruijn scan "is just a button" (which now is integrated on a single screen).

About De Bruijn: Bad news

We are using the existing (from old HAVOC firmware) debruijn algorithm, now connected into the "DE_BRUIJN TX" button, and its output is being transmitted as a sequence of packets for the selected encoder... as it shoud.  **But I am afraid that the resulting bit stream from that algorithm is not a De Bruijn pattern.**

Also it does not contemplate the tristate bits (some encoders support 3 values for each address bit: 1, 0 and F ("floating") which in turn multiplies greatly the number of possible combinations.

We are in the need of a better (and working) debruijn algorithm at this time.