### PR TITLE
Fix for warning: narrowing conversion

### DIFF
--- a/firmware/common/tpms_packet.cpp
+++ b/firmware/common/tpms_packet.cpp
@@ -40,7 +40,7 @@ Optional<Reading> Packet::reading_fsk_19k2_schrader() const {
 	case 64:
 		return Reading {
 			Reading::Type::FLM_64,
-			reader_.read(0, 32),
+			(uint32_t)reader_.read(0, 32),
 			Pressure { static_cast<int>(reader_.read(32, 8)) * 4 / 3 },
 			Temperature { static_cast<int>(reader_.read(40, 8) & 0x7f) - 56 }
 		};
@@ -48,7 +48,7 @@ Optional<Reading> Packet::reading_fsk_19k2_schrader() const {
 	case 72:
 		return Reading {
 			Reading::Type::FLM_72,
-			reader_.read(0, 32),
+			(uint32_t)reader_.read(0, 32),
 			Pressure { static_cast<int>(reader_.read(40, 8)) * 4 / 3 },
 			Temperature { static_cast<int>(reader_.read(48, 8)) - 56 }
 		};
@@ -56,7 +56,7 @@ Optional<Reading> Packet::reading_fsk_19k2_schrader() const {
 	case 80:
 		return Reading {
 			Reading::Type::FLM_80,
-			reader_.read(8, 32),
+			(uint32_t)reader_.read(8, 32),
 			Pressure { static_cast<int>(reader_.read(48, 8)) * 4 / 3 },
 			Temperature { static_cast<int>(reader_.read(56, 8)) - 56 }
 		};
@@ -85,7 +85,7 @@ Optional<Reading> Packet::reading_ook_8k192_schrader() const {
 	if( (checksum_calculated & 3) == 3 ) {
 		return Reading {
 			Reading::Type::Schrader,
-			reader_.read(3, 24),
+			(uint32_t)reader_.read(3, 24),
 			Pressure { static_cast<int>(reader_.read(27, 8)) * 4 / 3 },
 			{ },
 			Flags { static_cast<Flags>((flags << 4) | checksum) }
@@ -122,7 +122,7 @@ Optional<Reading> Packet::reading_ook_8k4_schrader() const {
 	if( checksum_calculated == checksum ) {
 		return Reading {
 			Reading::Type::GMC_96,
-			id,
+			(uint32_t)id,
 			Pressure { static_cast<int>(value_1) * 4 / 3 },
 			Temperature { static_cast<int>(value_0) - 56 }
 		};

--- a/firmware/common/tpms_packet.hpp
+++ b/firmware/common/tpms_packet.hpp
@@ -39,7 +39,7 @@ namespace tpms {
 
 using Flags = uint8_t;
 
-enum SignalType : uint32_t {
+enum SignalType {
 	FSK_19k2_Schrader = 1,
 	OOK_8k192_Schrader = 2,
 	OOK_8k4_Schrader = 3,


### PR DESCRIPTION
Removed unneeded casting , and fix for :

/opt/portapack-mayhem/firmware/common/tpms_packet.cpp:43:16: warning: narrowing conversion of '((const tpms::Packet*)this)->tpms::Packet::reader_.FieldReader<ManchesterDecoder, BitRemapNone>::read(0, 32)' from 'int32_t' {aka 'long int'} to 'uint32_t' {aka 'long unsigned int'} [-Wnarrowing]
   43 |    reader_.read(0, 32),
      |    ~~~~~~~~~~~~^~~~~~~
/opt/portapack-mayhem/firmware/common/tpms_packet.cpp:51:16: warning: narrowing conversion of '((const tpms::Packet*)this)->tpms::Packet::reader_.FieldReader<ManchesterDecoder, BitRemapNone>::read(0, 32)' from 'int32_t' {aka 'long int'} to 'uint32_t' {aka 'long unsigned int'} [-Wnarrowing]
   51 |    reader_.read(0, 32),
      |    ~~~~~~~~~~~~^~~~~~~
/opt/portapack-mayhem/firmware/common/tpms_packet.cpp:59:16: warning: narrowing conversion of '((const tpms::Packet*)this)->tpms::Packet::reader_.FieldReader<ManchesterDecoder, BitRemapNone>::read(8, 32)' from 'int32_t' {aka 'long int'} to 'uint32_t' {aka 'long unsigned int'} [-Wnarrowing]
   59 |    reader_.read(8, 32),
      |    ~~~~~~~~~~~~^~~~~~~
/opt/portapack-mayhem/firmware/common/tpms_packet.cpp: In member function 'Optional<tpms::Reading> tpms::Packet::reading_ook_8k192_schrader() const':
/opt/portapack-mayhem/firmware/common/tpms_packet.cpp:88:16: warning: narrowing conversion of '((const tpms::Packet*)this)->tpms::Packet::reader_.FieldReader<ManchesterDecoder, BitRemapNone>::read(3, 24)' from 'int32_t' {aka 'long int'} to 'uint32_t' {aka 'long unsigned int'} [-Wnarrowing]
   88 |    reader_.read(3, 24),
      |    ~~~~~~~~~~~~^~~~~~~
/opt/portapack-mayhem/firmware/common/tpms_packet.cpp: In member function 'Optional<tpms::Reading> tpms::Packet::reading_ook_8k4_schrader() const':
/opt/portapack-mayhem/firmware/common/tpms_packet.cpp:125:4: warning: narrowing conversion of '(long int)id' from 'long int' to 'uint32_t' {aka 'long unsigned int'} [-Wnarrowing]
  125 |    id,
