### PR TITLE
Final correction gcc 10 compile error #199 with sharebrained feedback

### DIFF
--- a/firmware/baseband/spectrum_collector.cpp
+++ b/firmware/baseband/spectrum_collector.cpp
@@ -27,7 +27,7 @@
 #include "event_m4.hpp"
 #include "portapack_shared_memory.hpp"
 
-#include "event_m4.hpp"
+/*  #include "event_m4.hpp"    that  line  is duplicated,  we can delete it .*/
 
 #include <algorithm>
 
@@ -105,24 +105,38 @@ void SpectrumCollector::post_message(const buffer_c16_t& data) {
 	}
 }
 
-template<typename T>
+/* 3 types of Windowing time domain shapes declaration , but only used Hamming  ,  shapes for  FFT  
+    GCC10 compile sintax error c/m  (1/2), 
+          The primary diff. between const and constexpr variables is that 
+          the initialization of a const var can be deferred until run time. 
+	      A constexpr var. must be initialized at compile time. ... 
+	      A var. can be declared with constexpr , when it has a literal type and is initialized.
+	 GCC compile sintax error c/m (2/2)
+ 	      Static assert --> Tests a software assertion at compile time for debugging.
+		  we keep the same safety  compile protection , just changing slightly the sintax  checking that the size of the called array is power of 2.
+	      if the bool  "constant expression" is TRUE (normal case) , the declaration has no effect.
+		  if the bool  "constant expression" is FALSE (abnormal array size) , it is aborted the compile with a msg error. 
+		  	  */ 
+
+
+template<typename T> // Although currently we are not using that Windowing shape, we apply the same GCC10 compile error c/m 
 static typename T::value_type spectrum_window_none(const T& s, const size_t i) {
-	static_assert(power_of_two(s.size()), "Array size must be power of 2");
+ static_assert(power_of_two(sizeof(s)), "Array size must be power of 2");   // c/m compile error GCC10 , OK for all GCC versions. 
 	return s[i];
 };
 
-template<typename T>
+template<typename T>   // Currently we are calling and using that Window shape.
 static typename T::value_type spectrum_window_hamming_3(const T& s, const size_t i) {
-	static_assert(power_of_two(s.size()), "Array size must be power of 2");
-	constexpr size_t mask = s.size() - 1;
+    static_assert(power_of_two(sizeof(s)), "Array size must be power of 2");   // c/m compile error GCC10 , OK for all GCC versions. 
+	const size_t mask = s.size() - 1;          // c/m compile error GCC10 , constexpr->const
 	// Three point Hamming window.
 	return s[i] * 0.54f + (s[(i-1) & mask] + s[(i+1) & mask]) * -0.23f;
 };
 
