### PR TITLE
New feature gcc 10 compile errors #199

### DIFF
--- a/firmware/baseband/spectrum_collector.cpp
+++ b/firmware/baseband/spectrum_collector.cpp
@@ -105,7 +105,7 @@ void SpectrumCollector::post_message(const buffer_c16_t& data) {
 	}
 }
 
-/* 3 types of Windowing time domain shapes declaration , but only used Hamming  ,  shapes for  FFT  
+/* 3 types of Spectrum Windowing shapes declaration , but only used Hamming  ,  shapes for  FFT  
     gcc10 compile sintax error c/m  (1/2), 
           The primary diff. between const and constexpr variables is that 
           the initialization of a const var can be deferred until run time. 
@@ -113,7 +113,7 @@ void SpectrumCollector::post_message(const buffer_c16_t& data) {
 	      A var. can be declared with constexpr , when it has a literal type and is initialized.
 	gcc10 compile sintax error c/m (2/2)
  	      Static assert --> Tests a software assertion at compile time for debugging.
-		  we keep the same safety  compile protection , just changing slightly the sintax  checking that the size of the called array is power of 2.
+		  we keep the same safety  compile protection , just changing slightly the sintax but checking the array_size = power of 2.
 	      if the bool  "constant expression" is TRUE (normal case) , the declaration has no effect.
 		  if the bool  "constant expression" is FALSE (abnormal array size) , it is aborted the compile with a msg error. 
 		  	  */ 


### PR DESCRIPTION
PULL REQUEST gcc10 Syntax compile error.  

As it was pointed in that open issue, https://github.com/eried/portapack-mayhem/issues/199
Cannot compile with GCC10 #199  (thanks olewales ! and all members  that added good comments and clues about it ) 

It seems that gcc10 introduced an old open issue correction, we think it is related to a bug fixed in GCC10: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=66477

And since then , we could not compile using gcc10 or greatest.
We got compiler error in the file , firmware/baseband/spectrum_collector.cpp
that abort the compile process.

After several  discussions and trial test,  finally I want to propose the following two changes :

In fact , we just need to change  2 line codes, in the used Spectrum Window , (but I added also the same changes in the other two not used (by now) Spectrum Windows (just in case ) .

_template<typename T>   // Currently we are calling and using that Window shape.
static typename T::value_type spectrum_window_hamming_3(const T& s, const size_t i) {
    static_assert(power_of_two(**sizeof(s)**), "Array size must be power of 2");   // c/m compile error gcc10 , OK for all gcc versions.
    **const** size_t mask = s.size() - 1;          // c/m compile error gcc10 , constexpr->const
    // Three point Hamming window.
    return s[i] * 0.54f + (s[(i-1) & mask] + s[(i+1) & mask]) * -0.23f;
};_






  Additional explantion : 
we had two compiler error types (when using GCC10) , 

**1-) static_assert declaration for syntax errors when the declaration is encountered. 
(lines  116-117 )**  (see attached original code condition) 

![image](https://user-images.githubusercontent.com/86470699/138588000-7b2e2fa6-e9da-4427-9172-178ce51773a0.png)


/opt/portapack-mayhem/firmware/baseband/spectrum_collector.cpp:117:19: error: 's' is not a constant expression
  117 |  constexpr size_t mask = s.size() - 1;

After checking  information about that  "constexpr"   

"The primary difference between **const and constexpr variables** is that the initialization of a const variable can be deferred until run time. **A constexpr variable must be initialized at compile time.** ... A variable can be declared with constexpr , when it has a literal type and is initialized."

And then I believed that,  as  (Olewales ) said  ,  it can be addressed,  changing  constesxpr --> to const .
           **_const size_t mask = s.size() - 1;_**  



**2-) constant-expression parameter when the template is instantiated. 
(line 145)** 

The compiler examines the static_assert declaration for syntax errors when the declaration is encountered. 

The compiler evaluates the constant-expression parameter immediately if it does not depend on a template parameter. Otherwise, the compiler evaluates the constant-expression parameter when the template is instantiated. 
Consequently, the compiler might issue a diagnostic message once when the declaration is encountered, and again when the template is instantiated.  


In instantiation of 'typename T::value_type spectrum_window_hamming_3(const T&, size_t) [with T = std::array<std::complex<float>, 256>; typename T::value_type = std::complex<float>; size_t = unsigned int]':
/opt/portapack-mayhem/firmware/baseband/spectrum_collector.cpp:145:79:   required from here
/opt/portapack-mayhem/firmware/baseband/spectrum_collector.cpp:116:28: error: non-constant condition for static assertion
  116 |  static_assert(power_of_two(s.size()), "Array size must be power of 2");
      |                ~~~~~~~~~~~~^~~~~~~~~~
/opt/portapack-mayhem/firmware/baseband/spectrum_collector.cpp:116:28: error: 's' is not a constant expression


And that error can also be addressed , changing slightly the syntaxis of the assert Bool condition, but keeping the same safe  (array size = power of 2 condition)

static_assert(power_of_two(sizeof(s)), "Array size must be power of 2");

**--------FINAL  CONFIRMATION in both gcc versions, with no side effects  (feel free to dobule check)** -------
Using gcc10 (in gentoo linux)  , and  gcc9 (Docker in Windows) 

I have confirmed : 

1-) It has been checked that the changes can be compiled with above 2 changes  without any more compile  errors.
(the change solve the problem in both gcc9 and gcc10).

2-) The generated binary code works well , same as before (from my opinion) , just no error compilation.
(no impact to the new binary code )

3-) It has confirmed that when changing (intentionally)  the array size of channel_spectrum (to a NON Power of 2 size value)  , in the file  firmware\baseband\spectrum_collector.hpp
(the safe compilation (bool array size checking=power of 2)  , still works in both gcc9 and gcc10)

Modifying that array size declaration 
std::array<std::complex<float>, 256> channel_spectrum { };
**⇒    // original condtion.  (NO COMPILE ERROR)**

std::array<std::complex<float>, 255> channel_spectrum { }; 
⇒   // Intentionally changed to a wrong value , ex. 255 
 **=> DETECTED as COMPILE error (as it should be)** 

This example is  Docker under windows (using gcc9) , but it produces same error in gcc10.
So the safe protecion seems to work  when calling that spectrum_window_hamming_3 with incorrect array size!


![image](https://user-images.githubusercontent.com/86470699/138587946-5df8cfb5-2ed0-451a-ac9e-3555153dfd0d.png)

Feel free to dobule check and comment about that potential PR fix, but in my opinion , we can apply to our next branch!

![image](https://user-images.githubusercontent.com/86470699/138588493-eb8a0cb2-6405-4fb1-9a6e-691069eb366a.png)


-------------------------------------------
