### PR TITLE
UI search app

### DIFF
--- a/firmware/application/CMakeLists.txt
+++ b/firmware/application/CMakeLists.txt
@@ -241,6 +241,8 @@ set(CPPSRC
 	apps/ui_remote.cpp
 	apps/ui_scanner.cpp
 	apps/ui_search.cpp
+	apps/ui_search_app_settings.cpp
+	apps/ui_search_app.cpp
 	apps/ui_sd_wipe.cpp
 	apps/ui_settings.cpp
 	apps/ui_siggen.cpp

--- a/firmware/application/apps/ui_search_app.cpp
+++ b/firmware/application/apps/ui_search_app.cpp
@@ -1,0 +1,1051 @@
+/*
+ * Copyright (C) 2015 Jared Boone, ShareBrained Technology, Inc.
+ * Copyright (C) 2018 Furrtek
+ *
+ * This file is part of PortaPack.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#include "ui_search_app.hpp"
+#include "ui_fileman.hpp"
+#include "ui_search_app_settings.hpp"
+
+using namespace portapack;
+
+namespace ui {
+
+	SearchAppThread::SearchAppThread( std::vector<int64_t> frequency_list	) : frequency_list_ {  std::move(frequency_list) } {
+		thread = chThdCreateFromHeap(NULL, 1024, NORMALPRIO + 10, SearchAppThread::static_fn, this);
+	}
+
+	SearchAppThread::~SearchAppThread() {
+		stop();
+	}
+
+	void SearchAppThread::stop() {
+		if( thread ) {
+			chThdTerminate(thread);
+			chThdWait(thread);
+			thread = nullptr;
+		}
+	}
+
+	void SearchAppThread::set_continuous(const bool v) {
+		_continuous = v;
+	}
+
+	void SearchAppThread::set_searching(const bool v) {
+		_searching = v;
+	}
+
+	void SearchAppThread::set_stepper( const int64_t v){
+		_stepper = v;
+	}
+
+	bool SearchAppThread::is_searching() {
+		return _searching;
+	}
+
+	void SearchAppThread::set_freq_lock(const uint32_t v) {
+		_freq_lock = v;
+	}
+	uint32_t SearchAppThread::is_freq_lock() {
+		return _freq_lock;
+	}
+	int64_t SearchAppThread::get_current_freq() {
+		return freq ;
+	}
+
+	void SearchAppThread::change_searching_direction() {
+		_fwd = !_fwd;
+		chThdSleepMilliseconds(300);	//Give some pause after reversing searching direction
+	}
+
+	bool SearchAppThread::get_searching_direction() {
+		return _fwd ;
+	}
+	void SearchAppThread::set_searching_direction( const bool v) {
+		_fwd = v ;
+	}
+
+	msg_t SearchAppThread::static_fn(void* arg) {
+		auto obj = static_cast<SearchAppThread*>(arg);
+		obj->run();
+		return 0;
+	}
+
+	void SearchAppThread::run() {
+		if (frequency_list_.size() )	{					//IF THERE IS A FREQUENCY LIST ...	
+			int64_t minfreq = 0 ;
+			int64_t maxfreq = 0 ;
+			bool has_looped = false ;
+			RetuneMessage message { };
+			int32_t frequency_index = 0 ;
+			bool restart_search = false;					//Flag whenever searching is restarting after a pause
+
+			if( frequency_list_[ 0 ] <  0 ) // first item to search is a range
+			{
+				freq = -frequency_list_[ 0 ] ;
+				minfreq = -frequency_list_[ 0 ] ;
+				maxfreq = -frequency_list_[ 1 ] ;
+				step = -frequency_list_[ 2 ] ;
+			}
+			else    //first item to search is a single freq
+			{
+				freq = frequency_list_[ 0 ] ;
+				minfreq = frequency_list_[ 0 ] ;
+				maxfreq = frequency_list_[ 0 ] ;
+				step = 0 ;
+			}
+
+			while( !chThdShouldTerminate() ) {
+				has_looped = false ;
+				if (_searching || _stepper != 0 ) {					//Searching
+					//Inform freq (for coloring purposes also!) 
+					message.freq = freq ;
+					message.range = frequency_index ;
+					EventDispatcher::send_message(message);
+					receiver_model.set_tuning_frequency( freq );	// Retune
+					if (_freq_lock == 0) {				//normal searching (not performing freq_lock)
+						if (!restart_search) {			//looping at full speed
+							/* we are doing a range */
+							if( frequency_list_[ frequency_index ] <  0 )
+							{
+
+								if ( (_fwd&&_stepper==0) || _stepper > 0 ) {	
+									//forward
+									freq += step ;
+									// if bigger than range max
+									if (freq > maxfreq ) {
+										// when going forward we already know that we can skip a whole range => two values in the list
+										frequency_index += 3 ;
+										// looping
+										if( (uint32_t)frequency_index >= frequency_list_.size() )
+										{
+											has_looped = true ;
+											frequency_index = 0  ;
+										}
+										if( frequency_list_[ frequency_index ] < 0 )
+										{
+											freq = -frequency_list_[ frequency_index ];
+											minfreq = -frequency_list_[ frequency_index ];
+											maxfreq = -frequency_list_[ frequency_index + 1 ];
+											step = -frequency_list_[ frequency_index + 2 ];
+										}
+										else
+										{
+											freq = frequency_list_[ frequency_index ];
+											minfreq = frequency_list_[ frequency_index ];
+											maxfreq = frequency_list_[ frequency_index ];
+											step = 0 ;
+										}
+									}
+								}
+								if( (!_fwd&&_stepper==0) || _stepper < 0 ) {	
+									//reverse
+									freq -= step ;
+									// if lower than range min
+									if (freq < minfreq ) {
+										// when back we have to check one step at a time
+										frequency_index -- ;
+										// looping
+										if( frequency_index < 0 )
+										{
+											has_looped = true ;
+											frequency_index = frequency_list_.size() - 1 ;
+										}
+										if( frequency_list_[ frequency_index ] < 0 )
+										{
+											frequency_index -= 2 ;
+											freq = -frequency_list_[ frequency_index + 1];
+											minfreq = -frequency_list_[ frequency_index ];
+											maxfreq = -frequency_list_[ frequency_index + 1 ];
+											step = -frequency_list_[ frequency_index + 2 ];
+										}
+										else
+										{
+											freq = frequency_list_[ frequency_index ];
+											minfreq = frequency_list_[ frequency_index ];
+											maxfreq = frequency_list_[ frequency_index ];
+											step = 0 ;
+										}
+									}
+								}
+							}
+							else
+							{
+								freq = frequency_list_[ frequency_index ] ; 
+								receiver_model.set_tuning_frequency( freq );	// Retune
+
+								if ( (_fwd&&_stepper==0) || _stepper > 0 ) {					//forward
+									frequency_index++;
+									// looping
+									if( (uint32_t)frequency_index >= frequency_list_.size() )
+									{
+										has_looped = true ;
+										frequency_index = 0 ;
+									}
+									if( frequency_list_[ frequency_index ] < 0 )
+									{
+										freq = -frequency_list_[ frequency_index ];
+										minfreq = -frequency_list_[ frequency_index ];
+										maxfreq = -frequency_list_[ frequency_index + 1 ];
+										step = -frequency_list_[ frequency_index + 2 ];
+									}
+									else
+									{
+										freq = frequency_list_[ frequency_index ];
+										minfreq = frequency_list_[ frequency_index ];
+										maxfreq = frequency_list_[ frequency_index ];
+										step = 0 ;
+									}
+								}
+								if( (!_fwd&&_stepper==0) || _stepper < 0 ) {		
+									//reverse
+									frequency_index--;
+									// if previous if under the list => go back from end
+									if( frequency_index < 0 )
+									{
+										has_looped = true ;
+										frequency_index =  frequency_list_.size() - 1 ;
+									}
+									// if we are now on a negative value we are on a range max. Skipping 2 more to be positionned on range min
+									if( frequency_list_[ frequency_index ] < 0 )
+									{
+										frequency_index -= 2 ;
+										freq = -frequency_list_[ frequency_index + 1 ];
+										minfreq = -frequency_list_[ frequency_index ];
+										maxfreq = -frequency_list_[ frequency_index + 1 ];
+										step = -frequency_list_[ frequency_index + 2 ];
+									}
+									else
+									{
+										freq = frequency_list_[ frequency_index ];
+										step = 0 ;
+										minfreq = frequency_list_[ frequency_index ];
+										maxfreq = frequency_list_[ frequency_index ];
+									}
+								}
+							}
+						}
+						else
+							restart_search=false;			//Effectively skipping first retuning, giving system time
+					} 
+					if( has_looped && !_continuous )
+					{
+						/* prepare values for the next run, when user will resume */
+						if( _fwd )
+						{
+							frequency_index = 0 ;
+							if( frequency_list_[ frequency_index ] < 0 )
+							{
+								freq = -frequency_list_[ frequency_index ];
+								minfreq = -frequency_list_[ frequency_index ];
+								maxfreq = -frequency_list_[ frequency_index + 1 ];
+								step = -frequency_list_[ frequency_index + 2 ];
+							}
+							else
+							{
+								freq = frequency_list_[ frequency_index ];
+								minfreq = frequency_list_[ frequency_index ];
+								maxfreq = frequency_list_[ frequency_index ];
+								step = 0 ;
+							}
+						}
+						else
+						{
+							frequency_index = frequency_list_.size() - 1 ;
+							if( frequency_list_[ frequency_index ] < 0 )
+							{
+								frequency_index -= 2 ;
+								freq = -frequency_list_[ frequency_index + 1];
+								minfreq = -frequency_list_[ frequency_index ];
+								maxfreq = -frequency_list_[ frequency_index + 1 ];
+								step = -frequency_list_[ frequency_index + 2 ];
+							}
+							else
+							{
+								freq = frequency_list_[ frequency_index ];
+								minfreq = frequency_list_[ frequency_index ];
+								maxfreq = frequency_list_[ frequency_index ];
+								step = 0 ;
+							}
+
+						}
+						// signal pause to handle_retune 
+						receiver_model.set_tuning_frequency( freq );	// Retune
+						message.freq = freq ;
+						message.range = 9999 ;
+						EventDispatcher::send_message(message);
+					}
+					if( _stepper > 0 ) {
+						_stepper -- ;
+						if( _stepper == 0 ) {
+							//Inform freq (for coloring purposes also!) 
+							message.freq = freq ;
+							message.range = frequency_index ;
+							EventDispatcher::send_message(message);
+							receiver_model.set_tuning_frequency( freq );	// Retune
+
+						}
+					}
+
+					if( _stepper < 0 ) {
+						_stepper ++ ;
+						if( _stepper == 0 ) {
+							//Inform freq (for coloring purposes also!) 
+							message.freq = freq ;
+							message.range = frequency_index ;
+							EventDispatcher::send_message(message);
+							receiver_model.set_tuning_frequency( freq );	// Retune
+						}
+					} 
+				}
+				chThdSleepMilliseconds(50);				//Needed to (eventually) stabilize the receiver into new freq
+			}
+		}
+	}
+
+	void SearchAppView::handle_retune( int64_t freq , uint32_t index ) {
+		static int64_t last_freq = 0 ;
+		static uint32_t last_index = 999999 ;
+		// special non continuous => set userpause when reaching the end of a range 
+		if( index == 9999 )
+		{
+			timer = 10 * wait ;
+			search_pause();
+			button_pause.set_text("RESTART");		//Show button for non continuous stop
+			userpause=true;	
+			return ;
+		}
+		current_index = index ;
+		if( current_index != last_index )
+		{
+			if( frequency_list[ current_index ] < 0 )
+			{
+				last_index = current_index ;
+				if( update_ranges )
+				{
+					button_manual_start.set_text( to_string_short_freq( (-frequency_list[ current_index ] ) ) );
+					frequency_range.min = (-frequency_list[ current_index ] );
+					button_manual_end.set_text( to_string_short_freq( ( -frequency_list[ current_index + 1 ] ) ) );
+					frequency_range.max = (-frequency_list[ current_index + 1 ] );
+				}
+			}
+		}
+		switch (search_thread->is_freq_lock())
+		{
+			case 0:						//NO FREQ LOCK, ONGOING STANDARD SCANNING
+				text_cycle.set( to_string_dec_uint( current_index + 1 , 3 ) );
+				if(description_list[current_index].size() > 0) desc_cycle.set( description_list[current_index] );	//Show new description	
+				break;
+			case 1:						//STARTING LOCK FREQ
+				big_display.set_style(&style_yellow);
+				break;
+			case MAX_FREQ_LOCK:				//FREQ IS STRONG: GREEN and search will pause when on_statistics_update()
+				big_display.set_style(&style_green);
+				if( autosave && last_freq != freq ) {
+					File search_file;
+					std::string freq_file_path = "/FREQMAN/"+output_file+".TXT" ;
+					auto result = search_file.open(freq_file_path);	//First search if freq is already in txt
+					std::string frequency_to_add = "f=" 
+						+ to_string_dec_uint( freq / 1000) 
+						+ to_string_dec_uint( freq % 1000UL, 3, '0');
+					if (!result.is_valid()) {
+						char one_char[1];		//Read it char by char
+						std::string line;		//and put read line in here
+						bool found=false;
+						for (size_t pointer=0; pointer < search_file.size();pointer++) {
+
+							search_file.seek(pointer);
+							search_file.read(one_char, 1);
+							if ((int)one_char[0] > 31) {			//ascii space upwards
+								line += one_char[0];				//Add it to the textline
+							}
+							else if (one_char[0] == '\n') {			//New Line
+								if (line.compare(0, frequency_to_add.size(),frequency_to_add) == 0) {
+									found=true;
+									break;
+								}
+								line.clear();						//Ready for next textline
+							}
+						}
+						if( !found) {
+							result = search_file.append(freq_file_path); //Second: append if it is not there
+							if( !result.is_valid() )
+							{
+								// add current description if it available 
+								if( description_list[current_index].size() > 0)
+								{
+									search_file.write_line(frequency_to_add + ",d=" + description_list[current_index] );
+								}
+								else
+								{
+									search_file.write_line(frequency_to_add + ",d=ADD FQ");
+								}
+							}
+						}
+					}
+					else {
+						result = search_file.create( freq_file_path );	//First freq if no output file
+						if( !result.is_valid() )
+						{
+							// add current description if it available 
+							if( description_list[current_index].size() > 0)
+							{
+								search_file.write_line(frequency_to_add + ",d=" + description_list[current_index] );
+							}
+							else
+							{
+								search_file.write_line(frequency_to_add + ",d=ADD FQ");
+							}
+						}
+					}
+				}
+				last_freq = freq ;
+				break;
+			default:	//freq lock is checking the signal, do not update display
+				return;
+		}
+		big_display.set( freq );	//UPDATE the big Freq after 0, 1 or MAX_FREQ_LOCK (at least, for color synching)
+	}
+
+	void SearchAppView::focus() {
+		field_mode.focus();
+	}
+
+	SearchAppView::~SearchAppView() {
+		audio::output::stop();
+		receiver_model.disable();
+		baseband::shutdown();
+	}
+
+	void SearchAppView::show_max() {		//show total number of freqs to search
+		text_max.set_style(&style_white);
+		text_max.set( "/ " + to_string_dec_uint(frequency_list.size()));
+	}
+
+	SearchAppView::SearchAppView( NavigationView& nav) : nav_ { nav } {
+
+		add_children( {
+				&labels,
+				&field_lna,
+				&field_vga,
+				&field_rf_amp,
+				&field_volume,
+				&field_bw,
+				&field_squelch,
+				&field_wait,
+				&rssi,
+				&text_cycle,
+				&text_max,
+				&desc_cycle,
+				&big_display,
+				&button_search_setup,
+				&button_manual_start,
+				&button_manual_end,
+				&button_manual_search,
+				&field_mode,
+				&step_mode,
+				&button_pause,
+				&button_audio_app,
+				&button_add,
+				&button_dir,
+				&button_restart,
+				&button_mic_app,
+				&button_remove
+		} );
+
+		def_step = change_mode(SEARCH_AM);	//Start on AM
+		field_mode.set_by_value(SEARCH_AM);	//Reflect the mode into the manual selector
+
+		//HELPER: Pre-setting a manual range, based on stored frequency
+		rf::Frequency stored_freq = persistent_memory::tuned_frequency();
+		frequency_range.min = stored_freq - 1000000;
+		button_manual_start.set_text(to_string_short_freq(frequency_range.min));
+		frequency_range.max = stored_freq + 1000000;
+		button_manual_end.set_text(to_string_short_freq(frequency_range.max));
+
+		// Loading settings
+		autostart = persistent_memory::search_app_autostart_search();
+		autosave = persistent_memory::search_app_autosave_freqs();
+		continuous = persistent_memory::search_app_continuous();
+		filedelete = persistent_memory::search_app_clear_output();
+		load_freqs = persistent_memory::search_app_load_freqs();
+		load_ranges = persistent_memory::search_app_load_ranges();
+		update_ranges = persistent_memory::search_app_update_ranges_when_searching();
+
+		//Loading input and output file from settings
+		SearchAppSetupLoadStrings( "SEARCH/SEARCH.CFG" , input_file , output_file );
+
+		button_manual_start.on_select = [this, &nav](ButtonWithEncoder& button) {
+			auto new_view = nav_.push<FrequencyKeypadView>(frequency_range.min);
+			new_view->on_changed = [this, &button](rf::Frequency f) {
+				frequency_range.min = f;
+				button_manual_start.set_text(to_string_short_freq(f));
+			};
+		};
+
+		button_manual_end.on_select = [this, &nav](ButtonWithEncoder& button) {
+			auto new_view = nav.push<FrequencyKeypadView>(frequency_range.max);
+			new_view->on_changed = [this, &button](rf::Frequency f) {
+				frequency_range.max = f;
+				button_manual_end.set_text(to_string_short_freq(f));
+			};
+		};
+
+		button_manual_start.on_change = [this]() {
+			frequency_range.min = frequency_range.min + button_manual_start.get_encoder_delta() * def_step ;
+			if( frequency_range.min < 1 )
+			{
+				frequency_range.min = 1 ;
+			}
+			if( frequency_range.min > ( MAX_UFREQ - def_step ) )
+			{
+				frequency_range.min = MAX_UFREQ - def_step ;
+			}
+			if( frequency_range.min > (frequency_range.max - def_step ) )
+			{
+				frequency_range.max = frequency_range.min + def_step ;
+				if( frequency_range.max > MAX_UFREQ )
+				{
+					frequency_range.min = MAX_UFREQ - def_step ;
+					frequency_range.max = MAX_UFREQ ;
+				}	
+			}
+			button_manual_start.set_text( to_string_short_freq(frequency_range.min) );
+			button_manual_end.set_text( to_string_short_freq(frequency_range.max) );
+			button_manual_start.set_encoder_delta( 0 );
+		}; 
+
+		button_manual_end.on_change = [this]() {
+			frequency_range.max = frequency_range.max + button_manual_end.get_encoder_delta() * def_step ;
+			if( frequency_range.max < ( def_step + 1 ) )
+			{
+				frequency_range.max = ( def_step + 1 );
+			}
+			if( frequency_range.max > MAX_UFREQ )
+			{
+				frequency_range.max = MAX_UFREQ ;
+			}
+			if( frequency_range.max < (frequency_range.min + def_step ) )
+			{
+				frequency_range.min = frequency_range.max - def_step ;
+				if( frequency_range.max < ( def_step + 1 ) )
+				{
+					frequency_range.min = 1 ;
+					frequency_range.max = ( def_step + 1 ) ;
+				}	
+			}
+			button_manual_start.set_text( to_string_short_freq(frequency_range.min) );
+			button_manual_end.set_text( to_string_short_freq(frequency_range.max) );
+			button_manual_end.set_encoder_delta( 0 );
+		}; 
+
+
+
+		button_pause.on_select = [this](ButtonWithEncoder&) {
+			if( search_thread && frequency_list.size() > 0 )
+			{
+				if( userpause )
+					user_resume();
+				else {
+					userpause=true;
+					search_pause();
+					button_pause.set_text("<RESUME>");	//PAUSED, show resume
+					search_thread->set_freq_lock(0); 		//Reset the search lock, since it's a new signal
+				}
+			}
+		};
+		button_pause.on_change = [this]() {
+			if( search_thread && frequency_list.size() > 0 )
+			{
+				if( userpause )
+				{
+					big_display.set_style(&style_white);		//Back to white color
+					search_thread-> set_stepper( button_pause.get_encoder_delta() );
+					button_pause.set_encoder_delta( 0 );
+				}
+			}
+		}; 
+
+		button_audio_app.on_select = [this](Button&) {
+			search_thread->stop();
+			nav_.pop();
+			nav_.push<AnalogAudioView>();
+		};
+
+		button_mic_app.on_select = [this](Button&) {
+			search_thread->stop();
+			nav_.pop();
+			nav_.push<MicTXView>();
+		};
+
+		button_remove.on_select = [this](Button&) {
+			if( search_thread && search_thread->get_current_freq() > 0 )
+			{
+				File search_file;
+				File tmpsearch_file;
+				std::string freq_file_path = "FREQMAN/" + output_file + ".TXT";
+				std::string tmp_freq_file_path = "FREQMAN/" + output_file + ".TXT.TMP";
+				auto result = search_file.open( freq_file_path );	//First search if freq is already in txt
+				if (!result.is_valid()) {
+					std::string frequency_to_remove = "f=" 
+						+ to_string_dec_uint(frequency_list[current_index] / 1000) 
+						+ to_string_dec_uint(frequency_list[current_index] % 1000UL, 3, '0');
+					char one_char[1];		//Read it char by char
+					std::string line;		//and put read line in here
+					bool found=false;
+					for (size_t pointer=0; pointer < search_file.size();pointer++) {
+						search_file.seek(pointer);
+						search_file.read(one_char, 1);
+						if ((int)one_char[0] > 31) {			//ascii space upwards
+							line += one_char[0];				//Add it to the textline
+						}
+						else if (one_char[0] == '\n') {			//New Line
+							if (line.compare(0, frequency_to_remove.size(),frequency_to_remove) == 0) {
+								found=true;
+								break;
+							}
+							line.clear();						//Ready for next textline
+						}
+					}
+					if( found )
+					{
+						/* reread and write tmp file */
+						delete_file( tmp_freq_file_path );
+						result = tmpsearch_file.open( tmp_freq_file_path );
+						if ( !result.is_valid() ) {
+							/* re read file and write tmp out */
+							for (size_t pointer=0; pointer < search_file.size();pointer++) {
+								search_file.seek(pointer);
+								search_file.read(one_char, 1);
+								if ((int)one_char[0] > 31) {			//ascii space upwards
+									line += one_char[0];				//Add it to the textline
+								}
+								else if (one_char[0] == '\n') {			//New Line
+									if( line.compare(0, frequency_to_remove.size(),frequency_to_remove) != 0 ) {
+										result = tmpsearch_file.write_line( line );
+									}
+									line.clear();					
+								}
+							}
+							delete &search_file;
+							delete &tmpsearch_file ;
+							delete_file( freq_file_path );
+							rename_file( tmp_freq_file_path , freq_file_path );
+						}
+					}
+				}
+			}
+		};
+
+		button_manual_search.on_select = [this](Button&) {
+			if (!frequency_range.min || !frequency_range.max) {
+				nav_.display_modal("Error", "Both START and END freqs\nneed a value");
+			} else if (frequency_range.min > frequency_range.max) {
+				nav_.display_modal("Error", "END freq\nis lower than START");
+			} else {
+				audio::output::stop();
+				search_thread->stop();	//STOP SCANNER THREAD
+
+				frequency_list.clear();
+				description_list.clear();
+
+				def_step = step_mode.selected_index_value();     //Use def_step from manual selector
+
+				description_list.push_back(
+						"R " + to_string_short_freq(frequency_range.min) + ">"
+						+ to_string_short_freq(frequency_range.max) + " S" 	// current Manual range
+						+ to_string_short_freq(def_step).erase(0,1) //euquiq: lame kludge to reduce spacing in step freq
+						);
+				frequency_list.push_back( -frequency_range.min ); // min range val
+				description_list.push_back( "!range max val" );
+				frequency_list.push_back( -frequency_range.max ); // max range val
+				description_list.push_back( "!range step val" );
+				frequency_list.push_back( -def_step ); 		  // custom range step
+
+				show_max(); /* display step information */
+				text_cycle.set( " " );
+				timer = 10 * wait ;
+				search_thread->set_freq_lock(0); 		//Reset the search lock
+
+				if ( userpause ) 						//If user-paused, resume
+					user_resume();
+				big_display.set_style(&style_white);		//Back to white color
+				start_search_thread(); //RESTART SCANNER THREAD
+				if (!search_thread->is_searching())
+					search_thread->set_searching(true);   // RESUME!
+			}
+		};
+
+		field_mode.on_change = [this](size_t, OptionsField::value_t v) {
+			receiver_model.disable();
+			baseband::shutdown();
+			change_mode(v);
+			if ( !search_thread->is_searching() ) 						//for some motive, audio output gets stopped.
+				audio::output::start();								//So if search was stopped we resume audio
+			receiver_model.enable(); 
+		};
+
+		button_dir.on_select = [this](Button&) {
+			search_thread->change_searching_direction();
+			fwd = search_thread->get_searching_direction();
+			if( fwd )
+			{
+				button_dir.set_text( "FW>" );
+			}
+			else
+			{
+				button_dir.set_text( "<RW" );
+			}
+			if ( userpause )				//If user-paused, resume
+				user_resume();
+			timer = 10 * wait ;
+			search_resume();
+			search_thread->set_freq_lock(0); 		//Reset the search lock
+			big_display.set_style(&style_white);		//Back to white color
+		};
+
+		button_restart.on_select = [this](Button&) {
+			if( frequency_list.size() > 0 )
+			{
+				def_step = step_mode.selected_index_value();     //Use def_step from manual selector
+				frequency_file_load( input_file , true );
+				if( fwd )
+				{
+					button_dir.set_text( "FW>" );
+				}
+				else
+				{
+					button_dir.set_text( "<RW" );
+				}
+				timer = wait * 10;	 		//Will trigger a search_resume() on_statistics_update, also advancing to next freq.
+				button_pause.set_text("PAUSE");		//Show button for pause
+				userpause=false;	
+			}
+		};
+
+
+		button_add.on_select = [this](Button&) {  //frequency_list[current_index]
+			if( search_thread && search_thread->get_current_freq() > 0 )
+			{
+				File search_file;
+				std::string freq_file_path = "FREQMAN/" + output_file + ".TXT";
+				std::string frequency_to_add = "f=" 
+					+ to_string_dec_uint(search_thread->get_current_freq() / 1000) 
+					+ to_string_dec_uint(search_thread->get_current_freq() % 1000UL, 3, '0');
+				auto result = search_file.open(freq_file_path);	//First search if freq is already in txt
+				if (!result.is_valid()) {
+					char one_char[1];		//Read it char by char
+					std::string line;		//and put read line in here
+					bool found=false;
+					for (size_t pointer=0; pointer < search_file.size();pointer++) {
+						search_file.seek(pointer);
+						search_file.read(one_char, 1);
+						if ((int)one_char[0] > 31) {			//ascii space upwards
+							line += one_char[0];				//Add it to the textline
+						}
+						else if (one_char[0] == '\n') {			//New Line
+							if (line.compare(0, frequency_to_add.size(),frequency_to_add) == 0) {
+								found=true;
+								break;
+							}
+							line.clear();						//Ready for next textline
+						}
+					}
+					if (found) {
+						nav_.display_modal("Error", "Frequency already exists");
+						big_display.set( search_thread->get_current_freq() );		//After showing an error
+					}
+					else {
+						result = search_file.append(freq_file_path); //Second: append if it is not there
+						if( !result.is_valid() )
+						{
+							// add current description if it available 
+							if( description_list[current_index].size() > 0)
+							{
+								search_file.write_line(frequency_to_add + ",d=" + description_list[current_index] );
+							}
+							else
+							{
+								search_file.write_line(frequency_to_add + ",d=ADD FQ");
+							}
+						}
+					}
+				}
+				else
+				{
+					result = search_file.create(freq_file_path); //third: create if it is not there
+					if( !result.is_valid() )
+					{
+						// add current description if it available 
+						if( description_list[current_index].size() > 0)
+						{
+							search_file.write_line(frequency_to_add + ",d=" + description_list[current_index] );
+						}
+						else
+						{
+							search_file.write_line(frequency_to_add + ",d=ADD FQ");
+						}
+					}
+				}
+			}
+		};
+		button_search_setup.on_select = [this,&nav](Button&) {
+			auto open_view = nav.push<SearchAppSetupView>(input_file,output_file); 
+			open_view -> on_changed = [this](std::vector<std::string> result) {
+				input_file = result[0];
+				output_file = result[1];
+				autosave = persistent_memory::search_app_autosave_freqs();
+				autostart = persistent_memory::search_app_autostart_search();
+				continuous = persistent_memory::search_app_continuous();
+				filedelete = persistent_memory::search_app_clear_output();
+				load_freqs = persistent_memory::search_app_load_freqs();
+				load_ranges = persistent_memory::search_app_load_ranges();
+				update_ranges = persistent_memory::search_app_update_ranges_when_searching();
+				frequency_file_load( input_file , true );
+				//  User experience will tell how they need the output file to be cleared 
+				// if( !filedelete )
+				// {
+				// delete_file( "FREQMAN/"+output_file+".TXT" );
+				// }
+				if( autostart )
+				{
+					timer = wait * 10;	 		//Will trigger a search_resume() on_statistics_update, also advancing to next freq.
+					button_pause.set_text("PAUSE");		//Show button for pause
+					userpause=false;	
+					search_resume();
+				}
+				else
+				{
+					search_pause();
+					button_pause.set_text("<RESUME>");		//Show button for pause
+					userpause=true;	
+				}
+			};
+		};
+
+		//PRE-CONFIGURATION:
+		field_wait.on_change = [this](int32_t v) {	wait = v;	}; 	field_wait.set_value(5);
+		field_squelch.on_change = [this](int32_t v) {	squelch = v;	}; 	field_squelch.set_value(-10);
+		field_volume.set_value((receiver_model.headphone_volume() - audio::headphone::volume_range().max).decibel() + 99);
+		field_volume.on_change = [this](int32_t v) { this->on_headphone_volume_changed(v);	};
+
+		if( !filedelete )
+		{
+			delete_file( "FREQMAN/"+output_file+".TXT" );
+		}
+
+		frequency_file_load( input_file );
+		if( search_thread && frequency_list.size() > 0 )
+		{
+			if( autostart )
+			{
+				timer = wait * 10;	 		//Will trigger a search_resume() on_statistics_update, also advancing to next freq.
+				button_pause.set_text("PAUSE");		//Show button for pause
+				userpause=false;	
+				search_resume();
+			}
+			else
+			{
+				userpause=true;
+				search_pause();
+				button_pause.set_text("<RESUME>");	//PAUSED, show resume
+				search_thread->set_freq_lock(0); 		//Reset the search lock, since there is no signal
+			}
+		}	
+	}
+
+
+	void SearchAppView::frequency_file_load(std::string file_name, bool stop_all_before) {
+
+		// stop everything running now if required
+		if (stop_all_before) {
+			search_thread->stop();
+		}
+
+		frequency_list.clear();                                 // clear the existing frequency list (expected behavior)
+		description_list.clear();
+
+		if ( load_freqman_file(file_name, database)  ) {
+			for(auto& entry : database) {								// READ LINE PER LINE
+				if (frequency_list.size() < MAX_DB_ENTRY) {					//We got space!
+					if( entry.type == RANGE && load_ranges )  {						//RANGE	
+						switch( entry.step ) {
+							case AM_US:	def_step = 10000;  	break ;
+							case AM_EUR:	def_step = 9000;  	break ;
+							case NFM_1: 	def_step = 12500;  	break ;
+							case NFM_2: 	def_step = 6250;	break ;	
+							case FM_1:	def_step = 100000; 	break ;
+							case FM_2:	def_step = 50000; 	break ;
+							case N_1:	def_step = 25000;  	break ;
+							case N_2:	def_step = 250000; 	break ;
+							case AIRBAND:	def_step = 8330;  	break ;
+							case STEP_DEF:
+							case ERROR_STEP:
+							default:	def_step = step_mode.selected_index_value();		//Use def_step from manual selector
+												break ;
+						}
+						frequency_list.push_back(-entry.frequency_a);		//Store starting freq and description
+						description_list.push_back( entry.description );
+
+						frequency_list.push_back(-entry.frequency_b);		//Store ending freq and description
+						description_list.push_back( "" );
+
+						frequency_list.push_back(-def_step);			//Store step 
+						description_list.push_back( "" );
+
+					} else if ( entry.type == SINGLE && load_freqs )  {
+						frequency_list.push_back(entry.frequency_a);
+						description_list.push_back("S: " + entry.description);
+					}
+				}
+				else
+				{
+					break; //No more space: Stop reading the txt file !
+				}		
+			}
+			show_max();
+		} 
+		else 
+		{
+			desc_cycle.set(" NO " + file_name + ".TXT FILE ..." );
+		} 
+		audio::output::stop();
+		step_mode.set_by_value(def_step); //Impose the default step into the manual step selector
+		start_search_thread(); 
+	}
+
+	void SearchAppView::on_statistics_update(const ChannelStatistics& statistics) {
+		if ( !userpause ) 									//Searching not user-paused
+		{
+			if (timer >= (wait * 10) ) 
+			{
+				timer = 0;
+				search_resume();
+			} 
+			else if (!timer) 
+			{
+				if (statistics.max_db > squelch ) {  		//There is something on the air...(statistics.max_db > -squelch) 
+					if (search_thread->is_freq_lock() >= MAX_FREQ_LOCK) { //checking time reached
+						search_pause();
+						timer++;	
+					} else {
+						search_thread->set_freq_lock( search_thread->is_freq_lock() + 1 ); //in lock period, still analyzing the signal
+					}
+				} else {									//There is NOTHING on the air
+					if (search_thread->is_freq_lock() > 0) {	//But are we already in freq_lock ?
+						big_display.set_style(&style_white);	//Back to white color
+						search_thread->set_freq_lock(0); 		//Reset the search lock, since there is no signal
+					}				
+				}
+			} 
+			else 	//Ongoing wait time
+			{
+				timer++;
+			}
+		}
+	}
+
+	void SearchAppView::search_pause() {
+		if (search_thread ->is_searching()) {
+			search_thread ->set_freq_lock(0); 		//Reset the search lock (because user paused, or MAX_FREQ_LOCK reached) for next freq search
+			search_thread ->set_searching(false); // WE STOP SCANNING
+			audio::output::start();
+		}
+	}
+
+
+	void SearchAppView::search_resume() {
+		audio::output::stop();
+		big_display.set_style(&style_white);		//Back to white color
+		if (!search_thread->is_searching())
+			search_thread->set_searching(true);   // RESUME!
+	}
+
+	void SearchAppView::user_resume() {
+		timer = wait * 10;			//Will trigger a search_resume() on_statistics_update, also advancing to next freq.
+		button_pause.set_text("PAUSE");		//Show button for pause
+		userpause=false;			//Resume searching
+	}
+
+	void SearchAppView::on_headphone_volume_changed(int32_t v) {
+		const auto new_volume = volume_t::decibel(v - 99) + audio::headphone::volume_range().max;
+		receiver_model.set_headphone_volume(new_volume);
+	}
+
+	size_t SearchAppView::change_mode(uint8_t new_mod) { //Before this, do a search_thread->stop();  After this do a start_search_thread()
+		using option_t = std::pair<std::string, int32_t>;
+		using options_t = std::vector<option_t>;
+		options_t bw;
+		field_bw.on_change = [this](size_t n, OptionsField::value_t) { (void)n; /* avoid unused warning */ };
+
+		switch (new_mod) {
+			case SEARCH_NFM:	//bw 16k (2) default
+				bw.emplace_back("8k5", 0);
+				bw.emplace_back("11k", 0);
+				bw.emplace_back("16k", 0);			
+				field_bw.set_options(bw);
+
+				baseband::run_image(portapack::spi_flash::image_tag_nfm_audio);
+				receiver_model.set_modulation(ReceiverModel::Mode::NarrowbandFMAudio);
+				field_bw.set_selected_index(2);
+				receiver_model.set_nbfm_configuration(field_bw.selected_index());
+				field_bw.on_change = [this](size_t n, OptionsField::value_t) { 	receiver_model.set_nbfm_configuration(n); };
+				receiver_model.set_sampling_rate(3072000);	receiver_model.set_baseband_bandwidth(1750000);	
+				break;
+			case SEARCH_AM:
+				bw.emplace_back("DSB", 0);
+				bw.emplace_back("USB", 0);
+				bw.emplace_back("LSB", 0);
+				bw.emplace_back("CW ", 0);
+				field_bw.set_options(bw);
+
+				baseband::run_image(portapack::spi_flash::image_tag_am_audio);
+				receiver_model.set_modulation(ReceiverModel::Mode::AMAudio);
+				field_bw.set_selected_index(0);
+				receiver_model.set_am_configuration(field_bw.selected_index());
+				field_bw.on_change = [this](size_t n, OptionsField::value_t) { receiver_model.set_am_configuration(n);	};		
+				receiver_model.set_sampling_rate(2000000);receiver_model.set_baseband_bandwidth(2000000); 
+				break;
+			case SEARCH_WFM:
+				bw.emplace_back("16k", 0);
+				field_bw.set_options(bw);
+
+				baseband::run_image(portapack::spi_flash::image_tag_wfm_audio);
+				receiver_model.set_modulation(ReceiverModel::Mode::WidebandFMAudio);
+				field_bw.set_selected_index(0);
+				receiver_model.set_wfm_configuration(field_bw.selected_index());
+				field_bw.on_change = [this](size_t n, OptionsField::value_t) {	receiver_model.set_wfm_configuration(n); };
+				receiver_model.set_sampling_rate(3072000);	receiver_model.set_baseband_bandwidth(2000000);	
+				break;
+		}
+
+		return search_mod_step[new_mod];
+	}
+
+	void SearchAppView::start_search_thread() {
+		receiver_model.enable(); 
+		receiver_model.set_squelch_level(0);
+		search_thread = std::make_unique<SearchAppThread>(frequency_list);
+		search_thread->set_continuous( continuous );
+		search_thread->set_searching_direction( fwd );
+	}
+
+
+} /* namespace ui */

