### PR TITLE
JAMMER NOW INCLUDES TWO TIMERS

### DIFF
--- a/firmware/application/apps/ui_jammer.cpp
+++ b/firmware/application/apps/ui_jammer.cpp
@@ -274,6 +274,8 @@ void JammerView::start_tx() {
 		transmitter_model.enable();
 
 		baseband::set_jammer(true, (JammerType)options_type.selected_index(), options_speed.selected_index_value());
+		cooling = false;
+		mscounter = 0; //euquiq: Reset internal ms counter for do_timer()
 	} else {
 		if (out_of_ranges)
 			nav_.display_modal("Error", "Jamming bandwidth too large.\nMust be less than 24MHz.");
@@ -289,6 +291,39 @@ void JammerView::stop_tx() {
 	radio::disable();
 	baseband::set_jammer(false, JammerType::TYPE_FSK, 0);
 	jamming = false;
+}
+
+//called each 1/60th of second
+void JammerView::on_timer() {
+	if (++mscounter == 60) {
+		if (jamming) 
+		{
+			if (cooling) 
+			{
+				if (++seconds >= field_timepause.value()) 
+				{	//Re-start TX
+					transmitter_model.enable();
+					button_transmit.set_text("STOP");
+					baseband::set_jammer(true, (JammerType)options_type.selected_index(), options_speed.selected_index_value());
+					cooling = false;
+					seconds = 0;
+				}
+			} 
+			else 
+			{
+				if (++seconds >= field_timetx.value()) //Start cooling period:
+				{
+					transmitter_model.disable();
+					button_transmit.set_text("PAUSED");
+					baseband::set_jammer(false, JammerType::TYPE_FSK, 0);
+					cooling = true;
+					seconds = 0;
+				}
+			}
+
+		}
+		mscounter = 0;
+	}
 }
 	
 JammerView::JammerView(
@@ -309,6 +344,8 @@ JammerView::JammerView(
 		&text_range_total,
 		&options_speed,
 		&options_hop,
+		&field_timetx,
+		&field_timepause,
 		&button_transmit
 	});
 	
@@ -321,8 +358,11 @@ JammerView::JammerView(
 	options_hop.set_selected_index(1);		// 50ms
 	button_transmit.set_style(&style_val);
 
+	field_timetx.set_value(30);
+	field_timepause.set_value(1);
+
 	button_transmit.on_select = [this](Button&) {
-		if (jamming)
+		if (jamming || cooling)
 			stop_tx();
 		else
 			start_tx();

--- a/firmware/application/apps/ui_jammer.hpp
+++ b/firmware/application/apps/ui_jammer.hpp
@@ -57,73 +57,6 @@ private:
 		.foreground = Color::grey(),
 	};
 	
-	/*static constexpr jammer_range_t range_presets[] = {
-		// GSM900 Orange
-		{ true, 935000000, 945000000 },		// BW:10M
-		// GSM1800 Orange
-		{ true, 1808000000, 1832000000 },	// BW:24M
-		
-		// GSM900 SFR
-		{ true, 950000000, 960000000 },		// BW:10M
-		// GSM1800 SFR
-		{ true, 1832000000, 1853000000 },	// BW:21M
-		
-		// GSM900 Bouygues
-		{ true, 925000000, 935000000 },		// BW:10M
-		// GSM1800 Bouygues
-		{ true, 1858000000, 1880000000 },	// BW:22M
-		
-		// GSM900 Free
-		{ true, 945000000, 950000000 },		// BW:5M
-		
-		// GSM-R
-		{ true, 921000000, 925000000 },		// BW:4M
-		
-		// DECT
-		{ true, 1880000000, 1900000000 },	// BW: 20MHz
-		
-		// PMV AFSK
-		{ true, 162930000, 162970000 },		// BW: 40kHz
-		
-		// ISM 433
-		{ true, 433050000, 434790000 },		// Center: 433.92MHz BW: 0.2%
-		
-		// ISM 868
-		{ true, 868000000, 868200000 },		// Center: 868.2MHz BW: 40kHz
-		
-		// GPS L1
-		{ true, 1575420000 - 500000, 1575420000 + 500000 },		// BW: 1MHz
-		// GPS L2
-		{ true, 1227600000 - 1000000, 1227600000 + 1000000 },	// BW: 2MHz
-		
-		// WLAN 2.4G CH1
-		{ true, 2412000000 - 11000000, 2412000000 + 11000000},	// BW: 22MHz
-		// WLAN 2.4G CH2
-		{ true, 2417000000 - 11000000, 2417000000 + 11000000},	// BW: 22MHz
-		// WLAN 2.4G CH3
-		{ true, 2422000000 - 11000000, 2422000000 + 11000000},	// BW: 22MHz
-		// WLAN 2.4G CH4
-		{ true, 2427000000 - 11000000, 2427000000 + 11000000},	// BW: 22MHz
-		// WLAN 2.4G CH5
-		{ true, 2432000000 - 11000000, 2432000000 + 11000000},	// BW: 22MHz
-		// WLAN 2.4G CH6
-		{ true, 2437000000 - 11000000, 2437000000 + 11000000},	// BW: 22MHz
-		// WLAN 2.4G CH7
-		{ true, 2442000000 - 11000000, 2442000000 + 11000000},	// BW: 22MHz
-		// WLAN 2.4G CH8
-		{ true, 2447000000 - 11000000, 2447000000 + 11000000},	// BW: 22MHz
-		// WLAN 2.4G CH9
-		{ true, 2452000000 - 11000000, 2452000000 + 11000000},	// BW: 22MHz
-		// WLAN 2.4G CH10
-		{ true, 2457000000 - 11000000, 2457000000 + 11000000},	// BW: 22MHz
-		// WLAN 2.4G CH11
-		{ true, 2462000000 - 11000000, 2462000000 + 11000000},	// BW: 22MHz
-		// WLAN 2.4G CH12
-		{ true, 2467000000 - 11000000, 2467000000 + 11000000},	// BW: 22MHz
-		// WLAN 2.4G CH13
-		{ true, 2472000000 - 11000000, 2472000000 + 11000000},	// BW: 22MHz
-	};*/
-	
 	Labels labels {
 		{ { 2 * 8, 9 * 8 + 4 }, "Start", Color::light_grey() },
 		{ { 23 * 8, 9 * 8 + 4 }, "Stop", Color::light_grey() },
@@ -178,12 +111,16 @@ private:
 	NavigationView& nav_;
 	
 	void start_tx();
+	void on_timer();
 	void stop_tx();
 	void set_jammer_channel(uint32_t i, uint32_t width, uint64_t center, uint32_t duration);
 	void on_retune(const rf::Frequency freq, const uint32_t range);
 	
 	JammerChannel * jammer_channels = (JammerChannel*)shared_memory.bb_data.data;
 	bool jamming { false };
+	bool cooling { false };		//euquiq: Indicates jammer in cooldown
+	uint16_t seconds = 0;		//euquiq: seconds counter for toggling tx / cooldown
+	uint16_t mscounter = 0;		//euquiq: Internal ms counter for do_timer()
 	
 	static constexpr Style style_val {
 		.font = font::fixed_8x16,
@@ -209,13 +146,17 @@ private:
 	};
 	
 	Labels labels {
-		{ { 3 * 8, 12 * 16 }, "Type:", Color::light_grey() },
-		{ { 2 * 8, 13 * 16 }, "Speed:", Color::light_grey() },
-		{ { 5 * 8, 14 * 16 }, "Hop:", Color::light_grey() }
+		{ { 6 * 8, 12 * 16 }, "Type:", Color::light_grey() },
+		{ { 5 * 8, 13 * 16 }, "Speed:", Color::light_grey() },
+		{ { 7 * 8, 14 * 16 }, "Hop:", Color::light_grey() },
+		{ { 3 * 8, 15 * 16 }, "Time TX:", Color::light_grey() },
+		{ { 0 * 8, 16 * 16 }, "Time Pause:", Color::light_grey() },
+		{ { 16 * 8, 15 * 16 }, "Secs.", Color::light_grey() },
+		{ { 16 * 8, 16 * 16 }, "Secs.", Color::light_grey() }
 	};
 	
 	OptionsField options_type {
-		{ 9 * 8, 12 * 16 },
+		{ 12 * 8, 12 * 16 },
 		8,
 		{
 			{ "Rand FSK", 0 },
@@ -235,7 +176,7 @@ private:
 	};
 	
 	OptionsField options_speed {
-		{ 9 * 8, 13 * 16 },
+		{ 12 * 8, 13 * 16 },
 		6,
 		{
 			{ "10Hz  ", 10 },
@@ -247,7 +188,7 @@ private:
 	};
 	
 	OptionsField options_hop {
-		{ 9 * 8, 14 * 16 },
+		{ 12 * 8, 14 * 16 },
 		5,
 		{
 			{ "10ms ", 1 },
@@ -259,9 +200,25 @@ private:
 			{ "10s  ", 1000 }
 		}
 	};
+
+	NumberField field_timetx {
+		{ 12 * 8, 15 * 16 },
+		3,
+		{ 1, 180 },
+		1,
+		' ',
+	};
+
+	NumberField field_timepause {
+		{ 12 * 8, 16 * 16 },
+		2,
+		{ 1, 60 },
+		1,
+		' ',
+	};
 	
 	Button button_transmit {
-		{ 9 * 8, 16 * 16, 96, 48 },
+		{ 18 * 8, 35 * 8, 96, 24 },
 		"START"
 	};
 	
@@ -272,6 +229,14 @@ private:
 			this->on_retune(message->freq, message->range);
 		}
 	};
+
+		MessageHandlerRegistration message_handler_frame_sync {
+		Message::ID::DisplayFrameSync,
+		[this](const Message* const) {
+			this->on_timer();
+		}
+	};
 };
 
 } /* namespace ui */
+

--- a/firmware/application/ui_navigation.cpp
+++ b/firmware/application/ui_navigation.cpp
@@ -467,7 +467,7 @@ TransmittersMenuView::TransmittersMenuView(NavigationView& nav) {
 		{ "APRS", 			ui::Color::green(),		&bitmap_icon_aprs,		[&nav](){ nav.push<APRSTXView>(); } },
 		{ "BHT Xy/EP", 		ui::Color::green(), 	&bitmap_icon_bht,		[&nav](){ nav.push<BHTView>(); } },
 		{ "GPS Sim",		ui::Color::yellow(),	&bitmap_icon_gps_sim,		[&nav](){ nav.push<GpsSimAppView>(); } },
-		{ "Jammer", 		ui::Color::yellow(),	&bitmap_icon_jammer,	[&nav](){ nav.push<JammerView>(); } },
+		{ "Jammer", 		ui::Color::green(),		&bitmap_icon_jammer,	[&nav](){ nav.push<JammerView>(); } },
 		{ "Key fob", 		ui::Color::orange(),	&bitmap_icon_keyfob,	[&nav](){ nav.push<KeyfobView>(); } },
 		{ "LGE tool", 		ui::Color::yellow(),	&bitmap_icon_lge,		[&nav](){ nav.push<LGEView>(); } },
 		{ "Morse",			ui::Color::green(),		&bitmap_icon_morse,		[&nav](){ nav.push<MorseView>(); } },


### PR DESCRIPTION
Each driving the TX and COOLDOWN timers.

TX can be adjusted from 1 to 180 seconds
Cooling down can be adjusted from 1 to 60 seconds.

NOTE: These two timers can be dynamically adjusted, even while the jammer is working.

This should solve the enhancement asked in https://github.com/eried/portapack-mayhem/issues/246