### PR TITLE
Feature radiosondes beep 371

### DIFF
--- a/firmware/application/apps/ui_sonde.hpp
+++ b/firmware/application/apps/ui_sonde.hpp
@@ -55,7 +55,15 @@ class SondeView : public View {
 public:
 	static constexpr uint32_t sampling_rate = 2457600;
 	static constexpr uint32_t baseband_bandwidth = 1750000;
+	static constexpr int rssi_sample_range = 256;
+	static constexpr float rssi_voltage_min = 0.4;
+	static constexpr float rssi_voltage_max = 2.2;
+	static constexpr float adc_voltage_max = 3.3;
 
+	static constexpr int raw_min = rssi_sample_range * rssi_voltage_min / adc_voltage_max;
+	static constexpr int raw_max = rssi_sample_range * rssi_voltage_max / adc_voltage_max;
+	static constexpr int raw_delta = raw_max - raw_min;
+		
 	SondeView(NavigationView& nav);
 	~SondeView();
 
@@ -68,10 +76,14 @@ private:
 	uint32_t target_frequency_ { 402700000 };
 	bool logging { false };
 	bool use_crc { false };
+	bool beep { false };
+
 	sonde::GPS_data gps_info { };
 	sonde::temp_humid temp_humid_info { };
 	std::string sonde_id { };
 	
+	// AudioOutput audio_output { };
+
 	Labels labels {
 		{ { 4 * 8, 2 * 16 }, "Type:", Color::light_grey() },
 		{ { 6 * 8, 3 * 16 }, "ID:", Color::light_grey() },
@@ -103,14 +115,29 @@ private:
 		{ 21 * 8, 0, 6 * 8, 4 },
 	};
 	
+	NumberField field_volume {
+		{ 28 * 8, 0 * 16 },
+		2,
+		{ 0, 99 },
+		1,
+		' ',
+	};
+	
+
+	Checkbox check_beep {
+		{ 22 * 8, 6 * 16 },
+		3,
+		"Beep"
+	};
+
 	Checkbox check_log {
-		{ 23 * 8, 6 * 16 },
+		{ 22 * 8, 8 * 16 },
 		3,
 		"Log"
 	};
 	
 	Checkbox check_crc {
-		{ 23 * 8, 8 * 16 },
+		{ 22 * 8, 10 * 16 },
 		3,
 		"CRC"
 	};
@@ -170,7 +197,10 @@ private:
 	};
 
 	void on_packet(const sonde::Packet& packet);
+	void on_headphone_volume_changed(int32_t v);
+	
 	void set_target_frequency(const uint32_t new_value);
+
 	uint32_t tuning_frequency() const;
 };
 

--- a/firmware/baseband/proc_sonde.cpp
+++ b/firmware/baseband/proc_sonde.cpp
@@ -26,9 +26,14 @@
 
 #include "event_m4.hpp"
 
+#include "audio_output.hpp"
+
 SondeProcessor::SondeProcessor() {
+
 	decim_0.configure(taps_11k0_decim_0.taps, 33554432);
 	decim_1.configure(taps_11k0_decim_1.taps, 131072);
+
+	audio_output.configure(false);
 }
 
 void SondeProcessor::execute(const buffer_c8_t& buffer) {
@@ -47,10 +52,76 @@ void SondeProcessor::execute(const buffer_c8_t& buffer) {
 			clock_recovery_fsk_4800(mf.get_output());
 		}
 	}
+
+	if(pitch_rssi_enabled) {
+		if(beep_playing) {
+			beep_loop();	
+		}
+		else {
+			silence_loop();
+		}
+	}
+}
+
+void SondeProcessor::on_message(const Message* const msg) {
+	switch(msg->id) {		
+		case Message::ID::RequestSignal:
+			if ((*reinterpret_cast<const RequestSignalMessage*>(msg)).signal == RequestSignalMessage::Signal::BeepRequest) {
+				play_beep();
+				chThdSleepMilliseconds(100);
+				stop_beep();
+			}		
+			break;
+
+		case Message::ID::PitchRSSIConfigure:
+			pitch_rssi_config(*reinterpret_cast<const PitchRSSIConfigureMessage*>(msg));
+			break;
+
+		default:
+			break;
+	}
+}
+
+void SondeProcessor::play_beep() {
+	beep_playing = true;
+}
+
+void SondeProcessor::stop_beep() {
+	beep_playing = false;
+}
+
+void SondeProcessor::beep_loop() {
+	for (size_t i = 0; i < sizeof(audio_buffer.p); i++) {
+		audio_buffer.p[i] = (sine_table_i8[(tone_phase & 0xFF000000U) >> 24]) * 128;
+		tone_phase += tone_delta;
+	}
+	
+	audio_output.write(audio_buffer);
+}
+
+void SondeProcessor::silence_loop() {
+	for (size_t i = 0; i < sizeof(audio_buffer.p); i++) {
+		audio_buffer.p[i] = 0;
+	}
+
+	audio_output.write(audio_buffer);
+}
+
+void SondeProcessor::pitch_rssi_config(const PitchRSSIConfigureMessage& message) {
+	// rtc::RTC datetime;
+	// rtcGetTime(&RTCD1, &datetime);
+
+	// log_file.write_entry(datetime, "pitch_rssi_config: message.rssi: " + message.rssi);
+
+	pitch_rssi_enabled = message.enabled;
+	tone_delta = (message.rssi * 10 + 1000) * ((1ULL << 32) / 24000);
+
+	// log_file.write_entry(datetime, "pitch_rssi_config: tone_delta: " + tone_delta);
 }
 
 int main() {
 	EventDispatcher event_dispatcher { std::make_unique<SondeProcessor>() };
 	event_dispatcher.run();
+
 	return 0;
 }


### PR DESCRIPTION
This is an implementation of the feature I have proposed in the issue:

https://github.com/eried/portapack-mayhem/issues/371

In its current state it provides a beep through the headphones or speaker everytime a packet is received.

I have also added the volume widget in order to be possible to control the volume of the beep.

In the tests I have performed I have not found any adverse impact from the addition of this feature. The beep can be enabled or disabled via the new checkbox that was added.

For the moment there is still the limitation of the pitch of the beep not varying with the RSSI level. Even though the implementation considers this, for some reason the phase delta for the tone doesn't appear to be getting updated accordingly. This is still being looked into.

I have created a video demonstrating the feature, which can be found here:

https://youtu.be/OiyZOGSUM4A