--- a/firmware/application/apps/ui_search_app.hpp
+++ b/firmware/application/apps/ui_search_app.hpp
@@ -1,0 +1,341 @@
+/*
+ * Copyright (C) 2015 Jared Boone, ShareBrained Technology, Inc.
+ * Copyright (C) 2018 Furrtek
+ *
+ * This file is part of PortaPack.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#include "ui.hpp"
+#include "receiver_model.hpp"
+#include "ui_receiver.hpp"
+#include "ui_font_fixed_8x16.hpp"
+#include "freqman.hpp"
+#include "analog_audio_app.hpp"
+#include "audio.hpp"
+#include "ui_mictx.hpp"
+#include "portapack_persistent_memory.hpp"
+#include "baseband_api.hpp"
+#include "string_format.hpp"
+#include "file.hpp"
+
+
+#define MAX_DB_ENTRY 500
+#define MAX_FREQ_LOCK 10 		//50ms cycles search locks into freq when signal detected, to verify signal is not spureous
+
+namespace ui {
+
+enum search_modulation_type { SEARCH_AM = 0,SEARCH_WFM,SEARCH_NFM };
+string const search_mod_name[3] = {"AM", "WFM", "NFM"};
+size_t const search_mod_step[3] = {9000, 100000, 12500 };
+
+class SearchAppThread {
+public:
+	SearchAppThread(std::vector<int64_t> frequency_list);
+	~SearchAppThread();
+
+	void set_searching(const bool v);
+	bool is_searching();
+
+	void set_freq_lock(const uint32_t v);
+	uint32_t is_freq_lock();
+	int64_t get_current_freq();
+
+	void set_stepper(const int64_t v);
+
+	void change_searching_direction();
+	bool get_searching_direction();
+	void set_searching_direction( const bool v);
+	
+	void set_continuous(const bool v);
+
+	void stop();
+
+	SearchAppThread(const SearchAppThread&) = delete;
+	SearchAppThread(SearchAppThread&&) = delete;
+	SearchAppThread& operator=(const SearchAppThread&) = delete;
+	SearchAppThread& operator=(SearchAppThread&&) = delete;
+
+private:
+	std::vector<int64_t> frequency_list_ { };
+	Thread* thread { nullptr };
+	int64_t freq = 0 ;
+	int64_t step = 0 ;
+	bool _searching { true };
+	bool _fwd { true };
+	bool _continuous { true };
+	int64_t _stepper { 0 };
+	int32_t _freq_lock { 0 };
+	static msg_t static_fn(void* arg);
+	void run();
+};
+
+class SearchAppView : public View {
+public:
+	SearchAppView(NavigationView& nav);
+	~SearchAppView();
+	
+	void focus() override;
+
+	void big_display_freq( int64_t f );
+
+	const Style style_grey {		// searching
+		.font = font::fixed_8x16,
+		.background = Color::black(),
+		.foreground = Color::grey(),
+	};
+
+	const Style style_white {		// searching
+		.font = font::fixed_8x16,
+		.background = Color::black(),
+		.foreground = Color::white(),
+	};
+	
+	const Style style_yellow {		//Found signal
+		.font = font::fixed_8x16,
+		.background = Color::black(),
+		.foreground = Color::dark_yellow(),
+	};
+
+	const Style style_green {		//Found signal
+		.font = font::fixed_8x16,
+		.background = Color::black(),
+		.foreground = Color::green(),
+	};
+
+	const Style style_red {		//erasing freq
+		.font = font::fixed_8x16,
+		.background = Color::black(),
+		.foreground = Color::red(),
+	};
+
+	std::string title() const override { return "Search"; };
+	std::vector<int64_t> frequency_list{ };
+	std::vector<string> description_list { };
+	// maximum usable freq
+	long long int MAX_UFREQ = 7000000000 ;
+	
+//void set_parent_rect(const Rect new_parent_rect) override;
+
+private:
+	NavigationView& nav_;
+
+	void start_search_thread();
+	size_t change_mode(uint8_t mod_type);
+	void show_max();
+	void search_pause();
+	void search_resume();
+	void user_resume();
+	void frequency_file_load(std::string file_name, bool stop_all_before = false);
+	void on_statistics_update(const ChannelStatistics& statistics);
+	void on_headphone_volume_changed(int32_t v);
+	void handle_retune( int64_t freq , uint32_t index );
+
+	jammer::jammer_range_t frequency_range { false, 0, 0 };  //perfect for manual search task too...
+	int32_t squelch { 0 };
+	uint32_t timer { 0 };
+	uint32_t wait { 0 };
+	int32_t def_step { 0 };
+	freqman_db database { };
+	uint32_t current_index { 0 };
+	bool userpause { false };
+	std::string input_file = { "SEARCH" };
+	std::string output_file = { "SEARCHRESULTS" };
+	bool autosave    = { true };
+	bool autostart   = { true };
+	bool continuous  = { true }; 
+	bool filedelete  = { true };
+	bool load_freqs  = { true };
+	bool load_ranges = { true };
+	bool update_ranges = { true };
+	bool fwd = { true };
+
+	Labels labels {
+		{ { 0 * 8, 0 * 16 }, "LNA:   VGA:   AMP:  VOL:", Color::light_grey() },
+		{ { 0 * 8, 1* 16 }, "BW:    SQUELCH:   db WAIT:", Color::light_grey() },
+		{ { 3 * 8, 10 * 16 }, "START       END     MANUAL", Color::light_grey() },
+		{ { 0 * 8, (26 * 8) + 4 }, "MODE:", Color::light_grey() },
+		{ { 11 * 8, (26 * 8) + 4 }, "STEP:", Color::light_grey() },
+	};
+	
+	LNAGainField field_lna {
+		{ 4 * 8, 0 * 16 }
+	};
+
+	VGAGainField field_vga {
+		{ 11 * 8, 0 * 16 }
+	};
+	
+	RFAmpField field_rf_amp {
+		{ 18 * 8, 0 * 16 }
+	};
+	
+	NumberField field_volume {
+		{ 24 * 8, 0 * 16 },
+		2,
+		{ 0, 99 },
+		1,
+		' ',
+	};
+
+	OptionsField field_bw {
+		{ 3 * 8, 1 * 16 },
+		4,
+		{ }
+	};		
+
+	NumberField field_squelch {
+		{ 15 * 8, 1 * 16 },
+		3,
+ 		{ -90, 20 },
+		1,
+		' ',
+	};
+
+	NumberField field_wait {
+		{ 26 * 8, 1 * 16 },
+		2,
+		{ 0, 99 },
+		1,
+		' ',
+	};
+
+	RSSI rssi {
+		{ 0 * 16, 2 * 16, 15 * 16, 8 },
+	}; 
+
+	Text text_cycle {
+		{ 0, 3 * 16, 3 * 8, 16 },  
+	};
+
+	Text text_max {
+		{ 4 * 8, 3 * 16, 18 * 8, 16 },  
+	};
+
+	Text desc_cycle {
+		{0, 4 * 16, 240, 16 },	   
+	};
+
+	BigFrequency big_display {		//Show frequency in glamour
+		{ 4, 6 * 16, 28 * 8, 52 },
+		0
+	};
+	
+	Button button_search_setup {
+		{ 22 * 8 + 6, 3 * 16 - 8, 7 * 8, 22 },
+		"PARAMS"
+	};
+
+	ButtonWithEncoder button_manual_start {
+		{ 0 * 8, 11 * 16, 11 * 8, 28 },
+		""
+	};
+
+	ButtonWithEncoder button_manual_end {
+		{ 12 * 8 - 6, 11 * 16, 11 * 8, 28 },
+		""
+	};
+
+	Button button_manual_search {
+		{ 23 * 8 - 3, 11 * 16, 7 * 8 , 28 },
+		"SEARCH"
+	};
+
+	OptionsField field_mode {
+		{ 5 * 8, (26 * 8) + 4 },
+		6,
+		{
+			{ " AM  ", 0 },
+			{ " WFM ", 1 },
+			{ " NFM ", 2 },
+		}
+	};
+
+	OptionsField step_mode {
+		{ 17 * 8, (26 * 8) + 4 },
+		12,
+		{
+			{ "5Khz (SA AM)", 	5000 },
+			{ "9Khz (EU AM)", 	9000 },
+			{ "10Khz(US AM)", 	10000 },
+			{ "50Khz (FM1)", 	50000 },
+			{ "100Khz(FM2)", 	100000 },
+			{ "6.25khz(NFM)",	6250 },
+			{ "12.5khz(NFM)",	12500 },
+			{ "25khz (N1)",		25000 },
+			{ "250khz (N2)",	250000 },
+			{ "8.33khz(AIR)",	8330 },
+			{ "15 khz(HFM)",	15000 }
+		}
+	};
+
+	ButtonWithEncoder button_pause {
+		{ 0, (15 * 16) - 4, 72, 28 },
+		"PAUSE"
+	}; 
+
+
+	Button button_audio_app {
+		{ 84, (15 * 16) - 4, 72, 28 },
+		"AUDIO"
+	};
+
+	Button button_add {
+		{ 168, (15 * 16) - 4, 72, 28 },
+		"STORE"
+	};
+
+	Button button_dir {
+		{ 0,  (35 * 8) - 4, 34, 28 },
+		"FW>"
+	};
+
+	Button button_restart {
+		{ 38, (35 * 8) - 4, 34, 28 },
+		"RST"
+	};
+
+	Button button_mic_app {
+		{ 84,  (35 * 8) - 4, 72, 28 },
+		"MIC TX"
+	};
+
+	Button button_remove {
+		{ 168, (35 * 8) - 4, 72, 28 },
+		"REMOVE"
+	};
+	
+	std::unique_ptr<SearchAppThread> search_thread { };
+	
+	MessageHandlerRegistration message_handler_retune {
+		Message::ID::Retune,
+		[this](const Message* const p) {
+			const auto message = *reinterpret_cast<const RetuneMessage*>(p);
+			this->handle_retune(message.freq,message.range);
+		}
+	};
+	
+	MessageHandlerRegistration message_handler_stats {
+		Message::ID::ChannelStatistics,
+		[this](const Message* const p) {
+			this->on_statistics_update(static_cast<const ChannelStatisticsMessage*>(p)->statistics);
+		}
+	};
+
+};
+
+} /* namespace ui */

