### PR TITLE
Fix for warning: comparison of integer expressions of different signedness

### DIFF
--- a/firmware/baseband/proc_adsbrx.cpp
+++ b/firmware/baseband/proc_adsbrx.cpp
@@ -120,7 +120,7 @@ void ADSBRXProcessor::execute(const buffer_c8_t& buffer) {
 			// the high levels as signals can be out of phase so part of the
 			// energy can be in the near samples
 			int32_t thisAmp = (shifter[1] + shifter[3] + shifter[8] + shifter[10]);
-			int32_t high = thisAmp / 9;
+			uint32_t high = thisAmp / 9;
 			if (
 				shifter[5] < high &&
 				shifter[6] < high &&


### PR DESCRIPTION
Fix warnings on shifter[] and high:
/opt/portapack-mayhem/firmware/baseband/proc_adsbrx.cpp:125:16: warning: comparison of integer expressions of different signedness: 'uint32_t' {aka 'long unsigned int'} and 'int32_t' {aka 'long int'} [-Wsign-compare]
  125 |     shifter[5] < high &&
      |     ~~~~~~~~~~~^~~~~~
