### PR TITLE
Minor improvements, to the previous excellent PR #329 AM-SSB-DSB Mic Functional from  aldude999

### DIFF
--- a/firmware/baseband/dsp_modulate.cpp
+++ b/firmware/baseband/dsp_modulate.cpp
@@ -62,8 +62,8 @@ void SSB::execute(const buffer_s16_t& audio, const buffer_c8_t& buffer) {
 				//default:	break;
 			//}
 
-			i *= 64.0f;
-			q *= 64.0f;
+			i *= 256.0f;   // Original 64.0f,  now x 4 (+12 dB's SSB BB modulation)	
+			q *= 256.0f;   // Original 64.0f,  now x 4 (+12 dB's SSB BB modulation)	
 			switch (mode) {
 				case Mode::LSB:	re = q;	im = i;	break;
 				case Mode::USB:	re = i;	im = q;	break;
@@ -123,9 +123,9 @@ void AM::execute(const buffer_s16_t& audio, const buffer_c8_t& buffer) {
 		}
 
 		q = sample / 32768.0f;
-		q *= 64.0f;
+		q *= 256.0f;										 // Original 64.0f,now x4 (+12 dB's BB_modulation in AM & DSB)	
 		switch (mode) {
-			case Mode::AM:	re = q + 20; im = q + 20; break;
+			case Mode::AM:	re = q + 80; im = q + 80; break; // Original DC add +20_DC_level=carrier,now x4 (+12dB's AM carrier)
 			case Mode::DSB:	re = q; im = q; break;
 			default:	break;
 		}


### PR DESCRIPTION
In the previous execellent  feature  :  AM/SSB/DSB Microphone Functionality #329   from https://github.com/aldude999, https://github.com/strijar,  and  several other members ... Thanks to all of them !  Really great feature achievement ! 
It was pointed a minor problem , by  https://github.com/teixeluis and I also could confirm it  by my self , 
that the FM modulation, was radiating  much more energy than the others AM / DSB / SSB  modes.
![image](https://user-images.githubusercontent.com/86470699/147852715-f40431f0-ea76-4f98-b92d-ba0e5bed8f87.png)

![image](https://user-images.githubusercontent.com/86470699/147852733-d34df8bc-faba-4223-becb-c9c0d0c2ad2c.png)

---------------------------------------------------------------------------------------------------------------------------------
I also measured and realisded that the carrier difference level was around -12 dB's (AM)  respect ,  FM .
Initially , I thought that the AM-DSB-SSB Mic App  were ok ,and I was suspecting  that the FM mode in the  Mic App    was over drived and  saturated . 

Therefore , I tried to build similar  transmitters ,  using  GNU RADIO companion , (TX_FM mod,  TX_AM mod,  TX_SSB,)  to  compare about  the radiated levels using exactly same HackRF device , and same Test settings and   I could confirm  the followowing issues : 
FM transmitter  ex, 

![image](https://user-images.githubusercontent.com/86470699/147853765-7fe337e0-f4ac-48e4-ace7-d3fbe22a769c.png)



**(1)   The problem was NOT related to an incorrect audio base-band  saturated  FM MIC APP,** (it seems not over saturating the amplitude out of Input BB dynamic margin (-1,+1) . It is not true , because embedded MIC FM APP gives similar  radiated smeeter signal  level than when using another  GNU RADIO  FM APP , (when driving it with +-0,5 input base band range  level -  not the maximum  -1 to 1 range) 
![image](https://user-images.githubusercontent.com/86470699/147852943-95b148c4-2b0a-42b3-9fe9-31d91c0d97a9.png)



Then from  that observation , we can confirm , that the  embedded  FM  MIC APP ,
 it is just fine (with margin, seems using  around correct range levels :  +-0,5 FM carrier amplitude) . It is correct !  

When comparing (a) MIC FM APP ,   (b) GNU RADIO FM APP :
Then clearly, we realised that  the problem is in the MIC AM APP , that  it should have now  so low  DC carrier level.

(2) Checking  and  studying  the public ,  AM GNU Radio Implementation , https://wiki.gnuradio.org/index.php/Simulation_example:_AM_transmitter_and_receiver
![image](https://user-images.githubusercontent.com/86470699/147853132-5429f3ee-84aa-4861-a39e-78b4c2ee626c.png)
I could understand about  the DC effect, and the BB amplification factor to achieve a correct AM  MODULATION ,
![image](https://user-images.githubusercontent.com/86470699/147853202-446d1253-762c-4c0c-b0bf-7879e4b4c2dc.png)

And keep margin for a correct  100% AM modulation.

![image](https://user-images.githubusercontent.com/86470699/147853239-34a197f6-c527-43d6-86fa-8a68576db9b3.png)

Then ,after testing  
**let me propose that  PR , with the following  minor improvement  modulation  constant  adjustments:** 

(a)  Increased  Previous AM - DC level  x4  , ==>   (+12 dB’s  AM  DC CARRIER level, now  similar as  FM  carrier )   

(b)   Increased   x 4  BB audio amp,signal in  AM / DSB   to keep aligned a similar  AM modulation index as before 
 , and  also consequently ,  +12dB's higher radiated level in  DSB that has suppressed carrier ) 

(c) Increased   x 4  BB audio amp,signal in  SSB  (USB / LSB)   (+12dB's higher radiated levels ) (to be coherent and aligned to the DSB modulation levels ).

now AM and FM similar radiated carrier levels.
DSB / SSB (USB/LSB) all off them , with same increased levels . (+12 dBs from previous)


**Confirmation ,** 
I could  confirm that now , after that PR,
AM and FM shows similar  radiated carrier  levels 
SSB , still  seems  -10 dB's  behind   AM - FM   (but  we increased  +12 dB's  from  previous version , so to me now it is much more acceptable level 

**Side effects :** 
To my  eyes,  I could  not  see any side effect. 
I  checked,  with my  iphone headphones MIC , that the Mic App is  transmitting  now  corrrectly all the MOD. types .
I checked using another  SDR  receiver , to confirm the  radiated spectrum levels , and the correct spectrum shape of the signals.
I also heard  all the demodulated types, using another SDR and also another Tecsun receiver  with headphones , to confirm a good audio sound quality .
(Obviously , you should prior adjust properly your MIC gain , to have a non saturated audio base band levels.) 
 Actually ,  the radiated  SSB levels  seems still around  -10 dB's respect  AM --FM levels ,  but as I already increased them (DSB-SSB)  +12 dB's in base band signal path from  previous condition ,to be safe ,  I do not want to increase them more .

Happy 2022 ! and  feel free to test it  and let's enjoy about it  !  
 (I hope that  https://github.com/aldude999 ,  https://github.com/strijar,  https://github.com/teixeluis ,... and any other welcome advanced testers woulld also agreed with it . )

José Luis. 


   