### PR TITLE
removed unused variables

### DIFF
--- a/firmware/baseband/tv_collector.cpp
+++ b/firmware/baseband/tv_collector.cpp
@@ -88,11 +88,9 @@ void TvCollector::post_message(const buffer_c16_t& data) {
 	// Called from baseband processing thread.
         float re, im;
 	float mag;
-        float max;
 	if( streaming && !channel_spectrum_request_update ) {
                 for(size_t i=0; i<256; i++) 
 		{
-			const auto s = data.p[i];
                         re = (float)(data.p[i].real());
 			im = (float)(data.p[i].imag());
 			mag = __builtin_sqrtf((re * re) + (im * im)) ;


### PR DESCRIPTION
Fix for:
/opt/portapack-mayhem/firmware/baseband/tv_collector.cpp: In member function 'void TvCollector::post_message(const buffer_c16_t&)':
/opt/portapack-mayhem/firmware/baseband/tv_collector.cpp:95:15: warning: variable 's' set but not used [-Wunused-but-set-variable]
   95 |    const auto s = data.p[i];
      |               ^
/opt/portapack-mayhem/firmware/baseband/tv_collector.cpp:91:15: warning: unused variable 'max' [-Wunused-variable]
   91 |         float max;
      |               ^~~
