### PR TITLE
Added nightly release pipeline

### DIFF
--- a/.github/workflows/create_nightly_release.yml
+++ b/.github/workflows/create_nightly_release.yml
@@ -1,0 +1,71 @@
+# ToDo: only trigger after 24 hours if there are actually changes: https://github.community/t/trigger-action-on-schedule-only-if-there-are-changes-to-the-branch/17887/4
+
+name: Nightly Release
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+    
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get current date
+        id: date
+        run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
+      - name: Checkout 
+        uses: actions/checkout@master
+        with:
+          ref: next
+          submodules: true
+      - name: Git Sumbodule Update
+        run: |
+          git submodule update --init --recursive
+      - name: Build the Docker image
+        run: docker build -t portapack-dev -f dockerfile-nogit . --tag my-image-name:$(date +%s)
+      - name: Make build folder
+        run: mkdir ${{ github.workspace }}/build
+      - name: Run the Docker image
+        run: docker run -i -v ${{ github.workspace }}:/havoc portapack-dev
+      - name: Create Firmware ZIP
+        run: |
+          zip --junk-paths firmware build/firmware/portapack-h1_h2-mayhem.bin
+      - name: Create SD Card ZIP
+        run: |
+          zip -r sdcard.zip sdcard
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: nightly-tag-${{ steps.date.outputs.date }}
+          release_name: Nightly-release - ${{ steps.date.outputs.date }}
+          body: |
+            **Nightly release - ${{ steps.date.outputs.date }}**
+            This build is the latest and greatest, although may not be the most stable as this is a nightly release.
+            You can find the changes in this commit ${{ github.sha }}
+          draft: false
+          prerelease: true
+      - name: Upload Firmware Asset
+        id: upload-firmware-asset 
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
+          asset_path: ./firmware.zip
+          asset_name: mayhem_nightly_${{ steps.date.outputs.date }}_FIRMWARE.zip
+          asset_content_type: application/zip
+      - name: Upload SD Card Assets
+        id: upload-sd-card-asset 
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
+          asset_path: ./sdcard.zip
+          asset_name: mayhem_nightly_${{ steps.date.outputs.date }}_COPY_TO_SDCARD.zip
+          asset_content_type: application/zip

--- a/.github/workflows/create_nightly_release.yml
+++ b/.github/workflows/create_nightly_release.yml
@@ -55,7 +55,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: ./firmware.zip
           asset_name: mayhem_nightly_${{ steps.date.outputs.date }}_FIRMWARE.zip
           asset_content_type: application/zip
@@ -65,7 +65,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: ./sdcard.zip
           asset_name: mayhem_nightly_${{ steps.date.outputs.date }}_COPY_TO_SDCARD.zip
           asset_content_type: application/zip


### PR DESCRIPTION
This is a nightly pipeline that will automatically build and upload the firmware and SD card file as a prerelease once a day at 00:00 UTC.

This wont cost anything as you get 2000 GitHub actions minutes free every month. This build takes 8 minutes to complete which means you can run it 250 times in month. but since max there are 31 days, you wont even come close to maxing out the free minutes.

Here is a screenshot of what the release looks like:
![image](https://user-images.githubusercontent.com/4393979/161354914-a308aca4-5194-4972-96c7-ba129812a413.png)


You can view my tests over here https://github.com/jLynx/portapack-mayhem/releases