### PR TITLE
Added missing contructors/operators/etc in ais_app

### DIFF
--- a/firmware/application/apps/ais_app.cpp
+++ b/firmware/application/apps/ais_app.cpp
@@ -254,8 +254,18 @@ AISRecentEntryDetailView::AISRecentEntryDetailView(NavigationView& nav) {
 
 		
 	};
-	
-	
+}
+
+
+AISRecentEntryDetailView::AISRecentEntryDetailView(const AISRecentEntryDetailView&Entry) : View()
+{
+    (void)Entry;
+}
+
+AISRecentEntryDetailView & AISRecentEntryDetailView::operator=(const AISRecentEntryDetailView&Entry) 
+{
+    (void)Entry;
+    return *this;
 }
 
 void AISRecentEntryDetailView::update_position() {

--- a/firmware/application/apps/ais_app.hpp
+++ b/firmware/application/apps/ais_app.hpp
@@ -127,6 +127,9 @@ public:
 	void focus() override;
 	void paint(Painter&) override;
 
+    AISRecentEntryDetailView(const AISRecentEntryDetailView&Entry);
+    AISRecentEntryDetailView &operator=(const AISRecentEntryDetailView&Entry);
+
 private:
 	AISRecentEntry entry_ { };
 


### PR DESCRIPTION
Fix for :

In file included from /opt/portapack-mayhem/firmware/application/ui_navigation.cpp:72:
/opt/portapack-mayhem/firmware/application/apps/ais_app.hpp:117:7: warning: 'class ui::AISRecentEntryDetailView' has pointer data members [-Weffc++]
  117 | class AISRecentEntryDetailView : public View {
      |       ^~~~~~~~~~~~~~~~~~~~~~~~
/opt/portapack-mayhem/firmware/application/apps/ais_app.hpp:117:7: warning:   but does not override 'ui::AISRecentEntryDetailView(const ui::AISRecentEntryDetailView&)' [-Weffc++]
/opt/portapack-mayhem/firmware/application/apps/ais_app.hpp:117:7: warning:   or 'operator=(const ui::AISRecentEntryDetailView&)' [-Weffc++]
