### PR TITLE
2021/12 QFP100 fix

### DIFF
--- a/firmware/application/portapack.cpp
+++ b/firmware/application/portapack.cpp
@@ -212,6 +212,9 @@ static const portapack::cpld::Config& portapack_cpld_config() {
 		persistent_memory::set_config_cpld(2);
 		return portapack::cpld::rev_20150901::config;
 	}
+	if (switches_state[(size_t)ui::KeyEvent::Left]){
+		persistent_memory::set_config_cpld(3);
+	}
 	if (switches_state[(size_t)ui::KeyEvent::Select]){
 		persistent_memory::set_config_cpld(0);
 	}
@@ -415,9 +418,8 @@ bool init() {
 	audio::init(portapack_audio_codec());
 
 	if( !portapack::cpld::update_if_necessary(portapack_cpld_config()) ) {
-		const auto switches_state = get_switches_state();
 		// If using a "2021/12 QFP100", press and hold the left button while booting. Should only need to do once.
-		if (!switches_state[(size_t)ui::KeyEvent::Left]){
+		if (portapack::persistent_memory::config_cpld() != 3){
 			shutdown_base();
 			return false;
 		}

--- a/firmware/application/portapack.cpp
+++ b/firmware/application/portapack.cpp
@@ -228,6 +228,11 @@ static const portapack::cpld::Config& portapack_cpld_config() {
 }
 
 Backlight* backlight() {
+	// if (portapack::persistent_memory::config_cpld() == 1) {
+	// 	return static_cast<portapack::Backlight*>(&backlight_cat4004);
+	// } else if (portapack::persistent_memory::config_cpld() == 2) {
+	// 	return static_cast<portapack::Backlight*>(&backlight_on_off);
+	// }
 	return (portapack_model() == PortaPackModel::R2_20170522)
 		? static_cast<portapack::Backlight*>(&backlight_cat4004) // R2_20170522
 		: static_cast<portapack::Backlight*>(&backlight_on_off); // R1_20150901
@@ -415,8 +420,12 @@ bool init() {
 	audio::init(portapack_audio_codec());
 
 	if( !portapack::cpld::update_if_necessary(portapack_cpld_config()) ) {
-		shutdown_base();
-		return false;
+		const auto switches_state = get_switches_state();
+		// If using a "2021/12 QFP100", press and hold the left button while booting. Should only need to do once.
+		if (!switches_state[(size_t)ui::KeyEvent::Left]){
+			shutdown_base();
+			return false;
+		}
 	}
 
 	if( !hackrf::cpld::load_sram() ) {

--- a/firmware/application/portapack.cpp
+++ b/firmware/application/portapack.cpp
@@ -228,11 +228,6 @@ static const portapack::cpld::Config& portapack_cpld_config() {
 }
 
 Backlight* backlight() {
-	// if (portapack::persistent_memory::config_cpld() == 1) {
-	// 	return static_cast<portapack::Backlight*>(&backlight_cat4004);
-	// } else if (portapack::persistent_memory::config_cpld() == 2) {
-	// 	return static_cast<portapack::Backlight*>(&backlight_on_off);
-	// }
 	return (portapack_model() == PortaPackModel::R2_20170522)
 		? static_cast<portapack::Backlight*>(&backlight_cat4004) // R2_20170522
 		: static_cast<portapack::Backlight*>(&backlight_on_off); // R1_20150901


### PR DESCRIPTION
Is your device has a black screen you will need to hold down the left button on first boot. Then you wont need to hold it down again.

I have updated the wiki here https://github.com/eried/portapack-mayhem/wiki/Won't-boot