### PR TITLE
fix unused result

### DIFF
--- a/firmware/baseband/proc_capture.cpp
+++ b/firmware/baseband/proc_capture.cpp
@@ -44,7 +44,11 @@ void CaptureProcessor::execute(const buffer_c8_t& buffer) {
 
 	if( stream ) {
 		const size_t bytes_to_write = sizeof(*decimator_out.p) * decimator_out.count;
-		const auto result = stream->write(decimator_out.p, bytes_to_write);
+		const size_t written = stream->write(decimator_out.p, bytes_to_write);
+		if( written != bytes_to_write )
+		{
+			//TODO eventually report error somewhere
+		}
 	}
 
 	feed_channel_stats(channel);


### PR DESCRIPTION
Fix for:
/opt/portapack-mayhem/firmware/baseband/proc_capture.cpp: In member function 'virtual void CaptureProcessor::execute(const buffer_c8_t&)':
/opt/portapack-mayhem/firmware/baseband/proc_capture.cpp:47:14: warning: unused variable 'result' [-Wunused-variable]
   47 |   const auto result = stream->write(decimator_out.p, bytes_to_write);
      |              ^~~~~~

In that particular case I added an empty test in case one day we want to report a problem