### PR TITLE
Increase more BW Options to Capture App

### DIFF
--- a/firmware/application/apps/capture_app.cpp
+++ b/firmware/application/apps/capture_app.cpp
@@ -74,17 +74,58 @@ CaptureAppView::CaptureAppView(NavigationView& nav) {
 	
 	option_bandwidth.on_change = [this](size_t, uint32_t base_rate) {
 		sampling_rate = 8 * base_rate;	// Decimation by 8 done on baseband side
-		
+  	    /* base_rate  is used for FFT calculation and display LCD, and also in  recording writing SD Card  rate. */
+		/* ex. sampling_rate values, 4Mhz, when recording 500 khz (BW) and fs 8 Mhz , when selected 1 Mhz BW ...*/ 
+	    /* ex. recording 500khz BW  to .C16 file, base_rate clock 500khz x2(I,Q) x 2 bytes (int signed) =2MB/sec rate SD Card  */
+
 		waterfall.on_hide();
 		record_view.set_sampling_rate(sampling_rate);
 		receiver_model.set_sampling_rate(sampling_rate);
+       /* Set up  proper anti aliasing BPF bandwith in MAX2837 before ADC sampling according to the new added BW Options . */ 
+		
+		switch(sampling_rate) {   // we use the var fs (sampling_rate) , to set up BPF aprox < fs_max/2 by Nyquist theorem. 
+	  
+	  			case 0 ... 2000000:  //  BW Captured range  (0 <= 250Khz max )  fs = 8 x 250 Khz 
+					anti_alias_baseband_bandwidth_filter = 1750000;  // Minimum BPF MAX2837 for all those lower BW options.
+        	 		break;
+
+				case 4000000 ... 6000000:    // BW capture  range (500k ... 750Khz max )  fs_max = 8 x 750Khz = 6Mhz 
+     				//  BW 500k ... 750khz   ,  ex. 500khz   (fs = 8*BW =  4Mhz) , BW 600Khz (fs = 4,8Mhz) , BW  750 Khz (fs = 6Mhz)  
+					anti_alias_baseband_bandwidth_filter = 2500000;  // in some IC MAX2837 appear 2250000 , but both works similar. 
+					break;	
+
+				case 8800000:    // BW capture 1,1Mhz  fs = 8 x 1,1Mhz = 8,8Mhz . (1Mhz showed slightly higher noise background).
+					anti_alias_baseband_bandwidth_filter = 3500000;   
+        	 		break;
+
+			    case 14000000:   // BW capture 1,75Mhz  , fs = 8 x 1,75Mhz = 14Mhz 
+				    // good BPF ,good matching, but LCD making flicker , refresh rate should be < 20 Hz , but reasonable picture   
+         			anti_alias_baseband_bandwidth_filter = 5000000; 
+        			break;
+
+    			case 16000000:   // BW capture 2Mhz  , fs = 8 x 2Mhz = 16Mhz
+                     //  good BPF ,good matching, but LCD making flicker , refresh rate should be < 20 Hz , but reasonable picture   
+         			anti_alias_baseband_bandwidth_filter = 6000000; 
+        			break;
+   
+            	case 20000000:   // BW capture 2,5Mhz  , fs= 8 x 2,5 Mhz = 20Mhz
+         			//  good BPF ,good matching, but LCD making flicker , refresh rate should be < 20 Hz , but reasonable picture 
+					 anti_alias_baseband_bandwidth_filter = 7000000; 
+	   	         	break;
+		   	
+      			default:         // BW capture 2,75Mhz, fs = 8 x 2,75Mhz= 22Mhz max ADC sampling)  and others.  
+        			 //  We tested also 9Mhz FPB stightly too much noise floor , better 8Mhz 
+					 anti_alias_baseband_bandwidth_filter = 8000000;
+		}   
+		receiver_model.set_baseband_bandwidth(anti_alias_baseband_bandwidth_filter);
+							
+		
 		waterfall.on_show();
 	};
 	
-	option_bandwidth.set_selected_index(7);		// 500k
+	option_bandwidth.set_selected_index(7);		// 500k,  Preselected starting default option 500khz 
 	
 	receiver_model.set_modulation(ReceiverModel::Mode::Capture);
-	receiver_model.set_baseband_bandwidth(baseband_bandwidth);
 	receiver_model.enable();
 
 	record_view.on_error = [&nav](std::string message) {

--- a/firmware/application/apps/capture_app.hpp
+++ b/firmware/application/apps/capture_app.hpp
@@ -48,7 +48,7 @@ private:
 	static constexpr ui::Dim header_height = 3 * 16;
 
 	uint32_t sampling_rate = 0;
-	static constexpr uint32_t baseband_bandwidth = 2500000;
+	uint32_t anti_alias_baseband_bandwidth_filter = 2500000; // we rename the previous var , and change type static constexpr to normal var.
 
 	void on_tuning_frequency_changed(rf::Frequency f);
 
@@ -95,7 +95,14 @@ private:
 			{ " 50k ", 50000 },
 			{ "100k ", 100000 },
 			{ "250k ", 250000 },
-			{ "500k ", 500000 }
+			{ "500k ", 500000 },   // Previous Limit bandwith Option with perfect micro SD write .C16 format operaton.
+			{ "600k ", 600000 },   // That extended option is still possible to record with FW version Mayhem v1.41 (< 2,5MB/sec)  
+ 			{ "750k ", 750000 },   // From that BW onwards, the LCD is ok, but the recorded file is auto decimated,(not real file size) 
+			{ "1100k", 1100000 },
+	       	{ "1750k", 1750000 },
+			{ "2000k", 2000000 },
+			{ "2500k", 2500000 },
+			{ "2750k", 2750000 }    // That is our max Capture option , to keep using later / 8 decimation (22Mhz sampling  ADC)
 		}
 	};
 	


