### PR TITLE
Fix adsb warnings

### DIFF
--- a/firmware/common/adsb.cpp
+++ b/firmware/common/adsb.cpp
@@ -319,14 +319,14 @@ void encode_frame_velo(ADSBFrame& frame, const uint32_t ICAO_address, const uint
 
 // Decoding method from dump1090
 adsb_vel decode_frame_velo(ADSBFrame& frame){
-	adsb_vel velo {false, 0, 0};
+	adsb_vel velo {false, 0, 0, 0};
 
 	uint8_t * frame_data = frame.get_raw_data();
 	uint8_t velo_type = frame.get_msg_sub();
 
 	if(velo_type >= 1 && velo_type <= 4){ //vertical rate is always present
 
-		velo.v_rate = (((frame_data[8] & 0x07 ) << 6) | ((frame_data[9]) >> 2) - 1) * 64;
+		velo.v_rate = (((frame_data[8] & 0x07 ) << 6) | ((frame_data[9] >> 2) - 1)) * 64;
 
 		if((frame_data[8] & 0x8) >> 3) velo.v_rate *= -1; //check v_rate sign
 	}

--- a/firmware/common/adsb_frame.hpp
+++ b/firmware/common/adsb_frame.hpp
@@ -69,7 +69,7 @@ public:
 	}
 
 	uint8_t * get_raw_data() const {
-		return (uint8_t* const)raw_data;
+		return (uint8_t* )raw_data;
 	}
 	
 	void make_CRC() {


### PR DESCRIPTION
Fix invalid return cast:
opt/portapack-mayhem/firmware/common/adsb_frame.hpp: In member function 'uint8_t* adsb::ADSBFrame::get_raw_data() const':
/opt/portapack-mayhem/firmware/common/adsb_frame.hpp:72:26: warning: type qualifiers ignored on cast result type [-Wignored-qualifiers]
   72 |   return (uint8_t* const)raw_data;
      |                          ^~~~~~~~
And missing initializer:
/opt/portapack-mayhem/firmware/common/adsb.cpp: In function 'adsb::adsb_vel adsb::decode_frame_velo(adsb::ADSBFrame&)':
/opt/portapack-mayhem/firmware/common/adsb.cpp:322:28: warning: missing initializer for member 'adsb::adsb_vel::v_rate' [-Wmissing-field-initializers]
  322 |  adsb_vel velo {false, 0, 0};
      |                            ^
