### PR TITLE
Fix #494 - Change App Titles

### DIFF
--- a/firmware/application/apps/ais_app.hpp
+++ b/firmware/application/apps/ais_app.hpp
@@ -166,7 +166,7 @@ public:
 
 	void focus() override;
 
-	std::string title() const override { return "AIS"; };
+	std::string title() const override { return "AIS Boats RX"; };
 
 private:
 	static constexpr uint32_t initial_target_frequency = 162025000;

--- a/firmware/application/apps/analog_audio_app.hpp
+++ b/firmware/application/apps/analog_audio_app.hpp
@@ -143,7 +143,7 @@ public:
 
 	void focus() override;
 
-	std::string title() const override { return "Analog audio"; };
+	std::string title() const override { return "Audio RX"; };
 
 	size_t get_spec_bw_index();
 	void set_spec_bw(size_t index, uint32_t bw);

--- a/firmware/application/apps/analog_tv_app.hpp
+++ b/firmware/application/apps/analog_tv_app.hpp
@@ -53,7 +53,7 @@ public:
 
 	void focus() override;
 
-	std::string title() const override { return "Analog TV"; };
+	std::string title() const override { return "Analog TV RX"; };
 	
 private:
 	static constexpr ui::Dim header_height = 3 * 16;

--- a/firmware/application/apps/ert_app.hpp
+++ b/firmware/application/apps/ert_app.hpp
@@ -125,7 +125,7 @@ public:
 
 	void focus() override;
 
-	std::string title() const override { return "ERT"; };
+	std::string title() const override { return "ERT Meter RX"; };
 
 private:
 	ERTRecentEntries recent { };

--- a/firmware/application/apps/gps_sim_app.hpp
+++ b/firmware/application/apps/gps_sim_app.hpp
@@ -44,7 +44,7 @@ public:
 	void set_parent_rect(const Rect new_parent_rect) override;
 	void focus() override;
 
-	std::string title() const override { return "GPS Simulator"; };
+	std::string title() const override { return "GPS Sim TX"; };
 	
 private:
 	NavigationView& nav_;

--- a/firmware/application/apps/lge_app.hpp
+++ b/firmware/application/apps/lge_app.hpp
@@ -40,7 +40,7 @@ public:
 	
 	void focus() override;
 	
