### PR TITLE
Added a couple snap values to the calls app.

### DIFF
--- a/firmware/application/apps/ui_search.hpp
+++ b/firmware/application/apps/ui_search.hpp
@@ -212,12 +212,14 @@ private:
 		true
 	};
 	OptionsField options_snap {
-		{ 17 * 8, 15 * 8 },
-		7,
-		{
+		{ 17 * 8, 15 * 8 }, // Position
+		7,                  // Length
+		{                   // Options
 			{ "25kHz  ", 25000 },
 			{ "12.5kHz", 12500 },
-			{ "8.33kHz", 8333 }
+			{ "8.33kHz", 8333 },
+			{ "2.5kHz", 2500 },
+			{ "500Hz", 500 }
 		}
 	};
 	


### PR DESCRIPTION
Adding a few common frequency snap values. 2.5kHz is pretty common in the United States amateur radio and 500Hz seemed like a good idea as well.
I would like to also change the default to 2.5kHz, but I left that out as I didn't know the rational behind the current 12.5kHz default.