### PR TITLE
Fixed uninitialized / missing switch cases, unused

### DIFF
--- a/firmware/application/apps/ui_scanner.cpp
+++ b/firmware/application/apps/ui_scanner.cpp
@@ -172,7 +172,7 @@ void ScannerView::show_max() {		//show total number of freqs to scan
 
 ScannerView::ScannerView(
 	NavigationView& nav
-	) : nav_ { nav }
+	) : nav_ { nav } , loaded_file_name { "SCANNER" }
 {
 	add_children({
 		&labels,
@@ -364,7 +364,7 @@ ScannerView::ScannerView(
 				big_display.set(frequency_list[current_index]);		//After showing an error
 			}
 			else {
-				auto result = scanner_file.append(freq_file_path); //Second: append if it is not there
+				scanner_file.append(freq_file_path); //Second: append if it is not there
 				scanner_file.write_line(frequency_to_add + ",d=ADD FQ");
 			}
 		} else
@@ -409,7 +409,12 @@ void ScannerView::frequency_file_load(std::string file_name, bool stop_all_befor
 						case FM_2:	def_step = 50000; 	break ;
 						case N_1:	def_step = 25000;  	break ;
 						case N_2:	def_step = 250000; 	break ;
-						case AIRBAND:def_step= 8330;  	break ;
+						case AIRBAND:   def_step= 8330;  	break ;
+						case ERROR_STEP:
+						case STEP_DEF:
+						default:
+							def_step = step_mode.selected_index_value(); //Use def_step from manual selector
+								 			break ;		
 					}
 					frequency_list.push_back(entry.frequency_a);		//Store starting freq and description
 					description_list.push_back("R" + to_string_short_freq(entry.frequency_a)
@@ -435,7 +440,7 @@ void ScannerView::frequency_file_load(std::string file_name, bool stop_all_befor
 	} 
 	else 
 	{
-		loaded_file_name = 'SCANNER'; // back to the default frequency file
+		loaded_file_name = "SCANNER"; // back to the default frequency file
 		desc_cycle.set(" NO " + file_name + ".TXT FILE ..." );
 	}
 	audio::output::stop();
@@ -504,7 +509,9 @@ size_t ScannerView::change_mode(uint8_t new_mod) { //Before this, do a scan_thre
 	using option_t = std::pair<std::string, int32_t>;
 	using options_t = std::vector<option_t>;
 	options_t bw;
-	field_bw.on_change = [this](size_t n, OptionsField::value_t) {	};
+	field_bw.on_change = [this](size_t n, OptionsField::value_t) { 
+		(void)n;  //avoid unused warning 
+	};
 
 	switch (new_mod) {
 	case NFM:	//bw 16k (2) default


### PR DESCRIPTION
Fix for:

/opt/portapack-mayhem/firmware/application/apps/ui_scanner.cpp:438:22: warning: character constant too long for its type
  438 |   loaded_file_name = 'SCANNER'; // back to the default frequency file
      |                      ^~~~~~~~~

/opt/portapack-mayhem/firmware/application/apps/ui_scanner.cpp: In constructor 'ui::ScannerView::ScannerView(ui::NavigationView&)':
/opt/portapack-mayhem/firmware/application/apps/ui_scanner.cpp:173:1: warning: 'ui::ScannerView::loaded_file_name' should be initialized in the member initialization list [-Weffc++]
  173 | ScannerView::ScannerView(
      | ^~~~~~~~~~~
/opt/portapack-mayhem/firmware/application/apps/ui_scanner.cpp: In lambda function:
/opt/portapack-mayhem/firmware/application/apps/ui_scanner.cpp:367:10: warning: variable 'result' set but not used [-Wunused-but-set-variable]
  367 |     auto result = scanner_file.append(freq_file_path); //Second: append if it is not there
      |          ^~~~~~
/opt/portapack-mayhem/firmware/application/apps/ui_scanner.cpp: In member function 'void ui::ScannerView::frequency_file_load(std::string, bool)':
/opt/portapack-mayhem/firmware/application/apps/ui_scanner.cpp:403:13: warning: enumeration value 'STEP_DEF' not handled in switch [-Wswitch]
  403 |      switch (entry.step) {
      |             ^
/opt/portapack-mayhem/firmware/application/apps/ui_scanner.cpp:403:13: warning: enumeration value 'ERROR_STEP' not handled in switch [-Wswitch]
/opt/portapack-mayhem/firmware/application/apps/ui_scanner.cpp:438:22: warning: unsigned conversion from 'int' to 'char' changes value from '1313752402' to ''R'' [-Woverflow]
  438 |   loaded_file_name = 'SCANNER'; // back to the default frequency file
      |                      ^~~~~~~~~

/opt/portapack-mayhem/firmware/application/apps/ui_scanner.cpp: In lambda function:
/opt/portapack-mayhem/firmware/application/apps/ui_scanner.cpp:507:37: warning: unused parameter 'n' [-Wunused-parameter]
  507 |  field_bw.on_change = [this](size_t n, OptionsField::value_t) { };
      |                              ~~~~~~~^