-	std::string title() const override { return "LGE tool"; };
+	std::string title() const override { return "LGE tool TX"; };
 
 private:
 	enum tx_modes {

--- a/firmware/application/apps/soundboard_app.hpp
+++ b/firmware/application/apps/soundboard_app.hpp
@@ -45,7 +45,7 @@ public:
 
 	void focus() override;
 	
-	std::string title() const override { return "Soundboard"; };
+	std::string title() const override { return "Soundboard TX"; };
 	
 private:
 	NavigationView& nav_;

--- a/firmware/application/apps/tpms_app.hpp
+++ b/firmware/application/apps/tpms_app.hpp
@@ -103,7 +103,7 @@ public:
 
 	void focus() override;
 
-	std::string title() const override { return "TPMS"; };
+	std::string title() const override { return "TPMS Cars RX"; };
 
 private:
 	static constexpr uint32_t initial_target_frequency = 315000000;

--- a/firmware/application/apps/ui_adsb_rx.hpp
+++ b/firmware/application/apps/ui_adsb_rx.hpp
@@ -361,7 +361,7 @@ public:
 	
 	void focus() override;
 	
-	std::string title() const override { return "ADS-B receive"; };
+	std::string title() const override { return "ADS-B RX"; };
 
 	void replace_entry(AircraftRecentEntry & entry);
 	AircraftRecentEntry find_or_create_entry(uint32_t ICAO_address);

--- a/firmware/application/apps/ui_adsb_tx.hpp
+++ b/firmware/application/apps/ui_adsb_tx.hpp
@@ -152,7 +152,7 @@ public:
 	
 	void focus() override;
 	
-	std::string title() const override { return "ADS-B transmit"; };
+	std::string title() const override { return "ADS-B TX"; };
 
 private:
 	/*enum tx_modes {

--- a/firmware/application/apps/ui_bht_tx.hpp
+++ b/firmware/application/apps/ui_bht_tx.hpp
@@ -178,7 +178,7 @@ public:
 
 	void focus() override;
 	
-	std::string title() const override { return "BHT transmit"; };
+	std::string title() const override { return "BHT Xy/EP TX"; };
 
 private:
 	void on_tx_progress(const uint32_t progress, const bool done);

--- a/firmware/application/apps/ui_coasterp.hpp
+++ b/firmware/application/apps/ui_coasterp.hpp
@@ -39,7 +39,7 @@ public:
 	
 	void focus() override;
 	
-	std::string title() const override { return "Si44xx TX"; };
+	std::string title() const override { return "BurgerPgr TX"; };
 
 private:
 	enum tx_modes {

--- a/firmware/application/apps/ui_debug.cpp
+++ b/firmware/application/apps/ui_debug.cpp
@@ -352,7 +352,7 @@ DebugMenuView::DebugMenuView(NavigationView& nav) {
 		{ "SD Card",		ui::Color::dark_cyan(),	&bitmap_icon_sdcard,	[&nav](){ nav.push<SDCardDebugView>(); } },
 		{ "Peripherals",	ui::Color::dark_cyan(),	&bitmap_icon_peripherals,	[&nav](){ nav.push<DebugPeripheralsMenuView>(); } },
 		{ "Temperature",	ui::Color::dark_cyan(),	&bitmap_icon_temperature,	[&nav](){ nav.push<TemperatureView>(); } },
-		{ "Buttons test",	ui::Color::dark_cyan(),	&bitmap_icon_controls,	[&nav](){ nav.push<DebugControlsView>(); } },
+		{ "Buttons Test",	ui::Color::dark_cyan(),	&bitmap_icon_controls,	[&nav](){ nav.push<DebugControlsView>(); } },
 	});
 	set_max_rows(2); // allow wider buttons
 }

--- a/firmware/application/apps/ui_debug.hpp
+++ b/firmware/application/apps/ui_debug.hpp
@@ -43,6 +43,8 @@ public:
 
 	void focus() override;
 
+	std::string title() const override { return "Memory"; };
+
 private:
 	Text text_title {
 		{ 96, 96, 48, 16 },
@@ -112,6 +114,8 @@ public:
 	explicit TemperatureView(NavigationView& nav);
 
 	void focus() override;
+
+	std::string title() const override { return "Temperature"; };
 
 private:
 	Text text_title {
@@ -251,6 +255,8 @@ public:
 	explicit DebugControlsView(NavigationView& nav);
 
 	void focus() override;
+
+	std::string title() const override { return "Buttons Test"; };
 
 private:
 	Text text_title {

--- a/firmware/application/apps/ui_encoders.hpp
+++ b/firmware/application/apps/ui_encoders.hpp
@@ -158,7 +158,7 @@ public:
 	
 	void focus() override;
 	
-	std::string title() const override { return "OOK transmit"; };
+	std::string title() const override { return "OOK TX"; };
 
 private:
 	NavigationView& nav_;

--- a/firmware/application/apps/ui_jammer.hpp
+++ b/firmware/application/apps/ui_jammer.hpp
@@ -106,7 +106,7 @@ public:
 	
 	void focus() override;
 	
-	std::string title() const override { return "Jammer"; };
+	std::string title() const override { return "Jammer TX"; };
 	
 private:
 	NavigationView& nav_;

--- a/firmware/application/apps/ui_keyfob.hpp
+++ b/firmware/application/apps/ui_keyfob.hpp
@@ -36,7 +36,7 @@ public:
 	
 	void focus() override;
 	
-	std::string title() const override { return "Keyfob (BETA)"; };
+	std::string title() const override { return "Key fob TX (beta)"; };
 
 private:
 	NavigationView& nav_;

--- a/firmware/application/apps/ui_lcr.hpp
+++ b/firmware/application/apps/ui_lcr.hpp
@@ -39,7 +39,7 @@ public:
 	
 	void focus() override;
 	
-	std::string title() const override { return "LCR transmit"; };
+	std::string title() const override { return "TEDI/LCR TX"; };
 	
 private:
 	struct scan_list_t {

--- a/firmware/application/apps/ui_mictx.hpp
+++ b/firmware/application/apps/ui_mictx.hpp
@@ -58,7 +58,7 @@ public:
 	};
 	*/
 
-	std::string title() const override { return "Mic TX RX"; };
+	std::string title() const override { return "Microphone"; };
 
 private:
 	static constexpr uint32_t sampling_rate = 1536000U;

--- a/firmware/application/apps/ui_rds.hpp
+++ b/firmware/application/apps/ui_rds.hpp
@@ -144,7 +144,7 @@ public:
 	
 	void focus() override;
 
-	std::string title() const override { return "RDS transmit"; };
+	std::string title() const override { return "RDS TX"; };
 
 private:
 	NavigationView& nav_;

--- a/firmware/application/apps/ui_scanner.hpp
+++ b/firmware/application/apps/ui_scanner.hpp
@@ -111,7 +111,7 @@ public:
 		.foreground = Color::red(),
 	};
 
