### PR TITLE
Save speaker state

### DIFF
--- a/firmware/application/apps/analog_audio_app.cpp
+++ b/firmware/application/apps/analog_audio_app.cpp
@@ -392,9 +392,10 @@ void AnalogAudioView::update_modulation(const ReceiverModel::Mode modulation) {
 	}
 	record_view.set_sampling_rate(sampling_rate);
 
-	if( !is_wideband_spectrum_mode ) {
-		audio::output::unmute();
-	}
+    // respect audio settings
+	//if( !is_wideband_spectrum_mode ) {
+	//	audio::output::unmute();
+	//}
 }
 
 /*void AnalogAudioView::squelched() {

--- a/firmware/application/apps/ui_settings.cpp
+++ b/firmware/application/apps/ui_settings.cpp
@@ -256,10 +256,7 @@ SetUIView::SetUIView(NavigationView& nav) {
 	}
 
 	checkbox_speaker.on_select = [this](Checkbox&, bool v) {
-    		if (v) audio::output::speaker_mute();		//Just mute audio if speaker is disabled
-
-			persistent_memory::set_config_speaker(v);	//Store Speaker status
-
+		persistent_memory::set_config_speaker(v);	    	//Store Speaker status
         StatusRefreshMessage message { };				//Refresh status bar with/out speaker
         EventDispatcher::send_message(message);
     };
@@ -291,14 +288,21 @@ SetAudioView::SetAudioView(NavigationView& nav) {
 	add_children({
 		&labels,
 		&field_tone_mix,
+		&checkbox_speaker_enabled,
 		&button_save,
 		&button_cancel
 	});
 
 	field_tone_mix.set_value(persistent_memory::tone_mix());
+	checkbox_speaker_enabled.set_value(persistent_memory::speaker_enabled());
+
 	
 	button_save.on_select = [&nav, this](Button&) {
 		persistent_memory::set_tone_mix(field_tone_mix.value());
+		portapack::set_speaker_mode(checkbox_speaker_enabled.value());
+        StatusRefreshMessage message { };				//Refresh status bar with green/grey speaker
+        EventDispatcher::send_message(message);
+		
 		nav.pop();
 	};
 

--- a/firmware/application/apps/ui_settings.hpp
+++ b/firmware/application/apps/ui_settings.hpp
@@ -282,17 +282,23 @@ public:
 	
 private:
 	Labels labels {
-		{ { 2 * 8, 3 * 16 }, "Tone key mix:   %", Color::light_grey() },
+		{ { 3 * 8, 3 * 16 }, "Tone key mix:   %", Color::light_grey() },
 	};
 	
 	NumberField field_tone_mix {
-		{ 16 * 8, 3 * 16 },
+		{ 17 * 8, 3 * 16 },
 		2,
 		{ 10, 99 },
 		1,
 		'0'
 	};
-	
+
+	Checkbox checkbox_speaker_enabled {
+		{ 3 * 8, 5 * 16 },
+		20,
+		"Enable speaker"
+	};	
+
 	Button button_save {
 		{ 2 * 8, 16 * 16, 12 * 8, 32 },
 		"Save"

--- a/firmware/application/portapack.cpp
+++ b/firmware/application/portapack.cpp
@@ -98,6 +98,7 @@ bool get_antenna_bias() {
 bool speaker_mode { false };
  void set_speaker_mode(const bool v) {
  	speaker_mode = v;
+    persistent_memory::set_speaker_enabled(v); // store state in persistent_memory
  	if (speaker_mode)
  		audio::output::speaker_unmute();
  	else
@@ -431,7 +432,10 @@ bool init() {
 	LPC_CREG->DMAMUX = portapack::gpdma_mux;
 	gpdma::controller.enable();
 
+
 	audio::init(portapack_audio_codec());
+    	set_speaker_mode(persistent_memory::speaker_enabled());
+
 
 	return true;
 }

--- a/firmware/application/ui_navigation.cpp
+++ b/firmware/application/ui_navigation.cpp
@@ -118,10 +118,21 @@ SystemStatusView::SystemStatusView(
 		&sd_card_status_view,
 	});
 	
-	if (portapack::persistent_memory::config_speaker()) 
-		button_speaker.hidden(false);
-	else
+	if (!portapack::persistent_memory::config_speaker()){ 
+		button_speaker.hidden(false);	
+		if(!portapack::persistent_memory::speaker_enabled()){
+			button_speaker.set_foreground(Color::light_grey());
+			button_speaker.set_bitmap(&bitmap_icon_speaker_mute);
+		}
+		else{
+ 		    
+ 		    button_speaker.set_foreground(Color::green());
+		    button_speaker.set_bitmap(&bitmap_icon_speaker);
+ 	    }
+	}		
+	else{
 		button_speaker.hidden(true);
+	}
 
 	button_back.id = -1;	// Special ID used by FocusManager
 	title.set_style(&style_systemstatus);
@@ -176,10 +187,18 @@ SystemStatusView::SystemStatusView(
 }
 
 void SystemStatusView::refresh() {
-	if (!portapack::persistent_memory::config_speaker()) {
-		button_speaker.set_foreground(Color::light_grey());
-		button_speaker.set_bitmap(&bitmap_icon_speaker_mute);
-		button_speaker.hidden(false);
+	if (!portapack::persistent_memory::config_speaker()) { 
+		button_speaker.hidden(false);	
+		if(!portapack::persistent_memory::speaker_enabled()){
+			button_speaker.set_foreground(Color::light_grey());
+			button_speaker.set_bitmap(&bitmap_icon_speaker_mute);
+		}
+		else
+		{
+ 		    
+ 		    button_speaker.set_foreground(Color::green());
+		    button_speaker.set_bitmap(&bitmap_icon_speaker);
+ 	    }
 	}		
 	else {
 		button_speaker.hidden(true);

--- a/firmware/common/portapack_persistent_memory.cpp
+++ b/firmware/common/portapack_persistent_memory.cpp
@@ -200,38 +200,17 @@ void set_serial_format(const serial_format_t new_value) {
 	data->serial_format = new_value;
 }
 
-/* static constexpr uint32_t playdead_magic = 0x88d3bb57;
-
-uint32_t playing_dead() {
-	return data->playing_dead;
-}
-
-void set_playing_dead(const uint32_t new_value) {
-	if( data->playdead_magic != playdead_magic ) {
-		set_playdead_sequence(0x8D1);	// U D L R
-	}
-	data->playing_dead = new_value;
-}
-
-uint32_t playdead_sequence() {
-	if( data->playdead_magic != playdead_magic ) {
-		set_playdead_sequence(0x8D1);	// U D L R
-	}
-	return data->playdead_sequence;
-}
-
-void set_playdead_sequence(const uint32_t new_value) {
-	data->playdead_sequence = new_value;
-	data->playdead_magic = playdead_magic;
-} */
 
 // ui_config is an uint32_t var storing information bitwise
