### PR TITLE
Added Datetime + Freq Filename to Audio App

### DIFF
--- a/firmware/application/apps/analog_audio_app.cpp
+++ b/firmware/application/apps/analog_audio_app.cpp
@@ -129,6 +129,9 @@ AnalogAudioView::AnalogAudioView(
 		&waterfall
 	});
 
+	//Filename Datetime and Frequency
+	record_view.set_filename_date_frequency(true);
+
 	field_frequency.set_value(receiver_model.tuning_frequency());
 	field_frequency.set_step(receiver_model.frequency_step());
 	field_frequency.on_change = [this](rf::Frequency f) {

--- a/firmware/application/apps/analog_audio_app.hpp
+++ b/firmware/application/apps/analog_audio_app.hpp
@@ -32,8 +32,6 @@
 
 #include "tone_key.hpp"
 
-#include "string_format.hpp"
-
 
 namespace ui {
 

--- a/firmware/application/apps/analog_audio_app.hpp
+++ b/firmware/application/apps/analog_audio_app.hpp
@@ -28,10 +28,12 @@
 #include "ui_receiver.hpp"
 #include "ui_spectrum.hpp"
 #include "ui_record_view.hpp"
-
 #include "ui_font_fixed_8x16.hpp"
 
 #include "tone_key.hpp"
+
+#include "string_format.hpp"
+
 
 namespace ui {
 
@@ -216,7 +218,10 @@ private:
 
 	RecordView record_view {
 		{ 0 * 8, 2 * 16, 30 * 8, 1 * 16 },
-		u"AUD_????", RecordView::FileType::WAV, 4096, 4
+		u"AUD",
+		RecordView::FileType::WAV, 
+		4096, 
+		4
 	};
 
 	spectrum::WaterfallWidget waterfall { true };

--- a/firmware/application/string_format.cpp
+++ b/firmware/application/string_format.cpp
@@ -129,6 +129,11 @@ std::string to_string_decimal(float decimal, int8_t precision) {
 	return result;
 }
 
+std::string to_string_freq(const uint64_t f) {
+	auto final_str = to_string_dec_int(f / 1000000,4) + to_string_dec_int(f % 1000000, 6, '0');
+	return final_str;
+}
+
 std::string to_string_short_freq(const uint64_t f) {
 	auto final_str = to_string_dec_int(f / 1000000,4) + "." + to_string_dec_int((f / 100) % 10000, 4, '0');
 	return final_str;

--- a/firmware/application/string_format.hpp
+++ b/firmware/application/string_format.hpp
@@ -48,6 +48,7 @@ std::string to_string_decimal(float decimal, int8_t precision);
 std::string to_string_hex(const uint64_t n, const int32_t l = 0);
 std::string to_string_hex_array(uint8_t * const array, const int32_t l = 0);
 
+std::string to_string_freq(const uint64_t f);
 std::string to_string_short_freq(const uint64_t f);
 std::string to_string_time_ms(const uint32_t ms);
 

--- a/firmware/application/ui_record_view.cpp
+++ b/firmware/application/ui_record_view.cpp
@@ -127,6 +127,11 @@ void RecordView::set_sampling_rate(const size_t new_sampling_rate) {
 	}
 }
 
+// Setter for datetime and frequency filename
+void RecordView::set_filename_date_frequency(bool set) {
+	filename_date_frequency = set;
+}
+
 bool RecordView::is_active() const {
 	return (bool)capture_thread;
 }
@@ -149,7 +154,24 @@ void RecordView::start() {
 		return;
 	}
 
-	auto base_path = next_filename_stem_matching_pattern(filename_stem_pattern);
+	// 
+    std::filesystem::path base_path;
+	if(filename_date_frequency) {
+     	rtcGetTime(&RTCD1, &datetime);
+
+		//ISO 8601 
+		std::string date_time = to_string_dec_uint(datetime.year(), 4, '0')  +
+			                    to_string_dec_uint(datetime.month(), 2, '0') + 
+			                    to_string_dec_uint(datetime.day(), 2, '0')   + "T" +
+								to_string_dec_uint(datetime.hour())          +
+								to_string_dec_uint(datetime.minute())        +
+								to_string_dec_uint(datetime.second());
+
+		base_path = filename_stem_pattern.string() + "_" + date_time + "_" + to_string_freq(receiver_model.tuning_frequency()) + "Hz";
+	} else {
+		base_path = next_filename_stem_matching_pattern(filename_stem_pattern);
+	}
+
 	if( base_path.empty() ) {
 		return;
 	}

--- a/firmware/application/ui_record_view.cpp
+++ b/firmware/application/ui_record_view.cpp
@@ -154,7 +154,7 @@ void RecordView::start() {
 		return;
 	}
 
-	// 
+	 
     std::filesystem::path base_path;
 	if(filename_date_frequency) {
      	rtcGetTime(&RTCD1, &datetime);

--- a/firmware/application/ui_record_view.hpp
+++ b/firmware/application/ui_record_view.hpp
@@ -63,6 +63,8 @@ public:
 
 	bool is_active() const;
 
+	void set_filename_date_frequency(bool set);
+
 private:
 	void toggle();
 	//void toggle_pitch_rssi();
@@ -75,6 +77,11 @@ private:
 	void handle_error(const File::Error error);
 
 	//bool pitch_rssi_enabled = false;
+	
+	// Time Stamp
+	bool filename_date_frequency = false;
+    rtc::RTC datetime { };
+
 	const std::filesystem::path filename_stem_pattern;
 	const FileType file_type;
 	const size_t write_size;


### PR DESCRIPTION
Hi,

I added the file name enhancement for the Audio App per the request of issue #498. Instead of wav file names being "AUD_0001.WAV" they're now "AUD_YYYYMMDDTHHMMSS_0000000000Hz.WAV". The file name dose become too long to read within the device UI however it doesn't break the file manager or wave viewer. 

Let me know what you think if this viable or not.
Thanks!



