### PR TITLE
Added missing initializer

### DIFF
--- a/firmware/application/apps/ui_sonde.hpp
+++ b/firmware/application/apps/ui_sonde.hpp
@@ -68,9 +68,9 @@ private:
 	uint32_t target_frequency_ { 402700000 };
 	bool logging { false };
 	bool use_crc { false };
-	sonde::GPS_data gps_info;
-	sonde::temp_humid temp_humid_info;
-	std::string sonde_id;
+	sonde::GPS_data gps_info { };
+	sonde::temp_humid temp_humid_info { };
+	std::string sonde_id { };
 	
 	Labels labels {
 		{ { 4 * 8, 2 * 16 }, "Type:", Color::light_grey() },


### PR DESCRIPTION
Fix for:
/opt/portapack-mayhem/firmware/application/apps/ui_sonde.cpp: In constructor 'ui::SondeView::SondeView(ui::NavigationView&)':
/opt/portapack-mayhem/firmware/application/apps/ui_sonde.cpp:43:1: warning: 'ui::SondeView::gps_info' should be initialized in the member initialization list [-Weffc++]
   43 | SondeView::SondeView(NavigationView& nav) {
      | ^~~~~~~~~
/opt/portapack-mayhem/firmware/application/apps/ui_sonde.cpp:43:1: warning: 'ui::SondeView::temp_humid_info' should be initialized in the member initialization list [-Weffc++]
/opt/portapack-mayhem/firmware/application/apps/ui_sonde.cpp:43:1: warning: 'ui::SondeView::sonde_id' should be initialized in the member initialization list [-Weffc++]

