### PR TITLE
Improvements to screen navigation

### DIFF
--- a/firmware/common/ui_focus.cpp
+++ b/firmware/common/ui_focus.cpp
@@ -142,7 +142,23 @@ static int32_t rect_distances(
 		return -1;
 	}
 
-	return (std::abs(perpendicular_axis_end - perpendicular_axis_start) + 1) * (on_axis_distance + 1);
+
+	switch(direction) {
+	case KeyEvent::Right:
+	case KeyEvent::Left:
+		return ((std::abs(perpendicular_axis_end - perpendicular_axis_start) + 1) ^ 3) * sqrt((on_axis_distance + 1));
+		break;
+
+	case KeyEvent::Up:
+	case KeyEvent::Down:
+		return (sqrt(std::abs(perpendicular_axis_end - perpendicular_axis_start) + 1)) * ((on_axis_distance + 1) ^ 3);
+		break;
+
+	default:
+		return 0;
+	}
+
+	
 }
 
 void FocusManager::update(


### PR DESCRIPTION
Some improvements for screen navigation, since it was driving me crazy.
Basically with this improvement:
- When moving horizontally (press left/right) more weight is given to the Y-axis and less to the X-distance. So making sure the 'line'  it's on has more preference.
- When moving vertically (press up/down) more weight is given to the Y-axis and less to the X-distance. So making sure the the nearest line has preference.
