### PR TITLE
Radiosonde beep pitch RSSI improvements. Keeping current frequency in battery backed RAM

### DIFF
--- a/firmware/application/apps/ui_sonde.cpp
+++ b/firmware/application/apps/ui_sonde.cpp
@@ -211,7 +211,7 @@ void SondeView::set_target_frequency(const uint32_t new_value) {
 	target_frequency_ = new_value;
 	//radio::set_tuning_frequency(tuning_frequency());
 	// we better remember the tuned frequency, by using this function instead:
-	receiver_model.set_tuning_frequency(tuning_frequency());
+	receiver_model.set_tuning_frequency(target_frequency_);
 }
 
 uint32_t SondeView::tuning_frequency() const {

--- a/firmware/baseband/proc_sonde.cpp
+++ b/firmware/baseband/proc_sonde.cpp
@@ -35,7 +35,7 @@ SondeProcessor::SondeProcessor() {
 
 	audio_output.configure(false);
 
-	tone_gen.configure(0, 1, ToneGen::tone_type::square);
+	tone_gen.configure(BEEP_BASE_FREQ, 1.0, ToneGen::tone_type::sine, AUDIO_SAMPLE_RATE);
 }
 
 void SondeProcessor::execute(const buffer_c8_t& buffer) {
@@ -135,9 +135,11 @@ void SondeProcessor::generate_silence() {
 
 void SondeProcessor::pitch_rssi_config(const PitchRSSIConfigureMessage& message) {
 	pitch_rssi_enabled = message.enabled;
-	uint32_t tone_delta = (int) ((float) message.rssi * (float) RSSI_PITCH_WEIGHT + (float) 1000) * ((float) (1ULL << 32) / (float) 24000);
+
+	uint32_t freq = (int) ((float) message.rssi * (float) RSSI_PITCH_WEIGHT + (float) BEEP_BASE_FREQ);
+
 	last_rssi = message.rssi;
-	tone_gen.configure(tone_delta, 1.0, ToneGen::tone_type::square);
+	tone_gen.configure(freq, 1.0, ToneGen::tone_type::sine, AUDIO_SAMPLE_RATE);
 }
 
 int main() {

--- a/firmware/baseband/proc_sonde.hpp
+++ b/firmware/baseband/proc_sonde.hpp
@@ -98,11 +98,13 @@
 #include <bitset>
 
 
-#define BEEP_MIN_DURATION 			80
-#define BEEP_DURATION_RANGE 		150
+#define BEEP_MIN_DURATION 			60
+#define BEEP_DURATION_RANGE 		100
+#define BEEP_BASE_FREQ				200
 #define RSSI_CEILING	 			1000
 #define PROPORTIONAL_BEEP_THRES		0.8
-#define RSSI_PITCH_WEIGHT			0.7
+#define RSSI_PITCH_WEIGHT			0.5
+#define AUDIO_SAMPLE_RATE			24000
 
 class SondeProcessor : public BasebandProcessor {
 public:

--- a/firmware/baseband/tone_gen.cpp
+++ b/firmware/baseband/tone_gen.cpp
@@ -24,8 +24,8 @@
 #include "sine_table_int8.hpp"
 
 
-int32_t ToneGen::tone_from_sine_table() {
-	int32_t tone_sample = sine_table_i8[(tone_phase_ & 0xFF000000U) >> 24] << 24;
+int32_t ToneGen::tone_sine() {
+	int32_t tone_sample = sine_table_i8[tone_phase_] * 0x1000000;
 	tone_phase_ += delta_;
 
 	return tone_sample;
@@ -47,14 +47,15 @@ int32_t ToneGen::tone_square() {
 }
 
 void ToneGen::configure(const uint32_t delta, const float tone_mix_weight) {
-	delta_ = delta;
+	delta_ = (uint8_t) ((delta & 0xFF000000U) >> 24);
 	tone_mix_weight_ = tone_mix_weight;
 	input_mix_weight_ = 1.0 - tone_mix_weight;
+
 	current_tone_type_ = sine;
 }
 
-void ToneGen::configure(const uint32_t delta, const float tone_mix_weight, const tone_type tone_type) {
-	delta_ = delta;
+void ToneGen::configure(const uint32_t freq, const float tone_mix_weight, const tone_type tone_type, const uint32_t sample_rate) {
+	delta_ = (uint8_t) ((freq * sizeof(sine_table_i8)) / sample_rate);
 	tone_mix_weight_ = tone_mix_weight;
 	input_mix_weight_ = 1.0 - tone_mix_weight;
 	current_tone_type_ = tone_type;
@@ -67,7 +68,7 @@ int32_t ToneGen::process(const int32_t sample_in) {
 	int32_t tone_sample = 0;
 	
 	if(current_tone_type_ == sine) {
-		tone_sample = tone_from_sine_table();
+		tone_sample = tone_sine();
 	}
 	else if(current_tone_type_ == square) {
 		tone_sample = tone_square();

--- a/firmware/baseband/tone_gen.hpp
+++ b/firmware/baseband/tone_gen.hpp
@@ -25,9 +25,6 @@
 
 #include <cstdint>
 #include <cstddef>
-#include <bitset>
-
-static const std::bitset<2048> wave_bits (0xFFFFFF);
 
 class ToneGen {
 public:
@@ -38,23 +35,24 @@ public:
 	{};*/
 
 	void configure(const uint32_t delta, const float tone_mix_weight);
-	void configure(const uint32_t delta, const float tone_mix_weight, const tone_type tone_type);
+	void configure(const uint32_t freq, const float tone_mix_weight, const tone_type tone_type, const uint32_t sample_rate);
 
 	int32_t process(const int32_t sample_in);
 
 private:
 	tone_type current_tone_type_ { sine };
 
-	//size_t sample_rate_;
 	float input_mix_weight_ { 1 };
 	float tone_mix_weight_ { 0 };
-	uint32_t delta_ { 0 };
-	uint32_t tone_phase_ { 0 };
+
+	uint8_t delta_ { 0 };
+	uint8_t tone_phase_ { 0 };
 
 	/**
-	 * Generator function for sine waves:
+	 * Generator function which selects every other sample from the reference sine waveform to the output sample:
 	 */
-	int32_t tone_from_sine_table();
+	int32_t tone_sine();
+
 
 	/**
 	 * Generator function for square waves:


### PR DESCRIPTION
Some improvements after the previous PR (https://github.com/eried/portapack-mayhem/pull/376):

 * beep tone and pitch are now better, with the pitch being more carefully increased proportionally to the RSSI;
 * also added variable beep duration, based on the RSSI;
 * added small change in order to store in the NVRAM the current frequency on the radiosondes app, in a similar way to what is currently being done in other apps.