### PR TITLE
Added missing default constructor

### DIFF
--- a/firmware/application/apps/ert_app.hpp
+++ b/firmware/application/apps/ert_app.hpp
@@ -50,6 +50,8 @@ struct ERTKey {
 	{
 	}
 
+	ERTKey( const ERTKey& other ) = default;
+
 	ERTKey& operator=(const ERTKey& other) {
 		id = other.id;
 		commodity_type = other.commodity_type;


### PR DESCRIPTION
Fix for:
opt/portapack-mayhem/firmware/application/./recent_entries.hpp: In instantiation of 'ui::RecentEntriesTable<Entries>::RecentEntriesTable(Entries&) [with Entries = std::__cxx11::list<ERTRecentEntry, std::allocator<ERTRecentEntry> >]':
/opt/portapack-mayhem/firmware/application/./recent_entries.hpp:240:19:   required from 'ui::RecentEntriesView<Entries>::RecentEntriesView(const ui::RecentEntriesColumns&, Entries&) [with Entries = std::__cxx11::list<ERTRecentEntry, std::allocator<ERTRecentEntry> >]'
/opt/portapack-mayhem/firmware/application/apps/ert_app.hpp:138:61:   required from here
/opt/portapack-mayhem/firmware/application/./recent_entries.hpp:193:11: warning: implicitly-declared 'constexpr ERTKey::ERTKey(const ERTKey&)' is deprecated [-Wdeprecated-copy]
  193 |  EntryKey selected_key = Entry::invalid_key;
      |           ^~~~~~~~~~~~
In file included from /opt/portapack-mayhem/firmware/application/ui_navigation.cpp:75:
/opt/portapack-mayhem/firmware/application/apps/ert_app.hpp:53:10: note: because 'ERTKey' has user-provided 'ERTKey& ERTKey::operator=(const ERTKey&)'
   53 |  ERTKey& operator=(const ERTKey& other) {
      |          ^~~~~~~~
