### PR TITLE
Fixed R1_20150901 vs R2_20170522 boot & detection issues

### DIFF
--- a/firmware/application/main.cpp
+++ b/firmware/application/main.cpp
@@ -169,7 +169,7 @@ int main(void) {
 
 		sdcStart(&SDCD1, nullptr);
 
-		controls_init();
+		// controls_init(); // Commented out as now happens in portapack.cpp
 		lcd_frame_sync_configure();
 		rtc_interrupt_enable();
 

--- a/firmware/application/portapack.cpp
+++ b/firmware/application/portapack.cpp
@@ -179,18 +179,24 @@ static PortaPackModel portapack_model() {
 	static Optional<PortaPackModel> model;
 
 	if( !model.is_valid() ) {
-		if( audio_codec_wm8731.detected() ) {
-			model = PortaPackModel::R1_20150901;
+		if( audio_codec_wm8731.detected() && audio_codec_ak4951.detected()) {
+			model = PortaPackModel::R2_20170522; // H2+
+		} else if( audio_codec_wm8731.detected() ) {
+			model = PortaPackModel::R1_20150901; // H1R1
 		} else {
-			model = PortaPackModel::R2_20170522;
+			model = PortaPackModel::R2_20170522; // H1R2
 		}
 	}
 
 	return model.value();
 }
 
+//audio_codec_wm8731 = H1R1 & H2
+//audio_codec_ak4951 = H1R2 (China/mine)
+
 static audio::Codec* portapack_audio_codec() {
 	/* I2C ready OK, Automatic recognition of audio chip */
+	// return static_cast<audio::Codec*>(&audio_codec_wm8731);
 	return (audio_codec_wm8731.detected())
 		? static_cast<audio::Codec*>(&audio_codec_wm8731)
 		: static_cast<audio::Codec*>(&audio_codec_ak4951)

--- a/firmware/application/portapack.cpp
+++ b/firmware/application/portapack.cpp
@@ -203,19 +203,28 @@ static audio::Codec* portapack_audio_codec() {
 }
 
 static const portapack::cpld::Config& portapack_cpld_config() {
-
 	const auto switches_state = get_switches_state();
 	if (switches_state[(size_t)ui::KeyEvent::Up]){
-		return portapack::cpld::rev_20150901::config;
-	}
-	if (switches_state[(size_t)ui::KeyEvent::Down]){
+		persistent_memory::set_config_cpld(1);
 		return portapack::cpld::rev_20170522::config;
 	}
+	if (switches_state[(size_t)ui::KeyEvent::Down]){
+		persistent_memory::set_config_cpld(2);
+		return portapack::cpld::rev_20150901::config;
+	}
+	if (switches_state[(size_t)ui::KeyEvent::Select]){
+		persistent_memory::set_config_cpld(0);
+	}
+	
 
+	if (portapack::persistent_memory::config_cpld() == 1) {
+		return portapack::cpld::rev_20170522::config;
+	} else if (portapack::persistent_memory::config_cpld() == 2) {
+		return portapack::cpld::rev_20150901::config;
+	}
 	return (portapack_model() == PortaPackModel::R2_20170522)
-		? portapack::cpld::rev_20170522::config
-		: portapack::cpld::rev_20150901::config
-		;
+			? portapack::cpld::rev_20170522::config
+			: portapack::cpld::rev_20150901::config;
 }
 
 Backlight* backlight() {

--- a/firmware/application/portapack.cpp
+++ b/firmware/application/portapack.cpp
@@ -179,8 +179,6 @@ static PortaPackModel portapack_model() {
 	static Optional<PortaPackModel> model;
 
 	if( !model.is_valid() ) {
-		/*For the time being, it is impossible to distinguish the hardware of R1 and R2 from the software level*/
-		/*At this point, I2c is not ready.*/
 		if( audio_codec_wm8731.detected() ) {
 			model = PortaPackModel::R1_20150901;
 		} else {

--- a/firmware/application/portapack.cpp
+++ b/firmware/application/portapack.cpp
@@ -186,19 +186,12 @@ static PortaPackModel portapack_model() {
 		} else {
 			model = PortaPackModel::R2_20170522;
 		}
-
-		// model = PortaPackModel::R1_20150901;
-
-		// ToDo: Do validation here to check if R2_20170522 or R1_20150901 (Gen1)
 	}
 
 	return model.value();
 }
 
 static audio::Codec* portapack_audio_codec() {
-
-	// Maybe we c ould change the model here
-
 	/* I2C ready OK, Automatic recognition of audio chip */
 	return (audio_codec_wm8731.detected())
 		? static_cast<audio::Codec*>(&audio_codec_wm8731)
@@ -207,9 +200,6 @@ static audio::Codec* portapack_audio_codec() {
 }
 
 static const portapack::cpld::Config& portapack_cpld_config() {
-	// This function here is teh decider if the device boots or not.
-
-	// return portapack::cpld::rev_20150901::config; // R1_20150901
 	return (portapack_model() == PortaPackModel::R2_20170522)
 		? portapack::cpld::rev_20170522::config
 		: portapack::cpld::rev_20150901::config
@@ -217,7 +207,6 @@ static const portapack::cpld::Config& portapack_cpld_config() {
 }
 
 Backlight* backlight() {
-	// return static_cast<portapack::Backlight*>(&backlight_on_off); // This should work for R1_20150901
 	return (portapack_model() == PortaPackModel::R2_20170522)
 		? static_cast<portapack::Backlight*>(&backlight_cat4004) // R2_20170522
 		: static_cast<portapack::Backlight*>(&backlight_on_off); // R1_20150901
@@ -329,6 +318,7 @@ bool init() {
 
 	i2c0.start(i2c_config_boot_clock);
 
+	// Keeping this here for now incase we need to revert
 	// if( !portapack::cpld::update_if_necessary(portapack_cpld_config()) ) {
 	// 	shutdown_base();
 	// 	return false;
@@ -349,7 +339,7 @@ bool init() {
 	set_clock_config(clock_config_irc);
 
 	cgu::pll1::disable();
-	
+
 	/* Incantation from LPC43xx UM10503 section 12.2.1.1, to bring the M4
 	 * core clock speed to the 110 - 204MHz range.
 	 */

--- a/firmware/application/portapack.cpp
+++ b/firmware/application/portapack.cpp
@@ -191,12 +191,11 @@ static PortaPackModel portapack_model() {
 	return model.value();
 }
 
-//audio_codec_wm8731 = H1R1 & H2
-//audio_codec_ak4951 = H1R2 (China/mine)
+//audio_codec_wm8731 = H1R1 & H2+
+//audio_codec_ak4951 = H1R2
 
 static audio::Codec* portapack_audio_codec() {
 	/* I2C ready OK, Automatic recognition of audio chip */
-	// return static_cast<audio::Codec*>(&audio_codec_wm8731);
 	return (audio_codec_wm8731.detected())
 		? static_cast<audio::Codec*>(&audio_codec_wm8731)
 		: static_cast<audio::Codec*>(&audio_codec_ak4951)

--- a/firmware/common/ak4951.cpp
+++ b/firmware/common/ak4951.cpp
@@ -115,6 +115,10 @@ void AK4951::init() {
 	// update(Register::DigitalFilterMode);
 }
 
+bool AK4951::detected() {
+	return reset();
+}
+
 bool AK4951::reset() {
 	io.audio_reset_state(true);
 

--- a/firmware/common/ak4951.hpp
+++ b/firmware/common/ak4951.hpp
@@ -823,6 +823,8 @@ public:
 	std::string name() const override {
 		return "AK4951";
 	}
+
+	bool detected();
 	
 	void init() override;
 	bool reset() override;

--- a/firmware/common/portapack_persistent_memory.cpp
+++ b/firmware/common/portapack_persistent_memory.cpp
@@ -82,6 +82,9 @@ struct data_t {
 	int32_t afsk_space_freq;
 	int32_t modem_baudrate;
 	int32_t modem_repeat;
+
+	// Hardware
+	uint32_t hardware_config;
 	
 	// Play dead unlock
 	uint32_t playdead_magic;
@@ -254,6 +257,10 @@ bool config_splash() {
 	return data->ui_config & (1 << 31);
 }
 
+uint8_t config_cpld() {
+	return data->hardware_config;
+}
+
 uint32_t config_backlight_timer() {
 	const uint32_t timer_seconds[8] = { 0, 5, 15, 30, 60, 180, 300, 600 };
 	return timer_seconds[data->ui_config & 7]; //first three bits, 8 possible values
@@ -285,6 +292,10 @@ void set_config_login(bool v) {
 
 void set_config_splash(bool v) {
 	data->ui_config = (data->ui_config & ~(1 << 31)) | (v << 31);
+}
+
+void set_config_cpld(uint8_t i) {
+	data->hardware_config = i;
 }
 
 void set_config_backlight_timer(uint32_t i) {

--- a/firmware/common/portapack_persistent_memory.hpp
+++ b/firmware/common/portapack_persistent_memory.hpp
@@ -74,6 +74,9 @@ void set_playdead_sequence(const uint32_t new_value);
 bool stealth_mode();
 void set_stealth_mode(const bool v);
 
+uint8_t config_cpld();
+void set_config_cpld(uint8_t i);
+
 bool config_splash();
 bool hide_clock();
 bool clock_with_date();


### PR DESCRIPTION
Fixed issues when the R1 devices wont boot. Tested on R1 (R1_20150901) and R2 (R2_20170522) devices

Fixes: https://github.com/eried/portapack-mayhem/issues/346 and https://github.com/eried/portapack-mayhem/pull/439