--- a/firmware/application/apps/ui_search_app_settings.cpp
+++ b/firmware/application/apps/ui_search_app_settings.cpp
@@ -1,0 +1,240 @@
+/*
+ * Copyright (C) 2015 Jared Boone, ShareBrained Technology, Inc.
+ * Copyright (C) 2016 Furrtek
+ *
+ * This file is part of PortaPack.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#include "ui_search_app_settings.hpp"
+#include "ui_navigation.hpp"
+#include "ui_fileman.hpp"
+#include "ui_textentry.hpp"
+
+#include "portapack.hpp"
+#include "portapack_persistent_memory.hpp"
+
+#define SETTINGS_NAME_MAX_LEN
+
+using namespace std;
+using namespace portapack;
+
+namespace ui {
+
+	bool SearchAppSetupLoadStrings( std::string source, std::string &input_file , std::string &output_file )
+	{
+		File settings_file;
+		size_t length, file_position = 0;
+		char * pos;
+		char * line_start;
+		char * line_end;
+		char file_data[257];
+
+		uint32_t it = 0 ;
+		uint32_t nb_params = 2 ;
+		std::string params[ 2 ];
+
+		auto result = settings_file.open( source );
+		if( !result.is_valid() )
+		{
+			while( it < nb_params )
+			{
+				// Read a 256 bytes block from file
+				settings_file.seek(file_position);
+				memset(file_data, 0, 257);
+				auto read_size = settings_file.read(file_data, 256);
+				if (read_size.is_error())
+					break ;
+				file_position += 256;
+				// Reset line_start to beginning of buffer
+				line_start = file_data;
+				pos=line_start;
+				while ((line_end = strstr(line_start, "\x0A"))) {
+					length = line_end - line_start - 1 ;
+					params[ it ]  = string( pos , length );
+					it ++ ;	
+					line_start = line_end + 1;
+					pos=line_start ;
+					if (line_start - file_data >= 256) 
+						break;
+					if( it >= nb_params )
+						break ;
+				}			
+				if (read_size.value() != 256)
+					break;	// End of file
+
+				// Restart at beginning of last incomplete line
+				file_position -= (file_data + 256 - line_start);
+			}
+		}
+		if( it < nb_params )
+		{
+			/* bad number of params, setting default */
+			input_file  = "SEARCH" ;
+			output_file = "SEARCHRESULT" ;	
+			return false ;
+		}
+		input_file = params[ 0 ];
+		output_file= params[ 1 ];
+		return true ;
+	}
+
+	bool SearchAppSetupSaveStrings( std::string dest, std::string input_file , std::string output_file )
+	{
+		File settings_file;
+
+		auto result = settings_file.create( dest );
+		if( result.is_valid() )
+			return false ;
+		settings_file.write_line( input_file );
+		settings_file.write_line( output_file );
+
+		return true ;
+	}
+
+
+
+	SearchAppSetupViewMain::SearchAppSetupViewMain(
+			NavigationView &nav , Rect parent_rect , std::string input_file , std::string output_file 
+			) : View( parent_rect ) , _input_file { input_file } , _output_file { output_file } 
+	{
+		hidden(true);
+		add_children({
+				&button_load_freqs,
+				&text_input_file,
+				&button_save_freqs,
+				&button_output_file,
+				&checkbox_autosave_freqs,
+				&checkbox_autostart_search,
+				&checkbox_continuous,
+				&checkbox_clear_output,
+				});
+
+		checkbox_autosave_freqs.set_value( persistent_memory::search_app_autosave_freqs() );
+		checkbox_autostart_search.set_value( persistent_memory::search_app_autostart_search() );
+		checkbox_continuous.set_value( persistent_memory::search_app_continuous() );
+		checkbox_clear_output.set_value( persistent_memory::search_app_clear_output() );
+
+		text_input_file.set( _input_file );	
+		button_output_file.set_text( _output_file );	
+
+		button_load_freqs.on_select = [this, &nav](Button&) {
+			auto open_view = nav.push<FileLoadView>(".TXT");
+			open_view->on_changed = [this,&nav](std::filesystem::path new_file_path) {
+				std::string dir_filter = "FREQMAN/";
+				std::string str_file_path = new_file_path.string();
+				if (str_file_path.find(dir_filter) != string::npos) { // assert file from the FREQMAN folder
+					// get the filename without txt extension so we can use load_freqman_file fcn
+					_input_file = new_file_path.stem().string();
+					text_input_file.set( _input_file );
+				} else {
+					nav.display_modal("LOAD ERROR", "A valid file from\nFREQMAN directory is\nrequired.");
+				}
+			};
+		};
+
+		button_save_freqs.on_select = [this, &nav](Button&) {
+			auto open_view = nav.push<FileLoadView>(".TXT");
+			open_view->on_changed = [this,&nav](std::filesystem::path new_file_path) {
+				std::string dir_filter = "FREQMAN/";
+				std::string str_file_path = new_file_path.string();
+				if (str_file_path.find(dir_filter) != string::npos) { // assert file from the FREQMAN folder
+					_output_file = new_file_path.stem().string();
+					button_output_file.set_text( _output_file );	
+				} else {
+					nav.display_modal("LOAD ERROR", "A valid file from\nFREQMAN directory is\nrequired.");
+				}
+			};
+		};
+
+		button_output_file.on_select =[this, &nav](Button&) {
+			text_prompt( nav, _output_file , 28 ,
+					[this](std::string& buffer) {
+					_output_file = buffer ;
+					button_output_file.set_text( _output_file );
+					}   );
+		};
+	};
+
+	void SearchAppSetupViewMain::Save( std::string &input_file , std::string &output_file ) {
+		persistent_memory::set_search_app_autosave_freqs(checkbox_autosave_freqs.value());
+		persistent_memory::set_search_app_autostart_search(checkbox_autostart_search.value());
+		persistent_memory::set_search_app_continuous(checkbox_continuous.value()); 
+		persistent_memory::set_search_app_clear_output(checkbox_clear_output.value()); 
+		SearchAppSetupSaveStrings( "SEARCH/SEARCH.CFG" , _input_file , _output_file );
+		input_file=_input_file ;
+		output_file=_output_file ;
+	};
+	void SearchAppSetupViewMore::Save() {
+		persistent_memory::set_search_app_load_freqs(checkbox_load_freqs.value()); 
+		persistent_memory::set_search_app_load_ranges(checkbox_load_ranges.value()); 
+		persistent_memory::set_search_app_update_ranges_when_searching(checkbox_update_ranges_when_searching.value()); 
+	};
+
+	void SearchAppSetupViewMain::focus() {
+		button_load_freqs.focus();
+	}
+
+	SearchAppSetupViewMore::SearchAppSetupViewMore(
+			Rect parent_rect
+			) : View( parent_rect ) {
+
+		hidden(true);
+
+		add_children({
+				&checkbox_load_freqs,
+				&checkbox_load_ranges,
+				&checkbox_update_ranges_when_searching
+				});
+
+		checkbox_load_freqs.set_value( persistent_memory::search_app_load_freqs() );
+		checkbox_load_ranges.set_value( persistent_memory::search_app_load_ranges() );
+		checkbox_update_ranges_when_searching.set_value( persistent_memory::search_app_update_ranges_when_searching() );
+	};
+
+	void SearchAppSetupViewMore::focus() {
+		checkbox_load_freqs.focus();
+	}
+
+	void SearchAppSetupView::focus() {
+		viewMain.focus();
+	}
+
+	SearchAppSetupView::SearchAppSetupView(
+			NavigationView& nav , std::string _input_file , std::string _output_file 
+			) : nav_ { nav } , input_file { _input_file } , output_file { _output_file }
+
+	{
+		add_children({
+				&tab_view,
+				&viewMain,
+				&viewMore,
+				&button_save
+				});
+
+		button_save.on_select = [this,&nav](Button&) {
+			viewMain.Save(input_file,output_file);
+			viewMore.Save();
+			//SearchAppSetupLoadStrings( "SEARCH/SEARCH.CFG" , input_file , output_file );
+			std::vector<std::string> messages ;
+			messages.push_back( input_file );
+			messages.push_back( output_file );
+			on_changed( messages );
+			nav.pop();
+		};
+	}
+} /* namespace ui */

