### PR TITLE
Fix __SIMD32 warning

### DIFF
--- a/firmware/baseband/channel_stats_collector.hpp
+++ b/firmware/baseband/channel_stats_collector.hpp
@@ -35,7 +35,7 @@ class ChannelStatsCollector {
 public:
 	template<typename Callback>
 	void feed(const buffer_c16_t& src, Callback callback) {
-		auto src_p = src.p;
+		void *src_p = src.p;
 		while(src_p < &src.p[src.count]) {
 			const uint32_t sample = *__SIMD32(src_p)++;
 			const uint32_t mag_sq = __SMUAD(sample, sample);


### PR DESCRIPTION
To fix __SIMD32 warning:
/home/travis/build/eried/portapack-mayhem/firmware/baseband/channel_stats_collector.hpp: In member function 'void ChannelStatsCollector::feed(const buffer_c16_t&, Callback)':
442/home/travis/build/eried/portapack-mayhem/firmware/chibios-portapack/os/hal/platforms/LPC43xx_M4/lpc43xx_m4.h:132:26: warning: dereferencing type-punned pointer will break strict-aliasing rules [-Wstrict-aliasing]
443 #define __SIMD32(addr)  (*(__SIMD32_TYPE **) & (addr))
444                         ~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
445/home/travis/build/eried/portapack-mayhem/firmware/baseband/channel_stats_collector.hpp:40:29: note: in expansion of macro '__SIMD32'
446    const uint32_t sample = *__SIMD32(src_p)++;
447                             ^~~~~~~~