### PR TITLE
Added missing initializer

### DIFF
--- a/firmware/application/apps/ui_adsb_rx.hpp
+++ b/firmware/application/apps/ui_adsb_rx.hpp
@@ -184,7 +184,7 @@ private:
 	AircraftRecentEntry 		entry_copy { 0 };
 	std::function<void(void)> 	on_close_ { };
 	bool 				send_updates { false };
-	std::database 			db;
+	std::database 			db = { };
 	std::string 			icao_code = "";
 	int 				return_code = 0;
 
@@ -279,7 +279,7 @@ private:
 	GeoMapView* 			geomap_view { nullptr };
 	ADSBRxAircraftDetailsView* 	aircraft_details_view { nullptr };
 	bool 				send_updates { false };
-	std::database 			db;	
+	std::database 			db = { };	
 	std::string 			airline_code = "";
 	int 				return_code = 0;
 	
@@ -368,7 +368,7 @@ public:
 	void sort_entries_by_state();
 
 private:
-	rf::Frequency prevFreq;
+	rf::Frequency prevFreq = { 0 };
 	std::unique_ptr<ADSBLogger> logger { };
 	void on_frame(const ADSBFrameMessage * message);
 	void on_tick_second();


### PR DESCRIPTION
Fix for:

/opt/portapack-mayhem/firmware/application/apps/ui_adsb_rx.cpp: In constructor 'ui::ADSBRxDetailsView::ADSBRxDetailsView(ui::NavigationView&, const ui::AircraftRecentEntry&, std::function<void()>)':
/opt/portapack-mayhem/firmware/application/apps/ui_adsb_rx.cpp:235:1: warning: 'ui::ADSBRxDetailsView::db' should be initialized in the member initialization list [-Weffc++]
  235 | ADSBRxDetailsView::ADSBRxDetailsView(
      | ^~~~~~~~~~~~~~~~~
/opt/portapack-mayhem/firmware/application/apps/ui_adsb_rx.cpp: In constructor 'ui::ADSBRxView::ADSBRxView(ui::NavigationView&)':
/opt/portapack-mayhem/firmware/application/apps/ui_adsb_rx.cpp:450:1: warning: 'ui::ADSBRxView::prevFreq' should be initialized in the member initialization list [-Weffc++]
