### PR TITLE
Stops duplicate nightly builds

### DIFF
--- a/.github/workflows/create_nightly_release.yml
+++ b/.github/workflows/create_nightly_release.yml
@@ -1,5 +1,3 @@
-# ToDo: only trigger after 24 hours if there are actually changes: https://github.community/t/trigger-action-on-schedule-only-if-there-are-changes-to-the-branch/17887/4
-
 name: Nightly Release
 
 on:
@@ -9,12 +7,31 @@ on:
   workflow_dispatch:
 
 jobs:
+  check_date:
+    runs-on: ubuntu-latest
+    name: Check latest commit
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: print latest_commit
+        run: echo ${{ github.sha }}
+
+      - name: check latest commit is less than a day
+        id: should_run
+        continue-on-error: true
+        run: test -z $(git rev-list  --after="24 hours" ${{ github.sha }}) && echo "::set-output name=should_run::false"
   build:
+    needs: check_date
+    if: ${{ needs.check_date.outputs.should_run != 'false' }}
     runs-on: ubuntu-latest
     steps:
       - name: Get current date
         id: date
         run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
+      - name: Get version date
+        id: version_date
+        run: echo "::set-output name=date::n_$(date +'%y%m%d')"
       - name: Checkout 
         uses: actions/checkout@master
         with:
@@ -28,7 +45,7 @@ jobs:
       - name: Make build folder
         run: mkdir ${{ github.workspace }}/build
       - name: Run the Docker image
-        run: docker run -i -v ${{ github.workspace }}:/havoc portapack-dev
+        run: docker run -e VERSION_STRING=${{ steps.version_date.outputs.date }} -i -v ${{ github.workspace }}:/havoc portapack-dev
       - name: Create Firmware ZIP
         run: |
           zip --junk-paths firmware build/firmware/portapack-h1_h2-mayhem.bin
@@ -46,6 +63,7 @@ jobs:
           body: |
             **Nightly release - ${{ steps.date.outputs.date }}**
             This build is the latest and greatest, although may not be the most stable as this is a nightly release.
+            Version: ${{ steps.version_date.outputs.date }}
             You can find the changes in this commit ${{ github.sha }}
           draft: false
           prerelease: true
@@ -57,7 +75,7 @@ jobs:
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: ./firmware.zip
-          asset_name: mayhem_nightly_${{ steps.date.outputs.date }}_FIRMWARE.zip
+          asset_name: mayhem_nightly_${{ steps.version_date.outputs.date }}_FIRMWARE.zip
           asset_content_type: application/zip
       - name: Upload SD Card Assets
         id: upload-sd-card-asset 


### PR DESCRIPTION
**Please only merge this after merging https://github.com/eried/portapack-mayhem/pull/529**

The update here means that nightlys wont run if no changes in the last 24 hours. This will stop duplicate nightly builds if no changes has been made between them