### PR TITLE
Easy fix to make bigger Radiosonde's QR-codes.

### DIFF
--- a/firmware/application/ui/ui_qrcode.cpp
+++ b/firmware/application/ui/ui_qrcode.cpp
@@ -45,7 +45,7 @@ QRCodeImage::QRCodeImage(
 void QRCodeImage::paint(Painter& painter) {
 	// The structure to manage the QR code
 	QRCode qrcode;
-	int qr_version = 10; // bigger versions aren't handled very well
+	int qr_version = 2; // bigger versions aren't handled very well
 
 	// Allocate a chunk of memory to store the QR code
 	uint8_t qrcodeBytes[qrcode_getBufferSize(qr_version)];
@@ -53,14 +53,13 @@ void QRCodeImage::paint(Painter& painter) {
 	qrcode_initText(&qrcode, qrcodeBytes, qr_version, ECC_HIGH, qr_text_);
 
 
-	display.fill_rectangle(Rect(92, 97, 63, 63), Color::white());
+	display.fill_rectangle(Rect(20, 30, 220, 220), Color::white());
 
 	for (uint8_t y = 0; y < qrcode.size; y++) {
     		for (uint8_t x = 0; x < qrcode.size; x++) {
         		if (qrcode_getModule(&qrcode, x, y)) {
-            			display.draw_pixel(Point(95+x,100+y), Color::black());
-
-        		} 
+                        display.fill_rectangle(Rect(30+(x*8), 40+(y*8), 8, 8), Color::black());
+        		}
     		}
 	}
 }

--- a/firmware/application/ui/ui_qrcode.cpp
+++ b/firmware/application/ui/ui_qrcode.cpp
@@ -58,7 +58,7 @@ void QRCodeImage::paint(Painter& painter) {
 	for (uint8_t y = 0; y < qrcode.size; y++) {
     		for (uint8_t x = 0; x < qrcode.size; x++) {
         		if (qrcode_getModule(&qrcode, x, y)) {
-                        display.fill_rectangle(Rect(30+(x*8), 40+(y*8), 8, 8), Color::black());
+        			display.fill_rectangle(Rect(30+(x*8), 40+(y*8), 8, 8), Color::black());
         		}
     		}
 	}


### PR DESCRIPTION
Fixed the QR code generator for the radiosonde app: the qr code is now 8 times larger and can be easily decoded by phones.

This solution solves the enhancement request #471.