### PR TITLE
Fixed #398: Changed datatype to be able to store > 255 second for backlight timer

### DIFF
--- a/firmware/application/portapack.cpp
+++ b/firmware/application/portapack.cpp
@@ -83,7 +83,7 @@ TransmitterModel transmitter_model;
 TemperatureLogger temperature_logger;
 
 bool antenna_bias { false };
-uint8_t bl_tick_counter { 0 };
+uint32_t bl_tick_counter { 0 };
 
 void set_antenna_bias(const bool v) {
 	antenna_bias = v;

--- a/firmware/application/portapack.hpp
+++ b/firmware/application/portapack.hpp
@@ -54,7 +54,7 @@ extern TransmitterModel transmitter_model;
 extern bool speaker_mode;
 void set_speaker_mode(const bool v);
 
-extern uint8_t bl_tick_counter;
+extern uint32_t bl_tick_counter;
 extern bool antenna_bias;
 
 extern TemperatureLogger temperature_logger;


### PR DESCRIPTION
Fixed #398 
Datatype of variable keeping track of time wasn't able to hold over 255 second, hence timer didn't work for periods > 255 seconds, like 5 minutes.