### PR TITLE
Prepadded MMSI in AIS app with zeros, so it's always 9 chars long

### DIFF
--- a/firmware/application/apps/ais_app.cpp
+++ b/firmware/application/apps/ais_app.cpp
@@ -59,7 +59,7 @@ static float latlon_float(const int32_t normalized) {
 static std::string mmsi(
 	const ais::MMSI& mmsi
 ) {
-	return to_string_dec_uint(mmsi, 9);
+	return to_string_dec_uint(mmsi, 9, '0'); // MMSI is always is always 9 characters pre-padded with zeros
 }
 
 static std::string navigational_status(const unsigned int value) {


### PR DESCRIPTION
Prepadded MMSI in AIS app with zeros, so it's always 9 chars long, for example 002442000 instead of   2442000