-// bits 0,1,2 store the backlight timer
-// bits 31, 30,29,28,27, 26, 25 stores the different single bit configs depicted below
-// bits on position 4 to 19 (16 bits) store the clkout frequency
-
+// bits 0-2 store the backlight timer
+// bits 4-19 (16 bits) store the clkout frequency
+// bits 23-31 store the different single bit configs depicted below
 bool show_bigger_qr_code() { // show bigger QR code
 	return data->ui_config & (1 << 23);
+}
+
+bool speaker_enabled() { // enable speaker
+	return data->ui_config & (1 << 24);
 }
 
 bool hide_clock() { // clock hidden from main menu
@@ -270,8 +249,13 @@ uint32_t config_backlight_timer() {
 	return timer_seconds[data->ui_config & 7]; //first three bits, 8 possible values
 }
 
+
 void set_show_bigger_qr_code(bool v) {
 	data->ui_config = (data->ui_config & ~(1 << 23)) | (v << 23);
+}
+
+void set_speaker_enabled(bool v) {
+	data->ui_config = (data->ui_config & ~(1 << 24)) | (v << 24);
 }
 
 void set_clock_hidden(bool v) {
@@ -309,18 +293,6 @@ void set_config_cpld(uint8_t i) {
 void set_config_backlight_timer(uint32_t i) {
 	data->ui_config = (data->ui_config & ~7) | (i & 7);
 }
-
-/*void set_config_textentry(uint8_t new_value) {
-	data->ui_config = (data->ui_config & ~0b100) | ((new_value & 1) << 2);
-}
-
-uint8_t ui_config_textentry() {
-	return ((data->ui_config >> 2) & 1);
-}*/
-
-/*void set_ui_config(const uint32_t new_value) {
-	data->ui_config = new_value;
-}*/
 
 uint32_t pocsag_last_address() {
 	return data->pocsag_last_address;

--- a/firmware/common/portapack_persistent_memory.hpp
+++ b/firmware/common/portapack_persistent_memory.hpp
@@ -83,6 +83,7 @@ bool hide_clock();
 bool clock_with_date();
 bool config_login();
 bool config_speaker();
+bool speaker_enabled();
 uint32_t config_backlight_timer();
 
 void set_config_splash(bool v);
@@ -91,6 +92,7 @@ void set_clock_hidden(bool v);
 void set_clock_with_date(bool v);
 void set_config_login(bool v);
 void set_config_speaker(bool v); 
+void set_speaker_enabled(bool v);
 void set_config_backlight_timer(uint32_t i);
 
 //uint8_t ui_config_textentry();


### PR DESCRIPTION
Save speaker state.

- using a bit field in the persistent memory
- removed mute upon start up (using new audio (speaker) setting instead)
- removed unmute on opening audio receive app (using new audio (speaker) setting instead)
- added checkbox in options -> audio
- icon in statusbar (when enabled) us using the bit field from persistent memory

Only tested on H1 with AK chip on headphone jack.

Should solve issue regarding speaker state #306 