### PR TITLE
Added missing initialisations

### DIFF
--- a/firmware/baseband/proc_pocsag.hpp
+++ b/firmware/baseband/proc_pocsag.hpp
@@ -95,7 +95,7 @@ private:
 	bool configured = false;
 	rx_states rx_state { WAITING };
 	pocsag::BitRate bitrate { pocsag::BitRate::FSK1200 };
-	bool phase;
+	bool phase = false ;
 	uint32_t codeword_count { 0 };
 	pocsag::POCSAGPacket packet { };
 	

--- a/firmware/common/pocsag_packet.hpp
+++ b/firmware/common/pocsag_packet.hpp
@@ -87,7 +87,7 @@ public:
 private:
 	BitRate bitrate_ { UNKNOWN };
 	PacketFlag flag_ { NORMAL };
-	std::array <uint32_t, 16> codewords;
+	std::array <uint32_t, 16> codewords { 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0  };
 	Timestamp timestamp_ { };
 };
 


### PR DESCRIPTION
Fix for:
/opt/portapack-mayhem/firmware/common/pocsag_packet.hpp: In constructor 'pocsag::POCSAGPacket::POCSAGPacket()':
/opt/portapack-mayhem/firmware/common/pocsag_packet.hpp:46:7: warning: 'pocsag::POCSAGPacket::codewords' should be initialized in the member initialization list [-Weffc++]
   46 | class POCSAGPacket {
      |       ^~~~~~~~~~~~
In file included from /opt/portapack-mayhem/firmware/baseband/proc_pocsag.cpp:25:
/opt/portapack-mayhem/firmware/baseband/proc_pocsag.hpp: At global scope:
/opt/portapack-mayhem/firmware/baseband/proc_pocsag.hpp:100:32: note: synthesized method 'pocsag::POCSAGPacket::POCSAGPacket()' first required here
  100 |  pocsag::POCSAGPacket packet { };
      |                                ^
/opt/portapack-mayhem/firmware/baseband/proc_pocsag.hpp: In instantiation of 'typename std::_MakeUniq<_Tp>::__single_object std::make_unique(_Args&& ...) [with _Tp = POCSAGProcessor; _Args = {}; typename std::_MakeUniq<_Tp>::__single_object = std::unique_ptr<POCSAGProcessor, std::default_delete<POCSAGProcessor> >]':
/opt/portapack-mayhem/firmware/baseband/proc_pocsag.cpp:178:71:   required from here
/opt/portapack-mayhem/firmware/baseband/proc_pocsag.hpp:44:7: warning: 'POCSAGProcessor::phase' should be initialized in the member initialization list [-Weffc++]
   44 | class POCSAGProcessor : public BasebandProcessor {
      |       ^~~~~~~~~~~~~~~
