### PR TITLE
“Antenna_DC_Bias_voltage_missing_in_AIS_and_RADIOSONDE”

### DIFF
--- a/firmware/application/apps/ais_app.cpp
+++ b/firmware/application/apps/ais_app.cpp
@@ -307,8 +307,13 @@ AISAppView::AISAppView(NavigationView& nav) : nav_ { nav } {
 	recent_entry_detail_view.hidden(true);
 
 	target_frequency_ = initial_target_frequency;
+  
+    receiver_model.set_tuning_frequency(tuning_frequency());
+    receiver_model.set_sampling_rate(sampling_rate);
+    receiver_model.set_baseband_bandwidth(baseband_bandwidth);
+    receiver_model.enable();  // Before using radio::enable(), but not updating Ant.DC-Bias.
 
-	radio::enable({
+/*  radio::enable({     //  this can be removed, previous version,no DC-bias control.
 		tuning_frequency(),
 		sampling_rate,
 		baseband_bandwidth,
@@ -316,8 +321,8 @@ AISAppView::AISAppView(NavigationView& nav) : nav_ { nav } {
 		receiver_model.rf_amp(),
 		static_cast<int8_t>(receiver_model.lna()),
 		static_cast<int8_t>(receiver_model.vga()),
-	});
-
+	}); */
+	
 	options_channel.on_change = [this](size_t, OptionsField::value_t v) {
 		this->on_frequency_changed(v);
 	};
@@ -337,7 +342,8 @@ AISAppView::AISAppView(NavigationView& nav) : nav_ { nav } {
 }
 
 AISAppView::~AISAppView() {
-	radio::disable();
+/*	radio::disable();  */
+	receiver_model.disable();   // to switch off all, including DC bias.
 
 	baseband::shutdown();
 }

--- a/firmware/application/apps/ais_app.cpp
+++ b/firmware/application/apps/ais_app.cpp
@@ -307,13 +307,8 @@ AISAppView::AISAppView(NavigationView& nav) : nav_ { nav } {
 	recent_entry_detail_view.hidden(true);
 
 	target_frequency_ = initial_target_frequency;
-  
-    receiver_model.set_tuning_frequency(tuning_frequency());
-    receiver_model.set_sampling_rate(sampling_rate);
-    receiver_model.set_baseband_bandwidth(baseband_bandwidth);
-    receiver_model.enable();  // Before using radio::enable(), but not updating Ant.DC-Bias.
 
-/*  radio::enable({     //  this can be removed, previous version,no DC-bias control.
+	radio::enable({
 		tuning_frequency(),
 		sampling_rate,
 		baseband_bandwidth,
@@ -321,8 +316,8 @@ AISAppView::AISAppView(NavigationView& nav) : nav_ { nav } {
 		receiver_model.rf_amp(),
 		static_cast<int8_t>(receiver_model.lna()),
 		static_cast<int8_t>(receiver_model.vga()),
-	}); */
-	
+	});
+
 	options_channel.on_change = [this](size_t, OptionsField::value_t v) {
 		this->on_frequency_changed(v);
 	};
@@ -342,8 +337,7 @@ AISAppView::AISAppView(NavigationView& nav) : nav_ { nav } {
 }
 
 AISAppView::~AISAppView() {
-/*	radio::disable();  */
-	receiver_model.disable();   // to switch off all, including DC bias.
+	radio::disable();
 
 	baseband::shutdown();
 }

--- a/firmware/application/apps/ui_sonde.cpp
+++ b/firmware/application/apps/ui_sonde.cpp
@@ -100,7 +100,12 @@ SondeView::SondeView(NavigationView& nav) {
 		use_crc = v;
 	};
 	
-	radio::enable({
+    receiver_model.set_tuning_frequency(tuning_frequency());
+    receiver_model.set_sampling_rate(sampling_rate);
+    receiver_model.set_baseband_bandwidth(baseband_bandwidth);
+    receiver_model.enable();   // Before using radio::enable(), but not updating Ant.DC-Bias.
+	
+	/* radio::enable({        // this can be removed, previous version, no DC-bias ant. control.
 		tuning_frequency(),
 		sampling_rate,
 		baseband_bandwidth,
@@ -108,7 +113,7 @@ SondeView::SondeView(NavigationView& nav) {
 		receiver_model.rf_amp(),
 		static_cast<int8_t>(receiver_model.lna()),
 		static_cast<int8_t>(receiver_model.vga()),
-	});
+	}); */
 
 
         // QR code with geo URI
@@ -153,7 +158,8 @@ SondeView::SondeView(NavigationView& nav) {
 
 SondeView::~SondeView() {
 	baseband::set_pitch_rssi(0, false);
-	radio::disable();
+/* 	radio::disable(); */  
+    receiver_model.disable();   // to switch off all, including DC bias.
 	baseband::shutdown();
 	audio::output::stop();
 }

--- a/firmware/application/apps/ui_sonde.cpp
+++ b/firmware/application/apps/ui_sonde.cpp
@@ -100,12 +100,7 @@ SondeView::SondeView(NavigationView& nav) {
 		use_crc = v;
 	};
 	
-    receiver_model.set_tuning_frequency(tuning_frequency());
-    receiver_model.set_sampling_rate(sampling_rate);
-    receiver_model.set_baseband_bandwidth(baseband_bandwidth);
-    receiver_model.enable();   // Before using radio::enable(), but not updating Ant.DC-Bias.
-	
-	/* radio::enable({        // this can be removed, previous version, no DC-bias ant. control.
+	radio::enable({
 		tuning_frequency(),
 		sampling_rate,
 		baseband_bandwidth,
@@ -113,7 +108,7 @@ SondeView::SondeView(NavigationView& nav) {
 		receiver_model.rf_amp(),
 		static_cast<int8_t>(receiver_model.lna()),
 		static_cast<int8_t>(receiver_model.vga()),
-	}); */
+	});
 
 
         // QR code with geo URI
@@ -158,8 +153,7 @@ SondeView::SondeView(NavigationView& nav) {
 
 SondeView::~SondeView() {
 	baseband::set_pitch_rssi(0, false);
-/* 	radio::disable(); */  
-    receiver_model.disable();   // to switch off all, including DC bias.
+	radio::disable();
 	baseband::shutdown();
 	audio::output::stop();
 }


### PR DESCRIPTION
Solving  previous  issue :
Portapack Antenna DC Voltage is missing in AIS and Radiosonde #216
**AIS App test validation :** 
First  I implemented the change into the AIS.cpp  file,  and we validated it in two steps :  
1-)  I confirmed that the Antenna DC-bias control works now  OK
2-)  @spudgunman  kindly  tested in live ,  that the Application works  same as before , in terms of demodulating and decoding CH87B , CH88B , 
      with correct  LNA, VGA, AMP  functionality . 
Thanks a lot   @spudgunman for your strong support  👏👏👏🙏!!!!!  (in th discord Test-drive channel) .

![image](https://user-images.githubusercontent.com/86470699/149640758-51dddaf0-82fc-450e-8c62-08d122a16789.png)


After that , I could see, that  the Sondes.cpp  had exactly the same software radio init  code structure than the AIS.cpp ,  so then , to  enable the Antenna DC-Bias control, I   just copy / paste exactly the  same solution from the AIS.  
 I confirmed that now the  DC bias control works ok in the Radiosondes,   and  as it is minor code change , all the rest should work  exactly same as before . 
 Anyway , if someone , has a close radiosonde, it would be appreciated to get feedback about its test .
 Feel free to  report here . 
I am 99% sure , that this Radiosonde App. will work  same as before that PR  +(just with the feature Ant BIAS control now activated )
 (I also will try to capture and test some radiosonde , to confirm that it works exactly same as before + ant. DC bias control. But , we need to check by web its launchment  date&time close to our area .

 **Radiosonde App  , test validation:**
 today I have been lucky, just now passed a weather ballon , close to home . And I could confirm that everything works as before (with DC bias on and off ) and the LNA, VGA, AMP .  
All ok , I can receive well modem type , battery voltage, time and date stamp , altitude, lat and long (but no temp nor humidity , as always in my previous test . But this is not related to that PR)

![48504851-76A4-4EAF-B424-A7694C644956](https://user-images.githubusercontent.com/86470699/149659163-3cb44939-8e97-4dcd-b5fa-7cd06f53fed6.jpeg)
 
With DC-BIAS ON ,  in the antenna   (with correct ON voltage with tester)
![image](https://user-images.githubusercontent.com/86470699/149663904-9d0e8f62-c777-4fd8-9f19-c1eb80821893.png)


With DC-BIAS OFF,  in the antenna (0V. with tester)
![image](https://user-images.githubusercontent.com/86470699/149663922-7b6e1160-8fae-49f2-a456-641a83d55bd1.png)

In both cases, similar reception, and working well   LNA, VGA,  AMP., and the BEEP function was also working well.