-template<typename T>
+template<typename T>   // Although currently we are not using that Windowing shape, we apply the same GCC10 compile error c/m  
 static typename T::value_type spectrum_window_blackman_3(const T& s, const size_t i) {
-	static_assert(power_of_two(s.size()), "Array size must be power of 2");
-	constexpr size_t mask = s.size() - 1;
+	static_assert(power_of_two(sizeof(s)), "Array size must be power of 2");   // c/m compile error GCC10 , OK for all GCC versions. 
+    const size_t mask = s.size() - 1;          // c/m compile error GCC10 , constexpr->const
 	// Three term Blackman window.
 	constexpr float alpha = 0.42f;
 	constexpr float beta = 0.5f * 0.5f;

--- a/firmware/baseband/spectrum_collector.cpp
+++ b/firmware/baseband/spectrum_collector.cpp
@@ -27,8 +27,6 @@
 #include "event_m4.hpp"
 #include "portapack_shared_memory.hpp"
 
-/*  #include "event_m4.hpp"    that  line  is duplicated,  we can delete it .*/
-
 #include <algorithm>
 
 void SpectrumCollector::on_message(const Message* const message) {
@@ -121,13 +119,13 @@ void SpectrumCollector::post_message(const buffer_c16_t& data) {
 
 template<typename T> // Although currently we are not using that Windowing shape, we apply the same GCC10 compile error c/m 
 static typename T::value_type spectrum_window_none(const T& s, const size_t i) {
- static_assert(power_of_two(sizeof(s)), "Array size must be power of 2");   // c/m compile error GCC10 , OK for all GCC versions. 
+static_assert(power_of_two(ARRAY_ELEMENTS(s)), "Array number of elements must be power of 2");   // c/m compile error GCC10 , OK for all GCC versions. 
 	return s[i];
 };
 
 template<typename T>   // Currently we are calling and using that Window shape.
 static typename T::value_type spectrum_window_hamming_3(const T& s, const size_t i) {
-    static_assert(power_of_two(sizeof(s)), "Array size must be power of 2");   // c/m compile error GCC10 , OK for all GCC versions. 
+    static_assert(power_of_two(ARRAY_ELEMENTS(s)), "Array number of elements must be power of 2");   // c/m compile error GCC10 , OK for all GCC versions. 
 	const size_t mask = s.size() - 1;          // c/m compile error GCC10 , constexpr->const
 	// Three point Hamming window.
 	return s[i] * 0.54f + (s[(i-1) & mask] + s[(i+1) & mask]) * -0.23f;
@@ -135,7 +133,7 @@ static typename T::value_type spectrum_window_hamming_3(const T& s, const size_t
 
 template<typename T>   // Although currently we are not using that Windowing shape, we apply the same GCC10 compile error c/m  
 static typename T::value_type spectrum_window_blackman_3(const T& s, const size_t i) {
-	static_assert(power_of_two(sizeof(s)), "Array size must be power of 2");   // c/m compile error GCC10 , OK for all GCC versions. 
+    static_assert(power_of_two(ARRAY_ELEMENTS(s)), "Array number of elements must be power of 2");   // c/m compile error GCC10 , OK for all GCC versions. 
     const size_t mask = s.size() - 1;          // c/m compile error GCC10 , constexpr->const
 	// Three term Blackman window.
 	constexpr float alpha = 0.42f;

--- a/firmware/baseband/spectrum_collector.hpp
+++ b/firmware/baseband/spectrum_collector.hpp
@@ -22,6 +22,9 @@
 #ifndef __SPECTRUM_COLLECTOR_H__
 #define __SPECTRUM_COLLECTOR_H__
 
+#define ARRAY_ELEMENTS(x) (sizeof(x) / sizeof(x[0]))     
+/* sizeof() compile-time operator that returns #bytes of (data type). We used it to get #elements_array */
+
 #include "dsp_types.hpp"
 #include "complex.hpp"
 


### PR DESCRIPTION
**This PULL request is INTEGRATING yesterday  PR  ("New feature gcc 10 compile errors #199" ) 
and in fact, it has the final  refine correction  .  (NO NEED TO APPLY BOTH PR'S ,  just that one is enough because it is integrating  both commits  )  .**
![image](https://user-images.githubusercontent.com/86470699/138764348-7bf6ac97-a80c-4c2b-93c4-be79a96f9d66.png)


So we need to merge to the next ,  just  that one PR,  , and ignore the previous one . ,  for solving  the GCC 10  compile error due to syntax problem)  
already pointed in  previous discussion ,  https://github.com/eried/portapack-mayhem/issues/199

I will not  repeat all  yesterday comments inside my previous PR. , that are correct, but the solution was not complelety OK.
After commenting the previous  PR with sharebrained  (original owner of those tow files, and many others) , he pointed me that  

(sharebrained comments ) ----------------------------------------------
" it looks like the proposed code changes will change what the assertion is testing. Before, it was making sure that the number of elements in the array was a power of 2. With the change, it is making sure the number of bytes of the array is a power of two. Those are different things, and changes what the assertion is testing. 
I was not familiar with the GCC10 issue.

It does appear to be my code, yes. I would recommend removing the static_assert, as the C++ standard apparently does not permit that test to be evaluated at compile time. "--------------

And sharebrained , was completelly correct, . But  I took  his feedback to not remove that assert,  and apply the small corrections, to keep that compile safe protection , as it was originally intended.


In my previous PR,   I was confusing  array size (in terms of bytes) ,  with number of  array elements (not bytes) 
When applying in previous PR  (NOT  CORRECT ) : 
 
static_assert(power_of_two(sizeof(s)), "Array size must be power of 2");
with , s =  std::array<std::complex<float>, 256> channel_spectrum { };


1-) Confirmed that previous PR ,   sizeof(s) = 2048   (not 256 array elements as it should be  ) 
  (256 elements * 2 float (real & imaginary part) * 4 bytes/ float = 2048 bytes.

Then sizeof(s) was NOT =  256 elements ,  
but, as it was also  a power of 2 ,( and it was  working well, but it was not same assert as in the original code ) . Then NOT  CORRECT solution.


2-) Now the  ARRAY_ELEMENTS(s) = 256 elements ,   
it does not matter  how we define each element of the array ,   float , complex float , int, ….

3-) Tested , that when intentionally changed the definition to a NON POWER of 2 , example 255,  it is also  detected at compiling-time (as it should be ) 


Then we addressed it , with the following two  changes  ,  (ALREADY MODIFYIED from previous yesterday PR) 

In this PR , we define a new  auxiliar  compile time operator , based on the previous sizeof() , 
#define ARRAY_ELEMENTS(x) (sizeof(x) / sizeof(x[0]))     
/* sizeof() compile-time operator that returns #bytes of (data type). We used it to get #elements_array */

static_assert(power_of_two(ARRAY_ELEMENTS(s)), "Array number of elements must be power of 2");   // c/m compile error GCC10 , OK for all GCC versions.

Special  thanks to sharebrained , for his time, and  support ,  to review my  previous PR proposal , and for his wise  feedback , 
The previous  PR, was working , avoiding GCC compile error, but not doing  exactly what it should do and protect.
This one Yes ! We are respecting original safe protection , in different syntax to avoid  GCC compile error.. 


