### PR TITLE
Fix warning: cast between incompatible function types 

### DIFF
--- a/firmware/chibios/os/kernel/src/chsys.c
+++ b/firmware/chibios/os/kernel/src/chsys.c
@@ -119,7 +119,7 @@ void chSysInit(void) {
      serve interrupts in its context while keeping the lowest energy saving
      mode compatible with the system status.*/
   chThdCreateStatic(_idle_thread_wa, sizeof(_idle_thread_wa), IDLEPRIO,
-                    (tfunc_t)_idle_thread, NULL);
+                    (void *)_idle_thread, NULL);
 #endif
 }
 


### PR DESCRIPTION
/opt/portapack-mayhem/firmware/chibios/os/kernel/src/chsys.c:122:21: warning: cast between incompatible function types from 'void (*)(void *)' to 'msg_t (*)(void *)' {aka 'long int (*)(void *)'} [-Wcast-function-type]
  122 |                     (tfunc_t)_idle_thread, NULL);
      |                     ^
