### PR TITLE
proc_aprsrx.cpp compile warning fix

### DIFF
--- a/firmware/baseband/proc_aprsrx.cpp
+++ b/firmware/baseband/proc_aprsrx.cpp
@@ -141,12 +141,11 @@ bool APRSRxProcessor::parse_bit(const uint8_t current_bit){
 	uint8_t decoded_bit = ~(current_bit ^ last_bit) & 0x1;
 	last_bit = current_bit;
 
-	int16_t log = decoded_bit == 0 ? -32768 : 32767;
-				
-	//if( stream ) {
-	//	const size_t bytes_to_write = sizeof(log) * 1;
-//		const auto result = stream->write(&log, bytes_to_write);
-//	}
+    //int16_t log = decoded_bit == 0 ? -32768 : 32767;
+    //if(stream){
+    //    const size_t bytes_to_write = sizeof(log) * 1;
+    //    const auto result = stream->write(&log, bytes_to_write);
+    //}
 
 	if(decoded_bit & 0x1){
 		if(ones_count < 8){


### PR DESCRIPTION
Compiler warning fix:
```
/havoc/firmware/baseband/proc_aprsrx.cpp: In member function 'bool APRSRxProcessor::parse_bit(uint8_t)':
/havoc/firmware/baseband/proc_aprsrx.cpp:144:10: warning: unused variable 'log' [-Wunused-variable]
144 | int16_t log = decoded_bit == 0 ? -32768 : 32767;
```