### PR TITLE
ISO datetime for Clock, FileManager, Frequency manager, added clock UI options

### DIFF
--- a/firmware/application/apps/ui_freqman.hpp
+++ b/firmware/application/apps/ui_freqman.hpp
@@ -103,19 +103,19 @@ private:
 	};
 	
 	Labels labels {
-		{ { 2 * 8, 14 * 8 }, "Save as:", Color::white() }
+		{ { 1 * 8, 12 * 8 }, "Save as:", Color::white() }
 	};
 	
 	Button button_save_name {
-		{ 2 * 8, 17 * 8, 14 * 8, 48 },
+		{ 1 * 8, 17 * 8, 12 * 8, 48 },
 		"Name (set)"
 	};
 	Button button_save_timestamp {
-		{ 2 * 8, 25 * 8, 14 * 8, 48 },
+		{ 1 * 8, 25 * 8, 12 * 8, 48 },
 		"Timestamp:"
 	};
 	LiveDateTime live_timestamp {
-		{ 17 * 8, 27 * 8, 11 * 8, 16 }
+		{ 14 * 8, 27 * 8, 16 * 8, 16 }
 	};
 };
 

--- a/firmware/application/apps/ui_settings.cpp
+++ b/firmware/application/apps/ui_settings.cpp
@@ -285,20 +285,28 @@ SetUIView::SetUIView(NavigationView& nav) {
 		&checkbox_bloff,
 		&options_bloff,
 		&checkbox_showsplash,
+		&checkbox_showclock,
+		&options_clockformat,		
 		&button_ok
 	});
 	
 	checkbox_speaker.set_value(persistent_memory::config_speaker());
 	checkbox_showsplash.set_value(persistent_memory::config_splash());
+	checkbox_showclock.set_value(!persistent_memory::hide_clock());
 	//checkbox_login.set_value(persistent_memory::config_login());
 	
 	uint32_t backlight_timer = persistent_memory::config_backlight_timer();
