### PR TITLE
Fixed redefined define, possibly overflowing variable, missing constructors

### DIFF
--- a/firmware/application/apps/ui_looking_glass_app.cpp
+++ b/firmware/application/apps/ui_looking_glass_app.cpp
@@ -164,9 +164,9 @@ void GlassView::PlotMarker(rf::Frequency fpos)
     pos = pos / marker_pixel_step; //Real pixel 
 
     portapack::display.fill_rectangle({0, 100, 240, 8}, Color::black()); //Clear old marker and whole marker rectangle btw
-    portapack::display.fill_rectangle({pos - 2, 100, 5, 3}, Color::red()); //Red marker middle
-    portapack::display.fill_rectangle({pos - 1, 103, 3, 3}, Color::red()); //Red marker middle
-    portapack::display.fill_rectangle({pos, 106, 1, 2}, Color::red()); //Red marker middle
+    portapack::display.fill_rectangle({(int16_t)pos - 2, 100, 5, 3}, Color::red()); //Red marker middle
+    portapack::display.fill_rectangle({(int16_t)pos - 1, 103, 3, 3}, Color::red()); //Red marker middle
+    portapack::display.fill_rectangle({(int16_t)pos, 106, 1, 2}, Color::red()); //Red marker middle
 }
 
 GlassView::GlassView(

--- a/firmware/application/apps/ui_looking_glass_app.cpp
+++ b/firmware/application/apps/ui_looking_glass_app.cpp
@@ -216,10 +216,12 @@ GlassView::GlassView(
 
     filter_config.set_selected_index(0);
 	filter_config.on_change = [this](size_t n, OptionsField::value_t v) {
+		(void)n;
 		min_color_power = v;
 	};
 
 	range_presets.on_change = [this](size_t n, OptionsField::value_t v) {
+		(void)n;
 		field_frequency_min.set_value(presets_db[v].min,false);
         field_frequency_max.set_value(presets_db[v].max,false);
         this->on_range_changed();

--- a/firmware/application/apps/ui_looking_glass_app.cpp
+++ b/firmware/application/apps/ui_looking_glass_app.cpp
@@ -100,7 +100,7 @@ void GlassView::on_channel_spectrum(const ChannelSpectrum &spectrum)
     }
 
     if (pixel_index) 
-        f_center += SEARCH_SLICE_WIDTH; //Move into the next bandwidth slice NOTE: spectrum.sampling_rate = SEARCH_SLICE_WIDTH
+        f_center += LOOKING_GLASS_SLICE_WIDTH; //Move into the next bandwidth slice NOTE: spectrum.sampling_rate = LOOKING_GLASS_SLICE_WIDTH
     else
         f_center = f_center_ini; //Start a new sweep
 
@@ -143,8 +143,8 @@ void GlassView::on_range_changed()
     else
         field_marker.set_step(marker_step); //step needs to be a pixel wide.
 
-    f_center_ini = f_min + (SEARCH_SLICE_WIDTH / 2);    //Initial center frequency for sweep
-    f_center_ini += SEARCH_SLICE_WIDTH;                 //euquiq: Why do I need to move the center ???!!! (shift needed for marker accuracy)
+    f_center_ini = f_min + (LOOKING_GLASS_SLICE_WIDTH / 2);    //Initial center frequency for sweep
+    f_center_ini += LOOKING_GLASS_SLICE_WIDTH;                 //euquiq: Why do I need to move the center ???!!! (shift needed for marker accuracy)
 
     PlotMarker(field_marker.value()); //Refresh marker on screen
 
@@ -153,13 +153,13 @@ void GlassView::on_range_changed()
     max_power = 0;
     bins_Hz_size = 0;                               //reset amount of Hz filled up by pixels
     
-    baseband::set_spectrum(SEARCH_SLICE_WIDTH, field_trigger.value());   
+    baseband::set_spectrum(LOOKING_GLASS_SLICE_WIDTH, field_trigger.value());   
     receiver_model.set_tuning_frequency(f_center_ini); //tune rx for this slice
 }
 
-void GlassView::PlotMarker(rf::Frequency pos)
+void GlassView::PlotMarker(rf::Frequency fpos)
 {
-    pos = pos * MHZ_DIV;
+    int64_t pos = fpos * MHZ_DIV;
     pos -= f_min;
     pos = pos / marker_pixel_step; //Real pixel 
 
@@ -240,11 +240,11 @@ GlassView::GlassView(
 
     field_trigger.set_value(32);   //Defaults to 32, as normal triggering resolution
     field_trigger.on_change = [this](int32_t v) {
-        baseband::set_spectrum(SEARCH_SLICE_WIDTH, v);
+        baseband::set_spectrum(LOOKING_GLASS_SLICE_WIDTH, v);
     };
 
     display.scroll_set_area( 109, 319);
-    baseband::set_spectrum(SEARCH_SLICE_WIDTH, field_trigger.value());	//trigger:
+    baseband::set_spectrum(LOOKING_GLASS_SLICE_WIDTH, field_trigger.value());	//trigger:
     // Discord User jteich:  WidebandSpectrum::on_message to set the trigger value. In WidebandSpectrum::execute ,
     // it keeps adding the output of the fft to the buffer until "trigger" number of calls are made, 
     //at which time it pushes the buffer up with channel_spectrum.feed
@@ -252,8 +252,8 @@ GlassView::GlassView(
     on_range_changed();
 
     receiver_model.set_modulation(ReceiverModel::Mode::SpectrumAnalysis);
-	receiver_model.set_sampling_rate(SEARCH_SLICE_WIDTH); //20mhz
-    receiver_model.set_baseband_bandwidth(SEARCH_SLICE_WIDTH); // possible values: 1.75/2.5/3.5/5/5.5/6/7/8/9/10/12/14/15/20/24/28MHz
+	receiver_model.set_sampling_rate(LOOKING_GLASS_SLICE_WIDTH); //20mhz
+    receiver_model.set_baseband_bandwidth(LOOKING_GLASS_SLICE_WIDTH); // possible values: 1.75/2.5/3.5/5/5.5/6/7/8/9/10/12/14/15/20/24/28MHz
     receiver_model.set_squelch_level(0);
 	receiver_model.enable();
 }

--- a/firmware/application/apps/ui_looking_glass_app.hpp
+++ b/firmware/application/apps/ui_looking_glass_app.hpp
@@ -33,7 +33,7 @@
 
  namespace ui
  {
-     #define SEARCH_SLICE_WIDTH	20000000 // Each slice bandwidth 20 MHz
+     #define LOOKING_GLASS_SLICE_WIDTH	20000000 // Each slice bandwidth 20 MHz
      #define MHZ_DIV	            1000000
      #define X2_MHZ_DIV	        2000000
 
@@ -41,6 +41,10 @@
      {
      public:
          GlassView(NavigationView &nav);
+
+	 GlassView( const GlassView &);
+	 GlassView& operator=(const GlassView &nav);
+
          ~GlassView();
          std::string title() const override { return "Looking Glass"; };
 
@@ -77,7 +81,7 @@
          rf::Frequency f_center { 0 };
          rf::Frequency f_center_ini { 0 };
          rf::Frequency marker_pixel_step { 0 };
-         rf::Frequency each_bin_size { SEARCH_SLICE_WIDTH  / 240 };
+         rf::Frequency each_bin_size { LOOKING_GLASS_SLICE_WIDTH  / 240 };
          rf::Frequency bins_Hz_size { 0 };
          uint8_t min_color_power { 0 };
          uint32_t pixel_index { 0 };


### PR DESCRIPTION
Fix for:

/opt/portapack-mayhem/firmware/application/apps/ui_looking_glass_app.hpp:36: warning: "SEARCH_SLICE_WIDTH" redefined
   36 |      #define SEARCH_SLICE_WIDTH 20000000 // Each slice bandwidth 20 MHz
      | 
In file included from /opt/portapack-mayhem/firmware/application/ui_navigation.cpp:58:
/opt/portapack-mayhem/firmware/application/apps/ui_search.hpp:33: note: this is the location of the previous definition
   33 | #define SEARCH_SLICE_WIDTH 2500000     // Search slice bandwidth
      | 

And:

/opt/portapack-mayhem/firmware/application/apps/ui_looking_glass_app.hpp:40:12: warning: 'class ui::GlassView' has pointer data members [-Weffc++]
   40 |      class GlassView : public View
      |            ^~~~~~~~~
/opt/portapack-mayhem/firmware/application/apps/ui_looking_glass_app.hpp:40:12: warning:   but does not override 'ui::GlassView(const ui::GlassView&)' [-Weffc++]
/opt/portapack-mayhem/firmware/application/apps/ui_looking_glass_app.hpp:40:12: warning:   or 'operator=(const ui::GlassView&)' [-Weffc++]

And:

/opt/portapack-mayhem/firmware/application/apps/ui_looking_glass_app.cpp:167:44: warning: narrowing conversion of '(pos - 2)' from 'rf::Frequency' {aka 'long long int'} to 'int' [-Wnarrowing]
  167 |     portapack::display.fill_rectangle({pos - 2, 100, 5, 3}, Color::red()); //Red marker middle
      |                                        ~~~~^~~
/opt/portapack-mayhem/firmware/application/apps/ui_looking_glass_app.cpp:168:44: warning: narrowing conversion of '(pos - 1)' from 'rf::Frequency' {aka 'long long int'} to 'int' [-Wnarrowing]
  168 |     portapack::display.fill_rectangle({pos - 1, 103, 3, 3}, Color::red()); //Red marker middle
      |                                        ~~~~^~~
/opt/portapack-mayhem/firmware/application/apps/ui_looking_glass_app.cpp:169:40: warning: narrowing conversion of 'pos' from 'rf::Frequency' {aka 'long long int'} to 'int' [-Wnarrowing]
  169 |     portapack::display.fill_rectangle({pos, 106, 1, 2}, Color::red()); //Red marker middle
      |                                        ^~~


