### PR TITLE
Added missing brace

### DIFF
--- a/firmware/application/ui_navigation.cpp
+++ b/firmware/application/ui_navigation.cpp
@@ -625,10 +625,12 @@ SystemView::SystemView(
 		navigation_view.push<SystemMenuView>();
 		
 		if (portapack::persistent_memory::config_splash())
+		{
 			navigation_view.push<BMPView>();
 			status_view.set_back_enabled(false);
 			status_view.set_title_image_enabled(true);
 			status_view.set_dirty();
+		}
 		//else
 		//	navigation_view.push<SystemMenuView>();
 			

--- a/firmware/application/ui_navigation.cpp
+++ b/firmware/application/ui_navigation.cpp
@@ -627,10 +627,10 @@ SystemView::SystemView(
 		if (portapack::persistent_memory::config_splash())
 		{
 			navigation_view.push<BMPView>();
+		}
 			status_view.set_back_enabled(false);
 			status_view.set_title_image_enabled(true);
 			status_view.set_dirty();
-		}
 		//else
 		//	navigation_view.push<SystemMenuView>();
 			


### PR DESCRIPTION
Fix for:

/opt/portapack-mayhem/firmware/application/ui_navigation.cpp: In constructor 'ui::SystemView::SystemView(ui::Context&, ui::Rect)':
/opt/portapack-mayhem/firmware/application/ui_navigation.cpp:627:3: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
  627 |   if (portapack::persistent_memory::config_splash())
      |   ^~
/opt/portapack-mayhem/firmware/application/ui_navigation.cpp:629:4: note: ...this statement, but the latter is misleadingly indented as if it were guarded by the 'if'
  629 |    status_view.set_back_enabled(false);
      |    ^~~~~~~~~~~

@eried you may want to check if what is in the block had to be in or not. Tested with and without and couldn't spot a difference.