### PR TITLE
removed unused var

### DIFF
--- a/firmware/application/apps/analog_tv_app.cpp
+++ b/firmware/application/apps/analog_tv_app.cpp
@@ -199,7 +199,7 @@ void AnalogTvView::on_show_options_rf_gain() {
 void AnalogTvView::on_show_options_modulation() {
 	std::unique_ptr<Widget> widget;
 
-	const auto modulation = static_cast<ReceiverModel::Mode>(receiver_model.modulation());
+	static_cast<ReceiverModel::Mode>(receiver_model.modulation());
 	tv.show_audio_spectrum_view(true);
 	
 	set_options_widget(std::move(widget));
@@ -216,6 +216,7 @@ void AnalogTvView::on_reference_ppm_correction_changed(int32_t v) {
 }
 
 void AnalogTvView::on_headphone_volume_changed(int32_t v) {
+	(void)v; //avoid warning
 	//tv::TVView::set_headphone_volume(this,v);
 }
 

--- a/firmware/application/apps/analog_tv_app.hpp
+++ b/firmware/application/apps/analog_tv_app.hpp
@@ -107,7 +107,7 @@ private:
 
 	std::unique_ptr<Widget> options_widget { };
 
-	tv::TVWidget tv { true };
+	tv::TVWidget tv { };
 
 	void on_tuning_frequency_changed(rf::Frequency f);
 	void on_baseband_bandwidth_changed(uint32_t bandwidth_hz);

--- a/firmware/application/ui/ui_tv.cpp
+++ b/firmware/application/ui/ui_tv.cpp
@@ -182,7 +182,7 @@ void TVView::clear() {
 
 /* TVWidget *******************************************************/
 
-TVWidget::TVWidget(const bool cursor) {
+TVWidget::TVWidget() {
 	add_children({
 		&tv_view,
 		&field_xcorr

--- a/firmware/application/ui/ui_tv.hpp
+++ b/firmware/application/ui/ui_tv.hpp
@@ -92,7 +92,7 @@ class TVWidget : public View {
 public:
 	std::function<void(int32_t offset)> on_select { };
 	
-	TVWidget(const bool cursor = false);
+	TVWidget();
 
 	TVWidget(const TVWidget&) = delete;
 	TVWidget(TVWidget&&) = delete;


### PR DESCRIPTION
Fix for:
opt/portapack-mayhem/firmware/application/ui/ui_tv.cpp: In constructor 'ui::tv::TVWidget::TVWidget(bool)':
/opt/portapack-mayhem/firmware/application/ui/ui_tv.cpp:185:31: warning: unused parameter 'cursor' [-Wunused-parameter]
  185 | TVWidget::TVWidget(const bool cursor) {
      |                    ~~~~~~~~~~~^~~~~~

And:
/opt/portapack-mayhem/firmware/application/apps/analog_tv_app.cpp: In member function 'void ui::AnalogTvView::on_show_options_modulation()':
/opt/portapack-mayhem/firmware/application/apps/analog_tv_app.cpp:202:13: warning: unused variable 'modulation' [-Wunused-variable]
202 | const auto modulation = static_castReceiverModel::Mode(receiver_model.modulation());
| ^~~~~~~~~~
/opt/portapack-mayhem/firmware/application/apps/analog_tv_app.cpp: In member function 'void ui::AnalogTvView::on_headphone_volume_changed(int32_t)':
/opt/portapack-mayhem/firmware/application/apps/analog_tv_app.cpp:218:56: warning: unused parameter 'v' [-Wunused-parameter]
218 | void AnalogTvView::on_headphone_volume_changed(int32_t v) {
| ~~~~~~~~^

