### PR TITLE
SD card backup storage

### DIFF
--- a/firmware/application/event_m0.cpp
+++ b/firmware/application/event_m0.cpp
@@ -222,7 +222,7 @@ void EventDispatcher::handle_local_queue() {
 }
 
 void EventDispatcher::handle_rtc_tick() {
-	// sd_card::poll_inserted();
+	sd_card::poll_inserted();
 
 	portapack::temperature_logger.second_tick();
 	

--- a/firmware/application/event_m0.cpp
+++ b/firmware/application/event_m0.cpp
@@ -222,7 +222,7 @@ void EventDispatcher::handle_local_queue() {
 }
 
 void EventDispatcher::handle_rtc_tick() {
-	sd_card::poll_inserted();
+	// sd_card::poll_inserted();
 
 	portapack::temperature_logger.second_tick();
 	

--- a/firmware/application/main.cpp
+++ b/firmware/application/main.cpp
@@ -137,6 +137,7 @@ Continuous (Fox-oring)
 
 #include "gcc.hpp"
 
+#include "file.hpp" 
 #include "sd_card.hpp"
 
 #include <string.h>
@@ -167,13 +168,24 @@ int main(void) {
 	if( portapack::init() ) {
 		portapack::display.init();
 
-		sdcStart(&SDCD1, nullptr);
+		// sdcStart(&SDCD1, nullptr);
+
+		// sd_card::poll_inserted();
 
 		// controls_init(); // Commented out as now happens in portapack.cpp
 		lcd_frame_sync_configure();
 		rtc_interrupt_enable();
 
 		event_loop();
+
+		// if(sd_card::status() == sd_card::Status::Mounted){
+		// 	make_new_directory("/2hardware"); 
+		// 	File file;                                                                     // Create File object
+		// 	auto sucess = file.append("/2hardware/1atest.txt");                         // Open file
+		// 	if(!sucess.is_valid()) {                                                       // 0 is success
+		// 		file.write_line("My Test string");
+		// 	}
+		// }
 
 		sdcDisconnect(&SDCD1);
 		sdcStop(&SDCD1);

--- a/firmware/application/main.cpp
+++ b/firmware/application/main.cpp
@@ -137,7 +137,6 @@ Continuous (Fox-oring)
 
 #include "gcc.hpp"
 
-#include "file.hpp" 
 #include "sd_card.hpp"
 
 #include <string.h>
@@ -168,9 +167,7 @@ int main(void) {
 	if( portapack::init() ) {
 		portapack::display.init();
 
-		// sdcStart(&SDCD1, nullptr);
-
-		// sd_card::poll_inserted();
+		// sdcStart(&SDCD1, nullptr); // Commented out as now happens in portapack.cpp
 
 		// controls_init(); // Commented out as now happens in portapack.cpp
 		lcd_frame_sync_configure();
@@ -178,14 +175,6 @@ int main(void) {
 
 		event_loop();
 
-		// if(sd_card::status() == sd_card::Status::Mounted){
-		// 	make_new_directory("/2hardware"); 
-		// 	File file;                                                                     // Create File object
-		// 	auto sucess = file.append("/2hardware/1atest.txt");                         // Open file
-		// 	if(!sucess.is_valid()) {                                                       // 0 is success
-		// 		file.write_line("My Test string");
-		// 	}
-		// }
 
 		sdcDisconnect(&SDCD1);
 		sdcStop(&SDCD1);

--- a/firmware/application/portapack.cpp
+++ b/firmware/application/portapack.cpp
@@ -50,6 +50,7 @@ using asahi_kasei::ak4951::AK4951;
 
 #include "file.hpp" 
 #include "sd_card.hpp"
+#include "string_format.hpp"
 
 namespace portapack {
 
@@ -180,6 +181,49 @@ enum class PortaPackModel {
 	R2_20170522,
 };
 
+static bool save_config(int8_t value){
+	persistent_memory::set_config_cpld(value);
+	if(sd_card::status() == sd_card::Status::Mounted){
+		make_new_directory("/hardware"); 
+		File file;
+		auto sucess = file.create("/hardware/settings.txt");
+		if(!sucess.is_valid()) {
+			file.write_line(to_string_dec_uint(value));
+		}
+	}
+	return true;
+}
+
+int read_file(std::string name) {
+	std::string return_string = "";
+    File file;
+    auto success = file.open(name);
+
+    if(!success.is_valid()) {
+        char one_char[1];
+        for(size_t pointer = 0; pointer < file.size() ; pointer++) {
+            file.seek(pointer);
+            file.read(one_char, 1);
+            return_string += one_char[0];
+        }
+		return std::stoi(return_string);
+    } 
+	return -1; 
+}
+
+static int load_config(){
+	int8_t value = portapack::persistent_memory::config_cpld();
+	if(value == 0){
+		if(sd_card::status() == sd_card::Status::Mounted){
+			int data = read_file("/hardware/settings.txt");
+			if(data != -1) {
+				return data;
+			}
+		}
+	}
+	return value;
+}
+
 static PortaPackModel portapack_model() {
 	static Optional<PortaPackModel> model;
 
@@ -208,33 +252,33 @@ static audio::Codec* portapack_audio_codec() {
 static const portapack::cpld::Config& portapack_cpld_config() {
 	const auto switches_state = get_switches_state();
 	if (switches_state[(size_t)ui::KeyEvent::Up]){
-		persistent_memory::set_config_cpld(1);
+		save_config(1);
 		return portapack::cpld::rev_20170522::config;
 	}
 	if (switches_state[(size_t)ui::KeyEvent::Down]){
-		persistent_memory::set_config_cpld(2);
+		save_config(2);
 		return portapack::cpld::rev_20150901::config;
 	}
 	if (switches_state[(size_t)ui::KeyEvent::Left]){
-		persistent_memory::set_config_cpld(3);
+		save_config(3);
 	}
 	if (switches_state[(size_t)ui::KeyEvent::Select]){
-		persistent_memory::set_config_cpld(0);
+		save_config(0);
 	}
 
-	if(sd_card::status() == sd_card::Status::Mounted){
-		make_new_directory("/hardware"); 
-		File file;
-		auto sucess = file.append("/hardware/settings.txt");
-		if(!sucess.is_valid()) {
-			file.write_line("Some settings data to show here");
-		}
-	}
+	// if(sd_card::status() == sd_card::Status::Mounted){
+	// 	make_new_directory("/hardware"); 
+	// 	File file;
+	// 	auto sucess = file.create("/hardware/settings.txt");
+	// 	if(!sucess.is_valid()) {
+	// 		file.write_line("Some settings data to show here");
+	// 	}
+	// }
 	
 
-	if (portapack::persistent_memory::config_cpld() == 1) {
+	if (load_config() == 1) {
 		return portapack::cpld::rev_20170522::config;
-	} else if (portapack::persistent_memory::config_cpld() == 2) {
+	} else if (load_config() == 2) {
 		return portapack::cpld::rev_20150901::config;
 	}
 	return (portapack_model() == PortaPackModel::R2_20170522)
@@ -434,7 +478,7 @@ bool init() {
 		 * But for some reason the persistent_memory check fails on some devices if we dont have the extra check in....
 		 * So dont ask me why that is, but we have to keep this redundant check in for the persistent_memory check to work.
 		 */
-		if (!switches_state[(size_t)ui::KeyEvent::Left] && portapack::persistent_memory::config_cpld() != 3){
+		if (!switches_state[(size_t)ui::KeyEvent::Left] && load_config() != 3){
 			shutdown_base();
 			return false;
 		}

--- a/firmware/application/portapack.cpp
+++ b/firmware/application/portapack.cpp
@@ -265,15 +265,6 @@ static const portapack::cpld::Config& portapack_cpld_config() {
 	if (switches_state[(size_t)ui::KeyEvent::Select]){
 		save_config(0);
 	}
-
-	// if(sd_card::status() == sd_card::Status::Mounted){
-	// 	make_new_directory("/hardware"); 
-	// 	File file;
-	// 	auto sucess = file.create("/hardware/settings.txt");
-	// 	if(!sucess.is_valid()) {
-	// 		file.write_line("Some settings data to show here");
-	// 	}
-	// }
 	
 
 	if (load_config() == 1) {

--- a/firmware/application/portapack.cpp
+++ b/firmware/application/portapack.cpp
@@ -213,12 +213,10 @@ int read_file(std::string name) {
 
 static int load_config(){
 	int8_t value = portapack::persistent_memory::config_cpld();
-	if(value == 0){
-		if(sd_card::status() == sd_card::Status::Mounted){
-			int data = read_file("/hardware/settings.txt");
-			if(data != -1) {
-				return data;
-			}
+	if(value == 0 && sd_card::status() == sd_card::Status::Mounted){
+		int data = read_file("/hardware/settings.txt");
+		if(data != -1) {
+			return data;
 		}
 	}
 	return value;

--- a/firmware/application/portapack.cpp
+++ b/firmware/application/portapack.cpp
@@ -196,18 +196,18 @@ static bool save_config(int8_t value){
 
 int read_file(std::string name) {
 	std::string return_string = "";
-    File file;
-    auto success = file.open(name);
+	File file;
+	auto success = file.open(name);
 
-    if(!success.is_valid()) {
-        char one_char[1];
-        for(size_t pointer = 0; pointer < file.size() ; pointer++) {
-            file.seek(pointer);
-            file.read(one_char, 1);
-            return_string += one_char[0];
-        }
+	if(!success.is_valid()) {
+		char one_char[1];
+		for(size_t pointer = 0; pointer < file.size() ; pointer++) {
+			file.seek(pointer);
+			file.read(one_char, 1);
+			return_string += one_char[0];
+		}
 		return std::stoi(return_string);
-    } 
+	} 
 	return -1; 
 }
 


### PR DESCRIPTION
Saving the boot config as a backup storage location if the user does not have an RTC battery. This is based off of the suggestion here https://github.com/eried/portapack-mayhem/issues/552

Tries to load config from persistent memory. If there is no config found or the value is 0, only then does it attempt to load from the SD card.

This way if the user doesn't have an RTC battery, then the value will always be 0 on boot meaning it loads from the SD card.

When saving a config it will write it both to persistent memory and to the micro SD card