### PR TITLE
Added changelog to release notes

### DIFF
--- a/.github/workflows/create_nightly_release.yml
+++ b/.github/workflows/create_nightly_release.yml
@@ -1,5 +1,3 @@
-# ToDo: only trigger after 24 hours if there are actually changes: https://github.community/t/trigger-action-on-schedule-only-if-there-are-changes-to-the-branch/17887/4
-
 name: Nightly Release
 
 on:
@@ -9,15 +7,35 @@ on:
   workflow_dispatch:
 
 jobs:
+  check_date:
+    runs-on: ubuntu-latest
+    name: Check latest commit
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: print latest_commit
+        run: echo ${{ github.sha }}
+
+      - name: check latest commit is less than a day
+        id: should_run
+        continue-on-error: true
+        run: test -z $(git rev-list  --after="24 hours" ${{ github.sha }}) && echo "::set-output name=should_run::false"
   build:
+    needs: check_date
+    if: ${{ needs.check_date.outputs.should_run != 'false' }}
     runs-on: ubuntu-latest
     steps:
       - name: Get current date
         id: date
         run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
+      - name: Get version date
+        id: version_date
+        run: echo "::set-output name=date::n_$(date +'%y%m%d')"
       - name: Checkout 
         uses: actions/checkout@master
         with:
+          fetch-depth: 0
           ref: next
           submodules: true
       - name: Git Sumbodule Update
@@ -28,13 +46,21 @@ jobs:
       - name: Make build folder
         run: mkdir ${{ github.workspace }}/build
       - name: Run the Docker image
-        run: docker run -i -v ${{ github.workspace }}:/havoc portapack-dev
+        run: docker run -e VERSION_STRING=${{ steps.version_date.outputs.date }} -i -v ${{ github.workspace }}:/havoc portapack-dev
       - name: Create Firmware ZIP
         run: |
           zip --junk-paths firmware build/firmware/portapack-h1_h2-mayhem.bin
       - name: Create SD Card ZIP
         run: |
           zip -r sdcard.zip sdcard
+      - name: Create changelog
+        run: |
+          CHANGELOG=$(git log next --since="24 hours" --pretty=format:"- %h - @%an: %s")
+          CHANGELOG="${CHANGELOG//'%'/'%25'}"
+          CHANGELOG="${CHANGELOG//$'\n'/'%0A'}"
+          CHANGELOG="${CHANGELOG//$'\r'/'%0D'}"
+          echo "::set-output name=content::$CHANGELOG"
+        id: changelog
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1
@@ -42,11 +68,13 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: nightly-tag-${{ steps.date.outputs.date }}
-          release_name: Nightly-release - ${{ steps.date.outputs.date }}
+          release_name: Nightly Release - ${{ steps.date.outputs.date }}
           body: |
             **Nightly release - ${{ steps.date.outputs.date }}**
             This build is the latest and greatest, although may not be the most stable as this is a nightly release.
-            You can find the changes in this commit ${{ github.sha }}
+            ## Release notes
+            ###  Revision (${{ steps.version_date.outputs.date }}):
+            ${{ steps.changelog.outputs.content }}
           draft: false
           prerelease: true
       - name: Upload Firmware Asset
@@ -57,7 +85,7 @@ jobs:
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: ./firmware.zip
-          asset_name: mayhem_nightly_${{ steps.date.outputs.date }}_FIRMWARE.zip
+          asset_name: mayhem_nightly_${{ steps.version_date.outputs.date }}_FIRMWARE.zip
           asset_content_type: application/zip
       - name: Upload SD Card Assets
         id: upload-sd-card-asset 

--- a/.github/workflows/create_nightly_release.yml
+++ b/.github/workflows/create_nightly_release.yml
@@ -95,5 +95,5 @@ jobs:
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: ./sdcard.zip
-          asset_name: mayhem_nightly_${{ steps.date.outputs.date }}_COPY_TO_SDCARD.zip
+          asset_name: mayhem_nightly_${{ steps.version_date.outputs.date }}_COPY_TO_SDCARD.zip
           asset_content_type: application/zip


### PR DESCRIPTION
**_This is to only be merged in once https://github.com/eried/portapack-mayhem/pull/529 & https://github.com/eried/portapack-mayhem/pull/530 are merged_** 

This pipeline change will automatically add a changelog to the nightly builds. Below is a screenshot of one it generated 
![image](https://user-images.githubusercontent.com/4393979/161420589-a53f62af-bb88-41b3-93dd-3ec59925ad48.png)
