### PR TITLE
Added a voided v

### DIFF
--- a/firmware/application/apps/ui_fileman.cpp
+++ b/firmware/application/apps/ui_fileman.cpp
@@ -216,6 +216,7 @@ FileSaveView::FileSaveView(
 }*/
 
 void FileLoadView::refresh_widgets(const bool v) {
+	(void)v; //avoid unused warning
 	set_dirty();
 }
 


### PR DESCRIPTION
Fix for:

/opt/portapack-mayhem/firmware/application/apps/ui_fileman.cpp: In member function 'void ui::FileLoadView::refresh_widgets(bool)':
/opt/portapack-mayhem/firmware/application/apps/ui_fileman.cpp:218:47: warning: unused parameter 'v' [-Wunused-parameter]
  218 | void FileLoadView::refresh_widgets(const bool v) {
      |                                    ~~~~~~~~~~~^
