### PR TITLE
aprs_packet.hpp compiler warning fix

### DIFF
--- a/firmware/common/aprs_packet.hpp
+++ b/firmware/common/aprs_packet.hpp
@@ -339,9 +339,9 @@ private:
 		std::string lat_str = "";
 		std::string lng_str = "";
 
-		bool is_north;
-		bool is_west;
-		uint8_t lng_offset;
+		bool is_north = false;
+		bool is_west = false;
+		uint8_t lng_offset = 0;
 		for(uint8_t i = DESTINATION_START; i < DESTINATION_START + ADDRESS_SIZE - 1; i++){
 			uint8_t ascii = payload[i] >> 1;
 


### PR DESCRIPTION
Solves compiler warnings.  
```
/havoc/firmware/common/aprs_packet.hpp:344:11: warning: 'lng_offset' may be used uninitialized in this function [-Wmaybe-
/havoc/firmware/common/aprs_packet.hpp:404:3: warning: 'is_west' may be used uninitialized in this function [-Wmaybe-uninitialized]
/havoc/firmware/common/aprs_packet.hpp:363:3: warning: 'is_north' may be used uninitialized in this function [-Wmaybe-uninitialized]
```
