### PR TITLE
Fix for weffc++

### DIFF
--- a/firmware/application/ui/ui_qrcode.cpp
+++ b/firmware/application/ui/ui_qrcode.cpp
@@ -43,8 +43,25 @@ QRCodeImage::QRCodeImage(
 	
 }
 
+QRCodeImage::~QRCodeImage( )
+{
+
+}
+
+QRCodeImage::QRCodeImage(const QRCodeImage&Image) : Widget { }
+{
+    (void)Image;
+}
+
+QRCodeImage & QRCodeImage::operator=(const QRCodeImage&Image)
+{
+    (void)Image;
+    return *this;
+}
+
 void QRCodeImage::paint(Painter& painter) {
 
+    (void)painter ;
 
 	// The structure to manage the QR code
 	QRCode qrcode;

--- a/firmware/application/ui/ui_qrcode.hpp
+++ b/firmware/application/ui/ui_qrcode.hpp
@@ -40,10 +40,13 @@ public:
 		qr_text_ = qr_text;
 	}
 	void paint(Painter& painter) override;
-
+                                                   // for -weffc++ to be killed
+    ~QRCodeImage();                                // destructor 
+    QRCodeImage(const QRCodeImage&Image);
+    QRCodeImage & operator=(const QRCodeImage &Image); // assignment
 
 private:
-	const char * qr_text_ ;
+	const char * qr_text_ = NULL ;
 };
 
 class QRCodeView : public View {


### PR DESCRIPTION
Fix for 

/opt/portapack-mayhem/firmware/application/ui/ui_qrcode.hpp:35:7: warning: 'class ui::QRCodeImage' has pointer data members [-Weffc++]
   35 | class QRCodeImage : public Widget {
      |       ^~~~~~~~~~~
[ 81%] Built target hackrf_usb_ram.elf
/opt/portapack-mayhem/firmware/application/ui/ui_qrcode.hpp:35:7: warning:   but does not override 'ui::QRCodeImage(const ui::QRCodeImage&)' [-Weffc++]
/opt/portapack-mayhem/firmware/application/ui/ui_qrcode.hpp:35:7: warning:   or 'operator=(const ui::QRCodeImage&)' [-Weffc++]