### PR TITLE
Minor improvements to the previous PR #395 Add Gain_TX to Replay App

### DIFF
--- a/firmware/application/apps/replay_app.cpp
+++ b/firmware/application/apps/replay_app.cpp
@@ -145,16 +145,23 @@ void ReplayAppView::start() {
 	field_rfgain.set_value(tx_gain);
 	receiver_model.set_tx_gain(tx_gain); 
     
+
+ 	field_rfamp.on_change = [this](int32_t v) {
+		rf_amp = (bool)v;
+	};
+	field_rfamp.set_value(rf_amp ? 14 : 0);
+		
 	radio::enable({
 		receiver_model.tuning_frequency(),
 		sample_rate * 8 ,
 		baseband_bandwidth,
 		rf::Direction::Transmit,
-		receiver_model.rf_amp(),
+        rf_amp,         //  previous code line : "receiver_model.rf_amp()," was passing the same rf_amp of all Receiver Apps  
 		static_cast<int8_t>(receiver_model.lna()),
 		static_cast<int8_t>(receiver_model.vga())
-	});
-}
+	}); 
+	 
+} 
 
 void ReplayAppView::stop(const bool do_loop) {
 	if( is_active() )
@@ -186,7 +193,9 @@ ReplayAppView::ReplayAppView(
 ) : nav_ (nav)
 {
 
-	tx_gain = 35;field_rfgain.set_value(tx_gain);
+	tx_gain = 35;field_rfgain.set_value(tx_gain);  // Initial default  value (-12 dB's max ).
+	field_rfamp.set_value(rf_amp ? 14 : 0);  // Initial default value True. (TX RF amp on , +14dB's)
+
 	baseband::run_image(portapack::spi_flash::image_tag_replay);
 
 	add_children({
@@ -198,7 +207,7 @@ ReplayAppView::ReplayAppView(
 		&progressbar,
 		&field_frequency,
 		&field_rfgain, 
-		&field_rf_amp,
+		&field_rfamp,       // let's not use common rf_amp
 		&check_loop,
 		&button_play,
 		&waterfall,

--- a/firmware/application/apps/replay_app.hpp
+++ b/firmware/application/apps/replay_app.hpp
@@ -52,6 +52,7 @@ private:
 	
 	uint32_t sample_rate = 0;
 	int32_t tx_gain { 47 };
+	bool rf_amp { true }; // aux private var to store temporal, Replay App rf_amp user selection.
 	static constexpr uint32_t baseband_bandwidth = 2500000;
 	const size_t read_size { 16384 };
 	const size_t buffer_count { 3 };
@@ -112,8 +113,12 @@ private:
 		1,
 		' '	
 	};
-	RFAmpField field_rf_amp {
-		{ 19 * 8, 2 * 16 }
+	NumberField field_rfamp {     // previously  I was using "RFAmpField field_rf_amp" but that is general Receiver amp setting.
+		{ 19 * 8, 2 * 16 },
+		2,
+		{ 0, 14 },                // this time we will display GUI , 0 or 14 dBs same as Mic App
+		14,
+		' '
 	};
 	Checkbox check_loop {
 		{ 21 * 8, 2 * 16 },


### PR DESCRIPTION
This PR , is an an update of the previous one  https://github.com/eried/portapack-mayhem/pull/395,
 about Replay App ,  correcting two several  minor  issues. (inspired with the job of  Mic App contributors . Thanks !!!) 

Before  talking about the MINOR IMPROVEMENTS, let me share the  updated previous frontend RF chart.,
where  I added more details , showing now :
usual  fw code ref. var labels //adj. margin range // adj. steps // and usual LCD GUI labels. 

![image](https://user-images.githubusercontent.com/86470699/144754900-fb5004e2-40ef-4fdd-bd83-3afad516a5d9.png)

**MINOR IMPROVEMENTS :** 
1-) In previous code ,  any RX(rf_amp) user setting  modification (in any receiver App ) , 
was modifying at the same time the TX (rf_amp) in Replay App and  viceversa.  (that might be sometimes confusing and annoying ). (That is not happening in the rest of TX App like ex. Mic App) . Then, this has been addressed in this PR

2-) In previous code , while we were in play mode , we could modify “in real time” the TX (rf_amp)  (that was good ) ,  but the TX LED  was following that rf_amp toggle setting (that was incorrect) because while we are in play mode,  we were  always in TX mode. (so TX_LED should be constant in ON while we are transmitting the file ).This has been addressed in this PR, but now , it is ignored any "live changes " of tx-freq,  tx-gain .  tx-rfamp, till next "stop" and "play" or next  automatic "loop" . 

3-) This time we also communized the TX  rf_amp GUI interface , (0 / 14 dBs gain) , same as Mic App .  

**Note :** 
same as before ,
i-)  to avoid any RF amplifier IC , 14dB’s,  accidental  damage (if user has   no antenna connection or antenna missmatching ) -  ,   the first “play” will not use max radiation antenna power . The initial values are  (GAIN =35 (-12dB's max)  ,  TX(rf_amp) = 1 =+14dB's)  ,  but of course  after first  “stop”, any other adj. of freq. / GAIN /, rf_amp, …, will be applyied at every new  “play” or  new “automatic loop” .  (so user will be able to put in max , but not the initial "play") 

**CONFIRMATION** 
I checked in three RECEIVER App's , (ex. in ADSB- App ,,  or  Capture App , or  Audio receiver ) that now , any RX_AMP setting is independent  from the selected TX_AMP in the Replay App.     (I did not check all, but i believe that all are now ok).


