### PR TITLE
removed a var, added a void, removed a unused initializer. 

### DIFF
--- a/firmware/application/apps/analog_tv_app.cpp
+++ b/firmware/application/apps/analog_tv_app.cpp
@@ -199,7 +199,7 @@ void AnalogTvView::on_show_options_rf_gain() {
 void AnalogTvView::on_show_options_modulation() {
 	std::unique_ptr<Widget> widget;
 
-	const auto modulation = static_cast<ReceiverModel::Mode>(receiver_model.modulation());
+	static_cast<ReceiverModel::Mode>(receiver_model.modulation());
 	tv.show_audio_spectrum_view(true);
 	
 	set_options_widget(std::move(widget));
@@ -216,6 +216,7 @@ void AnalogTvView::on_reference_ppm_correction_changed(int32_t v) {
 }
 
 void AnalogTvView::on_headphone_volume_changed(int32_t v) {
+	(void)v; //avoid warning
 	//tv::TVView::set_headphone_volume(this,v);
 }
 

--- a/firmware/application/apps/analog_tv_app.hpp
+++ b/firmware/application/apps/analog_tv_app.hpp
@@ -107,7 +107,7 @@ private:
 
 	std::unique_ptr<Widget> options_widget { };
 
-	tv::TVWidget tv { true };
+	tv::TVWidget tv { };
 
 	void on_tuning_frequency_changed(rf::Frequency f);
 	void on_baseband_bandwidth_changed(uint32_t bandwidth_hz);


### PR DESCRIPTION
Fix for:
/opt/portapack-mayhem/firmware/application/apps/analog_tv_app.cpp: In member function 'void ui::AnalogTvView::on_show_options_modulation()':
/opt/portapack-mayhem/firmware/application/apps/analog_tv_app.cpp:202:13: warning: unused variable 'modulation' [-Wunused-variable]
  202 |  const auto modulation = static_cast<ReceiverModel::Mode>(receiver_model.modulation());
      |             ^~~~~~~~~~
/opt/portapack-mayhem/firmware/application/apps/analog_tv_app.cpp: In member function 'void ui::AnalogTvView::on_headphone_volume_changed(int32_t)':
/opt/portapack-mayhem/firmware/application/apps/analog_tv_app.cpp:218:56: warning: unused parameter 'v' [-Wunused-parameter]
  218 | void AnalogTvView::on_headphone_volume_changed(int32_t v) {
      |                                                ~~~~~~~~^
