### PR TITLE
Added a quick way of moving the cursor to the top left (back) location

### DIFF
--- a/firmware/application/event_m0.cpp
+++ b/firmware/application/event_m0.cpp
@@ -298,6 +298,12 @@ void EventDispatcher::handle_switches() {
 	}
 
 	if( in_key_event ) {
+		if (switches_state[(size_t)ui::KeyEvent::Left] && switches_state[(size_t)ui::KeyEvent::Up])
+		{
+			const auto event = static_cast<ui::KeyEvent>(ui::KeyEvent::Back);
+			context.focus_manager().update(top_widget, event);
+		}
+
 		// If we're in a key event, return. We will ignore all additional key
 		// presses until the first key is released. We also want to ignore events
 		// where the last key held generates a key event when other pressed keys

--- a/firmware/common/ui.hpp
+++ b/firmware/common/ui.hpp
@@ -325,6 +325,7 @@ enum class KeyEvent {
 	Down = 2,
 	Up = 3,
 	Select = 4,
+	Back = 5, /* Left and Up together */
 };
 
 using EncoderEvent = int32_t;

--- a/firmware/common/ui_focus.cpp
+++ b/firmware/common/ui_focus.cpp
@@ -179,7 +179,14 @@ void FocusManager::update(
 		};
 
 		const auto nearest = std::min_element(collection.cbegin(), collection.cend(), compare_fn);
-		if( nearest != collection.cend() ) {
+		// Up and left to indicate back
+		if (event == KeyEvent::Back) {
+			collection.clear();
+			widget_collect_visible(top_widget, find_back_fn, collection);
+			if (!collection.empty())
+				set_focus_widget(collection[0].first);
+		}
+		else if( nearest != collection.cend() ) {
 			//focus->blur();
 			const auto new_focus = (*nearest).first;
 			set_focus_widget(new_focus);


### PR DESCRIPTION
Added the ability to use the Up and Left buttons simultaneously to cause the cursor to move to the top left of the screen.

I had intended to review this and see if there should be a more general 2 button solution, but it got beta tested when I dropped my bin file in discord #test-drive.  I had only tested on H2 and was worried that it either wouldn't be possible to do the 2 buttons on an H1 or would be too easy and therefore annoying.  All responses on discord were positive, so I have decided to create a pull request now, and then consider if there is merit in extending this later.