### PR TITLE
Moved calibytes and calfrchk to cpp file to avoid unused warning

### DIFF
--- a/firmware/common/sonde_packet.cpp
+++ b/firmware/common/sonde_packet.cpp
@@ -27,6 +27,9 @@
 
 namespace sonde {
 
+static uint8_t calibytes[51*16];	//need these vars to survive
+static uint8_t calfrchk[51];		//so subframes are preserved while populated
+
 //Defines for Vaisala RS41, from https://github.com/rs1729/RS/blob/master/rs41/rs41sg.c
 #define MASK_LEN 64
 

--- a/firmware/common/sonde_packet.hpp
+++ b/firmware/common/sonde_packet.hpp
@@ -32,9 +32,6 @@
 
 namespace sonde {
 
-	static uint8_t calibytes[51*16];	//need these vars to survive
-	static uint8_t calfrchk[51];		//so subframes are preserved while populated
-
 	struct GPS_data {
 		uint32_t alt { 0 };
 		float lat { 0 };


### PR DESCRIPTION
Fix unused:
/home/travis/build/eried/portapack-mayhem/firmware/common/sonde_packet.hpp:36:17: warning: 'sonde::calfrchk' defined but not used [-Wunused-variable]
417  static uint8_t calfrchk[51];  //so subframes are preserved while populated
418                 ^~~~~~~~
419/home/travis/build/eried/portapack-mayhem/firmware/common/sonde_packet.hpp:35:17: warning: 'sonde::calibytes' defined but not used [-Wunused-variable]
420  static uint8_t calibytes[51*16]; //need these vars to survive