### PR TITLE
Fixed warning: comparison of integer expressions of different signedness

### DIFF
--- a/firmware/baseband/dsp_hilbert.hpp
+++ b/firmware/baseband/dsp_hilbert.hpp
@@ -35,8 +35,8 @@ public:
 
 private:
 	uint8_t			n = 0;
-	SOSFilter<5>	sos_i;
-	SOSFilter<5>	sos_q;
+	SOSFilter<5>	sos_i = {};
+	SOSFilter<5>	sos_q = {};
 };
 
 } /* namespace dsp */

--- a/firmware/common/acars_packet.cpp
+++ b/firmware/common/acars_packet.cpp
@@ -84,7 +84,7 @@ bool Packet::crc_ok() const {
 		acars_fcs.process_byte(field_crc.read(i, 8));
 	}
 
-	return (acars_fcs.checksum() == field_crc.read(data_length(), fcs_length));
+	return (acars_fcs.checksum() == (unsigned)field_crc.read(data_length(), fcs_length));
 }
 
 size_t Packet::data_and_fcs_length() const {

--- a/firmware/common/ais_packet.cpp
+++ b/firmware/common/ais_packet.cpp
@@ -191,7 +191,7 @@ bool Packet::crc_ok() const {
 		ais_fcs.process_byte(field_crc.read(i, 8));
 	}
 
-	return (ais_fcs.checksum() == field_crc.read(data_length(), fcs_length));
+	return (ais_fcs.checksum() == (unsigned)field_crc.read(data_length(), fcs_length));
 }
 
 size_t Packet::data_and_fcs_length() const {


### PR DESCRIPTION
acars_packet , ais_packet  , dsp_hilbert warning fix