-	std::string title() const override { return "SCANNER"; };
+	std::string title() const override { return "Scanner"; };
 	std::vector<rf::Frequency> frequency_list{ };
 	std::vector<string> description_list { };
 

--- a/firmware/application/apps/ui_sd_wipe.hpp
+++ b/firmware/application/apps/ui_sd_wipe.hpp
@@ -38,7 +38,7 @@ public:
 	~WipeSDView();
 	void focus() override;
 	
-	std::string title() const override { return "Wipe FAT"; };	
+	std::string title() const override { return "Wipe SD Card"; };	
 
 private:
 	NavigationView& nav_;

--- a/firmware/application/apps/ui_settings.cpp
+++ b/firmware/application/apps/ui_settings.cpp
@@ -348,10 +348,10 @@ SettingsMenuView::SettingsMenuView(NavigationView& nav) {
 	add_items({
 		{ "Audio", 		ui::Color::dark_cyan(), &bitmap_icon_speaker,			[&nav](){ nav.push<SetAudioView>(); } },
 		{ "Radio",		ui::Color::dark_cyan(), &bitmap_icon_options_radio,		[&nav](){ nav.push<SetRadioView>(); } },
-		{ "Interface", 		ui::Color::dark_cyan(), &bitmap_icon_options_ui,		[&nav](){ nav.push<SetUIView>(); } },
+		{ "User Interface", 		ui::Color::dark_cyan(), &bitmap_icon_options_ui,		[&nav](){ nav.push<SetUIView>(); } },
 		{ "Date/Time",		ui::Color::dark_cyan(), &bitmap_icon_options_datetime,		[&nav](){ nav.push<SetDateTimeView>(); } },
-		{ "Touchscreen",	ui::Color::dark_cyan(), &bitmap_icon_options_touch,		[&nav](){ nav.push<TouchCalibrationView>(); } },
-		{ "QR code",		ui::Color::dark_cyan(), &bitmap_icon_qr_code,		[&nav](){ nav.push<SetQRCodeView>(); } }
+		{ "Calibration",	ui::Color::dark_cyan(), &bitmap_icon_options_touch,		[&nav](){ nav.push<TouchCalibrationView>(); } },
+		{ "QR Code",		ui::Color::dark_cyan(), &bitmap_icon_qr_code,		[&nav](){ nav.push<SetQRCodeView>(); } }
 	});
 	set_max_rows(2); // allow wider buttons
 }

--- a/firmware/application/apps/ui_settings.hpp
+++ b/firmware/application/apps/ui_settings.hpp
@@ -47,7 +47,7 @@ public:
 
 	void focus() override;
 	
