### PR TITLE
added a voided var

### DIFF
--- a/firmware/application/apps/soundboard_app.cpp
+++ b/firmware/application/apps/soundboard_app.cpp
@@ -130,6 +130,7 @@ void SoundBoardView::start_tx(const uint32_t id) {
 }*/
 
 void SoundBoardView::on_tx_progress(const uint32_t progress) {
+	(void)progress ; // avoid warning
 	//progressbar.set_value(progress);
 }
 


### PR DESCRIPTION
Fix for:
/opt/portapack-mayhem/firmware/application/apps/soundboard_app.cpp: In member function 'void ui::SoundBoardView::on_tx_progress(uint32_t)':
/opt/portapack-mayhem/firmware/application/apps/soundboard_app.cpp:132:52: warning: unused parameter 'progress' [-Wunused-parameter]
  132 | void SoundBoardView::on_tx_progress(const uint32_t progress) {
      |                                     ~~~~~~~~~~~~~~~^~~~~~~~
