### PR TITLE
Fix bug on radiosonde Meteoman Lat & lon calculation

### DIFF
--- a/firmware/common/field_reader.hpp
+++ b/firmware/common/field_reader.hpp
@@ -49,7 +49,7 @@ public:
 	/* The "start_bit" winds up being the MSB of the returned field value. */
 	/* The BitRemap functor determines which bits are read from the source
 	 * packet. */
-	uint32_t read(const size_t start_bit, const size_t length) const {
+	int32_t read(const size_t start_bit, const size_t length) const { //Euquiq: was uint32_t, used for calculating lat / lon in radiosondes, can be negative too
 		uint32_t value = 0;
 		for(size_t i=start_bit; i<(start_bit + length); i++) {
 			value = (value << 1) | data[bit_remap(i)];


### PR DESCRIPTION
The underlying function used for calculating Latitude and Longitude -also used in other places inside the radiosonde app- was returning a positive value always. It was spotted by user Miguelo over fb's hackrf private group.

But it needs to cope with negative values also (i.e. Lat and Lon)

Fixed by just changing the returning value into int32_t  ... even if the calculation is done in uint32_t, the actual sign is passed thru when returning the calculated value -those are the same 4 bytes, interpreted either as (before) unsigned or (now) signed-

Miguelo did run a test-drive firmware with this fix, reproting back that now Meteomodem sonde shows the right LAT / LON.