### PR TITLE
Added missing default constructor

### DIFF
--- a/firmware/common/ais_packet.hpp
+++ b/firmware/common/ais_packet.hpp
@@ -42,6 +42,7 @@ struct DateTime {
 
 template<size_t FieldSize, int32_t DegMax, uint32_t NAValue>
 struct LatLonBase {
+	
 	constexpr LatLonBase(
 	) : LatLonBase { raw_not_available }
 	{
@@ -58,6 +59,8 @@ struct LatLonBase {
 	) : raw_ { other.raw_ }
 	{
 	}
+	
+	LatLonBase& operator=( const LatLonBase &)=default;
 
 	int32_t normalized() const {
 		return static_cast<int32_t>(raw() << sign_extend_shift) / (1 << sign_extend_shift);


### PR DESCRIPTION
Fix for:
/opt/portapack-mayhem/firmware/application/apps/ais_app.hpp:117:7: warning: 'class ui::AISRecentEntryDetailView' has pointer data members [-Weffc++]
  117 | class AISRecentEntryDetailView : public View {
      |       ^~~~~~~~~~~~~~~~~~~~~~~~
/opt/portapack-mayhem/firmware/application/apps/ais_app.hpp:117:7: warning:   but does not override 'ui::AISRecentEntryDetailView(const ui::AISRecentEntryDetailView&)' [-Weffc++]
/opt/portapack-mayhem/firmware/application/apps/ais_app.hpp:117:7: warning:   or 'operator=(const ui::AISRecentEntryDetailView&)' [-Weffc++]