--- a/firmware/application/apps/ui_search_app_settings.hpp
+++ b/firmware/application/apps/ui_search_app_settings.hpp
@@ -1,0 +1,148 @@
+/*
+ * Copyright (C) 2014 Jared Boone, ShareBrained Technology, Inc.
+ * Copyright (C) 2016 Furrtek
+ *
+ * This file is part of PortaPack.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#include "serializer.hpp"
+#include "ui.hpp"
+#include "ui_widget.hpp"
+#include "ui_tabview.hpp"
+#include "ui_navigation.hpp"
+#include "string_format.hpp"
+
+namespace ui {
+	
+bool SearchAppSetupLoadStrings( std::string source, std::string &input_file , std::string &output_file );
+bool SearchAppSetupSaveStrings( std::string dest, const std::string input_file , const std::string output_file );
+
+class SearchAppSetupViewMain : public View {
+public:
+	SearchAppSetupViewMain( NavigationView& nav, Rect parent_rect , std::string input_file , std::string output_file );
+	void Save( std::string &input_file , std::string &output_file );
+	void focus() override;
+	
+private:
+	std::string _input_file  = { "SEARCH" };
+	std::string _output_file = { "SEARCHRESULTS" };
+	
+	
+	Button button_load_freqs {
+		{ 1 * 8 , 12 , 18 * 8 , 22 },
+		"select input file"
+	};
+	Text text_input_file {
+		{ 1 * 8 , 4 + 2 * 16, 18 * 8, 22 },  
+		"SEARCH"
+	};
+
+	Button button_save_freqs {
+		{ 1 * 8 , 4 * 16 - 8 , 18 * 8 , 22 },
+		"select output file"
+	};
+	Button button_output_file {
+		{ 1 * 8 , 5 * 16 - 2, 18 * 8, 22 },  
+		"SEARCHRESULTS"	
+	};
+
+	Checkbox checkbox_autosave_freqs {
+		{ 1 * 8, 7 * 16 - 4 },
+		3,
+		"autosave freqs"
+	};
+
+	Checkbox checkbox_autostart_search {
+		{ 1 * 8, 9 * 16 - 4 },
+		3,
+		"autostart searching"
+	};
+
+	Checkbox checkbox_continuous {
+		{ 1 * 8, 11 * 16 - 4 },
+		3,
+		"continuous"
+	};
+	Checkbox checkbox_clear_output {
+		{ 1 * 8, 13 * 16 - 4 },
+		3,
+		"clear output at start"
+	};
+};
+
+class SearchAppSetupViewMore : public View {
+public:
+	SearchAppSetupViewMore( Rect parent_rect );
+	void Save();
+	
+	void focus() override;
+	
+private:
+	Checkbox checkbox_load_freqs {
+		{ 1 * 8, 12 },
+		3,
+		"input: load freqs"
+	};
+
+	Checkbox checkbox_load_ranges {
+		{ 1 * 8, 42 },
+		3,
+		"input: load ranges"
+	};
+	Checkbox checkbox_update_ranges_when_searching {
+		{ 1 * 8, 72 },
+		3,
+		"auto update m-ranges"
+		};
+};
+
+
+
+
+class SearchAppSetupView : public View {
+public:
+	SearchAppSetupView( NavigationView& nav , std::string _input_file , std::string _output_file );
+	
+	std::function<void( std::vector<std::string> messages )> on_changed { };
+	
+	void focus() override;
+	
+	std::string title() const override { return "Search setup"; };
+
+private:
+	NavigationView& nav_;
+	
+	std::string input_file  = { "SEARCH" };
+	std::string output_file = { "SEARCHRESULTS" };
+	
+	Rect view_rect = { 0, 3 * 8, 240, 230 };
+
+	SearchAppSetupViewMain viewMain{ nav_ , view_rect , input_file , output_file };
+	SearchAppSetupViewMore viewMore{ view_rect };
+
+	TabView tab_view {
+		{ "Main", Color::cyan() , &viewMain },
+		{ "More", Color::green(), &viewMore }
+	};
+	Button button_save {
+		{ 9 * 8, 255, 14 * 8 , 40 },
+		"SAVE"
+	};
+};
+
+} /* namespace ui */