### PR DESCRIPTION
PR to **increase the BW Options in the Capture App , beyond the current max, 500khz.  (from 600Khz to 2,75Mhz)**  

Thanks a lot to @sharebrained  for your continuous  teaching ! ,  I understood from him, that in order to avoid the usual SDR FFT  DC spike , in that Capture App we are also using , as others SDR's ,  the fs/4 offset shift ,  
And if I understood it well,  later on , it will a postprocessing, with filtering and decimation ,  shifting to the center that badwith spectrum .
![image](https://user-images.githubusercontent.com/86470699/142776030-f1f18019-0839-4103-acc5-d4095e5af703.png)


Additionally ,  we are applying a faster fs sampling  , x 8 ,  and  later on in the post-processing part , we are applying , filtering and decimation /8 .
Based on the discussions and lessons from  Sharebrained , 
* The decimation is about 8x 
I-)because of the reduced useful bandwidth, 
Ii-)because of the offset tuning,
Iii-) and also because non-ideal filters don’t have cut-off frequencies right at 1/2 the output sampling rate.
Iv-) Also, the closer to perfect a filter gets, the more math the processor has to do, and the processor is only a 200 MHz Cortex-M4. 

We have here some of the  available  anti-aliasing filters on the MAX2837 : (the list is longer)

![image](https://user-images.githubusercontent.com/86470699/142775164-21f48d5a-12ed-4dcd-be07-9dff5f0a5dab.png)

**In previous Mayhem FW  version 1.41,  all the BW Options were using the COMMON FIXED  selection 2,25** (or 2,5Mhz in some specs) .
That I confirmed , that is perfect for the 500khz BW selection,  but we could still optimize slightly the background aliasing noise in the 250Khz options, 

**therefore ,  In this PR :** 
* All Lower BW  options <= 250Khz uses now ,  the MININMUM  anti-aliasing  BPF 1,75 Mhz,  (minor slight optimization respect current FW)
 
* and  for 500Khz , BPF  2,5 Mhz (as it was before, this was already optimized ) 

* For the rest of the new  options ,  I tried many different bandwith settings , and testing them , till fixing the best options to keep reasonable compromise between several dB's lost in the right part of the screen (respect left , due to non flat and nor  ideal BPF shapes) and the background aliasing noise. And even I shifted up  a little 1Mhz option to 1,1Mhz to have similar background aliasing noise than the other options ,using the above discrete BPF values .

After testing that new feature , we can see,
1-) All options work quite well in the LCD screen ,
 but > 1,5 Mhz , we start to see some flickering in the FFT waterfall (that is normal due to our CPU power limitatons) 

2-) But only we can REC perfect .C16 size files (matching with the metadata file .TXT ,where is specified the recorded rate )  till <= 600Khz  , (mean  600k* 2(I,Q) * 2 bytes (signed Int) = 2,4MB/sec, writing SD card.
Above this  600Khz BW Option ,  the  saved  .C16 format files, are automatically decimated by current SW ==> then at the moment those captures are not usefull for the Replay App- (but still good to see the recorded spectrum shape and details, with external sw tools like inspectrum in linux, or audacity , or others ...)
**We may have several future options to solve it ,** 

a-) maybe  hiding the "REC" icon button ,on those above BW >600Khz  options.

b-) or increase slightly the current FW  limitations to write > 2,4MB/s to the microSD , (maybe with good low latency SD Cards < 10-30 msegs (usual ones with 60-100 msegs random latency)   with min Write speed rate > 3MB/s (usual ones min rate >4MB/s) , then we may reach easily good performance. Example  with 3MB/S (able to record 750Khz BW in .C16 format) or , 3,5MB/s (875khz)  or 4MB/s ( 1Mhz)...

c.)  or trying to write another smaller  file with  8 bit format , )as it was suggested by **@heuristic1** , and also agreed by @sharebrained : "It may still be valid for some use cases to change the recording format to “.cs8” (complex<int8>) if people want to record at 2x the bandwidth while losing a small amount of dynamic range. The processing gain from filtering and decimation only increases the useful bit resolution to about 10 bits, not 16. But obviously, it’s difficult to pack and store 10-bit values efficiently on a byte-based computer"

d-) just , adding some message in the GUI , when user selects higher BW than the maximum recording SD Card rate  limit.

**I think that in the near future we should apply others  PR's   with the final recording solution for BW> 600Khz  ,  (a) , (b) , (c) or (d) .** (to avoid any potential user confusion when recording files above 600Khz , (that are in fact , decimated ones, and not usefull for Replay App) .  

Personally , I think that we should explore and investigate (b) and once we fix new extended recording  SD card rate  limit , then apply (d) to the rest of higher BW options .

Then  any help  on this issue  , will be always welcome and  highly appreciated ! .

I hope that you will also enjoy that feature , and hopefully , no side effects .

![image](https://user-images.githubusercontent.com/86470699/142774836-2a575489-0957-47ba-9ea6-b7b13b098552.png)
![image](https://user-images.githubusercontent.com/86470699/142774858-f06e3dc7-fdd5-44f2-b21d-165459c1f35d.png)
![image](https://user-images.githubusercontent.com/86470699/142774870-96cc8e58-6a59-42b3-b891-60869eec230c.png)
![image](https://user-images.githubusercontent.com/86470699/142774878-b77f52b7-01a9-4d77-89e5-09776e07fcfe.png)

