### PR TITLE
Fixed broken radio offset

### DIFF
--- a/firmware/application/portapack.cpp
+++ b/firmware/application/portapack.cpp
@@ -181,11 +181,12 @@ static PortaPackModel portapack_model() {
 	static Optional<PortaPackModel> model;
 
 	if( !model.is_valid() ) {
-		if( audio_codec_wm8731.detected() ) {
-			model = PortaPackModel::R1_20150901; // H1R1
-		} else {
-			model = PortaPackModel::R2_20170522; // H1R2, H2+
-		}
+		// if( audio_codec_wm8731.detected() ) {
+		// 	model = PortaPackModel::R1_20150901; // H1R1
+		// } else {
+		// 	model = PortaPackModel::R2_20170522; // H1R2, H2+
+		// }
+		model = PortaPackModel::R2_20170522;
 	}
 
 	return model.value();
@@ -361,7 +362,6 @@ bool init() {
 	i2c0.stop();
 
 	set_clock_config(clock_config_irc);
-
 	cgu::pll1::disable();
 
 	/* Incantation from LPC43xx UM10503 section 12.2.1.1, to bring the M4
@@ -410,12 +410,6 @@ bool init() {
 	clock_manager.enable_second_if_clock();
 	clock_manager.enable_codec_clocks();
 	radio::init();	
-	
-
-	LPC_CREG->DMAMUX = portapack::gpdma_mux;
-	gpdma::controller.enable();
-
-	audio::init(portapack_audio_codec());
 
 	if( !portapack::cpld::update_if_necessary(portapack_cpld_config()) ) {
 		// If using a "2021/12 QFP100", press and hold the left button while booting. Should only need to do once.
@@ -428,6 +422,11 @@ bool init() {
 	if( !hackrf::cpld::load_sram() ) {
 		chSysHalt();
 	}
+
+	LPC_CREG->DMAMUX = portapack::gpdma_mux;
+	gpdma::controller.enable();
+
+	audio::init(portapack_audio_codec());
 
 	return true;
 }

--- a/firmware/application/portapack.cpp
+++ b/firmware/application/portapack.cpp
@@ -181,12 +181,11 @@ static PortaPackModel portapack_model() {
 	static Optional<PortaPackModel> model;
 
 	if( !model.is_valid() ) {
-		// if( audio_codec_wm8731.detected() ) {
-		// 	model = PortaPackModel::R1_20150901; // H1R1
-		// } else {
-		// 	model = PortaPackModel::R2_20170522; // H1R2, H2+
-		// }
-		model = PortaPackModel::R2_20170522;
+		if( audio_codec_wm8731.detected() ) {
+			model = PortaPackModel::R1_20150901; // H1R1
+		} else {
+			model = PortaPackModel::R2_20170522; // H1R2, H2+
+		}
 	}
 
 	return model.value();

--- a/firmware/common/portapack_persistent_memory.cpp
+++ b/firmware/common/portapack_persistent_memory.cpp
@@ -83,9 +83,6 @@ struct data_t {
 	int32_t modem_baudrate;
 	int32_t modem_repeat;
 
-	// Hardware
-	uint32_t hardware_config;
-	
 	// Play dead unlock
 	uint32_t playdead_magic;
 	uint32_t playing_dead;
@@ -98,6 +95,9 @@ struct data_t {
 	uint32_t pocsag_ignore_address;
 	
 	int32_t tone_mix;
+
+	// Hardware
+	uint32_t hardware_config;
 };
 
 static_assert(sizeof(data_t) <= backup_ram.size(), "Persistent memory structure too large for VBAT-maintained region");


### PR DESCRIPTION
I noticed the 1.5.0 update broke FM radio and possibly other stuff. This update fixes that