### PR TITLE
Quoted out unused variable

### DIFF
--- a/firmware/baseband/proc_am_audio.cpp
+++ b/firmware/baseband/proc_am_audio.cpp
@@ -87,7 +87,7 @@ void NarrowbandAMAudio::configure(const AMConfigureMessage& message) {
 	constexpr size_t decim_2_output_fs = decim_2_input_fs / decim_2_decimation_factor;
 
 	constexpr size_t channel_filter_input_fs = decim_2_output_fs;
-	const size_t channel_filter_output_fs = channel_filter_input_fs / channel_filter_decimation_factor;
+	//const size_t channel_filter_output_fs = channel_filter_input_fs / channel_filter_decimation_factor;
 
 	decim_0.configure(message.decim_0_filter.taps, 33554432);
 	decim_1.configure(message.decim_1_filter.taps, 131072);


### PR DESCRIPTION
Fix for:
pt/portapack-mayhem/firmware/baseband/proc_am_audio.cpp: In member function 'void NarrowbandAMAudio::configure(const AMConfigureMessage&)':
/opt/portapack-mayhem/firmware/baseband/proc_am_audio.cpp:90:15: warning: unused variable 'channel_filter_output_fs' [-Wunused-variable]
   90 |  const size_t channel_filter_output_fs = channel_filter_input_fs / channel_filter_decimation_factor;
      |               ^~~~~~~~~~~~~~~~~~~~~~~~

I quoted it so we have a trace of the calculus if one day it's used