### PR TITLE
Update main.cpp

### DIFF
--- a/firmware/application/main.cpp
+++ b/firmware/application/main.cpp
@@ -140,6 +140,9 @@ Continuous (Fox-oring)
 #include "sd_card.hpp"
 
 #include <string.h>
+ 
+#include "rffc507x.hpp"      /* c/m, avoiding initial short ON Ant_DC_Bias pulse, from cold reset  */
+rffc507x::RFFC507x first_if;
 
 static void event_loop() {
 	ui::Context context;
@@ -160,6 +163,7 @@ static void event_loop() {
 }
 
 int main(void) {
+	first_if.init();    /* To avoid initial short Ant_DC_Bias pulse ,we need quick set up GP01_RFF507X =1 */
 	if( portapack::init() ) {
 		portapack::display.init();
 


### PR DESCRIPTION
**Remove initial short wrong Ant-DC_BIAS pulse. (<250 msegs ). even Top Portapack TITLE bar has ANT-DC-BIAS= 0FF.**

Even we deactivate ,  from  Top Portapack TITLE bar selection, the ANT-DC-BIAS , (OFF) , every time that we power up Portapack HackRF (cold reset) , it appears a short  3,3V   Ant_DC_bias pulse ,of around 250 msegs. 

We could obeserve, that  in "hot reset" , just pressing reset button , we just had a negligeable glitch .

And in case that you want to connect directly to your HackRf an external LNA that has a higher current demand , that the max drive current of HackRF one  (example >180mA ,  like the improved good SAWbird+ GOES (NOOELEC) , we want to avoid any damage to the internal  HackRF DC bias  Mosfet  from our HackRF DC-bias (with antenna port power (max 50 mA at 3.3 V)) .   

Therefore although , we set up OFF our Antenna DC bias  , but it turns , that although it is OFF ,  at every  initial power stage,  we got  some unwanted  short  DC-bias pulse to the antenna , (and the external LNA from Noolect , shows his  DC bias power_LED blinking at each HackRF cold reset.   And  we need to try to solve it or minimize it  !   (because , we may have problems if we connect an antenna that shows DC short , like  QFH , or  any transformer balun or a heavy LNA drive current ) .

After several  Discord discussions, 
Mr. "miek" also could measure and confirm it  **(see attatched yellow ANT DC BIAS curve)** , already commented  on HackRF discord,  (let me share his measurements and key right comments ) 
"miek — it's not just a brief blip though, it's turned on for a while (what i assume is the long delay at the start of main)"
![image](https://user-images.githubusercontent.com/86470699/134775927-336a9481-8d75-4562-8a5e-cb2a931557de.png)
![image](https://user-images.githubusercontent.com/86470699/134776042-7fff3bb5-8611-41d6-84df-76fe42195571.png)


Furhter investigation , with the great support and  help of  Mr. Clifford Heath,   showed, 

**1-) [CHECKING  CORRECT INITIAL REGISTER SETTINGS]**
That based on the  RFF507X reference manual ,  we should  send a correct init value .
of the register GPO  , adress 0x16  (22)  , with  contents  , 0x0206   (to keep the ANT DC BIAS PORT disable  for both possible mixer paths)    



![image](https://user-images.githubusercontent.com/86470699/134776307-e153c8bc-1ca9-4871-8996-1df506af8522.png)


And in Portapack Mayhem , we are already doint it correctly !  (writting initial default reg. GPO = 0X0206, excluding Lock)
(That was not the problem. Initial  GPO, reg. settings  were already  correct !!!!   (see attached  rffc507x.hpp ) 


![image](https://user-images.githubusercontent.com/86470699/134776382-b5853bcb-51e6-4354-a89b-a225a2ed4222.png)


**2-) [CHECKING TIMING INFLUENCE ]**
Then the problem,  was not the initial  register value  settings,  it was just the time delay of that initialization respect VAA rise time, and not high Z of the GPO port .
We need to initialitze the RFF507X  with those correct  register settings  as quick as possible ,  not after all the Display and main devices initialization .  The timing was the clue ! .  Then I just added a top init  RFF507X port  line to the main () . 

After that pull request,   we can observe just a minor negligeable  DC bias  glitch at power up.  But now , NO derating problem at all . 

See both power up (cold reset condition) , before / after c/m 

Before c/m : 
https://user-images.githubusercontent.com/86470699/134822463-73323757-9ad2-4481-8bd3-e592ade63a38.MP4


After c/m : 

https://user-images.githubusercontent.com/86470699/134822531-94c7bad1-21b9-4381-9c05-1adeb44ac809.MP4






