### PR TITLE
Add FrequencyStepView field to the TransmitterView class

### DIFF
--- a/firmware/application/ui/ui_transmitter.cpp
+++ b/firmware/application/ui/ui_transmitter.cpp
@@ -103,6 +103,7 @@ void TransmitterView::set_transmitting(const bool transmitting) {
 
 void TransmitterView::on_show() {
 	field_frequency.set_value(transmitter_model.tuning_frequency());
+	field_frequency_step.set_by_value(receiver_model.frequency_step());
 
 	field_gain.set_value(transmitter_model.tx_gain());
 	field_amp.set_value(transmitter_model.rf_amp() ? 14 : 0);
@@ -122,6 +123,7 @@ TransmitterView::TransmitterView(
 	
 	add_children({
 		&field_frequency,
+		&field_frequency_step,
 		&text_gain,
 		&field_gain,
 		&button_start,
@@ -156,6 +158,10 @@ TransmitterView::TransmitterView(
 	field_frequency.on_edit = [this]() {
 		if (on_edit_frequency)
 			on_edit_frequency();
+	};
+	
+	field_frequency_step.on_change = [this](size_t, OptionsField::value_t v) {
+		this->field_frequency.set_step(v);
 	};
 
 	field_gain.on_change = [this](uint32_t tx_gain) {

--- a/firmware/application/ui/ui_transmitter.hpp
+++ b/firmware/application/ui/ui_transmitter.hpp
@@ -128,7 +128,7 @@ private:
 		"kHz"
 	};
 	NumberField field_bw {
-		{ 14 * 8, 1 * 8 },
+		{ 15 * 8, 1 * 8 },
 		3,
 		{ 1, 150 },
 		1,

--- a/firmware/application/ui/ui_transmitter.hpp
+++ b/firmware/application/ui/ui_transmitter.hpp
@@ -124,8 +124,8 @@ private:
 	};
 
 	Text text_bw {
-		{ 11 * 8, 1 * 8, 9 * 8, 1 * 16 },
-		"BW:   kHz"
+		{ 18 * 8, 1 * 8, 3 * 8, 1 * 16 },
+		"kHz"
 	};
 	NumberField field_bw {
 		{ 14 * 8, 1 * 8 },
@@ -151,6 +151,10 @@ private:
 	Button button_start {
 		{ 21 * 8, 1 * 8, 9 * 8, 32 },
 		"START"
+	};
+	
+	FrequencyStepView field_frequency_step {
+		{ 10 * 8 - 4, 1 * 8 },
 	};
 
 	void on_tuning_frequency_changed(rf::Frequency f);


### PR DESCRIPTION
It is not convenient for me that the step of changing the frequency in the transmission modes (the `TransmitterView` class) is fixed. So I added the `FrequencyStepView` field to the first line in the middle (between `field_frequency` and `field_bw`)

![SCR_0002](https://user-images.githubusercontent.com/39090123/118323024-b1a9e780-b508-11eb-8fce-8bda537bb775.PNG)
