### PR TITLE
Quoted unused vars and voided one

### DIFF
--- a/firmware/baseband/proc_am_tv.cpp
+++ b/firmware/baseband/proc_am_tv.cpp
@@ -43,14 +43,15 @@ void WidebandFMAudio::execute(const buffer_c8_t& buffer) {
 	const buffer_c16_t buffer_c16 {spectrum.data(),spectrum.size(),buffer.sampling_rate};
 	channel_spectrum.feed(buffer_c16);
 
-        int8_t re, im;
-	int8_t mag;
+        int8_t re ;
+	//int8_t im;  
+	//int8_t mag;
 
         for (size_t i = 0; i < 128; i++) 
 	{
 		re = buffer.p[i].real();
-		im = buffer.p[i].imag();
-		mag = __builtin_sqrtf((re * re) + (im * im)) ;
+		//im = buffer.p[i].imag();
+		//mag = __builtin_sqrtf((re * re) + (im * im)) ;
 		const unsigned int v =  re + 127.0f; //timescope
 		audio_spectrum.db[i] = std::max(0U, std::min(255U, v));
 	}
@@ -75,6 +76,7 @@ void WidebandFMAudio::on_message(const Message* const message) {
 }
 
 void WidebandFMAudio::configure(const WFMConfigureMessage& message) {
+	(void)message; // avoid warning
 	configured = true;
 }
 


### PR DESCRIPTION
Fix for:
/opt/portapack-mayhem/firmware/baseband/proc_am_tv.cpp: In member function 'virtual void WidebandFMAudio::execute(const buffer_c8_t&)':
/opt/portapack-mayhem/firmware/baseband/proc_am_tv.cpp:47:9: warning: variable 'mag' set but not used [-Wunused-but-set-variable]
   47 |  int8_t mag;
      |         ^~~
/opt/portapack-mayhem/firmware/baseband/proc_am_tv.cpp: In member function 'void WidebandFMAudio::configure(const WFMConfigureMessage&)':
/opt/portapack-mayhem/firmware/baseband/proc_am_tv.cpp:77:60: warning: unused parameter 'message' [-Wunused-parameter]
   77 | void WidebandFMAudio::configure(const WFMConfigureMessage& message) {
      |                                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~

As previous fix for that case I kept the calculus by just quoting unused vars.
The call to (void)message is doing nothing but killing the warning.