### PR TITLE
Added return codes for delete_file() and rename_file() in file.hpp

### DIFF
--- a/firmware/application/file.cpp
+++ b/firmware/application/file.cpp
@@ -197,12 +197,12 @@ std::vector<std::filesystem::path> scan_root_directories(const std::filesystem::
 	return directory_list;
 }
 
-void delete_file(const std::filesystem::path& file_path) {
-	f_unlink(reinterpret_cast<const TCHAR*>(file_path.c_str()));
+uint32_t delete_file(const std::filesystem::path& file_path) {
+	return f_unlink(reinterpret_cast<const TCHAR*>(file_path.c_str()));
 }
 
-void rename_file(const std::filesystem::path& file_path, const std::filesystem::path& new_name) {
-	f_rename(reinterpret_cast<const TCHAR*>(file_path.c_str()), reinterpret_cast<const TCHAR*>(new_name.c_str()));
+uint32_t rename_file(const std::filesystem::path& file_path, const std::filesystem::path& new_name) {
+	return f_rename(reinterpret_cast<const TCHAR*>(file_path.c_str()), reinterpret_cast<const TCHAR*>(new_name.c_str()));
 }
 
 FATTimestamp file_created_date(const std::filesystem::path& file_path) {

--- a/firmware/application/file.hpp
+++ b/firmware/application/file.hpp
@@ -238,8 +238,8 @@ struct FATTimestamp {
 	uint16_t FAT_time;
 };
 
-void delete_file(const std::filesystem::path& file_path);
-void rename_file(const std::filesystem::path& file_path, const std::filesystem::path& new_name);
+uint32_t delete_file(const std::filesystem::path& file_path);
+uint32_t rename_file(const std::filesystem::path& file_path, const std::filesystem::path& new_name);
 FATTimestamp file_created_date(const std::filesystem::path& file_path);
 uint32_t make_new_directory(const std::filesystem::path& dir_path);
 


### PR DESCRIPTION
Hi,

While working on the DEV documentation I noticed two functions in file.hpp that handle SD Card file manipulation didn't return FRESULT codes defined in ff.h. I added returns for delete_file() and rename_file() and checked if it broke anything in the File Manager UI.

Thanks!  