### PR TITLE
Version automation/injection

### DIFF
--- a/.github/workflows/create_nightly_release.yml
+++ b/.github/workflows/create_nightly_release.yml
@@ -15,6 +15,9 @@ jobs:
       - name: Get current date
         id: date
         run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
+      - name: Get version date
+        id: version_date
+        run: echo "::set-output name=date::n_$(date +'%y%m%d')"
       - name: Checkout 
         uses: actions/checkout@master
         with:
@@ -28,7 +31,7 @@ jobs:
       - name: Make build folder
         run: mkdir ${{ github.workspace }}/build
       - name: Run the Docker image
-        run: docker run -i -v ${{ github.workspace }}:/havoc portapack-dev
+        run: docker run -e VERSION_STRING=${{ steps.version_date.outputs.date }} -i -v ${{ github.workspace }}:/havoc portapack-dev
       - name: Create Firmware ZIP
         run: |
           zip --junk-paths firmware build/firmware/portapack-h1_h2-mayhem.bin
@@ -46,6 +49,7 @@ jobs:
           body: |
             **Nightly release - ${{ steps.date.outputs.date }}**
             This build is the latest and greatest, although may not be the most stable as this is a nightly release.
+            Version: ${{ steps.version_date.outputs.date }}
             You can find the changes in this commit ${{ github.sha }}
           draft: false
           prerelease: true

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,7 @@ if ("$ENV{EnvironmentVariableName}" STREQUAL "")
 	if (GIT_VERSION_FOUND)
 		set(VERSION "unknown")
 	else (GIT_VERSION_FOUND)
-		set(VERSION "local-${GIT_VERSION}")
+		set(VERSION "git-${GIT_VERSION}")
 	endif (GIT_VERSION_FOUND)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,8 +25,8 @@ set(CMAKE_TOOLCHAIN_FILE ${CMAKE_CURRENT_LIST_DIR}/firmware/toolchain-arm-cortex
 
 project(portapack-h1)
 
-#set(VERSION "")
-if (NOT DEFINED VERSION)
+set(VERSION "$ENV{VERSION_STRING}")
+if ("$ENV{EnvironmentVariableName}" STREQUAL "")
 	execute_process(
 		COMMAND git log -n 1 --format=%h
 		WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,7 @@ if ("$ENV{EnvironmentVariableName}" STREQUAL "")
 	if (GIT_VERSION_FOUND)
 		set(VERSION "unknown")
 	else (GIT_VERSION_FOUND)
-		set(VERSION "git-${GIT_VERSION}")
+		set(VERSION "${GIT_VERSION}")
 	endif (GIT_VERSION_FOUND)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ set(CMAKE_TOOLCHAIN_FILE ${CMAKE_CURRENT_LIST_DIR}/firmware/toolchain-arm-cortex
 project(portapack-h1)
 
 set(VERSION "$ENV{VERSION_STRING}")
-if ("$ENV{EnvironmentVariableName}" STREQUAL "")
+if ("$ENV{VERSION_STRING}" STREQUAL "")
 	execute_process(
 		COMMAND git log -n 1 --format=%h
 		WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}

--- a/firmware/application/ui_navigation.hpp
+++ b/firmware/application/ui_navigation.hpp
@@ -190,7 +190,7 @@ namespace ui
 		void on_speaker();
 		void on_stealth();
 		void on_bias_tee();
-		//void on_textentry();
+		// void on_textentry();
 		void on_camera();
 		void on_title();
 		void refresh();
@@ -212,7 +212,7 @@ namespace ui
 		void refresh();
 
 	private:
-		// static constexpr auto version_string = "v1.4.4";
+		// static constexpr auto version_string = "v1.4.4"; // This is commented out as we are now setting the version via ENV (VERSION_STRING=v1.0.0)
 		NavigationView &nav_;
 
 		Rectangle backdrop{

--- a/firmware/application/ui_navigation.hpp
+++ b/firmware/application/ui_navigation.hpp
@@ -212,7 +212,7 @@ namespace ui
 		void refresh();
 
 	private:
-		static constexpr auto version_string = "v1.4.4";
+		// static constexpr auto version_string = "v1.4.4";
 		NavigationView &nav_;
 
 		Rectangle backdrop{
@@ -221,7 +221,7 @@ namespace ui
 
 		Text version{
 			{2, 0, 11 * 8, 16},
-			version_string};
+			VERSION_STRING};
 
 		LiveDateTime ltime{
 			{86, 0, 19 * 8, 16}};


### PR DESCRIPTION
When you build the firmware, you can now pass in the version number with the ENV `VERSION_STRING`. e.g `docker run -e VERSION_STRING=n1.0.0 -it -v ~/portapack-mayhem:/havoc portapack-dev`
![SCR_0015](https://user-images.githubusercontent.com/4393979/161400991-5c4dbbcf-3446-487c-b468-d31f2ab8da89.PNG) 
_(Above: Injected version number)_

![SCR_0016](https://user-images.githubusercontent.com/4393979/161401106-8814b2a6-9777-4201-8a66-593dd8acc990.PNG)
_(Above: git short hash as no version was injected)_



Benefits: 

- The reasons for this is that the version string is now no longer hardcoded into the code and can be injected at build time making it easier to maintain without requiring another commit to update it.
- Nightly builds can use a specific nightly version number, so instead of v1.4.4 it could be something like n1.4.4.
- When built without a version number, it will default to the commit short hash making it easier to track exactly what is in that version. This is useful when building locally.

Nightly release now contains the version number 
![image](https://user-images.githubusercontent.com/4393979/161401971-399c99f5-4343-4ec2-ac01-b22877496e35.png)



ToDo: (Before we merge this PR)
- Update nightly build script to inject build number - DONE

@eried message me on Discord before we merge this please :) 
