### PR TITLE
Fix for proc_aprsrx and aprs_packet warnings, they are related

### DIFF
--- a/firmware/baseband/proc_aprsrx.hpp
+++ b/firmware/baseband/proc_aprsrx.hpp
@@ -125,18 +125,18 @@ private:
 	uint32_t sample_bits { 0 };
 	uint32_t phase { }, phase_inc { };
 	int32_t sample_mixed { }, prev_mixed { }, sample_filtered { }, prev_filtered { };
-	uint8_t last_bit;
-	uint8_t ones_count = 0;
+	uint8_t last_bit = 0;
+	uint8_t ones_count = 0 ;
 	uint8_t current_byte = 0;
 	uint8_t byte_index = 0;
 	uint8_t packet_buffer[256];
 	size_t packet_buffer_size = 0;
 
 	bool configured { false };
-	bool wait_start { };
-	bool bit_value { };
+	bool wait_start { 0 };
+	bool bit_value { 0 };
 
-	aprs::APRSPacket aprs_packet;
+	aprs::APRSPacket aprs_packet { };
 
 	void configure(const APRSRxConfigureMessage& message);
 	void capture_config(const CaptureConfigMessage& message);

--- a/firmware/common/aprs_packet.hpp
+++ b/firmware/common/aprs_packet.hpp
@@ -259,7 +259,7 @@ private:
 	bool valid_checksum = false;
 	uint8_t payload[256];
 	char address_buffer[15];
-	uint8_t payload_size;
+	uint8_t payload_size = 0 ;
 	Timestamp timestamp_ { };
 
 	float parse_lat_str_cmp(const std::string& lat_str){


### PR DESCRIPTION
Fix for:

/opt/portapack-mayhem/firmware/baseband/proc_aprsrx.hpp: In instantiation of 'typename std::_MakeUniq<_Tp>::__single_object std::make_unique(_Args&& ...) [with _Tp = APRSRxProcessor; _Args = {}; typename std::_MakeUniq<_Tp>::__single_object = std::unique_ptr<APRSRxProcessor, std::default_delete<APRSRxProcessor> >]':
/opt/portapack-mayhem/firmware/baseband/proc_aprsrx.cpp:254:71:   required from here
/opt/portapack-mayhem/firmware/baseband/proc_aprsrx.hpp:76:7: warning: 'APRSRxProcessor::last_bit' should be initialized in the member initialization list [-Weffc++]
   76 | class APRSRxProcessor : public BasebandProcessor {
      |       ^~~~~~~~~~~~~~~
/opt/portapack-mayhem/firmware/baseband/proc_aprsrx.hpp:76:7: warning: 'APRSRxProcessor::aprs_packet' should be initialized in the member initialization list [-Weffc++]
In file included from /opt/portapack-mayhem/firmware/common/message.hpp:39,
                 from /opt/portapack-mayhem/firmware/baseband/channel_stats_collector.hpp:26,
                 from /opt/portapack-mayhem/firmware/baseband/baseband_processor.hpp:27,
                 from /opt/portapack-mayhem/firmware/baseband/proc_aprsrx.hpp:26,
                 from /opt/portapack-mayhem/firmware/baseband/proc_aprsrx.cpp:23:
/opt/portapack-mayhem/firmware/common/aprs_packet.hpp:49:7: warning: 'aprs::APRSPacket::payload_size' should be initialized in the member initialization list [-Weffc++]
