### PR TITLE
Replay App Enable Bias-tee

### DIFF
--- a/firmware/application/apps/replay_app.cpp
+++ b/firmware/application/apps/replay_app.cpp
@@ -97,6 +97,7 @@ void ReplayAppView::focus() {
 }
 
 void ReplayAppView::file_error() {
+	//stop(false);   // Fixes TX bug if there's a file error
 	nav_.display_modal("Error", "File read error.");
 }
 
@@ -121,6 +122,7 @@ void ReplayAppView::start() {
 	auto open_error = p->open(file_path);
 	if( open_error.is_valid() ) {
 		file_error();
+		return;                               // Fixes TX bug if there's a file error
 	} else {
 		reader = std::move(p);
 	}
@@ -150,17 +152,19 @@ void ReplayAppView::start() {
 		rf_amp = (bool)v;
 	};
 	field_rfamp.set_value(rf_amp ? 14 : 0);
+
+	//Enable Bias Tee if selected
+	radio::set_antenna_bias(portapack::get_antenna_bias());
 		
 	radio::enable({
 		receiver_model.tuning_frequency(),
-		sample_rate * 8 ,
+		sample_rate * 8,
 		baseband_bandwidth,
 		rf::Direction::Transmit,
         rf_amp,         //  previous code line : "receiver_model.rf_amp()," was passing the same rf_amp of all Receiver Apps  
 		static_cast<int8_t>(receiver_model.lna()),
 		static_cast<int8_t>(receiver_model.vga())
-	}); 
-	 
+	});  
 } 
 
 void ReplayAppView::stop(const bool do_loop) {
@@ -170,6 +174,7 @@ void ReplayAppView::stop(const bool do_loop) {
 	if (do_loop && check_loop.value()) {
 		start();
 	} else {
+		radio::set_antenna_bias(false);    //Turn off Bias Tee
 		radio::disable();
 		button_play.set_bitmap(&bitmap_play);
 	}

--- a/firmware/application/apps/replay_app.cpp
+++ b/firmware/application/apps/replay_app.cpp
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2016 Jared Boone, ShareBrained Technology, Inc.
  * Copyright (C) 2016 Furrtek
+ * Copyleft  (ↄ) 2022 NotPike
  *
  * This file is part of PortaPack.
  *
@@ -97,7 +98,6 @@ void ReplayAppView::focus() {
 }
 
 void ReplayAppView::file_error() {
-	//stop(false);   // Fixes TX bug if there's a file error
 	nav_.display_modal("Error", "File read error.");
 }
 


### PR DESCRIPTION
Hi,

I added Bias-tee support for the Replay App to support modern power amps like Nuand's BT-100 that use DC power from the SMA. 

I also fixed a logic bug where the radio will go into a TX state even if there's a file error. For example If you hit the TX button before selecting a file the radio will lock into a TX state and won't escape unless you select the correct file or exit the app. This fix was a simple return on line 125. 

If you have any questions please let me know.   