### PR TITLE
Fix for warning: 'MicTXProcessor::modulator' should be initialized

### DIFF
--- a/firmware/baseband/proc_mictx.hpp
+++ b/firmware/baseband/proc_mictx.hpp
@@ -51,7 +51,7 @@ private:
 	AudioInput audio_input { };
 	ToneGen tone_gen { };
 	ToneGen beep_gen { };
-	dsp::modulate::Modulator *modulator;
+	dsp::modulate::Modulator *modulator = NULL ;
 
 	bool am_enabled { false };
 	bool fm_enabled { true };


### PR DESCRIPTION
Fix for:
opt/portapack-mayhem/firmware/baseband/proc_mictx.hpp:32:7: warning: 'MicTXProcessor::modulator' should be initialized in the member initialization list [-Weffc++]
   32 | class MicTXProcessor : public BasebandProcessor 