-	
 	if (backlight_timer) {
 		checkbox_bloff.set_value(true);
 		options_bloff.set_by_value(backlight_timer);
 	} else {
 		options_bloff.set_selected_index(0);
+	}
+
+	if (persistent_memory::clock_with_date()) {
+		options_clockformat.set_selected_index(1);
+	} else {
+		options_clockformat.set_selected_index(0);
 	}
 
 	checkbox_speaker.on_select = [this](Checkbox&, bool v) {
@@ -316,7 +324,14 @@ SetUIView::SetUIView(NavigationView& nav) {
 		else
 			persistent_memory::set_config_backlight_timer(0);
 		
+		if (checkbox_showclock.value()){
+		    if (options_clockformat.selected_index() == 1)
+			    persistent_memory::set_clock_with_date(true);    
+     		else
+			    persistent_memory::set_clock_with_date(false);		
+		}		
 		persistent_memory::set_config_splash(checkbox_showsplash.value());
+		persistent_memory::set_clock_hidden(!checkbox_showclock.value());
 		//persistent_memory::set_config_login(checkbox_login.value());
 		nav.pop();
 	};

--- a/firmware/application/apps/ui_settings.hpp
+++ b/firmware/application/apps/ui_settings.hpp
@@ -51,8 +51,8 @@ public:
 
 private:
 	Labels labels {
-		{ { 6 * 8, 7 * 16 }, "YYYY/MM/DD HH:MM:SS", Color::grey() },
-		{ { 10 * 8, 9 * 16 }, "/  /     :  :", Color::light_grey() }
+		{ { 6 * 8, 7 * 16 }, "YYYY-MM-DD HH:MM:SS", Color::grey() },
+		{ { 10 * 8, 9 * 16 }, "-  -     :  :", Color::light_grey() }
 	};
 	
 	NumberField field_year {
@@ -226,19 +226,19 @@ private:
 	};*/
 	
 	Checkbox checkbox_speaker {
-		{ 3 * 8, 2 * 16 },
+		{ 3 * 8, 4 * 16 },
 		20,
 		"Hide H1 Speaker option"
 	};
+	
 	Checkbox checkbox_bloff {
-		{ 3 * 8, 5 * 16 },
+		{ 3 * 8, 6 * 16 },
 		20,
 		"Backlight off after:"
 	};
-
 	OptionsField options_bloff {
-		{ 52, 6 * 16 + 8 },
-		10,
+		{ 52, 7 * 16 + 8 },
+		20,
 		{
 			{ "5 seconds", 5 },
 			{ "15 seconds", 15 },
@@ -252,9 +252,24 @@ private:
 	
 	Checkbox checkbox_showsplash {
 		{ 3 * 8, 9 * 16 },
-		11,
+		20,
 		"Show splash"
 	};
+	
+	Checkbox checkbox_showclock {	
+		{ 3 * 8, 11 * 16 },
+		20,
+		"Show clock with:"
+	};
+
+	OptionsField options_clockformat {
+		{ 52, 12 * 16 + 8 },
+		20,
+		{
+			{ "time only", 0 },
+			{ "time and date", 1 }
+		}
+	};	
 	
 	Button button_ok {
 		{ 2 * 8, 16 * 16, 12 * 8, 32 },

--- a/firmware/application/string_format.cpp
+++ b/firmware/application/string_format.cpp
@@ -165,8 +165,8 @@ std::string to_string_datetime(const rtc::RTC& value, const TimeFormat format) {
 	std::string string { "" };
 	
 	if (format == YMDHMS) {
-		string += to_string_dec_uint(value.year(), 4) + "/" +
-					to_string_dec_uint(value.month(), 2, '0') + "/" +
+		string += to_string_dec_uint(value.year(), 4) + "-" +
+					to_string_dec_uint(value.month(), 2, '0') + "-" +
 					to_string_dec_uint(value.day(), 2, '0') + " ";
 	}
 	
@@ -189,11 +189,11 @@ std::string to_string_timestamp(const rtc::RTC& value) {
 }
 
 std::string to_string_FAT_timestamp(const FATTimestamp& timestamp) {
-	return to_string_dec_uint((timestamp.FAT_date >> 9) + 1980) + "/" +
-		to_string_dec_uint((timestamp.FAT_date >> 5) & 0xF, 2) + "/" +
-		to_string_dec_uint((timestamp.FAT_date & 0x1F), 2) + " " +
-		to_string_dec_uint((timestamp.FAT_time >> 11), 2) + ":" +
-		to_string_dec_uint((timestamp.FAT_time >> 5) & 0x3F, 2);
+	return to_string_dec_uint((timestamp.FAT_date >> 9) + 1980) + "-" +
+		to_string_dec_uint((timestamp.FAT_date >> 5) & 0xF, 2, '0') + "-" +
+		to_string_dec_uint((timestamp.FAT_date & 0x1F), 2, '0') + " " +
+		to_string_dec_uint((timestamp.FAT_time >> 11), 2, '0') + ":" +
+		to_string_dec_uint((timestamp.FAT_time >> 5) & 0x3F, 2, '0');
 }
 
 std::string unit_auto_scale(double n, const uint32_t base_nano, uint32_t precision) {

--- a/firmware/application/ui_navigation.cpp
+++ b/firmware/application/ui_navigation.cpp
@@ -68,7 +68,7 @@
 #include "ui_view_wav.hpp"
 #include "ui_whipcalc.hpp"
 
-#include "acars_app.hpp"
+//#include "acars_app.hpp"
 #include "ais_app.hpp"
 #include "analog_audio_app.hpp"
 #include "analog_tv_app.hpp"
@@ -350,11 +350,19 @@ InformationView::InformationView(
 	});
 
 	version.set_style(&style_infobar);
+
+	ltime.set_hide_clock(portapack::persistent_memory::hide_clock());
 	ltime.set_style(&style_infobar);
 	ltime.set_seconds_enabled(true);
-	ltime.set_date_enabled(false);
-
+	ltime.set_date_enabled(portapack::persistent_memory::clock_with_date());
 	set_dirty();
+}
+
+void InformationView::refresh() {
+	ltime.set_hide_clock(portapack::persistent_memory::hide_clock());
+	ltime.set_seconds_enabled(true);
+	ltime.set_date_enabled(portapack::persistent_memory::clock_with_date());	
+
 }
 
 /* Navigation ************************************************************/
@@ -387,6 +395,7 @@ void NavigationView::pop() {
 
 		update_view();
 	}
+
 }
 
 void NavigationView::pop_modal() {
@@ -606,6 +615,7 @@ SystemView::SystemView(
 		}
 		else{
 			add_child(&info_view);
+			info_view.refresh();
 		}
 		
 		this->status_view.set_back_enabled(!this->navigation_view.is_top());

--- a/firmware/application/ui_navigation.hpp
+++ b/firmware/application/ui_navigation.hpp
@@ -212,7 +212,7 @@ private:
 class InformationView : public View {
 public:
 	InformationView(NavigationView& nav);
-	
+	void refresh();	
 private:
 	static constexpr auto version_string = "v1.4.0";
 	NavigationView& nav_;
@@ -228,8 +228,10 @@ private:
 	};
 	
 	LiveDateTime ltime {
-		{174, 0, 8 * 8, 16}
+		{86, 0, 19 * 8, 16}
 	};
+	
+
 };
 
 class BMPView : public View {

--- a/firmware/common/portapack_persistent_memory.cpp
+++ b/firmware/common/portapack_persistent_memory.cpp
@@ -224,8 +224,16 @@ void set_playdead_sequence(const uint32_t new_value) {
 
 // ui_config is an uint32_t var storing information bitwise
 // bits 0,1,2 store the backlight timer
-// bits 31, 30,29,28,27 stores the different single bit configs depicted below
+// bits 31, 30,29,28,27, 26, 25 stores the different single bit configs depicted below
 // bits on position 4 to 19 (16 bits) store the clkout frequency
+
+bool hide_clock() { // clock hidden from main menu
+	return data->ui_config & (1 << 25);
+}
+
+bool clock_with_date() { // show clock with date, if not hidden
+	return data->ui_config & (1 << 26);
+}
 
 bool clkout_enabled() {
 	return data->ui_config & (1 << 27);
@@ -249,6 +257,14 @@ bool config_splash() {
 uint32_t config_backlight_timer() {
 	const uint32_t timer_seconds[8] = { 0, 5, 15, 30, 60, 180, 300, 600 };
 	return timer_seconds[data->ui_config & 7]; //first three bits, 8 possible values
+}
+
+void set_clock_hidden(bool v) {
+	data->ui_config = (data->ui_config & ~(1 << 25)) | (v << 25);
+}
+
+void set_clock_with_date(bool v) {
+	data->ui_config = (data->ui_config & ~(1 << 26)) | (v << 26);
 }
 
 void set_clkout_enabled(bool v) {

--- a/firmware/common/portapack_persistent_memory.hpp
+++ b/firmware/common/portapack_persistent_memory.hpp
@@ -75,11 +75,15 @@ bool stealth_mode();
 void set_stealth_mode(const bool v);
 
 bool config_splash();
+bool hide_clock();
+bool clock_with_date();
 bool config_login();
 bool config_speaker();
 uint32_t config_backlight_timer();
 
 void set_config_splash(bool v);
+void set_clock_hidden(bool v);
+void set_clock_with_date(bool v);
 void set_config_login(bool v);
 void set_config_speaker(bool v); 
 void set_config_backlight_timer(uint32_t i);

--- a/firmware/common/ui_widget.cpp
+++ b/firmware/common/ui_widget.cpp
@@ -410,23 +410,29 @@ void Labels::paint(Painter& painter) {
 void LiveDateTime::on_tick_second() {
 	rtcGetTime(&RTCD1, &datetime);
 	text = "";
-	
-	if(date_enabled){
-		text = to_string_dec_uint(datetime.month(), 2, '0') + "/" + to_string_dec_uint(datetime.day(), 2, '0') + " ";
-	}
-	
-	text = text + to_string_dec_uint(datetime.hour(), 2, '0') + ":" + to_string_dec_uint(datetime.minute(), 2, '0');
+	if(!hide_clock) {
+		if(date_enabled){
+			text = to_string_dec_uint(datetime.year(), 4, '0') + "-" +
+				   to_string_dec_uint(datetime.month(), 2, '0') + "-" + 
+				   to_string_dec_uint(datetime.day(), 2, '0') + " ";
+		}
+		else{
+			text = "           ";
+		}
+		
+		text = text + to_string_dec_uint(datetime.hour(), 2, '0') + ":" + to_string_dec_uint(datetime.minute(), 2, '0');
 
-	if(seconds_enabled){
-		text += ":";
+		if(seconds_enabled){
+			text += ":";
 
-		if(init_delay==0)
-			text += to_string_dec_uint(datetime.second(), 2, '0');
-		else
-		{
-			// Placeholder while the seconds are not updated
-			text += "XX";
-			init_delay--;
+			if(init_delay==0)
+				text += to_string_dec_uint(datetime.second(), 2, '0');
+			else
+			{
+				// Placeholder while the seconds are not updated
+				text += "XX";
+				init_delay--;
+			}
 		}
 	}
 	set_dirty();
@@ -458,6 +464,9 @@ void LiveDateTime::paint(Painter& painter) {
 		s,
 		text
 	);
+}
+void LiveDateTime::set_hide_clock(bool new_value){
+	this->hide_clock = new_value;
 }
 
 void LiveDateTime::set_date_enabled(bool new_value){

--- a/firmware/common/ui_widget.hpp
+++ b/firmware/common/ui_widget.hpp
@@ -244,6 +244,7 @@ public:
 
 	void paint(Painter& painter) override;
 
+	void set_hide_clock(bool new_value);
 	void set_seconds_enabled(bool new_value);
 	void set_date_enabled(bool new_value);
 
@@ -255,6 +256,7 @@ private:
 	void on_tick_second();
 	
 	uint16_t init_delay = 4;
+	bool hide_clock = false;
 	bool date_enabled = true;
 	bool seconds_enabled = false;
 	


### PR DESCRIPTION
ISO datetime for clock, file manager, frequency manager
Added option to show/hide clock (with/without date)

Date format is now always in ISO date, e.g. 2021-01-30 i.s.o. 2021/ 1/30 