### PR TITLE
Quick fix (as figures out by @bluegizmo83) to make sure WM8731S chips…

### DIFF
--- a/firmware/application/apps/ui_scanner.cpp
+++ b/firmware/application/apps/ui_scanner.cpp
@@ -484,6 +484,7 @@ void ScannerView::scan_pause() {
 		scan_thread->set_freq_lock(0); 		//Reset the scanner lock (because user paused, or MAX_FREQ_LOCK reached) for next freq scan	
 		scan_thread->set_scanning(false); // WE STOP SCANNING
 		audio::output::start();
+		on_headphone_volume_changed(field_volume.value()); // quick fix to make sure WM8731S chips don't stay silent after pause
 	}
 }
 


### PR DESCRIPTION
Quick fix (as figures out by @bluegizmo83) to make sure WM8731S chips don't stay silent after resuming after pause in scanner app.
See #462 for description of issue.

