### PR TITLE
Ui scanner manual search nolimits

### DIFF
--- a/firmware/application/CMakeLists.txt
+++ b/firmware/application/CMakeLists.txt
@@ -240,7 +240,7 @@ set(CPPSRC
 	apps/ui_rds.cpp
 	apps/ui_remote.cpp
 	apps/ui_scanner.cpp
-	apps/ui_search.cpp
+	apps/ui_calls.cpp
 	apps/ui_sd_wipe.cpp
 	apps/ui_settings.cpp
 	apps/ui_siggen.cpp

--- a/firmware/application/CMakeLists.txt
+++ b/firmware/application/CMakeLists.txt
@@ -239,6 +239,7 @@ set(CPPSRC
 	apps/ui_pocsag_tx.cpp
 	apps/ui_rds.cpp
 	apps/ui_remote.cpp
+	apps/ui_searchsetup.cpp
 	apps/ui_search.cpp
 	apps/ui_scanner.cpp
 	apps/ui_calls.cpp

--- a/firmware/application/CMakeLists.txt
+++ b/firmware/application/CMakeLists.txt
@@ -239,6 +239,7 @@ set(CPPSRC
 	apps/ui_pocsag_tx.cpp
 	apps/ui_rds.cpp
 	apps/ui_remote.cpp
+	apps/ui_search.cpp
 	apps/ui_scanner.cpp
 	apps/ui_calls.cpp
 	apps/ui_sd_wipe.cpp

--- a/firmware/application/apps/ui_calls.cpp
+++ b/firmware/application/apps/ui_calls.cpp
@@ -20,7 +20,7 @@
  * Boston, MA 02110-1301, USA.
  */
 
-#include "ui_search.hpp"
+#include "ui_calls.hpp"
 
 #include "baseband_api.hpp"
 #include "string_format.hpp"
@@ -30,7 +30,7 @@ using namespace portapack;
 namespace ui {
 
 template<>
-void RecentEntriesTable<SearchRecentEntries>::draw(
+void RecentEntriesTable<CallsRecentEntries>::draw(
 	const Entry& entry,
 	const Rect& target_rect,
 	Painter& painter,
@@ -48,16 +48,16 @@ void RecentEntriesTable<SearchRecentEntries>::draw(
 	painter.draw_string(target_rect.location(), style, to_string_short_freq(entry.frequency) + " " + entry.time + " " + str_duration);
 }
 
-void SearchView::focus() {
+void CallsView::focus() {
 	field_frequency_min.focus();
 }
 
-SearchView::~SearchView() {
+CallsView::~CallsView() {
 	receiver_model.disable();
 	baseband::shutdown();
 }
 
-void SearchView::do_detection() {
+void CallsView::do_detection() {
 	uint8_t power_max = 0;
 	int32_t bin_max = -1;
 	uint32_t slice_max = 0;
@@ -174,7 +174,7 @@ void SearchView::do_detection() {
 	}
 }
 
-void SearchView::add_spectrum_pixel(Color color) {
+void CallsView::add_spectrum_pixel(Color color) {
 	// Is avoiding floats really necessary ?
 	bin_skip_acc += bin_skip_frac;
 	if (bin_skip_acc < 0x10000) 
@@ -186,7 +186,7 @@ void SearchView::add_spectrum_pixel(Color color) {
 		spectrum_row[pixel_index++] = color;
 }
 
-void SearchView::on_channel_spectrum(const ChannelSpectrum& spectrum) {
+void CallsView::on_channel_spectrum(const ChannelSpectrum& spectrum) {
 	uint8_t max_power = 0;
 	int16_t max_bin = 0;
 	uint8_t power;
@@ -237,15 +237,15 @@ void SearchView::on_channel_spectrum(const ChannelSpectrum& spectrum) {
 	baseband::spectrum_streaming_start();
 }
 
-void SearchView::on_show() {
+void CallsView::on_show() {
 	baseband::spectrum_streaming_start();
 }
 
-void SearchView::on_hide() {
+void CallsView::on_hide() {
 	baseband::spectrum_streaming_stop();
 }
 
-void SearchView::on_range_changed() {
+void CallsView::on_range_changed() {
 	rf::Frequency slices_span, center_frequency;
 	int64_t offset;
 	size_t slice;
@@ -288,15 +288,15 @@ void SearchView::on_range_changed() {
 	slice_counter = 0;
 }
 
-void SearchView::on_lna_changed(int32_t v_db) {
+void CallsView::on_lna_changed(int32_t v_db) {
 	receiver_model.set_lna(v_db);
 }
 
-void SearchView::on_vga_changed(int32_t v_db) {
+void CallsView::on_vga_changed(int32_t v_db) {
 	receiver_model.set_vga(v_db);
 }
 
-void SearchView::do_timers() {
+void CallsView::do_timers() {
 	
 	if (timing_div >= 60) {
 		// ~1Hz
@@ -340,7 +340,7 @@ void SearchView::do_timers() {
 	timing_div++;
 }
 
-SearchView::SearchView(
+CallsView::CallsView(
 	NavigationView& nav
 ) : nav_ (nav)
 {
@@ -368,7 +368,7 @@ SearchView::SearchView(
 	baseband::set_spectrum(SEARCH_SLICE_WIDTH, 31);
 	
 	recent_entries_view.set_parent_rect({ 0, 28 * 8, 240, 12 * 8 });
-	recent_entries_view.on_select = [this, &nav](const SearchRecentEntry& entry) {
+	recent_entries_view.on_select = [this, &nav](const CallsRecentEntry& entry) {
 		nav.push<FrequencyKeypadView>(entry.frequency);
 	};
 	

--- a/firmware/application/apps/ui_calls.hpp
+++ b/firmware/application/apps/ui_calls.hpp
@@ -87,7 +87,7 @@ public:
 	void on_hide() override;
 	void focus() override;
 	
-	std::string title() const override { return "Search"; };
+	std::string title() const override { return "Calls"; };
 
 private:
 	NavigationView& nav_;

--- a/firmware/application/apps/ui_calls.hpp
+++ b/firmware/application/apps/ui_calls.hpp
@@ -38,7 +38,7 @@ namespace ui {
 #define DETECT_DELAY		5	// In 100ms units
 #define RELEASE_DELAY		6
 
-struct SearchRecentEntry {
+struct CallsRecentEntry {
 	using Key = rf::Frequency;
 	
 	static constexpr Key invalid_key = 0xffffffff;
@@ -47,12 +47,12 @@ struct SearchRecentEntry {
 	uint32_t duration { 0 };	// In 100ms units
 	std::string time { "" };
 
-	SearchRecentEntry(
-	) : SearchRecentEntry { 0 }
+	CallsRecentEntry(
+	) : CallsRecentEntry { 0 }
 	{
 	}
 	
-	SearchRecentEntry(
+	CallsRecentEntry(
 		const rf::Frequency frequency
 	) : frequency { frequency }
 	{
@@ -71,17 +71,17 @@ struct SearchRecentEntry {
 	}
 };
 
-using SearchRecentEntries = RecentEntries<SearchRecentEntry>;
+using CallsRecentEntries = RecentEntries<CallsRecentEntry>;
 
-class SearchView : public View {
+class CallsView : public View {
 public:
-	SearchView(NavigationView& nav);
-	~SearchView();
+	CallsView(NavigationView& nav);
+	~CallsView();
 	
-	SearchView(const SearchView&) = delete;
-	SearchView(SearchView&&) = delete;
-	SearchView& operator=(const SearchView&) = delete;
-	SearchView& operator=(SearchView&&) = delete;
+	CallsView(const CallsView&) = delete;
+	CallsView(CallsView&&) = delete;
+	CallsView& operator=(const CallsView&) = delete;
+	CallsView& operator=(CallsView&&) = delete;
 	
 	void on_show() override;
 	void on_hide() override;
@@ -146,8 +146,8 @@ private:
 		{ "Time", 8 },
 		{ "Duration", 11 }
 	} };
-	SearchRecentEntries recent { };
-	RecentEntriesView<RecentEntries<SearchRecentEntry>> recent_entries_view { columns, recent };
+	CallsRecentEntries recent { };
+	RecentEntriesView<RecentEntries<CallsRecentEntry>> recent_entries_view { columns, recent };
 	
 	Labels labels {
 		{ { 1 * 8, 0 }, "Min:      Max:       LNA VGA", Color::light_grey() },

--- a/firmware/application/apps/ui_scanner.cpp
+++ b/firmware/application/apps/ui_scanner.cpp
@@ -86,24 +86,26 @@ namespace ui {
 				if (_scanning) {						//Scanning
 					if (_freq_lock == 0) {				//normal scanning (not performing freq_lock)
 						if (!restart_scan) {			//looping at full speed
-							switch( frequency_list_[ 0 ] )
+							switch( frequency_list_[ MS_FLAG_IDX ] )
 							{
-								case -666 : // MANUAL SCAN   indexes: 0 => flag (-666) 1=>start , 2=>end , 3=> step , 4=> current freq
+								case MS_FLAG_VAL : // MANUAL SCAN   indexes: 0=> flag , 1=>start , 2=>end , 3=> step , 4=> current freq
 									if (_fwd) 
 									{	
 										//forward
-										frequency_list_[ 4 ] += frequency_list_[ 3 ];
-										if (frequency_list_[ 4 ] > frequency_list_[ 2 ])
-											frequency_list_[ 4 ] = frequency_list_[ 1 ] ;	
+										frequency_list_[ MS_CUR_FREQ_IDX ] += frequency_list_[ MS_FREQ_STEP_IDX ];
+										if (frequency_list_[ MS_CUR_FREQ_IDX ] > frequency_list_[ MS_MAX_FREQ_IDX ])
+											frequency_list_[ MS_CUR_FREQ_IDX ] = frequency_list_[ MS_MIN_FREQ_IDX ] ;	
 									} 
 									else
 									{	//reverse
-										frequency_list_[ 4 ] -= frequency_list_[ 3 ];
-										if (frequency_list_[ 4 ] < frequency_list_[ 1 ])
-											frequency_list_[ 4 ] = frequency_list_[ 2 ] ;	
+										frequency_list_[ MS_CUR_FREQ_IDX ] -= frequency_list_[ MS_FREQ_STEP_IDX ];
+										if (frequency_list_[ MS_CUR_FREQ_IDX ] < frequency_list_[ MS_MIN_FREQ_IDX ])
+											frequency_list_[ MS_CUR_FREQ_IDX ] = frequency_list_[ MS_MAX_FREQ_IDX ] ;	
 									}
-									receiver_model.set_tuning_frequency( frequency_list_[ 4 ] );	// Retune
-									message.range = -frequency_list_[ 4 ];	//Inform freq (for coloring purposes also!)
+									receiver_model.set_tuning_frequency( frequency_list_[ MS_CUR_FREQ_IDX ] );	// Retune
+									//Inform freq (for coloring purposes also!) 
+									//Negative Values for direct frequency setting (instead of giving an index in frequency_list)
+									message.range = -frequency_list_[ MS_CUR_FREQ_IDX ];			
 									break ;
 								default :
 									if (_fwd) 
@@ -228,7 +230,7 @@ namespace ui {
 		}
 		else
 		{
-			big_display.set( -i );	//UPDATE the big Freq after 0, 1 or MAX_FREQ_LOCK (at least, for color synching)
+			big_display.set( -i );	//UPDATE the big Freq after 0, 1 or MAX_FREQ_LOCK (at least, for color synching) MANUAL SEARCH MODE
 		}
 	}
 

--- a/firmware/application/apps/ui_scanner.cpp
+++ b/firmware/application/apps/ui_scanner.cpp
@@ -23,537 +23,644 @@
 #include "ui_scanner.hpp"
 #include "ui_fileman.hpp"
 
+using namespace std;
 using namespace portapack;
 
 namespace ui {
 
-ScannerThread::ScannerThread(
-	std::vector<rf::Frequency> frequency_list
-) : frequency_list_ {  std::move(frequency_list) }
-{
-	thread = chThdCreateFromHeap(NULL, 1024, NORMALPRIO + 10, ScannerThread::static_fn, this);
-}
-
-ScannerThread::~ScannerThread() {
-	stop();
-}
-
-void ScannerThread::stop() {
-	if( thread ) {
-		chThdTerminate(thread);
-		chThdWait(thread);
-		thread = nullptr;
-	}
-}
-
-void ScannerThread::set_scanning(const bool v) {
-	_scanning = v;
-}
-
-bool ScannerThread::is_scanning() {
-	return _scanning;
-}
-
-void ScannerThread::set_freq_lock(const uint32_t v) {
-	_freq_lock = v;
-}
-
-uint32_t ScannerThread::is_freq_lock() {
-	return _freq_lock;
-}
-
-void ScannerThread::set_freq_del(const uint32_t v) {
-	_freq_del = v;
-}
-
-void ScannerThread::change_scanning_direction() {
-	_fwd = !_fwd;
-	chThdSleepMilliseconds(300);	//Give some pause after reversing scanning direction
-
-}
-
-msg_t ScannerThread::static_fn(void* arg) {
-	auto obj = static_cast<ScannerThread*>(arg);
-	obj->run();
-	return 0;
-}
-
-void ScannerThread::run() {
-	if (frequency_list_.size())	{					//IF THERE IS A FREQUENCY LIST ...	
-		RetuneMessage message { };
-		uint32_t frequency_index = frequency_list_.size();
-		bool restart_scan = false;					//Flag whenever scanning is restarting after a pause
-		while( !chThdShouldTerminate() ) {
-			if (_scanning) {						//Scanning
-				if (_freq_lock == 0) {				//normal scanning (not performing freq_lock)
-					if (!restart_scan) {			//looping at full speed
-						if (_fwd) {					//forward
-							frequency_index++;
-							if (frequency_index >= frequency_list_.size())
-								frequency_index = 0;	
-
-						} else {					//reverse
-							if (frequency_index < 1)
-								frequency_index = frequency_list_.size();	
-							frequency_index--;
-						}
-						receiver_model.set_tuning_frequency(frequency_list_[frequency_index]);	// Retune
-					}
-					else
-						restart_scan=false;			//Effectively skipping first retuning, giving system time
-				} 
-				message.range = frequency_index;	//Inform freq (for coloring purposes also!)
-				EventDispatcher::send_message(message);
-			} 
-			else {									//NOT scanning 									
-				if (_freq_del != 0) {				//There is a frequency to delete
-					for (uint16_t i = 0; i < frequency_list_.size(); i++) {	//Search for the freq to delete
-						if (frequency_list_[i] == _freq_del) 
-						{							//found: Erase it
-							frequency_list_.erase(frequency_list_.begin() + i);
-							if (i==0)				//set scan index one place back to compensate
-								i=frequency_list_.size();
-							else
-								i--;
-							break;
-						}
-					}
-					_freq_del = 0;					//deleted.
-				}
-				else {
-					restart_scan=true;					//Flag the need for skipping a cycle when restarting scan
-				}
-			}
-			chThdSleepMilliseconds(50);				//Needed to (eventually) stabilize the receiver into new freq
-		}
-	}
-}
-
-void ScannerView::handle_retune(uint32_t i) {
-	switch (scan_thread->is_freq_lock())
+	ScannerThread::ScannerThread( std::vector<rf::Frequency> frequency_list	) : frequency_list_ {  std::move(frequency_list) }
 	{
-	case 0:										//NO FREQ LOCK, ONGOING STANDARD SCANNING
-		text_cycle.set( to_string_dec_uint(i + 1,3) );
-		current_index = i;		//since it is an ongoing scan, this is a new index
-		if (description_list[current_index].size() > 0) desc_cycle.set( description_list[current_index] );	//Show new description	
-		break;
-	case 1:										//STARTING LOCK FREQ
-		big_display.set_style(&style_yellow);
-		break;
-	case MAX_FREQ_LOCK:							//FREQ IS STRONG: GREEN and scanner will pause when on_statistics_update()
-		big_display.set_style(&style_green);
-		break;
-	default:	//freq lock is checking the signal, do not update display
-		return;
+		thread = chThdCreateFromHeap(NULL, 1024, NORMALPRIO + 10, ScannerThread::static_fn, this);
 	}
-	big_display.set(frequency_list[current_index]);	//UPDATE the big Freq after 0, 1 or MAX_FREQ_LOCK (at least, for color synching)
-}
 
-void ScannerView::focus() {
-	field_mode.focus();
-}
-
-ScannerView::~ScannerView() {
-	audio::output::stop();
-	receiver_model.disable();
-	baseband::shutdown();
-}
-
-void ScannerView::show_max() {		//show total number of freqs to scan
-	if (frequency_list.size() == MAX_DB_ENTRY) {
-		text_max.set_style(&style_red);
-		text_max.set( "/ " + to_string_dec_uint(MAX_DB_ENTRY) + " (DB MAX!)");
+	ScannerThread::~ScannerThread() {
+		stop();
 	}
-	else {
-		text_max.set_style(&style_grey);
-		text_max.set( "/ " + to_string_dec_uint(frequency_list.size()));
+
+	void ScannerThread::stop() {
+		if( thread ) {
+			chThdTerminate(thread);
+			chThdWait(thread);
+			thread = nullptr;
+		}
 	}
-}
 
-ScannerView::ScannerView(
-	NavigationView& nav
-	) : nav_ { nav }
-{
-	add_children({
-		&labels,
-		&field_lna,
-		&field_vga,
-		&field_rf_amp,
-		&field_volume,
-		&field_bw,
-		&field_squelch,
-		&field_wait,
-		&button_load,
-		&rssi,
-		&text_cycle,
-		&text_max,
-		&desc_cycle,
-		&big_display,
-		&button_manual_start,
-		&button_manual_end,
-		&field_mode,
-		&step_mode,
-		&button_manual_scan,
-		&button_pause,
-		&button_dir,
-		&button_audio_app,
-		&button_mic_app,
-		&button_add,
-		&button_remove
+	void ScannerThread::set_scanning(const bool v) {
+		_scanning = v;
+	}
 
-	});
+	bool ScannerThread::is_scanning() {
+		return _scanning;
+	}
 
-	def_step = change_mode(AM);	//Start on AM
-	field_mode.set_by_value(AM);	//Reflect the mode into the manual selector
+	void ScannerThread::set_freq_lock(const uint32_t v) {
+		_freq_lock = v;
+	}
 
-	//HELPER: Pre-setting a manual range, based on stored frequency
-	rf::Frequency stored_freq = persistent_memory::tuned_frequency();
-	frequency_range.min = stored_freq - 1000000;
-	button_manual_start.set_text(to_string_short_freq(frequency_range.min));
-	frequency_range.max = stored_freq + 1000000;
-	button_manual_end.set_text(to_string_short_freq(frequency_range.max));
+	uint32_t ScannerThread::is_freq_lock() {
+		return _freq_lock;
+	}
 
-	button_load.on_select = [this, &nav](Button&) {
-		// load txt files from the FREQMAN folder
-		auto open_view = nav.push<FileLoadView>(".TXT");
-		open_view->on_changed = [this](std::filesystem::path new_file_path) {
+	void ScannerThread::set_freq_del(const uint32_t v) {
+		_freq_del = v;
+	}
 
-			std::string dir_filter = "FREQMAN/";
-			std::string str_file_path = new_file_path.string();
+	void ScannerThread::change_scanning_direction() {
+		_fwd = !_fwd;
+		chThdSleepMilliseconds(300);	//Give some pause after reversing scanning direction
 
-			if (str_file_path.find(dir_filter) != string::npos) { // assert file from the FREQMAN folder
-				scan_pause();
-				// get the filename without txt extension so we can use load_freqman_file fcn
-				std::string str_file_name = new_file_path.stem().string();
-				frequency_file_load(str_file_name, true);
-			} else {
-				nav_.display_modal("LOAD ERROR", "A valid file from\nFREQMAN directory is\nrequired.");
+	}
+
+	msg_t ScannerThread::static_fn(void* arg) {
+		auto obj = static_cast<ScannerThread*>(arg);
+		obj->run();
+		return 0;
+	}
+
+	void ScannerThread::run() {
+		if (frequency_list_.size())	{					//IF THERE IS A FREQUENCY LIST ...	
+			RetuneMessage message { };
+			uint32_t frequency_index = frequency_list_.size();
+			bool restart_scan = false;					//Flag whenever scanning is restarting after a pause
+			while( !chThdShouldTerminate() ) {
+				if (_scanning) {						//Scanning
+					if (_freq_lock == 0) {				//normal scanning (not performing freq_lock)
+						if (!restart_scan) {			//looping at full speed
+							switch( frequency_list_[ 0 ] )
+							{
+								case -666 : // MANUAL SCAN   indexes: 0 => flag (-666) 1=>start , 2=>end , 3=> step , 4=> current freq
+									if (_fwd) 
+									{	
+										//forward
+										frequency_list_[ 4 ] += frequency_list_[ 3 ];
+										if (frequency_list_[ 4 ] > frequency_list_[ 2 ])
+											frequency_list_[ 4 ] = frequency_list_[ 1 ] ;	
+									} 
+									else
+									{	//reverse
+										frequency_list_[ 4 ] -= frequency_list_[ 3 ];
+										if (frequency_list_[ 4 ] < frequency_list_[ 1 ])
+											frequency_list_[ 4 ] = frequency_list_[ 2 ] ;	
+									}
+									receiver_model.set_tuning_frequency( frequency_list_[ 4 ] );	// Retune
+									message.range = -frequency_list_[ 4 ];	//Inform freq (for coloring purposes also!)
+									break ;
+								default :
+									if (_fwd) 
+									{					//forward
+										frequency_index++;
+										if (frequency_index >= frequency_list_.size())
+											frequency_index = 0;	
+									} 
+									else
+									{					//reverse
+										if (frequency_index < 1)
+											frequency_index = frequency_list_.size();	
+										frequency_index--;
+									}
+									receiver_model.set_tuning_frequency(frequency_list_[frequency_index]);	// Retune
+									message.range = frequency_index;	//Inform freq (for coloring purposes also!)
+									break ;
+							}
+
+						}
+						else
+							restart_scan=false;			//Effectively skipping first retuning, giving system time
+					} 
+					EventDispatcher::send_message(message);
+				} 
+				else {									//NOT scanning 									
+					if (_freq_del != 0) {				//There is a frequency to delete
+						for (uint16_t i = 0; i < frequency_list_.size(); i++) {	//Search for the freq to delete
+							if (frequency_list_[i] == _freq_del) 
+							{							//found: Erase it
+								frequency_list_.erase(frequency_list_.begin() + i);
+								if (i==0)				//set scan index one place back to compensate
+									i=frequency_list_.size();
+								else
+									i--;
+								break;
+							}
+						}
+						_freq_del = 0;					//deleted.
+					}
+					else {
+						restart_scan=true;					//Flag the need for skipping a cycle when restarting scan
+					}
+				}
+				chThdSleepMilliseconds(50);				//Needed to (eventually) stabilize the receiver into new freq
 			}
-		};
-	};
-
-	button_manual_start.on_select = [this, &nav](Button& button) {
-		auto new_view = nav_.push<FrequencyKeypadView>(frequency_range.min);
-		new_view->on_changed = [this, &button](rf::Frequency f) {
-			frequency_range.min = f;
-			button_manual_start.set_text(to_string_short_freq(f));
-		};
-	};
-	
-	button_manual_end.on_select = [this, &nav](Button& button) {
-		auto new_view = nav.push<FrequencyKeypadView>(frequency_range.max);
-		new_view->on_changed = [this, &button](rf::Frequency f) {
-			frequency_range.max = f;
-			button_manual_end.set_text(to_string_short_freq(f));
-		};
-	};
-
-	button_pause.on_select = [this](Button&) {
-		if ( userpause )
-			user_resume();
-		else {
-			scan_pause();
-			button_pause.set_text("RESUME");	//PAUSED, show resume
-			userpause=true;
 		}
-	};
+	}
 
-	button_audio_app.on_select = [this](Button&) {
-		scan_thread->stop();
-		nav_.pop();
-		nav_.push<AnalogAudioView>();
-	};
+	void ScannerView::handle_retune( long i ) {
+		switch (scan_thread->is_freq_lock())
+		{
+			case 0:										//NO FREQ LOCK, ONGOING STANDARD SCANNING
+				if( i >= 0 )
+				{
+					text_cycle.set( to_string_dec_uint(i + 1,3) );
+					current_index = i;		//since it is an ongoing scan, this is a new index
+					if (description_list[current_index].size() > 0) desc_cycle.set( description_list[current_index] );	//Show new description	
+				}
+				else
+				{
+					if (description_list[ 0 ].size() > 0) desc_cycle.set( description_list[ 0 ] );	//Show new description	
+				}
+				break;
+			case 1:										//STARTING LOCK FREQ
+				big_display.set_style(&style_yellow);
+				break;
+			case MAX_FREQ_LOCK:							//FREQ IS STRONG: GREEN and scanner will pause when on_statistics_update()
+				big_display.set_style(&style_green);
+				if( manual_search && i < 0 )
+				{
+					/* pumped from button add freq */
+					File scanner_file;
+					std::string freq_file_path = "FREQMAN/MSEARCHR.TXT";
 
-	button_mic_app.on_select = [this](Button&) {
-		scan_thread->stop();
-		nav_.pop();
-		nav_.push<MicTXView>();
-	};
+					auto result = scanner_file.open(freq_file_path);	//First search if freq is already in txt
+					if (!result.is_valid()) {
+						std::string frequency_to_add = "f=" 
+							+ to_string_dec_uint( -i / 1000) 
+							+ to_string_dec_uint( -i % 1000UL, 3, '0');
+						char one_char[1];		//Read it char by char
+						std::string line;		//and put read line in here
+						bool found=false;
+						for (size_t pointer=0; pointer < scanner_file.size();pointer++) {
 
-	button_remove.on_select = [this](Button&) {
-		if (frequency_list.size() > current_index) {
-			if (scan_thread->is_scanning())			//STOP Scanning if necessary
-				scan_thread->set_scanning(false);
-			scan_thread->set_freq_del(frequency_list[current_index]);
-			description_list.erase(description_list.begin() + current_index);
-			frequency_list.erase(frequency_list.begin() + current_index);
-			show_max();								//UPDATE new list size on screen
-			desc_cycle.set(" ");					//Clean up description (cosmetic detail)
-			scan_thread->set_freq_lock(0); 			//Reset the scanner lock
-			if ( userpause ) 						//If user-paused, resume
-				user_resume();
+							scanner_file.seek(pointer);
+							scanner_file.read(one_char, 1);
+							if ((int)one_char[0] > 31) {			//ascii space upwards
+								line += one_char[0];				//Add it to the textline
+							}
+							else if (one_char[0] == '\n') {			//New Line
+								if (line.compare(0, frequency_to_add.size(),frequency_to_add) == 0) {
+									found=true;
+									break;
+								}
+								line.clear();						//Ready for next textline
+							}
+						}
+						if( !found) {
+							auto result = scanner_file.append(freq_file_path); //Second: append if it is not there
+							scanner_file.write_line(frequency_to_add + ",d=ADD FQ");
+						}
+					} 
+					else
+					{
+						std::string frequency_to_add = "f=" 
+							+ to_string_dec_uint( -i / 1000) 
+							+ to_string_dec_uint( -i % 1000UL, 3, '0');
+
+						auto result = scanner_file.append(freq_file_path); //Second: append if it is not there
+						scanner_file.write_line(frequency_to_add + ",d=ADD FQ");
+					}
+
+				}
+				break;
+			default:	//freq lock is checking the signal, do not update display
+				return;
 		}
-	};
+		if( i >= 0 )
+		{
+			big_display.set(frequency_list[current_index]);	//UPDATE the big Freq after 0, 1 or MAX_FREQ_LOCK (at least, for color synching)
+		}
+		else
+		{
+			big_display.set( -i );	//UPDATE the big Freq after 0, 1 or MAX_FREQ_LOCK (at least, for color synching)
+		}
+	}
 
-	button_manual_scan.on_select = [this](Button&) {
-		if (!frequency_range.min || !frequency_range.max) {
-			nav_.display_modal("Error", "Both START and END freqs\nneed a value");
-		} else if (frequency_range.min > frequency_range.max) {
-			nav_.display_modal("Error", "END freq\nis lower than START");
-		} else {
+	void ScannerView::focus() {
+		field_mode.focus();
+	}
+
+	ScannerView::~ScannerView() {
 		audio::output::stop();
-		scan_thread->stop();	//STOP SCANNER THREAD
-		frequency_list.clear();
-		description_list.clear();
-		def_step = step_mode.selected_index_value();		//Use def_step from manual selector
-
-		description_list.push_back(
-			"M" + to_string_short_freq(frequency_range.min) + ">"
-	 		+ to_string_short_freq(frequency_range.max) + "S" 
-	 		+ to_string_short_freq(def_step).erase(0,1) //euquiq: lame kludge to reduce spacing in step freq
-		);
-
-		rf::Frequency frequency = frequency_range.min;
-		while (frequency_list.size() < MAX_DB_ENTRY &&  frequency <= frequency_range.max) { //add manual range				
-			frequency_list.push_back(frequency);
-			description_list.push_back("");				//If empty, will keep showing the last description
-			frequency+=def_step;
-		}
-		show_max();
-		if ( userpause ) 						//If user-paused, resume
-			user_resume();
-		big_display.set_style(&style_grey);		//Back to grey color
-		start_scan_thread(); //RESTART SCANNER THREAD
-		}
-	};
-
-	field_mode.on_change = [this](size_t, OptionsField::value_t v) {
 		receiver_model.disable();
 		baseband::shutdown();
-		change_mode(v);
-		if ( !scan_thread->is_scanning() ) 						//for some motive, audio output gets stopped.
-			audio::output::start();								//So if scan was stopped we resume audio
-		receiver_model.enable(); 
-	};
+	}
 
-	button_dir.on_select = [this](Button&) {
-		scan_thread->change_scanning_direction();
-		if ( userpause ) 						//If user-paused, resume
-			user_resume();
-		big_display.set_style(&style_grey);		//Back to grey color
-	};
-
-	button_add.on_select = [this](Button&) {  //frequency_list[current_index]
-		File scanner_file;
-		std::string freq_file_path = "FREQMAN/" + loaded_file_name + ".TXT";
-		auto result = scanner_file.open(freq_file_path);	//First search if freq is already in txt
-		if (!result.is_valid()) {
-			std::string frequency_to_add = "f=" 
-				+ to_string_dec_uint(frequency_list[current_index] / 1000) 
-				+ to_string_dec_uint(frequency_list[current_index] % 1000UL, 3, '0');
-			char one_char[1];		//Read it char by char
-			std::string line;		//and put read line in here
-			bool found=false;
-			for (size_t pointer=0; pointer < scanner_file.size();pointer++) {
-
-				scanner_file.seek(pointer);
-				scanner_file.read(one_char, 1);
-				if ((int)one_char[0] > 31) {			//ascii space upwards
-					line += one_char[0];				//Add it to the textline
-				}
-				else if (one_char[0] == '\n') {			//New Line
-					if (line.compare(0, frequency_to_add.size(),frequency_to_add) == 0) {
-						found=true;
-						break;
-					}
-					line.clear();						//Ready for next textline
-				}
-			}
-			if (found) {
-				nav_.display_modal("Error", "Frequency already exists");
-				big_display.set(frequency_list[current_index]);		//After showing an error
+	void ScannerView::show_max() {		//show total number of freqs to scan
+		if( frequency_list[ 0 ] == -666 )
+		{
+			text_max.set( "" );
+		}
+		else
+		{
+			if (frequency_list.size() == MAX_DB_ENTRY) {
+				text_max.set_style(&style_red);
+				text_max.set( "/ " + to_string_dec_uint(MAX_DB_ENTRY) + " (DB MAX!)");
 			}
 			else {
-				auto result = scanner_file.append(freq_file_path); //Second: append if it is not there
-				scanner_file.write_line(frequency_to_add + ",d=ADD FQ");
+				text_max.set_style(&style_grey);
+				text_max.set( "/ " + to_string_dec_uint(frequency_list.size()));
 			}
-		} else
-		{
-			nav_.display_modal("Error", "Cannot open " + loaded_file_name + ".TXT\nfor appending freq.");
-			big_display.set(frequency_list[current_index]);		//After showing an error
 		}
-	};
-
-	//PRE-CONFIGURATION:
-	field_wait.on_change = [this](int32_t v) {	wait = v;	}; 	field_wait.set_value(5);
-	field_squelch.on_change = [this](int32_t v) {	squelch = v;	}; 	field_squelch.set_value(-10);
-	field_volume.set_value((receiver_model.headphone_volume() - audio::headphone::volume_range().max).decibel() + 99);
-	field_volume.on_change = [this](int32_t v) { this->on_headphone_volume_changed(v);	};
-
-	// LEARN FREQUENCIES
-	std::string scanner_txt = "SCANNER";
-	frequency_file_load(scanner_txt);
-}
-
-void ScannerView::frequency_file_load(std::string file_name, bool stop_all_before) {
-
-	// stop everything running now if required
-	if (stop_all_before) {
-		scan_thread->stop();
-		frequency_list.clear(); // clear the existing frequency list (expected behavior)
-		description_list.clear();
-		def_step = step_mode.selected_index_value();		//Use def_step from manual selector
 	}
 
-	if ( load_freqman_file(file_name, database)  ) {
-		loaded_file_name = file_name; // keep loaded filename in memory
-		for(auto& entry : database) {									// READ LINE PER LINE
-			if (frequency_list.size() < MAX_DB_ENTRY) {					//We got space!
-				if (entry.type == RANGE)  {								//RANGE	
-					switch (entry.step) {
-						case AM_US:	def_step = 10000;  	break ;
-						case AM_EUR:def_step = 9000;  	break ;
-						case NFM_1: def_step = 12500;  	break ;
-						case NFM_2: def_step = 6250;	break ;	
-						case FM_1:	def_step = 100000; 	break ;
-						case FM_2:	def_step = 50000; 	break ;
-						case N_1:	def_step = 25000;  	break ;
-						case N_2:	def_step = 250000; 	break ;
-						case AIRBAND:def_step= 8330;  	break ;
-					}
-					frequency_list.push_back(entry.frequency_a);		//Store starting freq and description
-					description_list.push_back("R" + to_string_short_freq(entry.frequency_a)
-						+ ">" + to_string_short_freq(entry.frequency_b)
-						+ " S" + to_string_short_freq(def_step).erase(0,1) //euquiq: lame kludge to reduce spacing in step freq
-						);
-					while (frequency_list.size() < MAX_DB_ENTRY && entry.frequency_a <= entry.frequency_b) { //add the rest of the range
-						entry.frequency_a+=def_step;
-						frequency_list.push_back(entry.frequency_a);
-						description_list.push_back("");				//Token (keep showing the last description)
-					}
-				} else if ( entry.type == SINGLE)  {
-					frequency_list.push_back(entry.frequency_a);
-					description_list.push_back("S: " + entry.description);
-				}
-				show_max();
-			}
-			else
-			{
-				break; //No more space: Stop reading the txt file !
-			}		
-		}
-	} 
-	else 
+	ScannerView::ScannerView(
+			NavigationView& nav
+			) : nav_ { nav }
 	{
-		loaded_file_name = 'SCANNER'; // back to the default frequency file
-		desc_cycle.set(" NO " + file_name + ".TXT FILE ..." );
-	}
-	audio::output::stop();
-	step_mode.set_by_value(def_step); //Impose the default step into the manual step selector
-	start_scan_thread();
-}
+		add_children({
+				&labels,
+				&field_lna,
+				&field_vga,
+				&field_rf_amp,
+				&field_volume,
+				&field_bw,
+				&field_squelch,
+				&field_wait,
+				&button_load,
+				&rssi,
+				&text_cycle,
+				&text_max,
+				&desc_cycle,
+				&big_display,
+				&button_manual_start,
+				&button_manual_end,
+				&field_mode,
+				&step_mode,
+				&button_manual_scan,
+				&button_pause,
+				&button_dir,
+				&button_audio_app,
+				&button_mic_app,
+				&button_add,
+				&button_remove
 
-void ScannerView::on_statistics_update(const ChannelStatistics& statistics) {
-	if ( !userpause ) 									//Scanning not user-paused
-	{
-		if (timer >= (wait * 10) ) 
-		{
-			timer = 0;
-			scan_resume();
-		} 
-		else if (!timer) 
-		{
-			if (statistics.max_db > squelch ) {  		//There is something on the air...(statistics.max_db > -squelch) 
-				if (scan_thread->is_freq_lock() >= MAX_FREQ_LOCK) { //checking time reached
+		});
+
+		def_step = change_mode(AM);	//Start on AM
+		field_mode.set_by_value(AM);	//Reflect the mode into the manual selector
+
+		//HELPER: Pre-setting a manual range, based on stored frequency
+		rf::Frequency stored_freq = persistent_memory::tuned_frequency();
+		frequency_range.min = stored_freq - 1000000;
+		button_manual_start.set_text(to_string_short_freq(frequency_range.min));
+		frequency_range.max = stored_freq + 1000000;
+		button_manual_end.set_text(to_string_short_freq(frequency_range.max));
+
+		button_load.on_select = [this, &nav](Button&) {
+			// load txt files from the FREQMAN folder
+			auto open_view = nav.push<FileLoadView>(".TXT");
+			open_view->on_changed = [this](std::filesystem::path new_file_path) {
+
+				std::string dir_filter = "FREQMAN/";
+				std::string str_file_path = new_file_path.string();
+
+				if (str_file_path.find(dir_filter) != string::npos) { // assert file from the FREQMAN folder
 					scan_pause();
-					timer++;	
+					// get the filename without txt extension so we can use load_freqman_file fcn
+					std::string str_file_name = new_file_path.stem().string();
+					frequency_file_load(str_file_name, true);
+					manual_search = false ;
 				} else {
-					scan_thread->set_freq_lock( scan_thread->is_freq_lock() + 1 ); //in lock period, still analyzing the signal
+					nav_.display_modal("LOAD ERROR", "A valid file from\nFREQMAN directory is\nrequired.");
 				}
-			} else {									//There is NOTHING on the air
-				if (scan_thread->is_freq_lock() > 0) {	//But are we already in freq_lock ?
-					big_display.set_style(&style_grey);	//Back to grey color
-					scan_thread->set_freq_lock(0); 		//Reset the scanner lock, since there is no signal
-				}				
+			};
+		};
+
+		button_manual_start.on_select = [this, &nav](Button& button) {
+			auto new_view = nav_.push<FrequencyKeypadView>(frequency_range.min);
+			new_view->on_changed = [this, &button](rf::Frequency f) {
+				frequency_range.min = f;
+				button_manual_start.set_text(to_string_short_freq(f));
+			};
+		};
+
+		button_manual_end.on_select = [this, &nav](Button& button) {
+			auto new_view = nav.push<FrequencyKeypadView>(frequency_range.max);
+			new_view->on_changed = [this, &button](rf::Frequency f) {
+				frequency_range.max = f;
+				button_manual_end.set_text(to_string_short_freq(f));
+			};
+		};
+
+		button_pause.on_select = [this](Button&) {
+			if ( userpause )
+				user_resume();
+			else {
+				scan_pause();
+				button_pause.set_text("RESUME");	//PAUSED, show resume
+				userpause=true;
+			}
+		};
+
+		button_audio_app.on_select = [this](Button&) {
+			scan_thread->stop();
+			nav_.pop();
+			nav_.push<AnalogAudioView>();
+		};
+
+		button_mic_app.on_select = [this](Button&) {
+			scan_thread->stop();
+			nav_.pop();
+			nav_.push<MicTXView>();
+		};
+
+		button_remove.on_select = [this](Button&) {
+			if (frequency_list.size() > current_index) {
+				if (scan_thread->is_scanning())			//STOP Scanning if necessary
+					scan_thread->set_scanning(false);
+				scan_thread->set_freq_del(frequency_list[current_index]);
+				description_list.erase(description_list.begin() + current_index);
+				frequency_list.erase(frequency_list.begin() + current_index);
+				show_max();								//UPDATE new list size on screen
+				desc_cycle.set(" ");					//Clean up description (cosmetic detail)
+				scan_thread->set_freq_lock(0); 			//Reset the scanner lock
+				if ( userpause ) 						//If user-paused, resume
+					user_resume();
+			}
+		};
+
+		button_manual_scan.on_select = [this](Button&) {
+			if (!frequency_range.min || !frequency_range.max) {
+				nav_.display_modal("Error", "Both START and END freqs\nneed a value");
+			} else if (frequency_range.min > frequency_range.max) {
+				nav_.display_modal("Error", "END freq\nis lower than START");
+			} else {
+				manual_search = true ;
+
+				audio::output::stop();
+				scan_thread->stop();	//STOP SCANNER THREAD
+
+				frequency_list.clear();
+				description_list.clear();
+
+				def_step = step_mode.selected_index_value();		//Use def_step from manual selector
+
+				description_list.push_back(
+						"M" + to_string_short_freq(frequency_range.min) + ">"
+						+ to_string_short_freq(frequency_range.max) + "S" 
+						+ to_string_short_freq(def_step).erase(0,1) //euquiq: lame kludge to reduce spacing in step freq
+						);
+
+				frequency_list.push_back( -666 ); 		 // flag for the scanning thread to indicate manual scan
+				frequency_list.push_back( frequency_range.min ); // start value
+				frequency_list.push_back( frequency_range.max ); // end value
+				frequency_list.push_back( def_step );		 // steps
+				frequency_list.push_back( frequency_range.min ); // current value (initialized to start value)
+
+				show_max(); /* display step information */
+				text_cycle.set( "" );
+
+				/* commented old behavior
+				   rf::Frequency frequency = frequency_range.min;
+				   while (frequency_list.size() < MAX_DB_ENTRY &&  frequency <= frequency_range.max) { //add manual range				
+				   frequency_list.push_back(frequency);
+				   description_list.push_back("");				//If empty, will keep showing the last description
+				   frequency+=def_step;
+				   }
+				   show_max();
+				   */
+
+				if ( userpause ) 						//If user-paused, resume
+					user_resume();
+				big_display.set_style(&style_grey);		//Back to grey color
+				start_scan_thread(); //RESTART SCANNER THREAD
+			}
+		};
+
+		field_mode.on_change = [this](size_t, OptionsField::value_t v) {
+			receiver_model.disable();
+			baseband::shutdown();
+			change_mode(v);
+			if ( !scan_thread->is_scanning() ) 						//for some motive, audio output gets stopped.
+				audio::output::start();								//So if scan was stopped we resume audio
+			receiver_model.enable(); 
+		};
+
+		button_dir.on_select = [this](Button&) {
+			scan_thread->change_scanning_direction();
+			if ( userpause ) 						//If user-paused, resume
+				user_resume();
+			big_display.set_style(&style_grey);		//Back to grey color
+		};
+
+		button_add.on_select = [this](Button&) {  //frequency_list[current_index]
+			File scanner_file;
+			std::string freq_file_path = "FREQMAN/" + loaded_file_name + ".TXT";
+			auto result = scanner_file.open(freq_file_path);	//First search if freq is already in txt
+			if (!result.is_valid()) {
+				std::string frequency_to_add = "f=" 
+					+ to_string_dec_uint(frequency_list[current_index] / 1000) 
+					+ to_string_dec_uint(frequency_list[current_index] % 1000UL, 3, '0');
+				char one_char[1];		//Read it char by char
+				std::string line;		//and put read line in here
+				bool found=false;
+				for (size_t pointer=0; pointer < scanner_file.size();pointer++) {
+
+					scanner_file.seek(pointer);
+					scanner_file.read(one_char, 1);
+					if ((int)one_char[0] > 31) {			//ascii space upwards
+						line += one_char[0];				//Add it to the textline
+					}
+					else if (one_char[0] == '\n') {			//New Line
+						if (line.compare(0, frequency_to_add.size(),frequency_to_add) == 0) {
+							found=true;
+							break;
+						}
+						line.clear();						//Ready for next textline
+					}
+				}
+				if (found) {
+					nav_.display_modal("Error", "Frequency already exists");
+					big_display.set(frequency_list[current_index]);		//After showing an error
+				}
+				else {
+					auto result = scanner_file.append(freq_file_path); //Second: append if it is not there
+					scanner_file.write_line(frequency_to_add + ",d=ADD FQ");
+				}
+			} else
+			{
+				nav_.display_modal("Error", "Cannot open " + loaded_file_name + ".TXT\nfor appending freq.");
+				big_display.set(frequency_list[current_index]);		//After showing an error
+			}
+		};
+
+		//PRE-CONFIGURATION:
+		field_wait.on_change = [this](int32_t v) {	wait = v;	}; 	field_wait.set_value(5);
+		field_squelch.on_change = [this](int32_t v) {	squelch = v;	}; 	field_squelch.set_value(-10);
+		field_volume.set_value((receiver_model.headphone_volume() - audio::headphone::volume_range().max).decibel() + 99);
+		field_volume.on_change = [this](int32_t v) { this->on_headphone_volume_changed(v);	};
+
+		// LEARN FREQUENCIES
+		std::string scanner_txt = "SCANNER";
+		frequency_file_load(scanner_txt);
+	}
+
+	void ScannerView::frequency_file_load(std::string file_name, bool stop_all_before) {
+
+		// stop everything running now if required
+		if (stop_all_before) {
+			scan_thread->stop();
+			frequency_list.clear(); // clear the existing frequency list (expected behavior)
+			description_list.clear();
+			def_step = step_mode.selected_index_value();		//Use def_step from manual selector
+		}
+
+		if ( load_freqman_file(file_name, database)  ) {
+			loaded_file_name = file_name; // keep loaded filename in memory
+			for(auto& entry : database) {									// READ LINE PER LINE
+				if (frequency_list.size() < MAX_DB_ENTRY) {					//We got space!
+					if (entry.type == RANGE)  {								//RANGE	
+						switch (entry.step) {
+							case AM_US:	def_step = 10000;  	break ;
+							case AM_EUR:def_step = 9000;  	break ;
+							case NFM_1: def_step = 12500;  	break ;
+							case NFM_2: def_step = 6250;	break ;	
+							case FM_1:	def_step = 100000; 	break ;
+							case FM_2:	def_step = 50000; 	break ;
+							case N_1:	def_step = 25000;  	break ;
+							case N_2:	def_step = 250000; 	break ;
+							case AIRBAND:def_step= 8330;  	break ;
+						}
+						frequency_list.push_back(entry.frequency_a);		//Store starting freq and description
+						description_list.push_back("R" + to_string_short_freq(entry.frequency_a)
+								+ ">" + to_string_short_freq(entry.frequency_b)
+								+ " S" + to_string_short_freq(def_step).erase(0,1) //euquiq: lame kludge to reduce spacing in step freq
+								);
+						while (frequency_list.size() < MAX_DB_ENTRY && entry.frequency_a <= entry.frequency_b) { //add the rest of the range
+							entry.frequency_a+=def_step;
+							frequency_list.push_back(entry.frequency_a);
+							description_list.push_back("");				//Token (keep showing the last description)
+						}
+					} else if ( entry.type == SINGLE)  {
+						frequency_list.push_back(entry.frequency_a);
+						description_list.push_back("S: " + entry.description);
+					}
+					show_max();
+				}
+				else
+				{
+					break; //No more space: Stop reading the txt file !
+				}		
 			}
 		} 
-		else 	//Ongoing wait time
+		else 
 		{
+			loaded_file_name = 'SCANNER'; // back to the default frequency file
+			desc_cycle.set(" NO " + file_name + ".TXT FILE ..." );
+		}
+		audio::output::stop();
+		step_mode.set_by_value(def_step); //Impose the default step into the manual step selector
+		start_scan_thread();
+	}
+
+	void ScannerView::on_statistics_update(const ChannelStatistics& statistics) {
+		if ( !userpause ) 									//Scanning not user-paused
+		{
+			if (timer >= (wait * 10) ) 
+			{
+				timer = 0;
+				scan_resume();
+			} 
+			else if (!timer) 
+			{
+				if (statistics.max_db > squelch ) {  		//There is something on the air...(statistics.max_db > -squelch) 
+					if (scan_thread->is_freq_lock() >= MAX_FREQ_LOCK) { //checking time reached
+						scan_pause();
+						timer++;	
+					} else {
+						scan_thread->set_freq_lock( scan_thread->is_freq_lock() + 1 ); //in lock period, still analyzing the signal
+					}
+				} else {									//There is NOTHING on the air
+					if (scan_thread->is_freq_lock() > 0) {	//But are we already in freq_lock ?
+						big_display.set_style(&style_grey);	//Back to grey color
+						scan_thread->set_freq_lock(0); 		//Reset the scanner lock, since there is no signal
+					}				
+				}
+			} 
+			else 	//Ongoing wait time
+			{
 				timer++;
+			}
 		}
 	}
-}
 
-void ScannerView::scan_pause() {
-	if (scan_thread->is_scanning()) {
-		scan_thread->set_freq_lock(0); 		//Reset the scanner lock (because user paused, or MAX_FREQ_LOCK reached) for next freq scan	
-		scan_thread->set_scanning(false); // WE STOP SCANNING
-		audio::output::start();
-	}
-}
-
-void ScannerView::scan_resume() {
-	audio::output::stop();
-	big_display.set_style(&style_grey);		//Back to grey color
-	if (!scan_thread->is_scanning())
-		scan_thread->set_scanning(true);   // RESUME!
-}
-
-void ScannerView::user_resume() {
-	timer = wait * 10;					//Will trigger a scan_resume() on_statistics_update, also advancing to next freq.
-	button_pause.set_text("PAUSE");		//Show button for pause
-	userpause=false;					//Resume scanning
-}
-
-void ScannerView::on_headphone_volume_changed(int32_t v) {
-	const auto new_volume = volume_t::decibel(v - 99) + audio::headphone::volume_range().max;
-	receiver_model.set_headphone_volume(new_volume);
-}
-
-size_t ScannerView::change_mode(uint8_t new_mod) { //Before this, do a scan_thread->stop();  After this do a start_scan_thread()
-	using option_t = std::pair<std::string, int32_t>;
-	using options_t = std::vector<option_t>;
-	options_t bw;
-	field_bw.on_change = [this](size_t n, OptionsField::value_t) {	};
-
-	switch (new_mod) {
-	case NFM:	//bw 16k (2) default
-		bw.emplace_back("8k5", 0);
-		bw.emplace_back("11k", 0);
-		bw.emplace_back("16k", 0);			
-		field_bw.set_options(bw);
-
-		baseband::run_image(portapack::spi_flash::image_tag_nfm_audio);
-		receiver_model.set_modulation(ReceiverModel::Mode::NarrowbandFMAudio);
-		field_bw.set_selected_index(2);
-		receiver_model.set_nbfm_configuration(field_bw.selected_index());
-		field_bw.on_change = [this](size_t n, OptionsField::value_t) { 	receiver_model.set_nbfm_configuration(n); };
-		receiver_model.set_sampling_rate(3072000);	receiver_model.set_baseband_bandwidth(1750000);	
-		break;
-	case AM:
-		bw.emplace_back("DSB", 0);
-		bw.emplace_back("USB", 0);
-		bw.emplace_back("LSB", 0);
-		bw.emplace_back("CW ", 0);
-		field_bw.set_options(bw);
-
-		baseband::run_image(portapack::spi_flash::image_tag_am_audio);
-		receiver_model.set_modulation(ReceiverModel::Mode::AMAudio);
-		field_bw.set_selected_index(0);
-		receiver_model.set_am_configuration(field_bw.selected_index());
-		field_bw.on_change = [this](size_t n, OptionsField::value_t) { receiver_model.set_am_configuration(n);	};		
-		receiver_model.set_sampling_rate(2000000);receiver_model.set_baseband_bandwidth(2000000); 
-		break;
-	case WFM:
-		bw.emplace_back("16k", 0);
-		field_bw.set_options(bw);
-
-		baseband::run_image(portapack::spi_flash::image_tag_wfm_audio);
-		receiver_model.set_modulation(ReceiverModel::Mode::WidebandFMAudio);
-		field_bw.set_selected_index(0);
-		receiver_model.set_wfm_configuration(field_bw.selected_index());
-		field_bw.on_change = [this](size_t n, OptionsField::value_t) {	receiver_model.set_wfm_configuration(n); };
-		receiver_model.set_sampling_rate(3072000);	receiver_model.set_baseband_bandwidth(2000000);	
-		break;
+	void ScannerView::scan_pause() {
+		if (scan_thread->is_scanning()) {
+			scan_thread->set_freq_lock(0); 		//Reset the scanner lock (because user paused, or MAX_FREQ_LOCK reached) for next freq scan	
+			scan_thread->set_scanning(false); // WE STOP SCANNING
+			audio::output::start();
+		}
 	}
 
-	return mod_step[new_mod];
-}
+	void ScannerView::scan_resume() {
+		audio::output::stop();
+		big_display.set_style(&style_grey);		//Back to grey color
+		if (!scan_thread->is_scanning())
+			scan_thread->set_scanning(true);   // RESUME!
+	}
 
-void ScannerView::start_scan_thread() {
-	receiver_model.enable(); 
-	receiver_model.set_squelch_level(0);
-	scan_thread = std::make_unique<ScannerThread>(frequency_list);
-}
+	void ScannerView::user_resume() {
+		timer = wait * 10;					//Will trigger a scan_resume() on_statistics_update, also advancing to next freq.
+		button_pause.set_text("PAUSE");		//Show button for pause
+		userpause=false;					//Resume scanning
+	}
+
+	void ScannerView::on_headphone_volume_changed(int32_t v) {
+		const auto new_volume = volume_t::decibel(v - 99) + audio::headphone::volume_range().max;
+		receiver_model.set_headphone_volume(new_volume);
+	}
+
+	size_t ScannerView::change_mode(uint8_t new_mod) { //Before this, do a scan_thread->stop();  After this do a start_scan_thread()
+		using option_t = std::pair<std::string, int32_t>;
+		using options_t = std::vector<option_t>;
+		options_t bw;
+		field_bw.on_change = [this](size_t n, OptionsField::value_t) {	};
+
+		switch (new_mod) {
+			case NFM:	//bw 16k (2) default
+				bw.emplace_back("8k5", 0);
+				bw.emplace_back("11k", 0);
+				bw.emplace_back("16k", 0);			
+				field_bw.set_options(bw);
+
+				baseband::run_image(portapack::spi_flash::image_tag_nfm_audio);
+				receiver_model.set_modulation(ReceiverModel::Mode::NarrowbandFMAudio);
+				field_bw.set_selected_index(2);
+				receiver_model.set_nbfm_configuration(field_bw.selected_index());
+				field_bw.on_change = [this](size_t n, OptionsField::value_t) { 	receiver_model.set_nbfm_configuration(n); };
+				receiver_model.set_sampling_rate(3072000);	receiver_model.set_baseband_bandwidth(1750000);	
+				break;
+			case AM:
+				bw.emplace_back("DSB", 0);
+				bw.emplace_back("USB", 0);
+				bw.emplace_back("LSB", 0);
+				bw.emplace_back("CW ", 0);
+				field_bw.set_options(bw);
+
+				baseband::run_image(portapack::spi_flash::image_tag_am_audio);
+				receiver_model.set_modulation(ReceiverModel::Mode::AMAudio);
+				field_bw.set_selected_index(0);
+				receiver_model.set_am_configuration(field_bw.selected_index());
+				field_bw.on_change = [this](size_t n, OptionsField::value_t) { receiver_model.set_am_configuration(n);	};		
+				receiver_model.set_sampling_rate(2000000);receiver_model.set_baseband_bandwidth(2000000); 
+				break;
+			case WFM:
+				bw.emplace_back("16k", 0);
+				field_bw.set_options(bw);
+
+				baseband::run_image(portapack::spi_flash::image_tag_wfm_audio);
+				receiver_model.set_modulation(ReceiverModel::Mode::WidebandFMAudio);
+				field_bw.set_selected_index(0);
+				receiver_model.set_wfm_configuration(field_bw.selected_index());
+				field_bw.on_change = [this](size_t n, OptionsField::value_t) {	receiver_model.set_wfm_configuration(n); };
+				receiver_model.set_sampling_rate(3072000);	receiver_model.set_baseband_bandwidth(2000000);	
+				break;
+		}
+
+		return mod_step[new_mod];
+	}
+
+	void ScannerView::start_scan_thread() {
+		receiver_model.enable(); 
+		receiver_model.set_squelch_level(0);
+		scan_thread = std::make_unique<ScannerThread>(frequency_list);
+	}
 
 } /* namespace ui */

--- a/firmware/application/apps/ui_scanner.hpp
+++ b/firmware/application/apps/ui_scanner.hpp
@@ -222,21 +222,6 @@ private:
 		0
 	};
 
-	Button button_manual_start {
-		{ 0 * 8, 11 * 16, 11 * 8, 28 },
-		""
-	};
-
-	Button button_manual_end {
-		{ 12 * 8, 11 * 16, 11 * 8, 28 },
-		""
-	};
-
-	Button button_manual_scan {
-		{ 24 * 8, 11 * 16, 6 * 8, 28 },
-		"SCAN"
-	};
-
 	OptionsField field_mode {
 		{ 5 * 8, (26 * 8) + 4 },
 		6,

--- a/firmware/application/apps/ui_scanner.hpp
+++ b/firmware/application/apps/ui_scanner.hpp
@@ -154,7 +154,6 @@ private:
 	Labels labels {
 		{ { 0 * 8, 0 * 16 }, "LNA:   VGA:   AMP:  VOL:", Color::light_grey() },
 		{ { 0 * 8, 1* 16 }, "BW:    SQUELCH:   db WAIT:", Color::light_grey() },
-		{ { 3 * 8, 10 * 16 }, "START        END     MANUAL", Color::light_grey() },
 		{ { 0 * 8, (26 * 8) + 4 }, "MODE:", Color::light_grey() },
 		{ { 11 * 8, (26 * 8) + 4 }, "STEP:", Color::light_grey() },
 	};

--- a/firmware/application/apps/ui_scanner.hpp
+++ b/firmware/application/apps/ui_scanner.hpp
@@ -119,7 +119,7 @@ public:
 		.foreground = Color::red(),
 	};
 
-	std::string title() const override { return "SCANNER"; };
+	std::string title() const override { return "Scanner"; };
 	std::vector<rf::Frequency> frequency_list{ };
 	std::vector<string> description_list { };
 

--- a/firmware/application/apps/ui_scanner.hpp
+++ b/firmware/application/apps/ui_scanner.hpp
@@ -37,6 +37,14 @@
 #define MAX_DB_ENTRY 500
 #define MAX_FREQ_LOCK 10 		//50ms cycles scanner locks into freq when signal detected, to verify signal is not spureous
 
+/* indexes used in frequency_list in case of a manual search */
+#define MS_FLAG_IDX  0       // position of flag in list
+#define MS_FLAG_VAL  -666    // value of flag to tell it's a manual search ordered frequency_list
+#define MS_MIN_FREQ_IDX  1   // position of minimum frequency
+#define MS_MAX_FREQ_IDX  2   // position of maximum frequency
+#define MS_FREQ_STEP_IDX 3   // position or step 
+#define MS_CUR_FREQ_IDX  4   // position of currently used frequency
+
 namespace ui {
 
 enum modulation_type { AM = 0,WFM,NFM };
@@ -141,7 +149,7 @@ private:
 	std::string loaded_file_name;
 	uint32_t current_index { 0 };
 	bool userpause { false };
-	bool manual_search { false };
+	bool manual_search { false }; 
 	
 	Labels labels {
 		{ { 0 * 8, 0 * 16 }, "LNA:   VGA:   AMP:  VOL:", Color::light_grey() },

--- a/firmware/application/apps/ui_scanner.hpp
+++ b/firmware/application/apps/ui_scanner.hpp
@@ -130,7 +130,7 @@ private:
 
 	void on_statistics_update(const ChannelStatistics& statistics);
 	void on_headphone_volume_changed(int32_t v);
-	void handle_retune(uint32_t i);
+	void handle_retune( long i );
 
 	jammer::jammer_range_t frequency_range { false, 0, 0 };  //perfect for manual scan task too...
 	int32_t squelch { 0 };
@@ -141,6 +141,7 @@ private:
 	std::string loaded_file_name;
 	uint32_t current_index { 0 };
 	bool userpause { false };
+	bool manual_search { false };
 	
 	Labels labels {
 		{ { 0 * 8, 0 * 16 }, "LNA:   VGA:   AMP:  VOL:", Color::light_grey() },

--- a/firmware/application/apps/ui_search.cpp
+++ b/firmware/application/apps/ui_search.cpp
@@ -384,6 +384,7 @@ namespace ui {
 		};
 
 		button_manual_search.on_select = [this](Button&) {
+			
 
 			if (!frequency_range.min || !frequency_range.max) {
 				nav_.display_modal("Error", "Both START and END freqs\nneed a value");
@@ -429,6 +430,8 @@ namespace ui {
 					user_resume();
 				big_display.set_style(&style_grey);		//Back to grey color
 				start_search_thread(); //RESTART SCANNER THREAD
+				if (!search_thread->is_searching())
+					search_thread->set_searching(true);   // RESUME!
 			}
 		};
 

--- a/firmware/application/apps/ui_search.cpp
+++ b/firmware/application/apps/ui_search.cpp
@@ -296,7 +296,7 @@ namespace ui {
 				&button_audio_app,
 				&button_mic_app,
 				&button_add,
-				&button_load,
+				//&button_load,
 				&button_remove,
 				&button_search_setup
 
@@ -475,7 +475,7 @@ namespace ui {
 			}
 		};
 
-		button_load.on_select = [this, &nav](Button&) {
+		/*button_load.on_select = [this, &nav](Button&) {
 			// load txt files from the FREQMAN folder
 			auto open_view = nav.push<FileLoadView>(".TXT");
 			open_view->on_changed = [this](std::filesystem::path new_file_path) {
@@ -493,7 +493,7 @@ namespace ui {
 					nav_.display_modal("LOAD ERROR", "A valid file from\nFREQMAN directory is\nrequired.");
 				}
 			};
-		};
+		};*/
 
 
 		//PRE-CONFIGURATION:

--- a/firmware/application/apps/ui_search.cpp
+++ b/firmware/application/apps/ui_search.cpp
@@ -176,13 +176,13 @@ namespace ui {
 				break;
 			case MAX_FREQ_LOCK:							//FREQ IS STRONG: GREEN and search will pause when on_statistics_update()
 				big_display.set_style(&style_green);
-				if( manual_search && i < 0 )
+				if( autosave && manual_search && i < 0 )
 				{
 					static long last_freq = 0 ;
 
 					/* pumped from button add freq */
 					File search_file;
-					std::string freq_file_path = "FREQMAN/MSEARCHR.TXT";
+					std::string freq_file_path = "/FREQMAN/"+output_file+".TXT" ;
 
 					if( last_freq != i )
 					{
@@ -475,40 +475,27 @@ namespace ui {
 			}
 		};
 
-		/*button_load.on_select = [this, &nav](Button&) {
-			// load txt files from the FREQMAN folder
-			auto open_view = nav.push<FileLoadView>(".TXT");
-			open_view->on_changed = [this](std::filesystem::path new_file_path) {
-
-				std::string dir_filter = "FREQMAN/";
-				std::string str_file_path = new_file_path.string();
-
-				if (str_file_path.find(dir_filter) != string::npos) { // assert file from the FREQMAN folder
-					search_pause();
-					// get the filename without txt extension so we can use load_freqman_file fcn
-					std::string str_file_name = new_file_path.stem().string();
-					frequency_file_load(str_file_name, true);
-					manual_search = false ;
-				} else {
-					nav_.display_modal("LOAD ERROR", "A valid file from\nFREQMAN directory is\nrequired.");
-				}
-			};
-		};*/
-
+		button_search_setup.on_select = [this,&nav](Button&) {
+			
+			search_pause();
+			manual_search = false ;
+			
+			nav.push<SearchSetupView>(); 
+			
+			SearchSetupLoadStrings( "SEARCH/SEARCH.CFG" , input_file , output_file );
+			frequency_file_load( input_file , true );
+			autosave = persistent_memory::search_autosave_freqs();
+		};
 
 		//PRE-CONFIGURATION:
 		field_wait.on_change = [this](int32_t v) {	wait = v;	}; 	field_wait.set_value(5);
 		field_squelch.on_change = [this](int32_t v) {	squelch = v;	}; 	field_squelch.set_value(-10);
 		field_volume.set_value((receiver_model.headphone_volume() - audio::headphone::volume_range().max).decibel() + 99);
 		field_volume.on_change = [this](int32_t v) { this->on_headphone_volume_changed(v);	};
-
-		// LEARN FREQUENCIES
-		std::string search_txt = "SCANNER"; // add persistance read here
-		frequency_file_load(search_txt);
-
-		button_search_setup.on_select = [&nav](Button&) {
-			nav.push<SearchSetupView>(); 
-		};
+		
+		SearchSetupLoadStrings( "SEARCH/SEARCH.CFG" , input_file , output_file );
+		frequency_file_load( input_file );
+		autosave = persistent_memory::search_autosave_freqs();
 	}
 
 	void SearchView::frequency_file_load(std::string file_name, bool stop_all_before) {

--- a/firmware/application/apps/ui_search.cpp
+++ b/firmware/application/apps/ui_search.cpp
@@ -1,0 +1,674 @@
+/*
+ * Copyright (C) 2015 Jared Boone, ShareBrained Technology, Inc.
+ * Copyright (C) 2018 Furrtek
+ *
+ * This file is part of PortaPack.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#include "ui_search.hpp"
+#include "ui_fileman.hpp"
+
+using namespace std;
+using namespace portapack;
+
+namespace ui {
+
+	SearchThread::SearchThread( std::vector<rf::Frequency> frequency_list	) : frequency_list_ {  std::move(frequency_list) }
+	{
+		thread = chThdCreateFromHeap(NULL, 1024, NORMALPRIO + 10, SearchThread::static_fn, this);
+	}
+
+	SearchThread::~SearchThread() {
+		stop();
+	}
+
+	void SearchThread::stop() {
+		if( thread ) {
+			chThdTerminate(thread);
+			chThdWait(thread);
+			thread = nullptr;
+		}
+	}
+
+	void SearchThread::set_searching(const bool v) {
+		_searching = v;
+	}
+
+	bool SearchThread::is_searching() {
+		return _searching;
+	}
+
+	void SearchThread::set_freq_lock(const uint32_t v) {
+		_freq_lock = v;
+	}
+
+	uint32_t SearchThread::is_freq_lock() {
+		return _freq_lock;
+	}
+
+	void SearchThread::set_freq_del(const uint32_t v) {
+		_freq_del = v;
+	}
+
+	void SearchThread::change_searching_direction() {
+		_fwd = !_fwd;
+		chThdSleepMilliseconds(300);	//Give some pause after reversing searching direction
+
+	}
+
+	msg_t SearchThread::static_fn(void* arg) {
+		auto obj = static_cast<SearchThread*>(arg);
+		obj->run();
+		return 0;
+	}
+
+	void SearchThread::run() {
+		if (frequency_list_.size())	{					//IF THERE IS A FREQUENCY LIST ...	
+			RetuneMessage message { };
+			uint32_t frequency_index = frequency_list_.size();
+			bool restart_search = false;					//Flag whenever searching is restarting after a pause
+			while( !chThdShouldTerminate() ) {
+				if (_searching) {						//Scanning
+					if (_freq_lock == 0) {				//normal searching (not performing freq_lock)
+						if (!restart_search) {			//looping at full speed
+							switch( frequency_list_[ MS_FLAG_IDX ] )
+							{
+								case MS_FLAG_VAL : // MANUAL SCAN   indexes: 0=> flag , 1=>start , 2=>end , 3=> step , 4=> current freq
+									if (_fwd) 
+									{	
+										//forward
+										frequency_list_[ MS_CUR_FREQ_IDX ] += frequency_list_[ MS_FREQ_STEP_IDX ];
+										if (frequency_list_[ MS_CUR_FREQ_IDX ] > frequency_list_[ MS_MAX_FREQ_IDX ])
+											frequency_list_[ MS_CUR_FREQ_IDX ] = frequency_list_[ MS_MIN_FREQ_IDX ] ;	
+									} 
+									else
+									{	//reverse
+										frequency_list_[ MS_CUR_FREQ_IDX ] -= frequency_list_[ MS_FREQ_STEP_IDX ];
+										if (frequency_list_[ MS_CUR_FREQ_IDX ] < frequency_list_[ MS_MIN_FREQ_IDX ])
+											frequency_list_[ MS_CUR_FREQ_IDX ] = frequency_list_[ MS_MAX_FREQ_IDX ] ;	
+									}
+									receiver_model.set_tuning_frequency( frequency_list_[ MS_CUR_FREQ_IDX ] );	// Retune
+									//Inform freq (for coloring purposes also!) 
+									//Negative Values for direct frequency setting (instead of giving an index in frequency_list)
+									message.range = -frequency_list_[ MS_CUR_FREQ_IDX ];			
+									break ;
+								default :
+									if (_fwd) 
+									{					//forward
+										frequency_index++;
+										if (frequency_index >= frequency_list_.size())
+											frequency_index = 0;	
+									} 
+									else
+									{					//reverse
+										if (frequency_index < 1)
+											frequency_index = frequency_list_.size();	
+										frequency_index--;
+									}
+									receiver_model.set_tuning_frequency(frequency_list_[frequency_index]);	// Retune
+									message.range = frequency_index;	//Inform freq (for coloring purposes also!)
+									break ;
+							}
+
+						}
+						else
+							restart_search=false;			//Effectively skipping first retuning, giving system time
+					} 
+					EventDispatcher::send_message(message);
+				} 
+				else {									//NOT searching 									
+					if (_freq_del != 0) {				//There is a frequency to delete
+						for (uint16_t i = 0; i < frequency_list_.size(); i++) {	//Search for the freq to delete
+							if (frequency_list_[i] == _freq_del) 
+							{							//found: Erase it
+								frequency_list_.erase(frequency_list_.begin() + i);
+								if (i==0)				//set search index one place back to compensate
+									i=frequency_list_.size();
+								else
+									i--;
+								break;
+							}
+						}
+						_freq_del = 0;					//deleted.
+					}
+					else {
+						restart_search=true;					//Flag the need for skipping a cycle when restarting search
+					}
+				}
+				chThdSleepMilliseconds(50);				//Needed to (eventually) stabilize the receiver into new freq
+			}
+		}
+	}
+
+	void SearchView::handle_retune( long i ) {
+		switch (search_thread->is_freq_lock())
+		{
+			case 0:										//NO FREQ LOCK, ONGOING STANDARD SCANNING
+				if( i >= 0 )
+				{
+					text_cycle.set( to_string_dec_uint(i + 1,3) );
+					current_index = i;		//since it is an ongoing search, this is a new index
+					if (description_list[current_index].size() > 0) desc_cycle.set( description_list[current_index] );	//Show new description	
+				}
+				else
+				{
+					if (description_list[ 0 ].size() > 0) desc_cycle.set( description_list[ 0 ] );	//Show new description	
+				}
+				break;
+			case 1:										//STARTING LOCK FREQ
+				big_display.set_style(&style_yellow);
+				break;
+			case MAX_FREQ_LOCK:							//FREQ IS STRONG: GREEN and search will pause when on_statistics_update()
+				big_display.set_style(&style_green);
+				if( manual_search && i < 0 )
+				{
+					static long last_freq = 0 ;
+
+					/* pumped from button add freq */
+					File search_file;
+					std::string freq_file_path = "FREQMAN/MSEARCHR.TXT";
+
+					if( last_freq != i )
+					{
+						auto result = search_file.open(freq_file_path);	//First search if freq is already in txt
+						if (!result.is_valid()) {
+							std::string frequency_to_add = "f=" 
+								+ to_string_dec_uint( -i / 1000) 
+								+ to_string_dec_uint( -i % 1000UL, 3, '0');
+							char one_char[1];		//Read it char by char
+							std::string line;		//and put read line in here
+							bool found=false;
+							for (size_t pointer=0; pointer < search_file.size();pointer++) {
+
+								search_file.seek(pointer);
+								search_file.read(one_char, 1);
+								if ((int)one_char[0] > 31) {			//ascii space upwards
+									line += one_char[0];				//Add it to the textline
+								}
+								else if (one_char[0] == '\n') {			//New Line
+									if (line.compare(0, frequency_to_add.size(),frequency_to_add) == 0) {
+										found=true;
+										break;
+									}
+									line.clear();						//Ready for next textline
+								}
+							}
+							if( !found) {
+								auto result = search_file.append(freq_file_path); //Second: append if it is not there
+								search_file.write_line(frequency_to_add + ",d=ADD FQ");
+							}
+						}
+						else
+						{
+							std::string frequency_to_add = "f=" 
+								+ to_string_dec_uint( -i / 1000) 
+								+ to_string_dec_uint( -i % 1000UL, 3, '0');
+
+							auto result = search_file.append(freq_file_path); //Second: append if it is not there
+							search_file.write_line(frequency_to_add + ",d=ADD FQ");
+						}
+					}
+					last_freq = i ;
+				}
+				break;
+			default:	//freq lock is checking the signal, do not update display
+				return;
+		}
+		if( i >= 0 )
+		{
+			big_display.set(frequency_list[current_index]);	//UPDATE the big Freq after 0, 1 or MAX_FREQ_LOCK (at least, for color synching)
+		}
+		else
+		{
+			big_display.set( -i );	//UPDATE the big Freq after 0, 1 or MAX_FREQ_LOCK (at least, for color synching) MANUAL SEARCH MODE
+		}
+	}
+
+	void SearchView::focus() {
+		field_mode.focus();
+	}
+
+	SearchView::~SearchView() {
+		audio::output::stop();
+		receiver_model.disable();
+		baseband::shutdown();
+	}
+
+	void SearchView::show_max() {		//show total number of freqs to search
+		if( frequency_list[ 0 ] == -666 )
+		{
+			text_max.set( "" );
+		}
+		else
+		{
+			if (frequency_list.size() == MAX_DB_ENTRY) {
+				text_max.set_style(&style_red);
+				text_max.set( "/ " + to_string_dec_uint(MAX_DB_ENTRY) + " (DB MAX!)");
+			}
+			else {
+				text_max.set_style(&style_grey);
+				text_max.set( "/ " + to_string_dec_uint(frequency_list.size()));
+			}
+		}
+	}
+
+	SearchView::SearchView(
+			NavigationView& nav
+			) : nav_ { nav }
+	{
+		add_children({
+				&labels,
+				&field_lna,
+				&field_vga,
+				&field_rf_amp,
+				&field_volume,
+				&field_bw,
+				&field_squelch,
+				&field_wait,
+				&button_load,
+				&rssi,
+				&text_cycle,
+				&text_max,
+				&desc_cycle,
+				&big_display,
+				&button_manual_start,
+				&button_manual_end,
+				&field_mode,
+				&step_mode,
+				&button_manual_search,
+				&button_pause,
+				&button_dir,
+				&button_audio_app,
+				&button_mic_app,
+				&button_add,
+				&button_remove
+
+		});
+
+		def_step = change_mode(SEARCH_AM);	//Start on AM
+		field_mode.set_by_value(SEARCH_AM);	//Reflect the mode into the manual selector
+
+		//HELPER: Pre-setting a manual range, based on stored frequency
+		rf::Frequency stored_freq = persistent_memory::tuned_frequency();
+		frequency_range.min = stored_freq - 1000000;
+		button_manual_start.set_text(to_string_short_freq(frequency_range.min));
+		frequency_range.max = stored_freq + 1000000;
+		button_manual_end.set_text(to_string_short_freq(frequency_range.max));
+
+		button_load.on_select = [this, &nav](Button&) {
+			// load txt files from the FREQMAN folder
+			auto open_view = nav.push<FileLoadView>(".TXT");
+			open_view->on_changed = [this](std::filesystem::path new_file_path) {
+
+				std::string dir_filter = "FREQMAN/";
+				std::string str_file_path = new_file_path.string();
+
+				if (str_file_path.find(dir_filter) != string::npos) { // assert file from the FREQMAN folder
+					search_pause();
+					// get the filename without txt extension so we can use load_freqman_file fcn
+					std::string str_file_name = new_file_path.stem().string();
+					frequency_file_load(str_file_name, true);
+					manual_search = false ;
+				} else {
+					nav_.display_modal("LOAD ERROR", "A valid file from\nFREQMAN directory is\nrequired.");
+				}
+			};
+		};
+
+		button_manual_start.on_select = [this, &nav](Button& button) {
+			auto new_view = nav_.push<FrequencyKeypadView>(frequency_range.min);
+			new_view->on_changed = [this, &button](rf::Frequency f) {
+				frequency_range.min = f;
+				button_manual_start.set_text(to_string_short_freq(f));
+			};
+		};
+
+		button_manual_end.on_select = [this, &nav](Button& button) {
+			auto new_view = nav.push<FrequencyKeypadView>(frequency_range.max);
+			new_view->on_changed = [this, &button](rf::Frequency f) {
+				frequency_range.max = f;
+				button_manual_end.set_text(to_string_short_freq(f));
+			};
+		};
+
+		button_pause.on_select = [this](Button&) {
+			if ( userpause )
+				user_resume();
+			else {
+				search_pause();
+				button_pause.set_text("RESUME");	//PAUSED, show resume
+				userpause=true;
+			}
+		};
+
+		button_audio_app.on_select = [this](Button&) {
+			search_thread->stop();
+			nav_.pop();
+			nav_.push<AnalogAudioView>();
+		};
+
+		button_mic_app.on_select = [this](Button&) {
+			search_thread->stop();
+			nav_.pop();
+			nav_.push<MicTXView>();
+		};
+
+		button_remove.on_select = [this](Button&) {
+			if (frequency_list.size() > current_index) {
+				if (search_thread->is_searching())			//STOP Scanning if necessary
+					search_thread->set_searching(false);
+				search_thread->set_freq_del(frequency_list[current_index]);
+				description_list.erase(description_list.begin() + current_index);
+				frequency_list.erase(frequency_list.begin() + current_index);
+				show_max();								//UPDATE new list size on screen
+				desc_cycle.set(" ");					//Clean up description (cosmetic detail)
+				search_thread->set_freq_lock(0); 			//Reset the search lock
+				if ( userpause ) 						//If user-paused, resume
+					user_resume();
+			}
+		};
+
+		button_manual_search.on_select = [this](Button&) {
+
+			if (!frequency_range.min || !frequency_range.max) {
+				nav_.display_modal("Error", "Both START and END freqs\nneed a value");
+			} else if (frequency_range.min > frequency_range.max) {
+				nav_.display_modal("Error", "END freq\nis lower than START");
+			} else {
+				manual_search = true ;
+
+				audio::output::stop();
+				search_thread->stop();	//STOP SCANNER THREAD
+
+				frequency_list.clear();
+				description_list.clear();
+
+				def_step = step_mode.selected_index_value();		//Use def_step from manual selector
+
+				description_list.push_back(
+						"M" + to_string_short_freq(frequency_range.min) + ">"
+						+ to_string_short_freq(frequency_range.max) + "S" 
+						+ to_string_short_freq(def_step).erase(0,1) //euquiq: lame kludge to reduce spacing in step freq
+						);
+
+				frequency_list.push_back( -666 ); 		 // flag for the search thread to indicate manual search 
+				frequency_list.push_back( frequency_range.min ); // start value
+				frequency_list.push_back( frequency_range.max ); // end value
+				frequency_list.push_back( def_step );		 // steps
+				frequency_list.push_back( frequency_range.min ); // current value (initialized to start value)
+
+				show_max(); /* display step information */
+				text_cycle.set( "" );
+
+				/* commented old behavior
+				   rf::Frequency frequency = frequency_range.min;
+				   while (frequency_list.size() < MAX_DB_ENTRY &&  frequency <= frequency_range.max) { //add manual range				
+				   frequency_list.push_back(frequency);
+				   description_list.push_back("");				//If empty, will keep showing the last description
+				   frequency+=def_step;
+				   }
+				   show_max();
+				   */
+
+				if ( userpause ) 						//If user-paused, resume
+					user_resume();
+				big_display.set_style(&style_grey);		//Back to grey color
+				start_search_thread(); //RESTART SCANNER THREAD
+			}
+		};
+
+		field_mode.on_change = [this](size_t, OptionsField::value_t v) {
+			receiver_model.disable();
+			baseband::shutdown();
+			change_mode(v);
+			if ( !search_thread->is_searching() ) 						//for some motive, audio output gets stopped.
+				audio::output::start();								//So if search was stopped we resume audio
+			receiver_model.enable(); 
+		};
+
+		button_dir.on_select = [this](Button&) {
+			search_thread->change_searching_direction();
+			if ( userpause ) 						//If user-paused, resume
+				user_resume();
+			big_display.set_style(&style_grey);		//Back to grey color
+		};
+
+		button_add.on_select = [this](Button&) {  //frequency_list[current_index]
+			File search_file;
+			std::string freq_file_path = "FREQMAN/" + loaded_file_name + ".TXT";
+			auto result = search_file.open(freq_file_path);	//First search if freq is already in txt
+			if (!result.is_valid()) {
+				std::string frequency_to_add = "f=" 
+					+ to_string_dec_uint(frequency_list[current_index] / 1000) 
+					+ to_string_dec_uint(frequency_list[current_index] % 1000UL, 3, '0');
+				char one_char[1];		//Read it char by char
+				std::string line;		//and put read line in here
+				bool found=false;
+				for (size_t pointer=0; pointer < search_file.size();pointer++) {
+
+					search_file.seek(pointer);
+					search_file.read(one_char, 1);
+					if ((int)one_char[0] > 31) {			//ascii space upwards
+						line += one_char[0];				//Add it to the textline
+					}
+					else if (one_char[0] == '\n') {			//New Line
+						if (line.compare(0, frequency_to_add.size(),frequency_to_add) == 0) {
+							found=true;
+							break;
+						}
+						line.clear();						//Ready for next textline
+					}
+				}
+				if (found) {
+					nav_.display_modal("Error", "Frequency already exists");
+					big_display.set(frequency_list[current_index]);		//After showing an error
+				}
+				else {
+					auto result = search_file.append(freq_file_path); //Second: append if it is not there
+					search_file.write_line(frequency_to_add + ",d=ADD FQ");
+				}
+			} else
+			{
+				nav_.display_modal("Error", "Cannot open " + loaded_file_name + ".TXT\nfor appending freq.");
+				big_display.set(frequency_list[current_index]);		//After showing an error
+			}
+		};
+
+		//PRE-CONFIGURATION:
+		field_wait.on_change = [this](int32_t v) {	wait = v;	}; 	field_wait.set_value(5);
+		field_squelch.on_change = [this](int32_t v) {	squelch = v;	}; 	field_squelch.set_value(-10);
+		field_volume.set_value((receiver_model.headphone_volume() - audio::headphone::volume_range().max).decibel() + 99);
+		field_volume.on_change = [this](int32_t v) { this->on_headphone_volume_changed(v);	};
+
+		// LEARN FREQUENCIES
+		std::string search_txt = "SCANNER";
+		frequency_file_load(search_txt);
+	}
+
+	void SearchView::frequency_file_load(std::string file_name, bool stop_all_before) {
+
+		// stop everything running now if required
+		if (stop_all_before) {
+			search_thread->stop();
+			frequency_list.clear(); // clear the existing frequency list (expected behavior)
+			description_list.clear();
+			def_step = step_mode.selected_index_value();		//Use def_step from manual selector
+		}
+
+		if ( load_freqman_file(file_name, database)  ) {
+			loaded_file_name = file_name; // keep loaded filename in memory
+			for(auto& entry : database) {									// READ LINE PER LINE
+				if (frequency_list.size() < MAX_DB_ENTRY) {					//We got space!
+					if (entry.type == RANGE)  {								//RANGE	
+						switch (entry.step) {
+							case AM_US:	def_step = 10000;  	break ;
+							case AM_EUR:def_step = 9000;  	break ;
+							case NFM_1: def_step = 12500;  	break ;
+							case NFM_2: def_step = 6250;	break ;	
+							case FM_1:	def_step = 100000; 	break ;
+							case FM_2:	def_step = 50000; 	break ;
+							case N_1:	def_step = 25000;  	break ;
+							case N_2:	def_step = 250000; 	break ;
+							case AIRBAND:def_step= 8330;  	break ;
+						}
+						frequency_list.push_back(entry.frequency_a);		//Store starting freq and description
+						description_list.push_back("R" + to_string_short_freq(entry.frequency_a)
+								+ ">" + to_string_short_freq(entry.frequency_b)
+								+ " S" + to_string_short_freq(def_step).erase(0,1) //euquiq: lame kludge to reduce spacing in step freq
+								);
+						while (frequency_list.size() < MAX_DB_ENTRY && entry.frequency_a <= entry.frequency_b) { //add the rest of the range
+							entry.frequency_a+=def_step;
+							frequency_list.push_back(entry.frequency_a);
+							description_list.push_back("");				//Token (keep showing the last description)
+						}
+					} else if ( entry.type == SINGLE)  {
+						frequency_list.push_back(entry.frequency_a);
+						description_list.push_back("S: " + entry.description);
+					}
+					show_max();
+				}
+				else
+				{
+					break; //No more space: Stop reading the txt file !
+				}		
+			}
+		} 
+		else 
+		{
+			loaded_file_name = 'SCANNER'; // back to the default frequency file
+			desc_cycle.set(" NO " + file_name + ".TXT FILE ..." );
+		}
+		audio::output::stop();
+		step_mode.set_by_value(def_step); //Impose the default step into the manual step selector
+		start_search_thread();
+	}
+
+	void SearchView::on_statistics_update(const ChannelStatistics& statistics) {
+		if ( !userpause ) 									//Scanning not user-paused
+		{
+			if (timer >= (wait * 10) ) 
+			{
+				timer = 0;
+				search_resume();
+			} 
+			else if (!timer) 
+			{
+				if (statistics.max_db > squelch ) {  		//There is something on the air...(statistics.max_db > -squelch) 
+					if (search_thread->is_freq_lock() >= MAX_FREQ_LOCK) { //checking time reached
+						search_pause();
+						timer++;	
+					} else {
+						search_thread->set_freq_lock( search_thread->is_freq_lock() + 1 ); //in lock period, still analyzing the signal
+					}
+				} else {									//There is NOTHING on the air
+					if (search_thread->is_freq_lock() > 0) {	//But are we already in freq_lock ?
+						big_display.set_style(&style_grey);	//Back to grey color
+						search_thread->set_freq_lock(0); 		//Reset the search lock, since there is no signal
+					}				
+				}
+			} 
+			else 	//Ongoing wait time
+			{
+				timer++;
+			}
+		}
+	}
+
+	void SearchView::search_pause() {
+		if (search_thread->is_searching()) {
+			search_thread->set_freq_lock(0); 		//Reset the search lock (because user paused, or MAX_FREQ_LOCK reached) for next freq search	
+			search_thread->set_searching(false); // WE STOP SCANNING
+			audio::output::start();
+		}
+	}
+
+	void SearchView::search_resume() {
+		audio::output::stop();
+		big_display.set_style(&style_grey);		//Back to grey color
+		if (!search_thread->is_searching())
+			search_thread->set_searching(true);   // RESUME!
+	}
+
+	void SearchView::user_resume() {
+		timer = wait * 10;					//Will trigger a search_resume() on_statistics_update, also advancing to next freq.
+		button_pause.set_text("PAUSE");		//Show button for pause
+		userpause=false;					//Resume searching
+	}
+
+	void SearchView::on_headphone_volume_changed(int32_t v) {
+		const auto new_volume = volume_t::decibel(v - 99) + audio::headphone::volume_range().max;
+		receiver_model.set_headphone_volume(new_volume);
+	}
+
+	size_t SearchView::change_mode(uint8_t new_mod) { //Before this, do a search_thread->stop();  After this do a start_search_thread()
+		using option_t = std::pair<std::string, int32_t>;
+		using options_t = std::vector<option_t>;
+		options_t bw;
+		field_bw.on_change = [this](size_t n, OptionsField::value_t) {	};
+
+		switch (new_mod) {
+			case SEARCH_NFM:	//bw 16k (2) default
+				bw.emplace_back("8k5", 0);
+				bw.emplace_back("11k", 0);
+				bw.emplace_back("16k", 0);			
+				field_bw.set_options(bw);
+
+				baseband::run_image(portapack::spi_flash::image_tag_nfm_audio);
+				receiver_model.set_modulation(ReceiverModel::Mode::NarrowbandFMAudio);
+				field_bw.set_selected_index(2);
+				receiver_model.set_nbfm_configuration(field_bw.selected_index());
+				field_bw.on_change = [this](size_t n, OptionsField::value_t) { 	receiver_model.set_nbfm_configuration(n); };
+				receiver_model.set_sampling_rate(3072000);	receiver_model.set_baseband_bandwidth(1750000);	
+				break;
+			case SEARCH_AM:
+				bw.emplace_back("DSB", 0);
+				bw.emplace_back("USB", 0);
+				bw.emplace_back("LSB", 0);
+				bw.emplace_back("CW ", 0);
+				field_bw.set_options(bw);
+
+				baseband::run_image(portapack::spi_flash::image_tag_am_audio);
+				receiver_model.set_modulation(ReceiverModel::Mode::AMAudio);
+				field_bw.set_selected_index(0);
+				receiver_model.set_am_configuration(field_bw.selected_index());
+				field_bw.on_change = [this](size_t n, OptionsField::value_t) { receiver_model.set_am_configuration(n);	};		
+				receiver_model.set_sampling_rate(2000000);receiver_model.set_baseband_bandwidth(2000000); 
+				break;
+			case SEARCH_WFM:
+				bw.emplace_back("16k", 0);
+				field_bw.set_options(bw);
+
+				baseband::run_image(portapack::spi_flash::image_tag_wfm_audio);
+				receiver_model.set_modulation(ReceiverModel::Mode::WidebandFMAudio);
+				field_bw.set_selected_index(0);
+				receiver_model.set_wfm_configuration(field_bw.selected_index());
+				field_bw.on_change = [this](size_t n, OptionsField::value_t) {	receiver_model.set_wfm_configuration(n); };
+				receiver_model.set_sampling_rate(3072000);	receiver_model.set_baseband_bandwidth(2000000);	
+				break;
+		}
+
+		return search_mod_step[new_mod];
+	}
+
+	void SearchView::start_search_thread() {
+		receiver_model.enable(); 
+		receiver_model.set_squelch_level(0);
+		search_thread = std::make_unique<SearchThread>(frequency_list);
+	}
+
+} /* namespace ui */

--- a/firmware/application/apps/ui_search.cpp
+++ b/firmware/application/apps/ui_search.cpp
@@ -22,6 +22,7 @@
 
 #include "ui_search.hpp"
 #include "ui_fileman.hpp"
+#include "ui_searchsetup.hpp"
 
 using namespace std;
 using namespace portapack;
@@ -296,7 +297,8 @@ namespace ui {
 				&button_audio_app,
 				&button_mic_app,
 				&button_add,
-				&button_remove
+				&button_remove,
+				&button_search_setup
 
 		});
 
@@ -491,7 +493,7 @@ namespace ui {
 				big_display.set(frequency_list[current_index]);		//After showing an error
 			}
 		};
-
+		
 		//PRE-CONFIGURATION:
 		field_wait.on_change = [this](int32_t v) {	wait = v;	}; 	field_wait.set_value(5);
 		field_squelch.on_change = [this](int32_t v) {	squelch = v;	}; 	field_squelch.set_value(-10);
@@ -501,6 +503,10 @@ namespace ui {
 		// LEARN FREQUENCIES
 		std::string search_txt = "SCANNER";
 		frequency_file_load(search_txt);
+
+		button_search_setup.on_select = [&nav](Button&) {
+			nav.push<SearchSetupView>(); 
+		};
 	}
 
 	void SearchView::frequency_file_load(std::string file_name, bool stop_all_before) {

--- a/firmware/application/apps/ui_search.hpp
+++ b/firmware/application/apps/ui_search.hpp
@@ -150,6 +150,9 @@ private:
 	bool userpause { false };
 	bool manual_search { false }; 
 	bool settings_loaded { false };
+	std::string input_file ;
+	std::string output_file ;
+	bool autosave = { false };
 	
 	Labels labels {
 		{ { 0 * 8, 0 * 16 }, "LNA:   VGA:   AMP:  VOL:", Color::light_grey() },
@@ -295,7 +298,7 @@ private:
 		"DEL FQ"
 	};
 	Button button_search_setup {
-		{ 21 * 8, 3 * 16 - 8, 8 * 8, 22 },
+		{ 20 * 8, 3 * 16 - 8, 9 * 8, 22 },
 		"SETTINGS"
 	};
 	

--- a/firmware/application/apps/ui_search.hpp
+++ b/firmware/application/apps/ui_search.hpp
@@ -297,6 +297,11 @@ private:
 		{ 168, (35 * 8) - 4, 72, 28 },
 		"DEL FQ"
 	};
+	Button button_search_setup {
+		{ 12 * 8, 1 * 16, 96, 24 },
+		"settings"
+	};
+
 	
 	std::unique_ptr<SearchThread> search_thread { };
 	

--- a/firmware/application/apps/ui_search.hpp
+++ b/firmware/application/apps/ui_search.hpp
@@ -77,7 +77,7 @@ private:
 	std::vector<rf::Frequency> frequency_list_ { };
 	Thread* thread { nullptr };
 	
-	bool _searching { true };
+	bool _searching { false };
 	bool _fwd { true };
 	uint32_t _freq_lock { 0 };
 	uint32_t _freq_del { 0 };

--- a/firmware/application/apps/ui_search.hpp
+++ b/firmware/application/apps/ui_search.hpp
@@ -288,10 +288,6 @@ private:
 		"ADD FQ"
 	};
 
-	Button button_load {
-		{ 24 * 8, 3 * 16 - 8, 6 * 8, 22 },
-		"Load"
-	};
 
 	Button button_remove {
 		{ 168, (35 * 8) - 4, 72, 28 },
@@ -299,8 +295,13 @@ private:
 	};
 	Button button_search_setup {
 		{ 12 * 8, 1 * 16, 96, 24 },
-		"settings"
+		"Settings"
 	};
+	Button button_load {
+		{ 24 * 8, 3 * 16 - 8, 6 * 8, 22 },
+		"Load"
+	};
+
 
 	
 	std::unique_ptr<SearchThread> search_thread { };

--- a/firmware/application/apps/ui_search.hpp
+++ b/firmware/application/apps/ui_search.hpp
@@ -118,7 +118,7 @@ public:
 		.foreground = Color::red(),
 	};
 
-	std::string title() const override { return "SEARCH"; };
+	std::string title() const override { return "Search"; };
 	std::vector<rf::Frequency> frequency_list{ };
 	std::vector<string> description_list { };
 

--- a/firmware/application/apps/ui_search.hpp
+++ b/firmware/application/apps/ui_search.hpp
@@ -1,0 +1,319 @@
+/*
+ * Copyright (C) 2015 Jared Boone, ShareBrained Technology, Inc.
+ * Copyright (C) 2018 Furrtek
+ *
+ * This file is part of PortaPack.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#include "ui.hpp"
+#include "receiver_model.hpp"
+#include "ui_receiver.hpp"
+#include "ui_font_fixed_8x16.hpp"
+#include "freqman.hpp"
+#include "analog_audio_app.hpp"
+#include "audio.hpp"
+#include "ui_mictx.hpp"
+#include "portapack_persistent_memory.hpp"
+#include "baseband_api.hpp"
+#include "string_format.hpp"
+#include "file.hpp"
+
+
+#define MAX_DB_ENTRY 500
+#define MAX_FREQ_LOCK 10 		//50ms cycles search locks into freq when signal detected, to verify signal is not spureous
+
+/* indexes used in frequency_list in case of a manual search */
+#define MS_FLAG_IDX  0       // position of flag in list
+#define MS_FLAG_VAL  -666    // value of flag to tell it's a manual search ordered frequency_list
+#define MS_MIN_FREQ_IDX  1   // position of minimum frequency
+#define MS_MAX_FREQ_IDX  2   // position of maximum frequency
+#define MS_FREQ_STEP_IDX 3   // position or step 
+#define MS_CUR_FREQ_IDX  4   // position of currently used frequency
+
+namespace ui {
+
+enum search_modulation_type { SEARCH_AM = 0,SEARCH_WFM,SEARCH_NFM };
+string const search_mod_name[3] = {"AM", "WFM", "NFM"};
+size_t const search_mod_step[3] = {9000, 100000, 12500 };
+
+class SearchThread {
+public:
+	SearchThread(std::vector<rf::Frequency> frequency_list);
+	~SearchThread();
+
+	void set_searching(const bool v);
+	bool is_searching();
+
+	void set_freq_lock(const uint32_t v);
+	uint32_t is_freq_lock();
+
+	void set_freq_del(const uint32_t v);
+
+	void change_searching_direction();
+
+	void stop();
+
+	SearchThread(const SearchThread&) = delete;
+	SearchThread(SearchThread&&) = delete;
+	SearchThread& operator=(const SearchThread&) = delete;
+	SearchThread& operator=(SearchThread&&) = delete;
+
+private:
+	std::vector<rf::Frequency> frequency_list_ { };
+	Thread* thread { nullptr };
+	
+	bool _searching { true };
+	bool _fwd { true };
+	uint32_t _freq_lock { 0 };
+	uint32_t _freq_del { 0 };
+	static msg_t static_fn(void* arg);
+	void run();
+};
+
+class SearchView : public View {
+public:
+	SearchView(NavigationView& nav);
+	~SearchView();
+	
+	void focus() override;
+
+	void big_display_freq(rf::Frequency f);
+
+	const Style style_grey {		// searching
+		.font = font::fixed_8x16,
+		.background = Color::black(),
+		.foreground = Color::grey(),
+	};
+	
+	const Style style_yellow {		//Found signal
+		.font = font::fixed_8x16,
+		.background = Color::black(),
+		.foreground = Color::dark_yellow(),
+	};
+
+	const Style style_green {		//Found signal
+		.font = font::fixed_8x16,
+		.background = Color::black(),
+		.foreground = Color::green(),
+	};
+
+	const Style style_red {		//erasing freq
+		.font = font::fixed_8x16,
+		.background = Color::black(),
+		.foreground = Color::red(),
+	};
+
+	std::string title() const override { return "SCANNER"; };
+	std::vector<rf::Frequency> frequency_list{ };
+	std::vector<string> description_list { };
+
+//void set_parent_rect(const Rect new_parent_rect) override;
+
+private:
+	NavigationView& nav_;
+
+	void start_search_thread();
+	size_t change_mode(uint8_t mod_type);
+	void show_max();
+	void search_pause();
+	void search_resume();
+	void user_resume();
+	void frequency_file_load(std::string file_name, bool stop_all_before = false);
+
+	void on_statistics_update(const ChannelStatistics& statistics);
+	void on_headphone_volume_changed(int32_t v);
+	void handle_retune( long i );
+
+	jammer::jammer_range_t frequency_range { false, 0, 0 };  //perfect for manual search task too...
+	int32_t squelch { 0 };
+	uint32_t timer { 0 };
+	uint32_t wait { 0 };
+	size_t	def_step { 0 };
+	freqman_db database { };
+	std::string loaded_file_name;
+	uint32_t current_index { 0 };
+	bool userpause { false };
+	bool manual_search { false }; 
+	
+	Labels labels {
+		{ { 0 * 8, 0 * 16 }, "LNA:   VGA:   AMP:  VOL:", Color::light_grey() },
+		{ { 0 * 8, 1* 16 }, "BW:    SQUELCH:   db WAIT:", Color::light_grey() },
+		{ { 3 * 8, 10 * 16 }, "START        END     MANUAL", Color::light_grey() },
+		{ { 0 * 8, (26 * 8) + 4 }, "MODE:", Color::light_grey() },
+		{ { 11 * 8, (26 * 8) + 4 }, "STEP:", Color::light_grey() },
+	};
+	
+	LNAGainField field_lna {
+		{ 4 * 8, 0 * 16 }
+	};
+
+	VGAGainField field_vga {
+		{ 11 * 8, 0 * 16 }
+	};
+	
+	RFAmpField field_rf_amp {
+		{ 18 * 8, 0 * 16 }
+	};
+	
+	NumberField field_volume {
+		{ 24 * 8, 0 * 16 },
+		2,
+		{ 0, 99 },
+		1,
+		' ',
+	};
+
+	OptionsField field_bw {
+		{ 3 * 8, 1 * 16 },
+		4,
+		{ }
+	};		
+
+	NumberField field_squelch {
+		{ 15 * 8, 1 * 16 },
+		3,
+ 		{ -90, 20 },
+		1,
+		' ',
+	};
+
+	NumberField field_wait {
+		{ 26 * 8, 1 * 16 },
+		2,
+		{ 0, 99 },
+		1,
+		' ',
+	};
+
+	RSSI rssi {
+		{ 0 * 16, 2 * 16, 15 * 16, 8 },
+	}; 
+
+	Text text_cycle {
+		{ 0, 3 * 16, 3 * 8, 16 },  
+	};
+
+	Text text_max {
+		{ 4 * 8, 3 * 16, 18 * 8, 16 },  
+	};
+	
+	Text desc_cycle {
+		{0, 4 * 16, 240, 16 },	   
+	};
+
+	BigFrequency big_display {		//Show frequency in glamour
+		{ 4, 6 * 16, 28 * 8, 52 },
+		0
+	};
+
+	Button button_manual_start {
+		{ 0 * 8, 11 * 16, 11 * 8, 28 },
+		""
+	};
+
+	Button button_manual_end {
+		{ 12 * 8, 11 * 16, 11 * 8, 28 },
+		""
+	};
+
+	Button button_manual_search {
+		{ 24 * 8, 11 * 16, 6 * 8, 28 },
+		"SEARCH"
+	};
+
+	OptionsField field_mode {
+		{ 5 * 8, (26 * 8) + 4 },
+		6,
+		{
+			{ " AM  ", 0 },
+			{ " WFM ", 1 },
+			{ " NFM ", 2 },
+		}
+	};
+
+	OptionsField step_mode {
+		{ 17 * 8, (26 * 8) + 4 },
+		12,
+		{
+			{ "5Khz (SA AM)", 	5000 },
+			{ "9Khz (EU AM)", 	9000 },
+			{ "10Khz(US AM)", 	10000 },
+			{ "50Khz (FM1)", 	50000 },
+			{ "100Khz(FM2)", 	100000 },
+			{ "6.25khz(NFM)",	6250 },
+			{ "12.5khz(NFM)",	12500 },
+			{ "25khz (N1)",		25000 },
+			{ "250khz (N2)",	250000 },
+			{ "8.33khz(AIR)",	8330 }
+		}
+	};
+
+	Button button_pause {
+		{ 0, (15 * 16) - 4, 72, 28 },
+		"PAUSE"
+	};
+
+	Button button_dir {
+		{ 0,  (35 * 8) - 4, 72, 28 },
+		"FW><RV"
+	};
+
+	Button button_audio_app {
+		{ 84, (15 * 16) - 4, 72, 28 },
+		"AUDIO"
+	};
+
+	Button button_mic_app {
+		{ 84,  (35 * 8) - 4, 72, 28 },
+		"MIC TX"
+	};
+
+	Button button_add {
+		{ 168, (15 * 16) - 4, 72, 28 },
+		"ADD FQ"
+	};
+
+	Button button_load {
+		{ 24 * 8, 3 * 16 - 8, 6 * 8, 22 },
+		"Load"
+	};
+
+	Button button_remove {
+		{ 168, (35 * 8) - 4, 72, 28 },
+		"DEL FQ"
+	};
+	
+	std::unique_ptr<SearchThread> search_thread { };
+	
+	MessageHandlerRegistration message_handler_retune {
+		Message::ID::Retune,
+		[this](const Message* const p) {
+			const auto message = *reinterpret_cast<const RetuneMessage*>(p);
+			this->handle_retune(message.range);
+		}
+	};
+	
+	MessageHandlerRegistration message_handler_stats {
+		Message::ID::ChannelStatistics,
+		[this](const Message* const p) {
+			this->on_statistics_update(static_cast<const ChannelStatisticsMessage*>(p)->statistics);
+		}
+	};
+};
+
+} /* namespace ui */

--- a/firmware/application/apps/ui_search.hpp
+++ b/firmware/application/apps/ui_search.hpp
@@ -118,7 +118,7 @@ public:
 		.foreground = Color::red(),
 	};
 
-	std::string title() const override { return "SCANNER"; };
+	std::string title() const override { return "SEARCH"; };
 	std::vector<rf::Frequency> frequency_list{ };
 	std::vector<string> description_list { };
 

--- a/firmware/application/apps/ui_search.hpp
+++ b/firmware/application/apps/ui_search.hpp
@@ -149,6 +149,7 @@ private:
 	uint32_t current_index { 0 };
 	bool userpause { false };
 	bool manual_search { false }; 
+	bool settings_loaded { false };
 	
 	Labels labels {
 		{ { 0 * 8, 0 * 16 }, "LNA:   VGA:   AMP:  VOL:", Color::light_grey() },
@@ -294,13 +295,16 @@ private:
 		"DEL FQ"
 	};
 	Button button_search_setup {
-		{ 12 * 8, 1 * 16, 96, 24 },
-		"Settings"
+		{ 21 * 8, 3 * 16 - 8, 8 * 8, 22 },
+		"SETTINGS"
 	};
+	
+	/*
 	Button button_load {
 		{ 24 * 8, 3 * 16 - 8, 6 * 8, 22 },
 		"Load"
 	};
+	*/
 
 
 	
@@ -320,6 +324,7 @@ private:
 			this->on_statistics_update(static_cast<const ChannelStatisticsMessage*>(p)->statistics);
 		}
 	};
+
 };
 
 } /* namespace ui */

--- a/firmware/application/apps/ui_searchsetup.cpp
+++ b/firmware/application/apps/ui_searchsetup.cpp
@@ -1,0 +1,99 @@
+/*
+ * Copyright (C) 2015 Jared Boone, ShareBrained Technology, Inc.
+ * Copyright (C) 2016 Furrtek
+ *
+ * This file is part of PortaPack.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#include "ui_searchsetup.hpp"
+
+#include "portapack.hpp"
+#include "portapack_persistent_memory.hpp"
+
+using namespace portapack;
+
+namespace ui {
+
+void SearchSetupView::focus() {
+	field_baudrate.focus();
+}
+
+SearchSetupView::SearchSetupView(
+	NavigationView& nav
+)
+{
+	using option_t = std::pair<std::string, int32_t>;
+	using options_t = std::vector<option_t>;
+	options_t search_options;
+	
+	add_children({
+		&labels,
+		&field_baudrate,
+		&field_mark,
+		&field_space,
+		&field_repeat,
+		&options_search,
+		&button_set_search,
+		&sym_format,
+		&button_save
+	});
+	
+	options_search.set_options(search_options);
+	options_search.set_selected_index(0);
+	
+	sym_format.set_symbol_list(0, "6789");		// Data bits
+	sym_format.set_symbol_list(1, "NEo");		// Parity
+	sym_format.set_symbol_list(2, "012");		// Stop bits
+	sym_format.set_symbol_list(3, "ML");		// MSB/LSB first
+	
+	sym_format.set_sym(0, persistent_memory::serial_format().data_bits - 6);
+	sym_format.set_sym(1, persistent_memory::serial_format().parity);
+	sym_format.set_sym(2, persistent_memory::serial_format().stop_bits);
+	sym_format.set_sym(3, persistent_memory::serial_format().bit_order);
+	
+	field_mark.set_value(persistent_memory::afsk_mark_freq());
+	field_space.set_value(persistent_memory::afsk_space_freq());
+	field_repeat.set_value(persistent_memory::search_repeat());
+	
+	field_baudrate.set_value(persistent_memory::search_baudrate());
+	
+	button_set_search.on_select = [this, &nav](Button&) {
+		size_t search_def_index = options_search.selected_index();
+	};
+
+	button_save.on_select = [this,&nav](Button&) {
+		serial_format_t serial_format;
+		
+		persistent_memory::set_afsk_mark(field_mark.value());
+		persistent_memory::set_afsk_space(field_space.value());
+		
+		persistent_memory::set_search_baudrate(field_baudrate.value());
+		persistent_memory::set_search_repeat(field_repeat.value());
+		
+		serial_format.data_bits = sym_format.get_sym(0) + 6;
+		serial_format.parity = (parity_enum)sym_format.get_sym(1);
+		serial_format.stop_bits = sym_format.get_sym(2);
+		serial_format.bit_order = (order_enum)sym_format.get_sym(3);
+		
+		persistent_memory::set_serial_format(serial_format);
+		
+		nav.pop();
+	};
+}
+
+} /* namespace ui */

--- a/firmware/application/apps/ui_searchsetup.cpp
+++ b/firmware/application/apps/ui_searchsetup.cpp
@@ -30,68 +30,39 @@ using namespace portapack;
 namespace ui {
 
 void SearchSetupView::focus() {
-	field_baudrate.focus();
 }
 
 SearchSetupView::SearchSetupView(
 	NavigationView& nav
 )
 {
-	using option_t = std::pair<std::string, int32_t>;
-	using options_t = std::vector<option_t>;
-	options_t search_options;
-	
 	add_children({
 		&labels,
-		&field_baudrate,
-		&field_mark,
-		&field_space,
-		&field_repeat,
-		&options_search,
-		&button_set_search,
-		&sym_format,
+		&button_load_freqs,
+		&text_loaded_file,
+		&button_save_freqs,
+		&text_save_to_file,
+		&checkbox_autosave_freqs,
+		&checkbox_autorotate_file,
 		&button_save
 	});
-	
-	options_search.set_options(search_options);
-	options_search.set_selected_index(0);
-	
-	sym_format.set_symbol_list(0, "6789");		// Data bits
-	sym_format.set_symbol_list(1, "NEo");		// Parity
-	sym_format.set_symbol_list(2, "012");		// Stop bits
-	sym_format.set_symbol_list(3, "ML");		// MSB/LSB first
-	
-	sym_format.set_sym(0, persistent_memory::serial_format().data_bits - 6);
-	sym_format.set_sym(1, persistent_memory::serial_format().parity);
-	sym_format.set_sym(2, persistent_memory::serial_format().stop_bits);
-	sym_format.set_sym(3, persistent_memory::serial_format().bit_order);
-	
-	field_mark.set_value(persistent_memory::afsk_mark_freq());
-	field_space.set_value(persistent_memory::afsk_space_freq());
-	field_repeat.set_value(persistent_memory::search_repeat());
-	
-	field_baudrate.set_value(persistent_memory::search_baudrate());
-	
-	button_set_search.on_select = [this, &nav](Button&) {
-		size_t search_def_index = options_search.selected_index();
-	};
 
+	std::string input_freq_file { "SEARCH.TXT" };
+	std::string output_freq_file { "SEARCHFINDS.TXT" };
+	
+	bool autosave_freqs = persistent_memory::search_autosave_freqs();
+	bool autorotate_file = persistent_memory::search_autorotate_file();
+
+	uint32_t nb_max_freqs = 500 ; /* hard coded, experience will show if max value is too high */
+	uint32_t nb_freqs     = persistent_memory::search_nb_freqs();
+	
+//	checkbox_autosave_freqs =  persistent_memory::search_autosave_freqs();
+//	checkbox_autorotate_file = persistent_memory::search_autorotate_file();
+	
 	button_save.on_select = [this,&nav](Button&) {
-		serial_format_t serial_format;
-		
-		persistent_memory::set_afsk_mark(field_mark.value());
-		persistent_memory::set_afsk_space(field_space.value());
-		
-		persistent_memory::set_search_baudrate(field_baudrate.value());
-		persistent_memory::set_search_repeat(field_repeat.value());
-		
-		serial_format.data_bits = sym_format.get_sym(0) + 6;
-		serial_format.parity = (parity_enum)sym_format.get_sym(1);
-		serial_format.stop_bits = sym_format.get_sym(2);
-		serial_format.bit_order = (order_enum)sym_format.get_sym(3);
-		
-		persistent_memory::set_serial_format(serial_format);
-		
+		persistent_memory::set_search_autosave_freqs(checkbox_autosave_freqs.value());
+		persistent_memory::set_search_autorotate_file(checkbox_autorotate_file.value());
+		//persistent_memory::set_search_nb_freqs(  );
 		nav.pop();
 	};
 }

--- a/firmware/application/apps/ui_searchsetup.cpp
+++ b/firmware/application/apps/ui_searchsetup.cpp
@@ -27,10 +27,84 @@
 #include "portapack.hpp"
 #include "portapack_persistent_memory.hpp"
 
+#define SETTINGS_NAME_MAX_LEN
+
 using namespace std;
 using namespace portapack;
 
 namespace ui {
+
+	bool SearchSetupView::SearchSetupLoadStrings( std::string source, std::string &input_file , std::string &output_file )
+	{
+		File settings_file;
+		size_t length, n = 0, file_position = 0;
+		char * pos;
+		char * line_start;
+		char * line_end;
+		char file_data[257];
+
+		uint32_t it = 0 ;
+		uint32_t nb_params = 2 ;
+		std::string params[ 2 ];
+
+		auto result = settings_file.open( source );
+		if( !result.is_valid() )
+		{
+			while( it < nb_params )
+			{
+				// Read a 256 bytes block from file
+				settings_file.seek(file_position);
+				memset(file_data, 0, 257);
+				auto read_size = settings_file.read(file_data, 256);
+				if (read_size.is_error())
+					break ;
+				file_position += 256;
+				// Reset line_start to beginning of buffer
+				line_start = file_data;
+				pos=line_start;
+				while ((line_end = strstr(line_start, "\x0A"))) {
+
+					length = std::min(strcspn(pos, ",\x0A"), (size_t)256 );
+					params[ it ]  = string( pos , length );
+					it ++ ;	
+					line_start = line_end + 1;
+					pos=line_start ;
+					if (line_start - file_data >= 256) 
+						break;
+					if( it >= nb_params )
+						break ;
+				}			
+				if (read_size.value() != 256)
+					break;	// End of file
+
+				// Restart at beginning of last incomplete line
+				file_position -= (file_data + 256 - line_start);
+			}
+		}
+		if( it < nb_params )
+		{
+			/* bad number of params, setting default */
+			input_file  = "FREQMAN/SEARCH.TXT" ;
+			output_file = "FREQMAN/SEARCHRESULT" ;	
+			return false ;
+		}
+		input_file = params[ 0 ];
+		output_file= params[ 1 ];
+		return true ;
+	}
+
+	bool SearchSetupView::SearchSetupSaveStrings( std::string dest, std::string input_file , std::string output_file )
+	{
+		File settings_file;
+	
+		auto result = settings_file.create( dest );
+		if( result.is_valid() )
+			return false ;
+		settings_file.write_line( input_file );
+		settings_file.write_line( output_file );
+		return true ;
+	}
+
 
 	void SearchSetupView::focus() {
 		button_load_freqs.focus();
@@ -56,17 +130,21 @@ namespace ui {
 		checkbox_autosave_freqs.set_value( persistent_memory::search_autosave_freqs() );
 		checkbox_autostart_search.set_value( persistent_memory::search_autostart_search() );
 		checkbox_powersave.set_value( persistent_memory::search_powersave() );
+		checkbox_filemode.set_value( persistent_memory::search_filemode() );
 
-		text_input_file.set( "/FREQMAN/SEARCH.TXT" );	
-		text_output_file.set( "/FREQMAN/SEARCHRESULTS.TXT" );	
+		SearchSetupView::SearchSetupLoadStrings( "SEARCH/SEARCH.CFG" , input_file , output_file );
+
+		text_input_file.set( input_file );	
+		text_output_file.set( output_file );	
 
 		button_load_freqs.on_select = [this, &nav](Button&) {
 			auto open_view = nav.push<FileLoadView>(".TXT");
 			open_view->on_changed = [this](std::filesystem::path new_file_path) {
-				std::string dir_filter = "/FREQMAN/";
+				std::string dir_filter = "FREQMAN/";
 				std::string str_file_path = new_file_path.string();
 				if (str_file_path.find(dir_filter) != string::npos) { // assert file from the FREQMAN folder
-					text_input_file.set( str_file_path );
+					input_file = str_file_path ;
+					text_input_file.set( input_file );
 				} else {
 					nav_.display_modal("LOAD ERROR", "A valid file from\nFREQMAN directory is\nrequired.");
 				}
@@ -79,7 +157,8 @@ namespace ui {
 				std::string dir_filter = "FREQMAN/";
 				std::string str_file_path = new_file_path.string();
 				if (str_file_path.find(dir_filter) != string::npos) { // assert file from the FREQMAN folder
-					text_output_file.set( str_file_path );
+					output_file = str_file_path ;
+					text_output_file.set( output_file );
 				} else {
 					nav_.display_modal("LOAD ERROR", "A valid file from\nFREQMAN directory is\nrequired.");
 				}
@@ -87,12 +166,11 @@ namespace ui {
 		};
 
 		button_save.on_select = [this,&nav](Button&) {
-
-			/* add save input_freq_file */
-			/* add save output_freq_file */
 			persistent_memory::set_search_autosave_freqs(checkbox_autosave_freqs.value());
 			persistent_memory::set_search_autostart_search(checkbox_autostart_search.value());
 			persistent_memory::set_search_powersave(checkbox_powersave.value()); 
+			persistent_memory::set_search_filemode(checkbox_filemode.value()); 
+			SearchSetupView::SearchSetupSaveStrings( "SEARCH/SEARCH.CFG" , input_file , output_file );
 			nav.pop();
 		};
 	}

--- a/firmware/application/apps/ui_searchsetup.cpp
+++ b/firmware/application/apps/ui_searchsetup.cpp
@@ -42,23 +42,23 @@ namespace ui {
 
 	{
 		add_children({
-				&labels,
 				&button_load_freqs,
 				&text_input_file,
 				&button_save_freqs,
 				&text_output_file,
 				&checkbox_autosave_freqs,
-				&checkbox_autorotate_file,
 				&checkbox_autostart_search,
+				&checkbox_powersave,
+				&checkbox_filemode,
 				&button_save
 				});
 
 		checkbox_autosave_freqs.set_value( persistent_memory::search_autosave_freqs() );
-		checkbox_autorotate_file.set_value( persistent_memory::search_autorotate_file() );
 		checkbox_autostart_search.set_value( persistent_memory::search_autostart_search() );
+		checkbox_powersave.set_value( persistent_memory::search_powersave() );
 
 		text_input_file.set( "/FREQMAN/SEARCH.TXT" );	
-		text_output_file.set( "/FREQMAN/SEARCHFINDS.TXT" );	
+		text_output_file.set( "/FREQMAN/SEARCHRESULTS.TXT" );	
 
 		button_load_freqs.on_select = [this, &nav](Button&) {
 			auto open_view = nav.push<FileLoadView>(".TXT");
@@ -91,9 +91,8 @@ namespace ui {
 			/* add save input_freq_file */
 			/* add save output_freq_file */
 			persistent_memory::set_search_autosave_freqs(checkbox_autosave_freqs.value());
-			persistent_memory::set_search_autorotate_file(checkbox_autorotate_file.value());
-			persistent_memory::set_search_autostart_search(checkbox_autostart_search.value()); 
-			persistent_memory::set_search_nb_freqs( 500 );
+			persistent_memory::set_search_autostart_search(checkbox_autostart_search.value());
+			persistent_memory::set_search_powersave(checkbox_powersave.value()); 
 			nav.pop();
 		};
 	}

--- a/firmware/application/apps/ui_searchsetup.cpp
+++ b/firmware/application/apps/ui_searchsetup.cpp
@@ -34,7 +34,7 @@ using namespace portapack;
 
 namespace ui {
 
-	bool SearchSetupView::SearchSetupLoadStrings( std::string source, std::string &input_file , std::string &output_file )
+	bool SearchSetupLoadStrings( std::string source, std::string &input_file , std::string &output_file )
 	{
 		File settings_file;
 		size_t length, n = 0, file_position = 0;
@@ -63,8 +63,7 @@ namespace ui {
 				line_start = file_data;
 				pos=line_start;
 				while ((line_end = strstr(line_start, "\x0A"))) {
-
-					length = std::min(strcspn(pos, ",\x0A"), (size_t)256 );
+					length = line_end - line_start - 1 ;
 					params[ it ]  = string( pos , length );
 					it ++ ;	
 					line_start = line_end + 1;
@@ -84,8 +83,8 @@ namespace ui {
 		if( it < nb_params )
 		{
 			/* bad number of params, setting default */
-			input_file  = "FREQMAN/SEARCH.TXT" ;
-			output_file = "FREQMAN/SEARCHRESULT" ;	
+			input_file  = "SEARCH.TXT" ;
+			output_file = "SEARCHRESULT" ;	
 			return false ;
 		}
 		input_file = params[ 0 ];
@@ -93,10 +92,10 @@ namespace ui {
 		return true ;
 	}
 
-	bool SearchSetupView::SearchSetupSaveStrings( std::string dest, std::string input_file , std::string output_file )
+	bool SearchSetupSaveStrings( std::string dest, std::string input_file , std::string output_file )
 	{
 		File settings_file;
-	
+
 		auto result = settings_file.create( dest );
 		if( result.is_valid() )
 			return false ;
@@ -104,7 +103,6 @@ namespace ui {
 		settings_file.write_line( output_file );
 		return true ;
 	}
-
 
 	void SearchSetupView::focus() {
 		button_load_freqs.focus();
@@ -132,7 +130,7 @@ namespace ui {
 		checkbox_powersave.set_value( persistent_memory::search_powersave() );
 		checkbox_filemode.set_value( persistent_memory::search_filemode() );
 
-		SearchSetupView::SearchSetupLoadStrings( "SEARCH/SEARCH.CFG" , input_file , output_file );
+		SearchSetupLoadStrings( "SEARCH/SEARCH.CFG" , input_file , output_file );
 
 		text_input_file.set( input_file );	
 		text_output_file.set( output_file );	
@@ -143,7 +141,8 @@ namespace ui {
 				std::string dir_filter = "FREQMAN/";
 				std::string str_file_path = new_file_path.string();
 				if (str_file_path.find(dir_filter) != string::npos) { // assert file from the FREQMAN folder
-					input_file = str_file_path ;
+					// get the filename without txt extension so we can use load_freqman_file fcn
+					input_file = new_file_path.stem().string();
 					text_input_file.set( input_file );
 				} else {
 					nav_.display_modal("LOAD ERROR", "A valid file from\nFREQMAN directory is\nrequired.");
@@ -157,7 +156,7 @@ namespace ui {
 				std::string dir_filter = "FREQMAN/";
 				std::string str_file_path = new_file_path.string();
 				if (str_file_path.find(dir_filter) != string::npos) { // assert file from the FREQMAN folder
-					output_file = str_file_path ;
+					output_file = new_file_path.stem().string();
 					text_output_file.set( output_file );
 				} else {
 					nav_.display_modal("LOAD ERROR", "A valid file from\nFREQMAN directory is\nrequired.");
@@ -170,7 +169,7 @@ namespace ui {
 			persistent_memory::set_search_autostart_search(checkbox_autostart_search.value());
 			persistent_memory::set_search_powersave(checkbox_powersave.value()); 
 			persistent_memory::set_search_filemode(checkbox_filemode.value()); 
-			SearchSetupView::SearchSetupSaveStrings( "SEARCH/SEARCH.CFG" , input_file , output_file );
+			SearchSetupSaveStrings( "SEARCH/SEARCH.CFG" , input_file , output_file );
 			nav.pop();
 		};
 	}

--- a/firmware/application/apps/ui_searchsetup.hpp
+++ b/firmware/application/apps/ui_searchsetup.hpp
@@ -1,0 +1,109 @@
+/*
+ * Copyright (C) 2014 Jared Boone, ShareBrained Technology, Inc.
+ * Copyright (C) 2016 Furrtek
+ *
+ * This file is part of PortaPack.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#include "serializer.hpp"
+
+#include "ui.hpp"
+#include "ui_widget.hpp"
+#include "ui_navigation.hpp"
+
+namespace ui {
+
+class SearchSetupView : public View {
+public:
+	SearchSetupView(NavigationView& nav);
+	
+	void focus() override;
+	
+	std::string title() const override { return "Search setup"; };
+
+private:
+	void update_freq(rf::Frequency f);
+	
+	Labels labels {
+		{ { 2 * 8, 11 * 8 }, "Baudrate:", Color::light_grey() },
+		{ { 2 * 8, 13 * 8 }, "Mark:      Hz", Color::light_grey() },
+		{ { 2 * 8, 15 * 8 }, "Space:     Hz", Color::light_grey() },
+		{ { 140, 15 * 8 }, "Repeat:", Color::light_grey() },
+		{ { 1 * 8, 6 * 8 }, "Search preset:", Color::light_grey() },
+		{ { 2 * 8, 22 * 8 }, "Serial format:", Color::light_grey() }
+	};
+
+	NumberField field_baudrate {
+		{ 11 * 8, 11 * 8 },
+		5,
+		{ 50, 9600 },
+		25,
+		' '
+	};
+
+	NumberField field_mark {
+		{ 8 * 8, 13 * 8 },
+		5,
+		{ 100, 15000 },
+		25,
+		' '
+	};
+	
+	NumberField field_space {
+		{ 8 * 8, 15 * 8 },
+		5,
+		{ 100, 15000 },
+		25,
+		' '
+	};
+	
+	NumberField field_repeat {
+		{ 204, 15 * 8 },
+		2,
+		{ 1, 99 },
+		1,
+		' '
+	};
+	
+	OptionsField options_search {
+		{ 15 * 8, 6 * 8 },
+		7,
+		{
+		}
+	};
+	
+	SymField sym_format {
+		{ 16 * 8, 22 * 8 },
+		4,
+		SymField::SYMFIELD_DEF
+	};
+	
+	Button button_set_search {
+		{ 23 * 8, 6 * 8 - 4, 6 * 8, 24 },
+		"SET"
+	};
+	
+	Button button_save {
+		{ 9 * 8, 250, 96, 40 },
+		"Save"
+	};
+
+
+};
+
+} /* namespace ui */

--- a/firmware/application/apps/ui_searchsetup.hpp
+++ b/firmware/application/apps/ui_searchsetup.hpp
@@ -37,13 +37,15 @@ public:
 	std::string title() const override { return "Search setup"; };
 
 private:
+	NavigationView& nav_;
+
 	uint32_t nb_freqs { 250 };
 
 	Button button_load_freqs {
 		{ 1 * 8 , 1 * 16 , 18 * 8 , 22 },
 		"Input freqs File:"
 	};
-	Text text_loaded_file {
+	Text text_input_file {
 		{ 1 * 8 , 8 + 2 * 16, 20 * 8, 22 },  
 		""
 	};
@@ -52,26 +54,33 @@ private:
 		{ 1 * 8 , 4 * 16 , 18 * 8 , 22 },
 		"Save freqs to   :"
 	};
-	Text text_save_to_file {
+	Text text_output_file {
 		{ 1 * 8 , 8 + 5 * 16, 20 * 8, 22 },  
 		""	
 	};
 
 	Labels labels {
-		{ { 1 * 8, 8 * 16 }, "NB Max Freqs/file:"        , Color::light_grey() },
+		{ { 1 * 8, 7 * 16 }, "NB Max Freqs/file:"        , Color::light_grey() },
 	};
 
 	Checkbox checkbox_autosave_freqs {
-		{ 1 * 8, 10 * 16 },
+		{ 1 * 8, 9 * 16 },
 		3,
 		"Auto Save freqs"
 	};
 
 	Checkbox checkbox_autorotate_file {
-		{ 1 * 8, 12 * 16 },
+		{ 1 * 8, 11 * 16 },
 		3,
 		"Auto Rotate file"
 	};
+
+	Checkbox checkbox_autostart_search {
+		{ 1 * 8, 13 * 16 },
+		3,
+		"Auto Start Search"
+	};
+
 
 	Button button_save {
 		{ 9 * 8, 250, 14 * 8 , 40 },

--- a/firmware/application/apps/ui_searchsetup.hpp
+++ b/firmware/application/apps/ui_searchsetup.hpp
@@ -28,13 +28,14 @@
 #include "string_format.hpp"
 
 namespace ui {
+	
+bool SearchSetupLoadStrings( std::string source, std::string &input_file , std::string &output_file );
+bool SearchSetupSaveStrings( std::string dest, const std::string input_file , const std::string output_file );
 
 class SearchSetupView : public View {
 public:
 	SearchSetupView(NavigationView& nav);
 	
-	bool SearchSetupLoadStrings( std::string source, std::string &input_file , std::string &output_file );
-	bool SearchSetupSaveStrings( std::string dest, const std::string input_file , const std::string output_file );
 	
 	void focus() override;
 	
@@ -79,12 +80,12 @@ private:
 	Checkbox checkbox_powersave {
 		{ 1 * 8, 11 * 16 },
 		3,
-		"Slower GUI/more CPU power"
+		"Slower GUI,more CPU power"
 	};
 	Checkbox checkbox_filemode {
 		{ 1 * 8, 13 * 16 },
 		3,
-		"check:append,else overwrite"
+		"On:append, Off:overwrite"
 	};
 
 	Button button_save {

--- a/firmware/application/apps/ui_searchsetup.hpp
+++ b/firmware/application/apps/ui_searchsetup.hpp
@@ -37,73 +37,46 @@ public:
 	std::string title() const override { return "Search setup"; };
 
 private:
-	void update_freq(rf::Frequency f);
-	
+	uint32_t nb_freqs { 250 };
+
+	Button button_load_freqs {
+		{ 1 * 8 , 1 * 16 , 18 * 8 , 22 },
+		"Input freqs File:"
+	};
+	Text text_loaded_file {
+		{ 1 * 8 , 8 + 2 * 16, 20 * 8, 22 },  
+		""
+	};
+
+	Button button_save_freqs {
+		{ 1 * 8 , 4 * 16 , 18 * 8 , 22 },
+		"Save freqs to   :"
+	};
+	Text text_save_to_file {
+		{ 1 * 8 , 8 + 5 * 16, 20 * 8, 22 },  
+		""	
+	};
+
 	Labels labels {
-		{ { 2 * 8, 11 * 8 }, "Baudrate:", Color::light_grey() },
-		{ { 2 * 8, 13 * 8 }, "Mark:      Hz", Color::light_grey() },
-		{ { 2 * 8, 15 * 8 }, "Space:     Hz", Color::light_grey() },
-		{ { 140, 15 * 8 }, "Repeat:", Color::light_grey() },
-		{ { 1 * 8, 6 * 8 }, "Search preset:", Color::light_grey() },
-		{ { 2 * 8, 22 * 8 }, "Serial format:", Color::light_grey() }
+		{ { 1 * 8, 8 * 16 }, "NB Max Freqs/file:"        , Color::light_grey() },
 	};
 
-	NumberField field_baudrate {
-		{ 11 * 8, 11 * 8 },
-		5,
-		{ 50, 9600 },
-		25,
-		' '
+	Checkbox checkbox_autosave_freqs {
+		{ 1 * 8, 10 * 16 },
+		3,
+		"Auto Save freqs"
 	};
 
-	NumberField field_mark {
-		{ 8 * 8, 13 * 8 },
-		5,
-		{ 100, 15000 },
-		25,
-		' '
+	Checkbox checkbox_autorotate_file {
+		{ 1 * 8, 12 * 16 },
+		3,
+		"Auto Rotate file"
 	};
-	
-	NumberField field_space {
-		{ 8 * 8, 15 * 8 },
-		5,
-		{ 100, 15000 },
-		25,
-		' '
-	};
-	
-	NumberField field_repeat {
-		{ 204, 15 * 8 },
-		2,
-		{ 1, 99 },
-		1,
-		' '
-	};
-	
-	OptionsField options_search {
-		{ 15 * 8, 6 * 8 },
-		7,
-		{
-		}
-	};
-	
-	SymField sym_format {
-		{ 16 * 8, 22 * 8 },
-		4,
-		SymField::SYMFIELD_DEF
-	};
-	
-	Button button_set_search {
-		{ 23 * 8, 6 * 8 - 4, 6 * 8, 24 },
-		"SET"
-	};
-	
+
 	Button button_save {
-		{ 9 * 8, 250, 96, 40 },
-		"Save"
+		{ 9 * 8, 250, 14 * 8 , 40 },
+		"Save Settings"
 	};
-
-
 };
 
 } /* namespace ui */

--- a/firmware/application/apps/ui_searchsetup.hpp
+++ b/firmware/application/apps/ui_searchsetup.hpp
@@ -59,28 +59,28 @@ private:
 		""	
 	};
 
-	Labels labels {
-		{ { 1 * 8, 7 * 16 }, "NB Max Freqs/file:"        , Color::light_grey() },
-	};
-
 	Checkbox checkbox_autosave_freqs {
-		{ 1 * 8, 9 * 16 },
+		{ 1 * 8, 7 * 16 },
 		3,
 		"Auto Save freqs"
 	};
 
-	Checkbox checkbox_autorotate_file {
-		{ 1 * 8, 11 * 16 },
-		3,
-		"Auto Rotate file"
-	};
-
 	Checkbox checkbox_autostart_search {
-		{ 1 * 8, 13 * 16 },
+		{ 1 * 8, 9 * 16 },
 		3,
 		"Auto Start Search"
 	};
 
+	Checkbox checkbox_powersave {
+		{ 1 * 8, 11 * 16 },
+		3,
+		"Slower GUI/more CPU power"
+	};
+	Checkbox checkbox_filemode {
+		{ 1 * 8, 13 * 16 },
+		3,
+		"check:append,else overwrite"
+	};
 
 	Button button_save {
 		{ 9 * 8, 250, 14 * 8 , 40 },

--- a/firmware/application/apps/ui_searchsetup.hpp
+++ b/firmware/application/apps/ui_searchsetup.hpp
@@ -25,12 +25,16 @@
 #include "ui.hpp"
 #include "ui_widget.hpp"
 #include "ui_navigation.hpp"
+#include "string_format.hpp"
 
 namespace ui {
 
 class SearchSetupView : public View {
 public:
 	SearchSetupView(NavigationView& nav);
+	
+	bool SearchSetupLoadStrings( std::string source, std::string &input_file , std::string &output_file );
+	bool SearchSetupSaveStrings( std::string dest, const std::string input_file , const std::string output_file );
 	
 	void focus() override;
 	
@@ -39,7 +43,8 @@ public:
 private:
 	NavigationView& nav_;
 
-	uint32_t nb_freqs { 250 };
+	std::string input_file ;
+	std::string output_file ;
 
 	Button button_load_freqs {
 		{ 1 * 8 , 1 * 16 , 18 * 8 , 22 },

--- a/firmware/application/ui_navigation.cpp
+++ b/firmware/application/ui_navigation.cpp
@@ -54,6 +54,7 @@
 #include "ui_pocsag_tx.hpp"
 #include "ui_rds.hpp"
 #include "ui_remote.hpp"
+#include "ui_search.hpp"
 #include "ui_scanner.hpp"
 #include "ui_calls.hpp"
 #include "ui_sd_wipe.hpp"
@@ -543,6 +544,7 @@ SystemMenuView::SystemMenuView(NavigationView& nav) {
 		{ "Capture",	ui::Color::red(),			&bitmap_icon_capture,	[&nav](){ nav.push<CaptureAppView>(); } },
 		{ "Replay",		ui::Color::green(),			&bitmap_icon_replay,	[&nav](){ nav.push<ReplayAppView>(); } },
 		{ "Calls",		ui::Color::yellow(),	    &bitmap_icon_search,	[&nav](){ nav.push<CallsView>(); } },
+		{ "Search",	ui::Color::yellow(),			&bitmap_icon_scanner,	[&nav](){ nav.push<SearchView>(); } },
 		{ "Scanner",	ui::Color::yellow(),			&bitmap_icon_scanner,	[&nav](){ nav.push<ScannerView>(); } },
 		{ "Microphone",	ui::Color::yellow(),		&bitmap_icon_microphone,[&nav](){ nav.push<MicTXView>(); } },
 		{ "Looking Glass",	ui::Color::yellow(),		&bitmap_icon_looking,	[&nav](){ nav.push<GlassView>(); } },

--- a/firmware/application/ui_navigation.cpp
+++ b/firmware/application/ui_navigation.cpp
@@ -55,7 +55,7 @@
 #include "ui_rds.hpp"
 #include "ui_remote.hpp"
 #include "ui_scanner.hpp"
-#include "ui_search.hpp"
+#include "ui_calls.hpp"
 #include "ui_sd_wipe.hpp"
 #include "ui_settings.hpp"
 #include "ui_siggen.hpp"
@@ -542,7 +542,7 @@ SystemMenuView::SystemMenuView(NavigationView& nav) {
 		{ "Transmit", 	ui::Color::cyan(),			&bitmap_icon_transmit,	[&nav](){ nav.push<TransmittersMenuView>(); } },
 		{ "Capture",	ui::Color::red(),			&bitmap_icon_capture,	[&nav](){ nav.push<CaptureAppView>(); } },
 		{ "Replay",		ui::Color::green(),			&bitmap_icon_replay,	[&nav](){ nav.push<ReplayAppView>(); } },
-		{ "Calls",		ui::Color::yellow(),	    &bitmap_icon_search,	[&nav](){ nav.push<SearchView>(); } },
+		{ "Calls",		ui::Color::yellow(),	    &bitmap_icon_search,	[&nav](){ nav.push<CallsView>(); } },
 		{ "Scanner",	ui::Color::yellow(),			&bitmap_icon_scanner,	[&nav](){ nav.push<ScannerView>(); } },
 		{ "Microphone",	ui::Color::yellow(),		&bitmap_icon_microphone,[&nav](){ nav.push<MicTXView>(); } },
 		{ "Looking Glass",	ui::Color::yellow(),		&bitmap_icon_looking,	[&nav](){ nav.push<GlassView>(); } },

--- a/firmware/application/ui_navigation.cpp
+++ b/firmware/application/ui_navigation.cpp
@@ -524,6 +524,17 @@ UtilitiesMenuView::UtilitiesMenuView(NavigationView& nav) {
 	set_max_rows(2); // allow wider buttons
 }
 
+
+/* Call Scan Search *****************************************************/
+SpyMenuView::SpyMenuView(NavigationView& nav) {
+	add_items({
+		{ "Calls",		ui::Color::yellow(),	    &bitmap_icon_search,	[&nav](){ nav.push<CallsView>(); } },
+		{ "Search",	ui::Color::yellow(),			&bitmap_icon_scanner,	[&nav](){ nav.push<SearchView>(); } },
+		{ "Scanner",	ui::Color::yellow(),			&bitmap_icon_scanner,	[&nav](){ nav.push<ScannerView>(); } },
+		});
+	set_max_rows(2); // allow wider buttons
+}
+
 /* SystemMenuView ********************************************************/
 
 void SystemMenuView::hackrf_mode(NavigationView& nav) {
@@ -542,17 +553,15 @@ SystemMenuView::SystemMenuView(NavigationView& nav) {
 		{ "Receive", 	ui::Color::cyan(),			&bitmap_icon_receivers,	[&nav](){ nav.push<ReceiversMenuView>(); } },
 		{ "Transmit", 	ui::Color::cyan(),			&bitmap_icon_transmit,	[&nav](){ nav.push<TransmittersMenuView>(); } },
 		{ "Capture",	ui::Color::red(),			&bitmap_icon_capture,	[&nav](){ nav.push<CaptureAppView>(); } },
-		{ "Replay",		ui::Color::green(),			&bitmap_icon_replay,	[&nav](){ nav.push<ReplayAppView>(); } },
-		{ "Calls",		ui::Color::yellow(),	    &bitmap_icon_search,	[&nav](){ nav.push<CallsView>(); } },
-		{ "Search",	ui::Color::yellow(),			&bitmap_icon_scanner,	[&nav](){ nav.push<SearchView>(); } },
-		{ "Scanner",	ui::Color::yellow(),			&bitmap_icon_scanner,	[&nav](){ nav.push<ScannerView>(); } },
-		{ "Microphone",	ui::Color::yellow(),		&bitmap_icon_microphone,[&nav](){ nav.push<MicTXView>(); } },
+		{ "Replay",	ui::Color::green(),			&bitmap_icon_replay,	[&nav](){ nav.push<ReplayAppView>(); } },
+		{ "Microphone",	ui::Color::yellow(),			&bitmap_icon_microphone,[&nav](){ nav.push<MicTXView>(); } },
+		{ "Spy",	ui::Color::yellow(),			&bitmap_icon_scanner,   [&nav](){ nav.push<SpyMenuView>(); } },
 		{ "Looking Glass",	ui::Color::yellow(),		&bitmap_icon_looking,	[&nav](){ nav.push<GlassView>(); } },
-		{ "Tools",		ui::Color::cyan(),			&bitmap_icon_utilities,	[&nav](){ nav.push<UtilitiesMenuView>(); } },
+		{ "Tools",		ui::Color::cyan(),		&bitmap_icon_utilities,	[&nav](){ nav.push<UtilitiesMenuView>(); } },
 		{ "Options", 	ui::Color::cyan(),			&bitmap_icon_setup,	  	[&nav](){ nav.push<SettingsMenuView>(); } },
-		{ "Debug",		ui::Color::light_grey(),	&bitmap_icon_debug,		[&nav](){ nav.push<DebugMenuView>(); } },
+		{ "Debug",	ui::Color::light_grey(),		&bitmap_icon_debug,		[&nav](){ nav.push<DebugMenuView>(); } },
 		{ "HackRF", 	ui::Color::cyan(),			&bitmap_icon_hackrf,	[this, &nav](){ hackrf_mode(nav); } },
-		//{ "About", 		ui::Color::cyan(),			nullptr,				[&nav](){ nav.push<AboutView>(); } }
+		//{ "About", 	ui::Color::cyan(),			nullptr,				[&nav](){ nav.push<AboutView>(); } }
 	});
 	set_max_rows(2); // allow wider buttons
 	set_arrow_enabled(false);

--- a/firmware/application/ui_navigation.cpp
+++ b/firmware/application/ui_navigation.cpp
@@ -531,6 +531,7 @@ SpyMenuView::SpyMenuView(NavigationView& nav) {
 		{ "Calls",		ui::Color::yellow(),	    &bitmap_icon_search,	[&nav](){ nav.push<CallsView>(); } },
 		{ "Search",	ui::Color::yellow(),			&bitmap_icon_scanner,	[&nav](){ nav.push<SearchView>(); } },
 		{ "Scanner",	ui::Color::yellow(),			&bitmap_icon_scanner,	[&nav](){ nav.push<ScannerView>(); } },
+		{ "Looking Glass",	ui::Color::yellow(),		&bitmap_icon_looking,	[&nav](){ nav.push<GlassView>(); } },
 		});
 	set_max_rows(2); // allow wider buttons
 }
@@ -556,7 +557,6 @@ SystemMenuView::SystemMenuView(NavigationView& nav) {
 		{ "Replay",	ui::Color::green(),			&bitmap_icon_replay,	[&nav](){ nav.push<ReplayAppView>(); } },
 		{ "Microphone",	ui::Color::yellow(),			&bitmap_icon_microphone,[&nav](){ nav.push<MicTXView>(); } },
 		{ "Spy",	ui::Color::yellow(),			&bitmap_icon_scanner,   [&nav](){ nav.push<SpyMenuView>(); } },
-		{ "Looking Glass",	ui::Color::yellow(),		&bitmap_icon_looking,	[&nav](){ nav.push<GlassView>(); } },
 		{ "Tools",		ui::Color::cyan(),		&bitmap_icon_utilities,	[&nav](){ nav.push<UtilitiesMenuView>(); } },
 		{ "Options", 	ui::Color::cyan(),			&bitmap_icon_setup,	  	[&nav](){ nav.push<SettingsMenuView>(); } },
 		{ "Debug",	ui::Color::light_grey(),		&bitmap_icon_debug,		[&nav](){ nav.push<DebugMenuView>(); } },

--- a/firmware/application/ui_navigation.cpp
+++ b/firmware/application/ui_navigation.cpp
@@ -556,12 +556,12 @@ SystemMenuView::SystemMenuView(NavigationView& nav) {
 		{ "Capture",	ui::Color::red(),			&bitmap_icon_capture,	[&nav](){ nav.push<CaptureAppView>(); } },
 		{ "Replay",	ui::Color::green(),			&bitmap_icon_replay,	[&nav](){ nav.push<ReplayAppView>(); } },
 		{ "Microphone",	ui::Color::yellow(),			&bitmap_icon_microphone,[&nav](){ nav.push<MicTXView>(); } },
-		{ "Spy",	ui::Color::yellow(),			&bitmap_icon_scanner,   [&nav](){ nav.push<SpyMenuView>(); } },
-		{ "Tools",		ui::Color::cyan(),		&bitmap_icon_utilities,	[&nav](){ nav.push<UtilitiesMenuView>(); } },
-		{ "Options", 	ui::Color::cyan(),			&bitmap_icon_setup,	  	[&nav](){ nav.push<SettingsMenuView>(); } },
+		{ "RF Spy",	ui::Color::yellow(),			&bitmap_icon_scanner,   [&nav](){ nav.push<SpyMenuView>(); } },
+		{ "Tools",	ui::Color::cyan(),			&bitmap_icon_utilities,	[&nav](){ nav.push<UtilitiesMenuView>(); } },
+		{ "Options", 	ui::Color::cyan(),			&bitmap_icon_setup,	[&nav](){ nav.push<SettingsMenuView>(); } },
 		{ "HackRF", 	ui::Color::cyan(),			&bitmap_icon_hackrf,	[this, &nav](){ hackrf_mode(nav); } },
-		{ "Debug",	ui::Color::light_grey(),		&bitmap_icon_debug,		[&nav](){ nav.push<DebugMenuView>(); } },
-		//{ "About", 	ui::Color::cyan(),			nullptr,				[&nav](){ nav.push<AboutView>(); } }
+		{ "Debug",	ui::Color::light_grey(),		&bitmap_icon_debug,	[&nav](){ nav.push<DebugMenuView>(); } },
+		//{ "About", 	ui::Color::cyan(),			nullptr,		[&nav](){ nav.push<AboutView>(); } }
 	});
 	set_max_rows(2); // allow wider buttons
 	set_arrow_enabled(false);

--- a/firmware/application/ui_navigation.cpp
+++ b/firmware/application/ui_navigation.cpp
@@ -559,8 +559,8 @@ SystemMenuView::SystemMenuView(NavigationView& nav) {
 		{ "Spy",	ui::Color::yellow(),			&bitmap_icon_scanner,   [&nav](){ nav.push<SpyMenuView>(); } },
 		{ "Tools",		ui::Color::cyan(),		&bitmap_icon_utilities,	[&nav](){ nav.push<UtilitiesMenuView>(); } },
 		{ "Options", 	ui::Color::cyan(),			&bitmap_icon_setup,	  	[&nav](){ nav.push<SettingsMenuView>(); } },
-		{ "Debug",	ui::Color::light_grey(),		&bitmap_icon_debug,		[&nav](){ nav.push<DebugMenuView>(); } },
 		{ "HackRF", 	ui::Color::cyan(),			&bitmap_icon_hackrf,	[this, &nav](){ hackrf_mode(nav); } },
+		{ "Debug",	ui::Color::light_grey(),		&bitmap_icon_debug,		[&nav](){ nav.push<DebugMenuView>(); } },
 		//{ "About", 	ui::Color::cyan(),			nullptr,				[&nav](){ nav.push<AboutView>(); } }
 	});
 	set_max_rows(2); // allow wider buttons

--- a/firmware/application/ui_navigation.hpp
+++ b/firmware/application/ui_navigation.hpp
@@ -271,7 +271,7 @@ public:
 class SpyMenuView : public BtnGridView {
 public:
 	SpyMenuView(NavigationView& nav);
-	std::string title() const override { return "SpyFreqs"; };	
+	std::string title() const override { return "RF Spy"; };	
 };
 
 class SystemMenuView : public BtnGridView {

--- a/firmware/application/ui_navigation.hpp
+++ b/firmware/application/ui_navigation.hpp
@@ -268,6 +268,12 @@ public:
 	std::string title() const override { return "Utilities"; };	
 };
 
+class SpyMenuView : public BtnGridView {
+public:
+	SpyMenuView(NavigationView& nav);
+	std::string title() const override { return "Spy"; };	
+};
+
 class SystemMenuView : public BtnGridView {
 public:
 	SystemMenuView(NavigationView& nav);

--- a/firmware/application/ui_navigation.hpp
+++ b/firmware/application/ui_navigation.hpp
@@ -271,7 +271,7 @@ public:
 class SpyMenuView : public BtnGridView {
 public:
 	SpyMenuView(NavigationView& nav);
-	std::string title() const override { return "Spy"; };	
+	std::string title() const override { return "SpyFreqs"; };	
 };
 
 class SystemMenuView : public BtnGridView {

--- a/firmware/common/portapack_persistent_memory.cpp
+++ b/firmware/common/portapack_persistent_memory.cpp
@@ -197,30 +197,30 @@ void set_modem_repeat(const uint32_t new_value) {
 	data->modem_repeat = modem_repeat_range.clip(new_value);
 }
 
-void set_search_nb_freqs(const uint32_t i) {
-	data->search_nb_freqs = i ;
-}
+/* Search app */
 void set_search_autosave_freqs(bool v ){
 	data->search_searchconfig = (data->search_searchconfig & ~0x10000000UL) | (!v << 28); 
 }
-void set_search_autorotate_file(bool v ){
+void set_search_autostart_search(bool v ){
 	data->search_searchconfig = (data->search_searchconfig & ~0x20000000UL) | (!v << 29); 
 }
-void set_search_autostart_search(bool v ){
+void set_search_powersave(bool v ){
 	data->search_searchconfig = (data->search_searchconfig & ~0x40000000UL) | (!v << 30); 
 }
-
-uint32_t search_nb_freqs() {
-	return data->search_nb_freqs ;
+void set_search_filemode(bool v ){
+	data->search_searchconfig = (data->search_searchconfig & ~0x80000000UL) | (!v << 31); 
 }
 bool search_autosave_freqs() {
-	return (data->search_searchconfig & 0x10000000UL) ? false : true; // Default true
-}
-bool search_autorotate_file() {
-	return (data->search_searchconfig & 0x20000000UL) ? false : true; // Default true
+	return (data->search_searchconfig & 0x10000000UL) ? false : true;
 }
 bool search_autostart_search() {
-	return (data->search_searchconfig & 0x40000000UL) ? false : true; // Default true
+	return (data->search_searchconfig & 0x20000000UL) ? false : true; 
+}
+bool search_powersave() {
+	return (data->search_searchconfig & 0x40000000UL) ? false : true;
+}
+bool search_filemode() {
+	return (data->search_searchconfig & 0x80000000UL) ? false : true;
 }
 
 serial_format_t serial_format() {

--- a/firmware/common/portapack_persistent_memory.cpp
+++ b/firmware/common/portapack_persistent_memory.cpp
@@ -63,6 +63,14 @@ using modem_repeat_range_t = range_t<int32_t>;
 constexpr modem_repeat_range_t modem_repeat_range { 1, 99 };
 constexpr int32_t modem_repeat_reset_value { 5 };
 
+using search_baudrate_range_t = range_t<int32_t>;
+constexpr search_baudrate_range_t search_baudrate_range { 50, 9600 };
+constexpr int32_t search_baudrate_reset_value { 1200 };
+
+using search_repeat_range_t = range_t<int32_t>;
+constexpr search_repeat_range_t search_repeat_range { 1, 99 };
+constexpr int32_t search_repeat_reset_value { 5 };
+
 using clkout_freq_range_t = range_t<uint32_t>;
 constexpr clkout_freq_range_t clkout_freq_range { 10, 60000 };
 constexpr uint32_t clkout_freq_reset_value { 10000 };
@@ -82,6 +90,8 @@ struct data_t {
 	int32_t afsk_space_freq;
 	int32_t modem_baudrate;
 	int32_t modem_repeat;
+	int32_t search_baudrate;
+	int32_t search_repeat;
 	
 	// Play dead unlock
 	uint32_t playdead_magic;
@@ -188,6 +198,25 @@ uint8_t modem_repeat() {
 void set_modem_repeat(const uint32_t new_value) {
 	data->modem_repeat = modem_repeat_range.clip(new_value);
 }
+
+int32_t search_baudrate() {
+	search_baudrate_range.reset_if_outside(data->search_baudrate, search_baudrate_reset_value);
+	return data->search_baudrate;
+}
+
+void set_search_baudrate(const int32_t new_value) {
+	data->search_baudrate = search_baudrate_range.clip(new_value);
+}
+
+uint8_t search_repeat() {
+	search_repeat_range.reset_if_outside(data->search_repeat, search_repeat_reset_value);
+	return data->search_repeat;
+}
+
+void set_search_repeat(const uint32_t new_value) {
+	data->search_repeat = search_repeat_range.clip(new_value);
+}
+
 
 serial_format_t serial_format() {
 	return data->serial_format;

--- a/firmware/common/portapack_persistent_memory.cpp
+++ b/firmware/common/portapack_persistent_memory.cpp
@@ -71,14 +71,6 @@ using search_nb_freqs_range_t = range_t<uint32_t>;
 constexpr search_nb_freqs_range_t search_nb_freqs_range{ 10, 500 };
 constexpr uint32_t search_nb_freqs_reset_value { 250 };
 
-using search_autosave_freqs_range_t = range_t<bool>;
-constexpr search_autosave_freqs_range_t search_autosave_freqs_range{ 0, 1 };
-constexpr bool search_autosave_freqs_reset_value { true };
-
-using search_autorotate_file_range_t = range_t<bool>;
-constexpr search_autorotate_file_range_t search_autorotate_file_range{ 0, 1 };
-constexpr bool search_autorotate_file_reset_value { true };
-
 /* struct must pack the same way on M4 and M0 cores. */
 struct data_t {
 	int64_t tuned_frequency;
@@ -96,8 +88,7 @@ struct data_t {
 	int32_t modem_repeat;
 
 	// Search
-	bool search_autosave_freqs ;
-	bool search_autorotate_file ;
+	uint32_t search_searchconfig ;
 	uint32_t search_nb_freqs ;
 	
 	// Play dead unlock
@@ -206,23 +197,30 @@ void set_modem_repeat(const uint32_t new_value) {
 	data->modem_repeat = modem_repeat_range.clip(new_value);
 }
 
-bool search_autosave_freqs() {
-	return (data->search_autosave_freqs & 0x10000000UL) ? false : true; // Default true
+void set_search_nb_freqs(const uint32_t i) {
+	data->search_nb_freqs = i ;
 }
-bool set_search_autosave_freqs(bool new_value ){
-	data->search_autosave_freqs = (data->search_autosave_freqs & ~0x10000000UL) | (!new_value << 28); 
+void set_search_autosave_freqs(bool v ){
+	data->search_searchconfig = (data->search_searchconfig & ~0x10000000UL) | (!v << 28); 
 }
-bool search_autorotate_file() {
-	return (data->search_autorotate_file & 0x10000000UL) ? false : true; // Default true
+void set_search_autorotate_file(bool v ){
+	data->search_searchconfig = (data->search_searchconfig & ~0x20000000UL) | (!v << 29); 
 }
-bool set_search_autorotate_file(bool new_value){
-	data->search_autorotate_file = (data->search_autorotate_file & ~0x10000000UL) | (!new_value << 28); 
+void set_search_autostart_search(bool v ){
+	data->search_searchconfig = (data->search_searchconfig & ~0x40000000UL) | (!v << 30); 
 }
+
 uint32_t search_nb_freqs() {
 	return data->search_nb_freqs ;
 }
-void set_search_nb_freqs(const uint32_t new_value) {
-	data->search_nb_freqs = new_value ;
+bool search_autosave_freqs() {
+	return (data->search_searchconfig & 0x10000000UL) ? false : true; // Default true
+}
+bool search_autorotate_file() {
+	return (data->search_searchconfig & 0x20000000UL) ? false : true; // Default true
+}
+bool search_autostart_search() {
+	return (data->search_searchconfig & 0x40000000UL) ? false : true; // Default true
 }
 
 serial_format_t serial_format() {

--- a/firmware/common/portapack_persistent_memory.cpp
+++ b/firmware/common/portapack_persistent_memory.cpp
@@ -63,17 +63,21 @@ using modem_repeat_range_t = range_t<int32_t>;
 constexpr modem_repeat_range_t modem_repeat_range { 1, 99 };
 constexpr int32_t modem_repeat_reset_value { 5 };
 
-using search_baudrate_range_t = range_t<int32_t>;
-constexpr search_baudrate_range_t search_baudrate_range { 50, 9600 };
-constexpr int32_t search_baudrate_reset_value { 1200 };
-
-using search_repeat_range_t = range_t<int32_t>;
-constexpr search_repeat_range_t search_repeat_range { 1, 99 };
-constexpr int32_t search_repeat_reset_value { 5 };
-
 using clkout_freq_range_t = range_t<uint32_t>;
 constexpr clkout_freq_range_t clkout_freq_range { 10, 60000 };
 constexpr uint32_t clkout_freq_reset_value { 10000 };
+
+using search_nb_freqs_range_t = range_t<uint32_t>;
+constexpr search_nb_freqs_range_t search_nb_freqs_range{ 10, 500 };
+constexpr uint32_t search_nb_freqs_reset_value { 250 };
+
+using search_autosave_freqs_range_t = range_t<bool>;
+constexpr search_autosave_freqs_range_t search_autosave_freqs_range{ 0, 1 };
+constexpr bool search_autosave_freqs_reset_value { true };
+
+using search_autorotate_file_range_t = range_t<bool>;
+constexpr search_autorotate_file_range_t search_autorotate_file_range{ 0, 1 };
+constexpr bool search_autorotate_file_reset_value { true };
 
 /* struct must pack the same way on M4 and M0 cores. */
 struct data_t {
@@ -90,8 +94,11 @@ struct data_t {
 	int32_t afsk_space_freq;
 	int32_t modem_baudrate;
 	int32_t modem_repeat;
-	int32_t search_baudrate;
-	int32_t search_repeat;
+
+	// Search
+	bool search_autosave_freqs ;
+	bool search_autorotate_file ;
+	uint32_t search_nb_freqs ;
 	
 	// Play dead unlock
 	uint32_t playdead_magic;
@@ -199,24 +206,24 @@ void set_modem_repeat(const uint32_t new_value) {
 	data->modem_repeat = modem_repeat_range.clip(new_value);
 }
 
-int32_t search_baudrate() {
-	search_baudrate_range.reset_if_outside(data->search_baudrate, search_baudrate_reset_value);
-	return data->search_baudrate;
+bool search_autosave_freqs() {
+	return (data->search_autosave_freqs & 0x10000000UL) ? false : true; // Default true
 }
-
-void set_search_baudrate(const int32_t new_value) {
-	data->search_baudrate = search_baudrate_range.clip(new_value);
+bool set_search_autosave_freqs(bool new_value ){
+	data->search_autosave_freqs = (data->search_autosave_freqs & ~0x10000000UL) | (!new_value << 28); 
 }
-
-uint8_t search_repeat() {
-	search_repeat_range.reset_if_outside(data->search_repeat, search_repeat_reset_value);
-	return data->search_repeat;
+bool search_autorotate_file() {
+	return (data->search_autorotate_file & 0x10000000UL) ? false : true; // Default true
 }
-
-void set_search_repeat(const uint32_t new_value) {
-	data->search_repeat = search_repeat_range.clip(new_value);
+bool set_search_autorotate_file(bool new_value){
+	data->search_autorotate_file = (data->search_autorotate_file & ~0x10000000UL) | (!new_value << 28); 
 }
-
+uint32_t search_nb_freqs() {
+	return data->search_nb_freqs ;
+}
+void set_search_nb_freqs(const uint32_t new_value) {
+	data->search_nb_freqs = new_value ;
+}
 
 serial_format_t serial_format() {
 	return data->serial_format;

--- a/firmware/common/portapack_persistent_memory.hpp
+++ b/firmware/common/portapack_persistent_memory.hpp
@@ -65,6 +65,12 @@ void set_modem_baudrate(const int32_t new_value);
 uint8_t modem_repeat();
 void set_modem_repeat(const uint32_t new_value);
 
+int32_t search_baudrate();
+void set_search_baudrate(const int32_t new_value);
+
+uint8_t search_repeat();
+void set_search_repeat(const uint32_t new_value);
+
 uint32_t playing_dead();
 void set_playing_dead(const uint32_t new_value);
 

--- a/firmware/common/portapack_persistent_memory.hpp
+++ b/firmware/common/portapack_persistent_memory.hpp
@@ -65,11 +65,14 @@ void set_modem_baudrate(const int32_t new_value);
 uint8_t modem_repeat();
 void set_modem_repeat(const uint32_t new_value);
 
-int32_t search_baudrate();
-void set_search_baudrate(const int32_t new_value);
+bool search_autosave_freqs();
+bool set_search_autosave_freqs(bool v);
 
-uint8_t search_repeat();
-void set_search_repeat(const uint32_t new_value);
+bool search_autorotate_file();
+bool set_search_autorotate_file(bool v);
+
+uint32_t search_nb_freqs();
+void set_search_nb_freqs(const uint32_t new_value);
 
 uint32_t playing_dead();
 void set_playing_dead(const uint32_t new_value);

--- a/firmware/common/portapack_persistent_memory.hpp
+++ b/firmware/common/portapack_persistent_memory.hpp
@@ -65,15 +65,15 @@ void set_modem_baudrate(const int32_t new_value);
 uint8_t modem_repeat();
 void set_modem_repeat(const uint32_t new_value);
 
-uint32_t search_nb_freqs();
+/* Search app */
 bool     search_autosave_freqs();
-bool     search_autorotate_file();
 bool     search_autostart_search();
-
-void set_search_nb_freqs(const uint32_t i);
+bool     search_powersave();
+bool     search_filemode();
 void set_search_autosave_freqs(bool v);
-void set_search_autorotate_file(bool v);
 void set_search_autostart_search(bool v);
+void set_search_powersave(bool v);
+void set_search_filemode(bool v);
 
 uint32_t playing_dead();
 void set_playing_dead(const uint32_t new_value);

--- a/firmware/common/portapack_persistent_memory.hpp
+++ b/firmware/common/portapack_persistent_memory.hpp
@@ -65,14 +65,15 @@ void set_modem_baudrate(const int32_t new_value);
 uint8_t modem_repeat();
 void set_modem_repeat(const uint32_t new_value);
 
-bool search_autosave_freqs();
-bool set_search_autosave_freqs(bool v);
-
-bool search_autorotate_file();
-bool set_search_autorotate_file(bool v);
-
 uint32_t search_nb_freqs();
-void set_search_nb_freqs(const uint32_t new_value);
+bool     search_autosave_freqs();
+bool     search_autorotate_file();
+bool     search_autostart_search();
+
+void set_search_nb_freqs(const uint32_t i);
+void set_search_autosave_freqs(bool v);
+void set_search_autorotate_file(bool v);
+void set_search_autostart_search(bool v);
 
 uint32_t playing_dead();
 void set_playing_dead(const uint32_t new_value);


### PR DESCRIPTION
### Quick introduction to used terms

- A scan is when using a defined list
- A search is when using one or many ranges of frequencies with step
- Both are using all the frequencies in their hand and pause on a frequency when matching criteria (like modulation, amplitude,...)

### Original Behavior

Scanner app have two mode:
- Scan frequencies based on a loaded FREQMAN/freqs.txt file and add/del them manually when the scan is pausing on one
- Search frequencies based on the manual start, end, and step and add/del them manually when the search is pausing on one

Limitations:
- A maximum of 500 scanned freqs in scan mode
- A maximum of 500 **steps** in search mode

### New behavior

Scan mode (exploit list of freqs):
- Nothing is changing on the scan side: still loading a list of frequencies and keep the old behavior
- Manual search is took out of the scanner app
- No more loading of ranges are possible, only freqs are taken in the list

Search mode(exploit ranges of freqs or a manual range) :
- Scan app is cloned into a new Search app, only keeping what was "manual scan" in original app
- Search does not suffer any number of searched frequencies limits
- Loading from files: no frequency loading, only ranges 
- Search is auto saving found frequencies in FREQMAN/SEARCHRESULTS.TXT
- Only matching frequencies are saved to the file, as singletons (one frequency will not be added more than one time)
- FREQMAN/SEARCHRESULTS.TXT is used in append mode
- A new FREQMAN/SEARCHRESULTS.TXT is created if it does not exist
- Search app have a settings button instead of a load button
- Loading of freq files is done by settings page
- Setting output file is done by settings page
- Autostart is an option
- Autosave found freqs to file is an option
- Powersave is an option to try to reduce GUI updates and keep more CPU for the search
- All settings are preserved if an optional battery is on, else only input/output names are saved

### Expected search workflow with the new behavior
- Start a search
- When you think it has turned around enough to catch what you need pause the search

- Directly use the FREQMAN/SEARCHRESULTS.TXT in the Scan app to make a pause each time a frequency is matching  or use File manager to rename the FREQMAN/SEARCHRESULTS.TXT file and use that renamed file in the scan app

### What is done

- Making the search work with wide ranges
- Auto saving in FREQMAN/SEARCHRESULTS.TXT
- Rename Calls app source files and functions/template so it's not overlapping with the new Search app
- Cloning the Scan app into Search app
- A new menu entry named "RF Spy", added to hold Calls, Search and Scan app
- Cleaned out manual search (originally named manual scan) from Scan app
- Settings button in place of 'Load' in Search app
- Settings: Load frequency file, Set output filename, checkbox autostart, autosave, powersave (slower GUI updates), Save

### What is coming for the Search App

- Allow loading of ranges from freq files
- Linking GUI to funtionnalities instead of default values
- Progress meter accordingly to the current range
- Adding a new icon for Search app
- Adding a new icon for "RF Spy" menu entry