-	std::string title() const override { return "Set Date/Time"; };
+	std::string title() const override { return "Date/Time"; };
 
 private:
 	Labels labels {
@@ -322,7 +322,7 @@ public:
 	
 	void focus() override;
 	
-	std::string title() const override { return "QR code"; };
+	std::string title() const override { return "QR Code"; };
 	
 private:
 	Checkbox checkbox_bigger_qr {

--- a/firmware/application/apps/ui_siggen.hpp
+++ b/firmware/application/apps/ui_siggen.hpp
@@ -40,7 +40,7 @@ public:
 	
 	void focus() override;
 	
-	std::string title() const override { return "Generator"; };
+	std::string title() const override { return "Signal gen"; };
 
 private:
 	void start_tx();

--- a/firmware/application/ui_navigation.cpp
+++ b/firmware/application/ui_navigation.cpp
@@ -522,14 +522,14 @@ UtilitiesMenuView::UtilitiesMenuView(NavigationView& nav) {
 	add_items({
 		//{ "Test app", 		ui::Color::dark_grey(),	nullptr,				[&nav](){ nav.push<TestView>(); } },
 		//{ "..", 			ui::Color::light_grey(),&bitmap_icon_previous,		[&nav](){ nav.pop(); } },
-		{ "Freq manager",	ui::Color::green(), 	&bitmap_icon_freqman,		[&nav](){ nav.push<FrequencyManagerView>(); } },
+		{ "Freq. manager",	ui::Color::green(), 	&bitmap_icon_freqman,		[&nav](){ nav.push<FrequencyManagerView>(); } },
 		{ "File manager", 	ui::Color::yellow(),	&bitmap_icon_dir,			[&nav](){ nav.push<FileManagerView>(); } },
 		//{ "Notepad",		ui::Color::dark_grey(),	&bitmap_icon_notepad,		[&nav](){ nav.push<NotImplementedView>(); } },
 		{ "Signal gen", 	ui::Color::green(), 	&bitmap_icon_cwgen,			[&nav](){ nav.push<SigGenView>(); } },
 		//{ "Tone search",	ui::Color::dark_grey(), nullptr,					[&nav](){ nav.push<ToneSearchView>(); } },
-		{ "Wave viewer",	ui::Color::yellow(),	&bitmap_icon_soundboard,	[&nav](){ nav.push<ViewWavView>(); } },
+		{ "WAV viewer",	ui::Color::yellow(),	&bitmap_icon_soundboard,	[&nav](){ nav.push<ViewWavView>(); } },
 		{ "Antenna length",	ui::Color::green(),		&bitmap_icon_tools_antenna,	[&nav](){ nav.push<WhipCalcView>(); } },
-		{ "Wipe SD card",	ui::Color::red(),		&bitmap_icon_tools_wipesd,	[&nav](){ nav.push<WipeSDView>(); } },
+		{ "Wipe SD Card",	ui::Color::red(),		&bitmap_icon_tools_wipesd,	[&nav](){ nav.push<WipeSDView>(); } },
 	});
 	set_max_rows(2); // allow wider buttons
 }
@@ -553,12 +553,12 @@ SystemMenuView::SystemMenuView(NavigationView& nav) {
 		{ "Transmit", 	ui::Color::cyan(),			&bitmap_icon_transmit,	[&nav](){ nav.push<TransmittersMenuView>(); } },
 		{ "Capture",	ui::Color::red(),			&bitmap_icon_capture,	[&nav](){ nav.push<CaptureAppView>(); } },
 		{ "Replay",		ui::Color::green(),			&bitmap_icon_replay,	[&nav](){ nav.push<ReplayAppView>(); } },
-		{ "Calls",		ui::Color::yellow(),	    &bitmap_icon_search,	[&nav](){ nav.push<SearchView>(); } },
+		{ "Search",		ui::Color::yellow(),	    &bitmap_icon_search,	[&nav](){ nav.push<SearchView>(); } },
 		{ "Scanner",	ui::Color::yellow(),			&bitmap_icon_scanner,	[&nav](){ nav.push<ScannerView>(); } },
 		{ "Microphone",	ui::Color::yellow(),		&bitmap_icon_microphone,[&nav](){ nav.push<MicTXView>(); } },
 		{ "Looking Glass",	ui::Color::yellow(),		&bitmap_icon_looking,	[&nav](){ nav.push<GlassView>(); } },
-		{ "Tools",		ui::Color::cyan(),			&bitmap_icon_utilities,	[&nav](){ nav.push<UtilitiesMenuView>(); } },
-		{ "Options", 	ui::Color::cyan(),			&bitmap_icon_setup,	  	[&nav](){ nav.push<SettingsMenuView>(); } },
+		{ "Utilities",		ui::Color::cyan(),			&bitmap_icon_utilities,	[&nav](){ nav.push<UtilitiesMenuView>(); } },
+		{ "Settings", 	ui::Color::cyan(),			&bitmap_icon_setup,	  	[&nav](){ nav.push<SettingsMenuView>(); } },
 		{ "Debug",		ui::Color::light_grey(),	&bitmap_icon_debug,		[&nav](){ nav.push<DebugMenuView>(); } },
 		{ "HackRF", 	ui::Color::cyan(),			&bitmap_icon_hackrf,	[this, &nav](){ hackrf_mode(nav); } },
 		//{ "About", 		ui::Color::cyan(),			nullptr,				[&nav](){ nav.push<AboutView>(); } }

--- a/firmware/application/ui_navigation.hpp
+++ b/firmware/application/ui_navigation.hpp
@@ -248,14 +248,14 @@ namespace ui
 	{
 	public:
 		ReceiversMenuView(NavigationView &nav);
-		std::string title() const override { return "Receivers"; };
+		std::string title() const override { return "Receive"; };
 	};
 
 	class TransmittersMenuView : public BtnGridView
 	{
 	public:
 		TransmittersMenuView(NavigationView &nav);
-		std::string title() const override { return "Transmitters"; };
+		std::string title() const override { return "Transmit"; };
 	};
 
 	class UtilitiesMenuView : public BtnGridView

--- a/firmware/application/ui_sd_card_debug.hpp
+++ b/firmware/application/ui_sd_card_debug.hpp
@@ -38,6 +38,8 @@ public:
 
 	void focus() override;
 
+	std::string title() const override { return "SD Card"; };
+
 private:
 	SignalToken sd_card_status_signal_token { };
 


### PR DESCRIPTION
I choose what I think are the best Titles based on existing titles/class names and so on. There were also inconsistencies between TX and Transmit and RX and receive. I renamed them to shorter version TX and RX also added it as suffix where possible to make it clearer in what mode you are in. If you have any other title suggestions or changes please use Add comment on Files Changed Screen so I can change it.