--- a/firmware/common/portapack_persistent_memory.cpp
+++ b/firmware/common/portapack_persistent_memory.cpp
@@ -34,290 +34,333 @@ using portapack::memory::map::backup_ram;
 #include <utility>
 
 namespace portapack {
-namespace persistent_memory {
 
-constexpr rf::Frequency tuned_frequency_reset_value { 100000000 };
+	namespace persistent_memory {
 
-using ppb_range_t = range_t<ppb_t>;
-constexpr ppb_range_t ppb_range { -99000, 99000 };
-constexpr ppb_t ppb_reset_value { 0 };
+		constexpr rf::Frequency tuned_frequency_reset_value { 100000000 };
 
-using tone_mix_range_t = range_t<int32_t>;
-constexpr tone_mix_range_t tone_mix_range { 10, 99 };
-constexpr int32_t tone_mix_reset_value { 20 };
+		using ppb_range_t = range_t<ppb_t>;
+		constexpr ppb_range_t ppb_range { -99000, 99000 };
+		constexpr ppb_t ppb_reset_value { 0 };
 
-using afsk_freq_range_t = range_t<int32_t>;
-constexpr afsk_freq_range_t afsk_freq_range { 1, 4000 };
-constexpr int32_t afsk_mark_reset_value { 1200 };
-constexpr int32_t afsk_space_reset_value { 2200 };
+		using tone_mix_range_t = range_t<int32_t>;
+		constexpr tone_mix_range_t tone_mix_range { 10, 99 };
+		constexpr int32_t tone_mix_reset_value { 20 };
 
-using modem_baudrate_range_t = range_t<int32_t>;
-constexpr modem_baudrate_range_t modem_baudrate_range { 50, 9600 };
-constexpr int32_t modem_baudrate_reset_value { 1200 };
+		using afsk_freq_range_t = range_t<int32_t>;
+		constexpr afsk_freq_range_t afsk_freq_range { 1, 4000 };
+		constexpr int32_t afsk_mark_reset_value { 1200 };
+		constexpr int32_t afsk_space_reset_value { 2200 };
 
-/*using modem_bw_range_t = range_t<int32_t>;
-constexpr modem_bw_range_t modem_bw_range { 1000, 50000 };
-constexpr int32_t modem_bw_reset_value { 15000 };*/
+		using modem_baudrate_range_t = range_t<int32_t>;
+		constexpr modem_baudrate_range_t modem_baudrate_range { 50, 9600 };
+		constexpr int32_t modem_baudrate_reset_value { 1200 };
 
-using modem_repeat_range_t = range_t<int32_t>;
-constexpr modem_repeat_range_t modem_repeat_range { 1, 99 };
-constexpr int32_t modem_repeat_reset_value { 5 };
+		/*using modem_bw_range_t = range_t<int32_t>;
+		  constexpr modem_bw_range_t modem_bw_range { 1000, 50000 };
+		  constexpr int32_t modem_bw_reset_value { 15000 };*/
 
-using clkout_freq_range_t = range_t<uint32_t>;
-constexpr clkout_freq_range_t clkout_freq_range { 10, 60000 };
-constexpr uint32_t clkout_freq_reset_value { 10000 };
+		using modem_repeat_range_t = range_t<int32_t>;
+		constexpr modem_repeat_range_t modem_repeat_range { 1, 99 };
+		constexpr int32_t modem_repeat_reset_value { 5 };
 
-/* struct must pack the same way on M4 and M0 cores. */
-struct data_t {
-	int64_t tuned_frequency;
-	int32_t correction_ppb;
-	uint32_t touch_calibration_magic;
-	touch::Calibration touch_calibration;
+		using clkout_freq_range_t = range_t<uint32_t>;
+		constexpr clkout_freq_range_t clkout_freq_range { 10, 60000 };
+		constexpr uint32_t clkout_freq_reset_value { 10000 };
 
-	// Modem
-	uint32_t modem_def_index;
-	serial_format_t serial_format;
-	int32_t modem_bw;
-	int32_t afsk_mark_freq;
-	int32_t afsk_space_freq;
-	int32_t modem_baudrate;
-	int32_t modem_repeat;
-	
-	// Play dead unlock
-	uint32_t playdead_magic;
-	uint32_t playing_dead;
-	uint32_t playdead_sequence;
-	
-	// UI
-	uint32_t ui_config;
-	
-	uint32_t pocsag_last_address;
-	uint32_t pocsag_ignore_address;
-	
-	int32_t tone_mix;
-};
+		/* struct must pack the same way on M4 and M0 cores. */
+		struct data_t {
+			int64_t tuned_frequency;
+			int32_t correction_ppb;
+			uint32_t touch_calibration_magic;
+			touch::Calibration touch_calibration;
 
-static_assert(sizeof(data_t) <= backup_ram.size(), "Persistent memory structure too large for VBAT-maintained region");
+			// Modem
+			uint32_t modem_def_index;
+			serial_format_t serial_format;
+			int32_t modem_bw;
+			int32_t afsk_mark_freq;
+			int32_t afsk_space_freq;
+			int32_t modem_baudrate;
+			int32_t modem_repeat;
 
-static data_t* const data = reinterpret_cast<data_t*>(backup_ram.base());
+			// Play dead unlock
+			uint32_t playdead_magic;
+			uint32_t playing_dead;
+			uint32_t playdead_sequence;
 
-rf::Frequency tuned_frequency() {
-	rf::tuning_range.reset_if_outside(data->tuned_frequency, tuned_frequency_reset_value);
-	return data->tuned_frequency;
-}
+			// UI
+			uint32_t ui_config;
 
-void set_tuned_frequency(const rf::Frequency new_value) {
-	data->tuned_frequency = rf::tuning_range.clip(new_value);
-}
+			uint32_t pocsag_last_address;
+			uint32_t pocsag_ignore_address;
 
-ppb_t correction_ppb() {
-	ppb_range.reset_if_outside(data->correction_ppb, ppb_reset_value);
-	return data->correction_ppb;
-}
+			int32_t tone_mix;
 
-void set_correction_ppb(const ppb_t new_value) {
-	const auto clipped_value = ppb_range.clip(new_value);
-	data->correction_ppb = clipped_value;
-	portapack::clock_manager.set_reference_ppb(clipped_value);
-}
+			// Search
+			uint32_t search_app_searchconfig ;
+		};
 
-static constexpr uint32_t touch_calibration_magic = 0x074af82f;
+		static_assert(sizeof(data_t) <= backup_ram.size(), "Persistent memory structure too large for VBAT-maintained region");
 
-void set_touch_calibration(const touch::Calibration& new_value) {
-	data->touch_calibration = new_value;
-	data->touch_calibration_magic = touch_calibration_magic;
-}
+		static data_t* const data = reinterpret_cast<data_t*>(backup_ram.base());
 
-const touch::Calibration& touch_calibration() {
-	if( data->touch_calibration_magic != touch_calibration_magic ) {
-		set_touch_calibration(touch::default_calibration());
-	}
-	return data->touch_calibration;
-}
+		rf::Frequency tuned_frequency() {
+			rf::tuning_range.reset_if_outside(data->tuned_frequency, tuned_frequency_reset_value);
+			return data->tuned_frequency;
+		}
 
-int32_t tone_mix() {
-	tone_mix_range.reset_if_outside(data->tone_mix, tone_mix_reset_value);
-	return data->tone_mix;
-}
+		void set_tuned_frequency(const rf::Frequency new_value) {
+			data->tuned_frequency = rf::tuning_range.clip(new_value);
+		}
 
-void set_tone_mix(const int32_t new_value) {
-	data->tone_mix = tone_mix_range.clip(new_value);
-}
+		ppb_t correction_ppb() {
+			ppb_range.reset_if_outside(data->correction_ppb, ppb_reset_value);
+			return data->correction_ppb;
+		}
 
-int32_t afsk_mark_freq() {
-	afsk_freq_range.reset_if_outside(data->afsk_mark_freq, afsk_mark_reset_value);
-	return data->afsk_mark_freq;
-}
+		void set_correction_ppb(const ppb_t new_value) {
+			const auto clipped_value = ppb_range.clip(new_value);
+			data->correction_ppb = clipped_value;
+			portapack::clock_manager.set_reference_ppb(clipped_value);
+		}
 
-void set_afsk_mark(const int32_t new_value) {
-	data->afsk_mark_freq = afsk_freq_range.clip(new_value);
-}
+		static constexpr uint32_t touch_calibration_magic = 0x074af82f;
 
-int32_t afsk_space_freq() {
-	afsk_freq_range.reset_if_outside(data->afsk_space_freq, afsk_space_reset_value);
-	return data->afsk_space_freq;
-}
+		void set_touch_calibration(const touch::Calibration& new_value) {
+			data->touch_calibration = new_value;
+			data->touch_calibration_magic = touch_calibration_magic;
+		}
 
-void set_afsk_space(const int32_t new_value) {
-	data->afsk_space_freq = afsk_freq_range.clip(new_value);
-}
+		const touch::Calibration& touch_calibration() {
+			if( data->touch_calibration_magic != touch_calibration_magic ) {
+				set_touch_calibration(touch::default_calibration());
+			}
+			return data->touch_calibration;
+		}
 
-int32_t modem_baudrate() {
-	modem_baudrate_range.reset_if_outside(data->modem_baudrate, modem_baudrate_reset_value);
-	return data->modem_baudrate;
-}
+		int32_t tone_mix() {
+			tone_mix_range.reset_if_outside(data->tone_mix, tone_mix_reset_value);
+			return data->tone_mix;
+		}
 
-void set_modem_baudrate(const int32_t new_value) {
-	data->modem_baudrate = modem_baudrate_range.clip(new_value);
-}
+		void set_tone_mix(const int32_t new_value) {
+			data->tone_mix = tone_mix_range.clip(new_value);
+		}
 
-/*int32_t modem_bw() {
-	modem_bw_range.reset_if_outside(data->modem_bw, modem_bw_reset_value);
-	return data->modem_bw;
-}
+		int32_t afsk_mark_freq() {
+			afsk_freq_range.reset_if_outside(data->afsk_mark_freq, afsk_mark_reset_value);
+			return data->afsk_mark_freq;
+		}
 
-void set_modem_bw(const int32_t new_value) {
-	data->modem_bw = modem_bw_range.clip(new_value);
-}*/
+		void set_afsk_mark(const int32_t new_value) {
+			data->afsk_mark_freq = afsk_freq_range.clip(new_value);
+		}
 
-uint8_t modem_repeat() {
-	modem_repeat_range.reset_if_outside(data->modem_repeat, modem_repeat_reset_value);
-	return data->modem_repeat;
-}
+		int32_t afsk_space_freq() {
+			afsk_freq_range.reset_if_outside(data->afsk_space_freq, afsk_space_reset_value);
+			return data->afsk_space_freq;
+		}
 
-void set_modem_repeat(const uint32_t new_value) {
-	data->modem_repeat = modem_repeat_range.clip(new_value);
-}
+		void set_afsk_space(const int32_t new_value) {
+			data->afsk_space_freq = afsk_freq_range.clip(new_value);
+		}
 
-serial_format_t serial_format() {
-	return data->serial_format;
-}
+		int32_t modem_baudrate() {
+			modem_baudrate_range.reset_if_outside(data->modem_baudrate, modem_baudrate_reset_value);
+			return data->modem_baudrate;
+		}
 
-void set_serial_format(const serial_format_t new_value) {
-	data->serial_format = new_value;
-}
+		void set_modem_baudrate(const int32_t new_value) {
+			data->modem_baudrate = modem_baudrate_range.clip(new_value);
+		}
 
-/* static constexpr uint32_t playdead_magic = 0x88d3bb57;
+		/*int32_t modem_bw() {
+		  modem_bw_range.reset_if_outside(data->modem_bw, modem_bw_reset_value);
+		  return data->modem_bw;
+		  }
 
-uint32_t playing_dead() {
-	return data->playing_dead;
-}
+		  void set_modem_bw(const int32_t new_value) {
+		  data->modem_bw = modem_bw_range.clip(new_value);
+		  }*/
 
-void set_playing_dead(const uint32_t new_value) {
-	if( data->playdead_magic != playdead_magic ) {
-		set_playdead_sequence(0x8D1);	// U D L R
-	}
-	data->playing_dead = new_value;
-}
+		uint8_t modem_repeat() {
+			modem_repeat_range.reset_if_outside(data->modem_repeat, modem_repeat_reset_value);
+			return data->modem_repeat;
+		}
 
-uint32_t playdead_sequence() {
-	if( data->playdead_magic != playdead_magic ) {
-		set_playdead_sequence(0x8D1);	// U D L R
-	}
-	return data->playdead_sequence;
-}
+		void set_modem_repeat(const uint32_t new_value) {
+			data->modem_repeat = modem_repeat_range.clip(new_value);
+		}
 
-void set_playdead_sequence(const uint32_t new_value) {
-	data->playdead_sequence = new_value;
-	data->playdead_magic = playdead_magic;
-} */
+		serial_format_t serial_format() {
+			return data->serial_format;
+		}
 
-// ui_config is an uint32_t var storing information bitwise
-// bits 0,1,2 store the backlight timer
-// bits 31, 30,29,28,27 stores the different single bit configs depicted below
-// bits on position 4 to 19 (16 bits) store the clkout frequency
+		void set_serial_format(const serial_format_t new_value) {
+			data->serial_format = new_value;
+		}
 
-bool clkout_enabled() {
-	return data->ui_config & (1 << 27);
-}
+		static constexpr uint32_t playdead_magic = 0x88d3bb57;
 
-bool config_speaker() {
-	return data->ui_config & (1 << 28);
-}
-bool stealth_mode() {
-	return data->ui_config & (1 << 29);
-}
+		uint32_t playing_dead() {
+			return data->playing_dead;
+		}
 
-bool config_login() {
-	return data->ui_config & (1 << 30);
-}
+		void set_playing_dead(const uint32_t new_value) {
+			if( data->playdead_magic != playdead_magic ) {
+				set_playdead_sequence(0x8D1);	// U D L R
+			}
+			data->playing_dead = new_value;
+		}
 
-bool config_splash() {
-	return data->ui_config & (1 << 31);
-}
+		uint32_t playdead_sequence() {
+			if( data->playdead_magic != playdead_magic ) {
+				set_playdead_sequence(0x8D1);	// U D L R
+			}
+			return data->playdead_sequence;
+		}
 
-uint32_t config_backlight_timer() {
-	const uint32_t timer_seconds[8] = { 0, 5, 15, 30, 60, 180, 300, 600 };
-	return timer_seconds[data->ui_config & 7]; //first three bits, 8 possible values
-}
+		void set_playdead_sequence(const uint32_t new_value) {
+			data->playdead_sequence = new_value;
+			data->playdead_magic = playdead_magic;
+		}
 
-void set_clkout_enabled(bool v) {
-	data->ui_config = (data->ui_config & ~(1 << 27)) | (v << 27);
-}
+		bool config_speaker() {
+			return (data->ui_config & 0x10000000UL) ? false : true; // Default true
+		}
+		bool stealth_mode() {
+			return (data->ui_config & 0x20000000UL) ? true : false;
+		}
 
-void set_config_speaker(bool v) {
-	data->ui_config = (data->ui_config & ~(1 << 28)) | (v << 28);
-}
+		void set_config_speaker(bool new_value) {
+			data->ui_config = (data->ui_config & ~0x10000000UL) | (!new_value << 28); 
+		}
 
-void set_stealth_mode(bool v) {
-	data->ui_config = (data->ui_config & ~(1 << 29)) | (v << 29);
-}
+		void set_stealth_mode(const bool v) {
+			data->ui_config = (data->ui_config & ~0x20000000UL) | (v << 29);
+		}
 
-void set_config_login(bool v) {
-	data->ui_config = (data->ui_config & ~(1 << 30)) | (v << 30);
-}
+		bool config_splash() {
+			return (data->ui_config & 0x80000000UL) ? true : false;
+		}
 
-void set_config_splash(bool v) {
-	data->ui_config = (data->ui_config & ~(1 << 31)) | (v << 31);
-}
+		bool config_login() {
+			return (data->ui_config & 0x40000000UL) ? true : false;
+		}
 
-void set_config_backlight_timer(uint32_t i) {
-	data->ui_config = (data->ui_config & ~7) | (i & 7);
-}
+		uint32_t config_backlight_timer() {
+			const uint32_t timer_seconds[8] = { 0, 5, 15, 30, 60, 180, 300, 600 };
 
-/*void set_config_textentry(uint8_t new_value) {
-	data->ui_config = (data->ui_config & ~0b100) | ((new_value & 1) << 2);
-}
+			return timer_seconds[data->ui_config & 0x00000007UL];
+		}
 
-uint8_t ui_config_textentry() {
-	return ((data->ui_config >> 2) & 1);
-}*/
+		void set_config_splash(bool v) {
+			data->ui_config = (data->ui_config & ~0x80000000UL) | (v << 31);
+		}
 
-/*void set_ui_config(const uint32_t new_value) {
-	data->ui_config = new_value;
-}*/
+		void set_config_login(bool v) {
+			data->ui_config = (data->ui_config & ~0x40000000UL) | (v << 30);
+		}
 
-uint32_t pocsag_last_address() {
-	return data->pocsag_last_address;
-}
+		void set_config_backlight_timer(uint32_t i) {
+			data->ui_config = (data->ui_config & ~0x00000007UL) | (i & 7);
+		}
 
-void set_pocsag_last_address(uint32_t address) {
-	data->pocsag_last_address = address;
-}
+		/*void set_config_textentry(uint8_t new_value) {
+		  data->ui_config = (data->ui_config & ~0b100) | ((new_value & 1) << 2);
+		  }
 
-uint32_t pocsag_ignore_address() {
-	return data->pocsag_ignore_address;
-}
+		  uint8_t ui_config_textentry() {
+		  return ((data->ui_config >> 2) & 1);
+		  }*/
 
-void set_pocsag_ignore_address(uint32_t address) {
-	data->pocsag_ignore_address = address;
-}
+		/*void set_ui_config(const uint32_t new_value) {
+		  data->ui_config = new_value;
+		  }*/
 
-uint32_t clkout_freq() {
-	uint16_t freq = (data->ui_config & 0x000FFFF0) >> 4;
-	if(freq < clkout_freq_range.minimum || freq > clkout_freq_range.maximum) {
-		data->ui_config = (data->ui_config & ~0x000FFFF0) | clkout_freq_reset_value << 4;
-		return clkout_freq_reset_value;
-	}
-	else {
-		return freq;
-	}
-}
+		uint32_t pocsag_last_address() {
+			return data->pocsag_last_address;
+		}
 
-void set_clkout_freq(uint32_t freq) {
-	data->ui_config = (data->ui_config & ~0x000FFFF0) | (clkout_freq_range.clip(freq) << 4);
-}
+		void set_pocsag_last_address(uint32_t address) {
+			data->pocsag_last_address = address;
+		}
 
+		uint32_t pocsag_ignore_address() {
+			return data->pocsag_ignore_address;
+		}
 
-} /* namespace persistent_memory */
+		void set_pocsag_ignore_address(uint32_t address) {
+			data->pocsag_ignore_address = address;
+		}
+
+		bool clkout_enabled() {
+			return (data->ui_config & 0x08000000UL);
+		}
+
+		void set_clkout_enabled(bool enable) {
+			data->ui_config = (data->ui_config & ~0x08000000UL) | (enable << 27);
+		}
+
+		uint32_t clkout_freq() {
+			uint16_t freq = (data->ui_config & 0x000FFFF0) >> 4;
+			if(freq < clkout_freq_range.minimum || freq > clkout_freq_range.maximum) {
+				data->ui_config = (data->ui_config & ~0x000FFFF0) | clkout_freq_reset_value << 4;
+				return clkout_freq_reset_value;
+			}
+			else {
+				return freq;
+			}
+		}
+
+		void set_clkout_freq(uint32_t freq) {
+			data->ui_config = (data->ui_config & ~0x000FFFF0) | (clkout_freq_range.clip(freq) << 4);
+		}
+
+		/* Search app */
+		bool search_app_autosave_freqs() {
+			return (data->search_app_searchconfig & 0x80000000UL) ? true : false ; //default false
+		}
+		bool search_app_autostart_search() {
+			return (data->search_app_searchconfig & 0x40000000UL) ? false : true; //default true
+		}
+		bool search_app_continuous() {
+			return (data->search_app_searchconfig & 0x20000000UL) ? false : true; //default true
+		}
+		bool search_app_clear_output() {
+			return (data->search_app_searchconfig & 0x10000000UL) ? false : true; //default true
+		}
+		bool search_app_load_freqs() {
+			return (data->search_app_searchconfig & 0x08000000UL) ? true : false; //default false
+		}
+		bool search_app_load_ranges() {
+			return (data->search_app_searchconfig & 0x04000000UL) ? false : true; //default true
+		}
+		bool search_app_update_ranges_when_searching() {
+			return (data->search_app_searchconfig & 0x02000000UL) ? false : true; //default true
+		}
+		void set_search_app_autosave_freqs(const bool v ){
+			data->search_app_searchconfig = (data->search_app_searchconfig & ~0x80000000UL) | (v << 31); 
+		}
+		void set_search_app_autostart_search(const bool v ){
+			data->search_app_searchconfig = (data->search_app_searchconfig & ~0x40000000UL) | (!v << 30); 
+		}
+		void set_search_app_continuous(const bool v ){
+			data->search_app_searchconfig = (data->search_app_searchconfig & ~0x20000000UL) | (!v << 29); 
+		}
+		void set_search_app_clear_output(const bool v ){
+			data->search_app_searchconfig = (data->search_app_searchconfig & ~0x10000000UL) | (!v << 28); 
+		}
+		void set_search_app_load_freqs(const bool v ){
+			data->search_app_searchconfig = (data->search_app_searchconfig & ~0x08000000UL) | (v << 27); 
+		}
+		void set_search_app_load_ranges(const bool v ){
+			data->search_app_searchconfig = (data->search_app_searchconfig & ~0x04000000UL) | (!v << 26); 
+		} 
+		void set_search_app_update_ranges_when_searching(const bool v ){
+			data->search_app_searchconfig = (data->search_app_searchconfig & ~0x02000000UL) | (!v << 25); 
+		} 
+
+	} /* namespace persistent_memory */
 } /* namespace portapack */

--- a/firmware/common/portapack_persistent_memory.hpp
+++ b/firmware/common/portapack_persistent_memory.hpp
@@ -34,71 +34,88 @@ using namespace modems;
 using namespace serializer;
 
 namespace portapack {
-namespace persistent_memory {
 
-using ppb_t = int32_t;
+	namespace persistent_memory {
 
-rf::Frequency tuned_frequency();
-void set_tuned_frequency(const rf::Frequency new_value);
+		using ppb_t = int32_t;
 
-ppb_t correction_ppb();
-void set_correction_ppb(const ppb_t new_value);
+		rf::Frequency tuned_frequency();
+		void set_tuned_frequency(const rf::Frequency new_value);
 
-void set_touch_calibration(const touch::Calibration& new_value);
-const touch::Calibration& touch_calibration();
+		ppb_t correction_ppb();
+		void set_correction_ppb(const ppb_t new_value);
 
-serial_format_t serial_format();
-void set_serial_format(const serial_format_t new_value);
+		void set_touch_calibration(const touch::Calibration& new_value);
+		const touch::Calibration& touch_calibration();
 
-int32_t tone_mix();
-void set_tone_mix(const int32_t new_value);
+		serial_format_t serial_format();
+		void set_serial_format(const serial_format_t new_value);
 
-int32_t afsk_mark_freq();
-void set_afsk_mark(const int32_t new_value);
+		int32_t tone_mix();
+		void set_tone_mix(const int32_t new_value);
 
-int32_t afsk_space_freq();
-void set_afsk_space(const int32_t new_value);
+		int32_t afsk_mark_freq();
+		void set_afsk_mark(const int32_t new_value);
 
-int32_t modem_baudrate();
-void set_modem_baudrate(const int32_t new_value);
+		int32_t afsk_space_freq();
+		void set_afsk_space(const int32_t new_value);
 
-uint8_t modem_repeat();
-void set_modem_repeat(const uint32_t new_value);
+		int32_t modem_baudrate();
+		void set_modem_baudrate(const int32_t new_value);
 
-uint32_t playing_dead();
-void set_playing_dead(const uint32_t new_value);
+		uint8_t modem_repeat();
+		void set_modem_repeat(const uint32_t new_value);
 
-uint32_t playdead_sequence();
-void set_playdead_sequence(const uint32_t new_value);
+		uint32_t playing_dead();
+		void set_playing_dead(const uint32_t new_value);
 
-bool stealth_mode();
-void set_stealth_mode(const bool v);
+		uint32_t playdead_sequence();
+		void set_playdead_sequence(const uint32_t new_value);
 
-bool config_splash();
-bool config_login();
-bool config_speaker();
-uint32_t config_backlight_timer();
+		bool stealth_mode();
+		void set_stealth_mode(const bool v);
 
-void set_config_splash(bool v);
-void set_config_login(bool v);
-void set_config_speaker(bool v); 
-void set_config_backlight_timer(uint32_t i);
+		bool config_splash();
+		bool config_login();
+		bool config_speaker();
+		uint32_t config_backlight_timer();
 
-//uint8_t ui_config_textentry();
-//void set_config_textentry(uint8_t new_value);
+		void set_config_splash(bool v);
+		void set_config_login(bool v);
+		void set_config_speaker(bool new_value); 
+		void set_config_backlight_timer(uint32_t i);
 
-uint32_t pocsag_last_address();
-void set_pocsag_last_address(uint32_t address);
+		//uint8_t ui_config_textentry();
+		//void set_config_textentry(uint8_t new_value);
 
-uint32_t pocsag_ignore_address();
-void set_pocsag_ignore_address(uint32_t address);
+		uint32_t pocsag_last_address();
+		void set_pocsag_last_address(uint32_t address);
 
-bool clkout_enabled();
-void set_clkout_enabled(bool v);
-uint32_t clkout_freq();
-void set_clkout_freq(uint32_t freq);
+		uint32_t pocsag_ignore_address();
+		void set_pocsag_ignore_address(uint32_t address);
 
-} /* namespace persistent_memory */
+		bool clkout_enabled();
+		void set_clkout_enabled(bool enable);
+		uint32_t clkout_freq();
+		void set_clkout_freq(uint32_t freq);
+
+		/* Search app */
+		bool     search_app_autosave_freqs();
+		bool     search_app_autostart_search();
+		bool     search_app_continuous();
+		bool     search_app_clear_output();
+		bool     search_app_load_freqs();
+		bool     search_app_load_ranges();
+		bool     search_app_update_ranges_when_searching();
+		void set_search_app_autosave_freqs(const bool v);
+		void set_search_app_autostart_search(const bool v);
+		void set_search_app_continuous(const bool v);
+		void set_search_app_clear_output(const bool v);
+		void set_search_app_load_freqs(const bool v);
+		void set_search_app_load_ranges(const bool v);
+		void set_search_app_update_ranges_when_searching(const bool v);
+
+	} /* namespace persistent_memory */
 } /* namespace portapack */
 
 #endif/*__PORTAPACK_PERSISTENT_MEMORY_H__*/

--- a/firmware/common/ui_widget.cpp
+++ b/firmware/common/ui_widget.cpp
@@ -957,6 +957,160 @@ bool Button::on_touch(const TouchEvent event) {
 #endif
 }
 
+/* ButtonWithEncoder ****************************************************************/
+
+ButtonWithEncoder::ButtonWithEncoder(
+	Rect parent_rect,
+	std::string text,
+	bool instant_exec
+) : Widget { parent_rect },
+	text_ { text },
+	instant_exec_ { instant_exec }
+{
+	set_focusable(true);
+}
+
+void ButtonWithEncoder::set_text(const std::string value) {
+	text_ = value;
+	set_dirty();
+}
+int32_t ButtonWithEncoder::get_encoder_delta() {
+	return encoder_delta ;
+}
+void ButtonWithEncoder::set_encoder_delta( const int32_t delta )
+{
+	encoder_delta = delta ;
+}
+
+std::string ButtonWithEncoder::text() const {
+	return text_;
+}
+
+void ButtonWithEncoder::paint(Painter& painter) {
+	Color bg, fg;
+	const auto r = screen_rect();
+
+	if (has_focus() || highlighted()) {
+		bg = style().foreground;
+		fg = Color::black();
+	} else {
+		bg = Color::grey();
+		fg = style().foreground;
+	}
+	
+	const Style paint_style = { style().font, bg, fg };
+	
+	painter.draw_rectangle({r.location(), {r.size().width(), 1}}, Color::light_grey());
+	painter.draw_rectangle({r.location().x(), r.location().y() + r.size().height() - 1, r.size().width(), 1}, Color::dark_grey());
+	painter.draw_rectangle({r.location().x() + r.size().width() - 1, r.location().y(), 1, r.size().height()}, Color::dark_grey());
+
+	painter.fill_rectangle(
+		{ r.location().x(), r.location().y() + 1, r.size().width() - 1, r.size().height() - 2 },
+		paint_style.background
+	);
+
+	const auto label_r = paint_style.font.size_of(text_);
+	painter.draw_string(
+		{ r.location().x() + (r.size().width() - label_r.width()) / 2, r.location().y() + (r.size().height() - label_r.height()) / 2 },
+		paint_style,
+		text_
+	);
+}
+
+void ButtonWithEncoder::on_focus() {
+	if( on_highlight )
+		on_highlight(*this);
+}
+
+bool ButtonWithEncoder::on_key(const KeyEvent key) {
+	if( key == KeyEvent::Select ) {
+		if( on_select ) {
+			on_select(*this);
+			return true;
+		}
+	} else {
+		if( on_dir ) {
+			return on_dir(*this, key);
+		}
+	}
+
+	return false;
+}
+
+bool ButtonWithEncoder::on_touch(const TouchEvent event) {
+	switch(event.type) {
+	case TouchEvent::Type::Start:
+		set_highlighted(true);
+		set_dirty();
+		if( on_touch_press) {
+			on_touch_press(*this);
+		}
+		if( on_select && instant_exec_ ) {
+			on_select(*this);
+		}
+		return true;
+
+
+	case TouchEvent::Type::End:
+		set_highlighted(false);
+		set_dirty();
+		if( on_touch_release) {
+			on_touch_release(*this);
+		}
+		if( on_select && !instant_exec_ ) {
+			on_select(*this);
+		}
+		return true;
+
+	default:
+		return false;
+	}
+#if 0
+	switch(event.type) {
+	case TouchEvent::Type::Start:
+		flags.highlighted = true;
+		set_dirty();
+		return true;
+
+	case TouchEvent::Type::Move:
+		{
+			const bool new_highlighted = screen_rect().contains(event.point);
+			if( flags.highlighted != new_highlighted ) {
+				flags.highlighted = new_highlighted;
+				set_dirty();
+			}
+		}
+		return true;
+
+	case TouchEvent::Type::End:
+		if( flags.highlighted ) {
+			flags.highlighted = false;
+			set_dirty();
+			if( on_select ) {
+				on_select(*this);
+			}
+		}
+		return true;
+
+	default:
+		return false;
+	}
+#endif
+}
+bool ButtonWithEncoder::on_encoder(const EncoderEvent delta) {
+ 	if( delta != 0 )
+	{
+		encoder_delta += delta ;	
+		delta_change = true ;
+		on_change();
+	}
+	else
+		delta_change = 0 ;
+	return true ;
+}
+
+
+
 /* NewButton ****************************************************************/
 
 NewButton::NewButton(

--- a/firmware/common/ui_widget.hpp
+++ b/firmware/common/ui_widget.hpp
@@ -410,6 +410,51 @@ private:
 	bool instant_exec_ { false };
 };
 
+
+
+class ButtonWithEncoder : public Widget {
+public:
+	std::function<void(ButtonWithEncoder&)> on_select { };
+	std::function<void(ButtonWithEncoder&)> on_touch_release { }; // Executed when releasing touch, after on_select.
+	std::function<void(ButtonWithEncoder&)> on_touch_press { }; // Executed when touching, before on_select.
+	std::function<bool(ButtonWithEncoder&, KeyEvent)> on_dir { };
+	std::function<void(ButtonWithEncoder&)> on_highlight { };
+
+	ButtonWithEncoder(Rect parent_rect, std::string text, bool instant_exec); // instant_exec: Execute on_select when you touching instead of releasing
+	ButtonWithEncoder(
+		Rect parent_rect,
+		std::string text
+	) : ButtonWithEncoder { parent_rect, text, false }
+	{
+	}
+
+	ButtonWithEncoder(
+	) : ButtonWithEncoder { { }, { } }
+	{
+	}
+
+	std::function<void()> on_change { };
+
+	void set_text(const std::string value);
+	int32_t get_encoder_delta();
+	void set_encoder_delta( const int32_t delta );
+	std::string text() const;
+
+	void paint(Painter& painter) override;
+
+	void on_focus() override;
+	bool on_key(const KeyEvent key) override;
+	bool on_touch(const TouchEvent event) override;
+	bool on_encoder(const EncoderEvent delta) override;
+
+private:
+	std::string text_;
+	int32_t encoder_delta  = 0 ;
+	bool delta_change = 0 ;
+	bool instant_exec_ { false };
+};
+
+
 class NewButton : public Widget {
 public:
 	std::function<void(void)> on_select { };


### PR DESCRIPTION
Search app is a fork of scanner app.

The aim was to separate Search from Scan and to improve ranges scanning.

Search app allow to search on a list of ranges and generate a list of frequencies for Scanner App.

It's having settings in persistent memory and on the SD card ( A folder with name SEARCH is needed at the root of the SD for input/output file settings to be saved across restarts).

There is now a button to restart the current input file without reloading it (i.e because you started a manual search on a given range).

On pause mode, < RESUME > is displayed. The < > indicate that while the highlight is on the button you can use the rotary encoder to step along the list. It will automatically step when it's a range and jump when it's frequency.

Wiki doc is ready at https://github.com/GullCode/portapack-mayhem/wiki/Search