### PR TITLE
“antenna dc bias missing in ais and radiosonde”

### DIFF
--- a/firmware/application/apps/ais_app.cpp
+++ b/firmware/application/apps/ais_app.cpp
@@ -307,8 +307,13 @@ AISAppView::AISAppView(NavigationView& nav) : nav_ { nav } {
 	recent_entry_detail_view.hidden(true);
 
 	target_frequency_ = initial_target_frequency;
+  
+    receiver_model.set_tuning_frequency(tuning_frequency());
+    receiver_model.set_sampling_rate(sampling_rate);
+    receiver_model.set_baseband_bandwidth(baseband_bandwidth);
+    receiver_model.enable();  // Before using radio::enable(), but not updating Ant.DC-Bias.
 
-	radio::enable({
+/*  radio::enable({     //  this can be removed, previous version,no DC-bias control.
 		tuning_frequency(),
 		sampling_rate,
 		baseband_bandwidth,
@@ -316,8 +321,8 @@ AISAppView::AISAppView(NavigationView& nav) : nav_ { nav } {
 		receiver_model.rf_amp(),
 		static_cast<int8_t>(receiver_model.lna()),
 		static_cast<int8_t>(receiver_model.vga()),
-	});
-
+	}); */
+	
 	options_channel.on_change = [this](size_t, OptionsField::value_t v) {
 		this->on_frequency_changed(v);
 	};
@@ -337,7 +342,8 @@ AISAppView::AISAppView(NavigationView& nav) : nav_ { nav } {
 }
 
 AISAppView::~AISAppView() {
-	radio::disable();
+/*	radio::disable();  */
+	receiver_model.disable();   // to switch off all, including DC bias.
 
 	baseband::shutdown();
 }

--- a/firmware/application/apps/ais_app.cpp
+++ b/firmware/application/apps/ais_app.cpp
@@ -307,13 +307,8 @@ AISAppView::AISAppView(NavigationView& nav) : nav_ { nav } {
 	recent_entry_detail_view.hidden(true);
 
 	target_frequency_ = initial_target_frequency;
-  
-    receiver_model.set_tuning_frequency(tuning_frequency());
-    receiver_model.set_sampling_rate(sampling_rate);
-    receiver_model.set_baseband_bandwidth(baseband_bandwidth);
-    receiver_model.enable();  // Before using radio::enable(), but not updating Ant.DC-Bias.
 
-/*  radio::enable({     //  this can be removed, previous version,no DC-bias control.
+	radio::enable({
 		tuning_frequency(),
 		sampling_rate,
 		baseband_bandwidth,
@@ -321,8 +316,8 @@ AISAppView::AISAppView(NavigationView& nav) : nav_ { nav } {
 		receiver_model.rf_amp(),
 		static_cast<int8_t>(receiver_model.lna()),
 		static_cast<int8_t>(receiver_model.vga()),
-	}); */
-	
+	});
+
 	options_channel.on_change = [this](size_t, OptionsField::value_t v) {
 		this->on_frequency_changed(v);
 	};
@@ -342,8 +337,7 @@ AISAppView::AISAppView(NavigationView& nav) : nav_ { nav } {
 }
 
 AISAppView::~AISAppView() {
-/*	radio::disable();  */
-	receiver_model.disable();   // to switch off all, including DC bias.
+	radio::disable();
 
 	baseband::shutdown();
 }

--- a/firmware/application/apps/ui_sonde.cpp
+++ b/firmware/application/apps/ui_sonde.cpp
@@ -100,7 +100,12 @@ SondeView::SondeView(NavigationView& nav) {
 		use_crc = v;
 	};
 	
-	radio::enable({
+    receiver_model.set_tuning_frequency(tuning_frequency());
+    receiver_model.set_sampling_rate(sampling_rate);
+    receiver_model.set_baseband_bandwidth(baseband_bandwidth);
+    receiver_model.enable();   // Before using radio::enable(), but not updating Ant.DC-Bias.
+	
+	/* radio::enable({        // this can be removed, previous version, no DC-bias ant. control.
 		tuning_frequency(),
 		sampling_rate,
 		baseband_bandwidth,
@@ -108,7 +113,7 @@ SondeView::SondeView(NavigationView& nav) {
 		receiver_model.rf_amp(),
 		static_cast<int8_t>(receiver_model.lna()),
 		static_cast<int8_t>(receiver_model.vga()),
-	});
+	}); */
 
 
         // QR code with geo URI
@@ -153,7 +158,8 @@ SondeView::SondeView(NavigationView& nav) {
 
 SondeView::~SondeView() {
 	baseband::set_pitch_rssi(0, false);
-	radio::disable();
+/* 	radio::disable(); */  
+    receiver_model.disable();   // to switch off all, including DC bias.
 	baseband::shutdown();
 	audio::output::stop();
 }

--- a/firmware/application/apps/ui_sonde.cpp
+++ b/firmware/application/apps/ui_sonde.cpp
@@ -100,12 +100,7 @@ SondeView::SondeView(NavigationView& nav) {
 		use_crc = v;
 	};
 	
-    receiver_model.set_tuning_frequency(tuning_frequency());
-    receiver_model.set_sampling_rate(sampling_rate);
-    receiver_model.set_baseband_bandwidth(baseband_bandwidth);
-    receiver_model.enable();   // Before using radio::enable(), but not updating Ant.DC-Bias.
-	
-	/* radio::enable({        // this can be removed, previous version, no DC-bias ant. control.
+	radio::enable({
 		tuning_frequency(),
 		sampling_rate,
 		baseband_bandwidth,
@@ -113,7 +108,7 @@ SondeView::SondeView(NavigationView& nav) {
 		receiver_model.rf_amp(),
 		static_cast<int8_t>(receiver_model.lna()),
 		static_cast<int8_t>(receiver_model.vga()),
-	}); */
+	});
 
 
         // QR code with geo URI
@@ -158,8 +153,7 @@ SondeView::SondeView(NavigationView& nav) {
 
 SondeView::~SondeView() {
 	baseband::set_pitch_rssi(0, false);
-/* 	radio::disable(); */  
-    receiver_model.disable();   // to switch off all, including DC bias.
+	radio::disable();
 	baseband::shutdown();
 	audio::output::stop();
 }


### PR DESCRIPTION
I tried several times to delete the submodule Hackrf from that PR, but I could not .

I think , as it is not applying  any  line code change on the submodule Hackrf ,  let's proceed as it is .

Already validated. 