### PR TITLE
Add_Gain_TX_to_GPS_sim_App_issue_480

### DIFF
--- a/firmware/application/apps/gps_sim_app.cpp
+++ b/firmware/application/apps/gps_sim_app.cpp
@@ -140,13 +140,24 @@ void GpsSimAppView::start() {
 			}
 		);
 	}
+	field_rfgain.on_change = [this](int32_t v) {
+		tx_gain = v;
+	};  
+	field_rfgain.set_value(tx_gain);
+	receiver_model.set_tx_gain(tx_gain); 
+    
+
+ 	field_rfamp.on_change = [this](int32_t v) {
+		rf_amp = (bool)v;
+	};
+	field_rfamp.set_value(rf_amp ? 14 : 0);
 	
 	radio::enable({
 		receiver_model.tuning_frequency(),
 		sample_rate ,
 		baseband_bandwidth,
 		rf::Direction::Transmit,
-		receiver_model.rf_amp(),
+		rf_amp,         //  previous code line : "receiver_model.rf_amp()," was passing the same rf_amp of all Receiver Apps  
 		static_cast<int8_t>(receiver_model.lna()),
 		static_cast<int8_t>(receiver_model.vga())
 	});
@@ -181,6 +192,9 @@ GpsSimAppView::GpsSimAppView(
 	NavigationView& nav
 ) : nav_ (nav)
 {
+	tx_gain = 35;field_rfgain.set_value(tx_gain);  // Initial default  value (-12 dB's max 47dBs ).
+	field_rfamp.set_value(rf_amp ? 14 : 0);  // Initial default value True. (TX RF amp on , +14dB's)
+	
 	baseband::run_image(portapack::spi_flash::image_tag_gps);
 
 	add_children({
@@ -191,8 +205,8 @@ GpsSimAppView::GpsSimAppView(
 		&text_duration,
 		&progressbar,
 		&field_frequency,
-		&field_lna,
-		&field_rf_amp,
+		&field_rfgain,
+		&field_rfamp,       // let's not use common persistent rf_amp , local rfamp is enough
 		&check_loop,
 		&button_play,
 		&waterfall,

--- a/firmware/application/apps/gps_sim_app.hpp
+++ b/firmware/application/apps/gps_sim_app.hpp
@@ -52,6 +52,8 @@ private:
 	static constexpr ui::Dim header_height = 3 * 16;
 	
 	uint32_t sample_rate = 0;
+	int32_t tx_gain { 47 };
+	bool rf_amp { true }; // aux private var to store temporal, same as Replay App rf_amp user selection.
 	static constexpr uint32_t baseband_bandwidth = 3000000; //filter bandwidth
 	const size_t read_size { 16384 };
 	const size_t buffer_count { 3 };
@@ -76,7 +78,7 @@ private:
 	bool ready_signal { false };
 
 	Labels labels {
-		{ { 10 * 8, 2 * 16 }, "LNA:   A:", Color::light_grey() }
+		{ { 10 * 8, 2 * 16 }, "GAIN   A:", Color::light_grey() }
 	};
 	
 	Button button_open {
@@ -104,11 +106,19 @@ private:
 	FrequencyField field_frequency {
 		{ 0 * 8, 2 * 16 },
 	};
-	LNAGainField field_lna {
-		{ 14 * 8, 2 * 16 }
+	NumberField field_rfgain {
+		{ 14 * 8, 2 * 16 },
+		2,
+		{ 0, 47 },
+		1,
+		' '	
 	};
-	RFAmpField field_rf_amp {
-		{ 19 * 8, 2 * 16 }
+	NumberField field_rfamp {     // previously we were using "RFAmpField field_rf_amp" but that is general Receiver amp setting.
+		{ 19 * 8, 2 * 16 },
+		2,
+		{ 0, 14 },                // this time we will display GUI , 0 or 14 dBs same as Mic and Replay App
+		14,
+		' '
 	};
 	Checkbox check_loop {
 		{ 21 * 8, 2 * 16 },


### PR DESCRIPTION
This PR ,  address the pointed bug by @beged ,issue  #480 
Adding  Gain control to the GPS Sim App .
(we are clonning the two previous PR's n #395 and #446 of the Replay App, correcting TX Gain control to this GPS Sim App )

I was not familiar with that GPS Sim  App.  Very interesting !!!! 
 In fact it is very similar to the Replay App, but instead of playing  files.C16 (BW <=600Khz) ,
this time it plays higher BW = 2,6Mhz (sample rate)  at the fixed  GPS freq.  (frequency 1575.42M)   using generated  dummy sim files.C8 

I already tested its correct functionality , in terms of RF level adjusement ,  but  just in case that some one else wants to also test it ,  I will upload that test  binary in the Discord , test drive area.
![image](https://user-images.githubusercontent.com/86470699/151679783-1f21008b-db38-4e9f-81ce-12e307648556.png)

![image](https://user-images.githubusercontent.com/86470699/151679790-02c61cf0-712a-47f3-b7a3-bd771ed7817e.png)

As @beged pointed ,closing a mobile with GPS on ,in my case , it detects the satellite constellation , but just replaying  20 secs, it might be not enough to lock and show the new simulated lat / long  coordenates :  " 
"yes the 20 sec records may not be enough... depends on phone too... but usually longer is required, and there are several other factors, like you need a TCXO ref GPSDO ref externally injected for very precise frequency and so on..."

![image](https://user-images.githubusercontent.com/86470699/151679938-ce5337ee-02e1-43e0-9c61-2b4d10fff220.png)


Thanks, 


