### PR TITLE
ui_adsb_rx.hpp compiler warning fix

### DIFF
--- a/firmware/application/apps/ui_adsb_rx.hpp
+++ b/firmware/application/apps/ui_adsb_rx.hpp
@@ -49,7 +49,7 @@ struct AircraftRecentEntry {
 	uint16_t hits { 0 };
 	uint32_t age { 0 };
 	adsb_pos pos { false, 0, 0, 0 };
-	adsb_vel velo { false, 0, 999 };
+	adsb_vel velo { false, 0, 999, 0 };
 	ADSBFrame frame_pos_even { };
 	ADSBFrame frame_pos_odd { };
 	


### PR DESCRIPTION
compiler warning fix.

```
In file included from /havoc/firmware/application/ui_navigation.cpp:34:
/havoc/firmware/application/apps/ui_adsb_rx.hpp:52:32: warning: missing initializer for member 'adsb::adsb_vel::v_rate' [-Wmissing-field-initializers]
52 | adsb_vel velo { false, 0, 999 };

In file included from /havoc/firmware/application/apps/ui_adsb_rx.cpp:23:
/havoc/firmware/application/apps/ui_adsb_rx.hpp:52:32: warning: missing initializer for member 'adsb::adsb_vel::v_rate' [-Wmissing-field-initializers]
52 | adsb_vel velo { false, 0, 999 };
```

