### PR TITLE
Added missing initialisation

### DIFF
--- a/firmware/baseband/proc_audiotx.hpp
+++ b/firmware/baseband/proc_audiotx.hpp
@@ -50,7 +50,7 @@ private:
 	int32_t sample { 0 }, delta { };
 	int8_t re { 0 }, im { 0 };
 	
-	size_t progress_interval_samples, progress_samples = 0;
+	size_t progress_interval_samples = 0 , progress_samples = 0;
 	
 	bool configured { false };
 	uint32_t bytes_read { 0 };


### PR DESCRIPTION
Fix for:
In file included from /opt/portapack-mayhem/firmware/baseband/proc_audiotx.cpp:23:
/opt/portapack-mayhem/firmware/baseband/proc_audiotx.hpp: In instantiation of 'typename std::_MakeUniq<_Tp>::__single_object std::make_unique(_Args&& ...) [with _Tp = AudioTXProcessor; _Args = {}; typename std::_MakeUniq<_Tp>::__single_object = std::unique_ptr<AudioTXProcessor, std::default_delete<AudioTXProcessor> >]':
/opt/portapack-mayhem/firmware/baseband/proc_audiotx.cpp:118:72:   required from here
/opt/portapack-mayhem/firmware/baseband/proc_audiotx.hpp:31:7: warning: 'AudioTXProcessor::progress_interval_samples' should be initialized in the member initialization list [-Weffc++]
   31 | class AudioTXProcessor : public BasebandProcessor {
      |       ^~~~~~~~~~~~~~~~
