### PR TITLE
Added missing initializer

### DIFF
--- a/firmware/application/apps/ui_settings.cpp
+++ b/firmware/application/apps/ui_settings.cpp
@@ -155,7 +155,7 @@ SetRadioView::SetRadioView(
 	});
 
 	SetFrequencyCorrectionModel model {
-		static_cast<int8_t>(portapack::persistent_memory::correction_ppb() / 1000)
+		static_cast<int8_t>(portapack::persistent_memory::correction_ppb() / 1000) , 0
 	};
 
 	form_init(model);


### PR DESCRIPTION
Fix for:
/opt/portapack-mayhem/firmware/application/apps/ui_settings.cpp: In constructor 'ui::SetRadioView::SetRadioView(ui::NavigationView&)':
/opt/portapack-mayhem/firmware/application/apps/ui_settings.cpp:159:2: warning: missing initializer for member 'ui::SetFrequencyCorrectionModel::freq' [-Wmissing-field-initializers]
  159 |  };
      |  ^
