### PR TITLE
Added a ui_config flag to manage gui return icon status

### DIFF
--- a/firmware/application/apps/ui_debug.cpp
+++ b/firmware/application/apps/ui_debug.cpp
@@ -31,6 +31,7 @@
 #include "ui_sd_card_debug.hpp"
 
 #include "portapack.hpp"
+#include "portapack_persistent_memory.hpp"
 using namespace portapack;
 
 #include "irq_controls.hpp"
@@ -345,8 +346,11 @@ DebugPeripheralsMenuView::DebugPeripheralsMenuView(NavigationView& nav) {
 /* DebugMenuView *********************************************************/
 
 DebugMenuView::DebugMenuView(NavigationView& nav) {
+    if( portapack::persistent_memory::show_gui_return_icon() )
+    {
+        add_items( { { "..", 		ui::Color::light_grey(),&bitmap_icon_previous,	[&nav](){ nav.pop(); } } } );
+    }
 	add_items({
-		//{ "..",				ui::Color::light_grey(),&bitmap_icon_previous,	[&nav](){ nav.pop(); } },
 		{ "Memory", 		ui::Color::dark_cyan(),	&bitmap_icon_memory,	[&nav](){ nav.push<DebugMemoryView>(); } },
 		//{ "Radio State",	ui::Color::white(),	nullptr,	[&nav](){ nav.push<NotImplementedView>(); } },
 		{ "SD Card",		ui::Color::dark_cyan(),	&bitmap_icon_sdcard,	[&nav](){ nav.push<SDCardDebugView>(); } },

--- a/firmware/application/apps/ui_settings.cpp
+++ b/firmware/application/apps/ui_settings.cpp
@@ -234,6 +234,7 @@ SetUIView::SetUIView(NavigationView& nav) {
 		&checkbox_showsplash,
 		&checkbox_showclock,
 		&options_clockformat,
+		&checkbox_guireturnflag,
 		&button_save,
 		&button_cancel
 	});
@@ -242,6 +243,7 @@ SetUIView::SetUIView(NavigationView& nav) {
 	checkbox_speaker.set_value(persistent_memory::config_speaker());
 	checkbox_showsplash.set_value(persistent_memory::config_splash());
 	checkbox_showclock.set_value(!persistent_memory::hide_clock());
+	checkbox_guireturnflag.set_value(persistent_memory::show_gui_return_icon());
 	
 	uint32_t backlight_timer = persistent_memory::config_backlight_timer();
 	if (backlight_timer) {
@@ -284,6 +286,7 @@ SetUIView::SetUIView(NavigationView& nav) {
 	
 		persistent_memory::set_config_splash(checkbox_showsplash.value());
 		persistent_memory::set_clock_hidden(!checkbox_showclock.value());
+		persistent_memory::set_gui_return_icon(checkbox_guireturnflag.value());
 		persistent_memory::set_disable_touchscreen(checkbox_disable_touchscreen.value());
 		nav.pop();
 	};
@@ -345,6 +348,10 @@ void SetQRCodeView::focus() {
 }
 
 SettingsMenuView::SettingsMenuView(NavigationView& nav) {
+    if( portapack::persistent_memory::show_gui_return_icon() )
+    {
+        add_items( { { "..", 		ui::Color::light_grey(),&bitmap_icon_previous,	[&nav](){ nav.pop(); } } } );
+    }
 	add_items({
 		{ "Audio", 		ui::Color::dark_cyan(), &bitmap_icon_speaker,			[&nav](){ nav.push<SetAudioView>(); } },
 		{ "Radio",		ui::Color::dark_cyan(), &bitmap_icon_options_radio,		[&nav](){ nav.push<SetRadioView>(); } },

--- a/firmware/application/apps/ui_settings.hpp
+++ b/firmware/application/apps/ui_settings.hpp
@@ -275,7 +275,7 @@ private:
     Checkbox checkbox_guireturnflag {	
 		{ 3 * 8, 14 * 16 },
 		25,
-		"add return icon in menus"
+		"add return icon in GUI"
 	};
 	
 	Button button_save {

--- a/firmware/application/apps/ui_settings.hpp
+++ b/firmware/application/apps/ui_settings.hpp
@@ -271,6 +271,12 @@ private:
 			{ "time and date", 1 }
 		}
 	};	
+
+    Checkbox checkbox_guireturnflag {	
+		{ 3 * 8, 14 * 16 },
+		25,
+		"add return icon in menus"
+	};
 	
 	Button button_save {
 		{ 2 * 8, 16 * 16, 12 * 8, 32 },

--- a/firmware/application/ui_navigation.cpp
+++ b/firmware/application/ui_navigation.cpp
@@ -466,9 +466,9 @@ void NavigationView::focus() {
 ReceiversMenuView::ReceiversMenuView(NavigationView& nav) {
     if( portapack::persistent_memory::show_gui_return_icon() )
     {
-        add_items( { { "..", 		ui::Color::light_grey(),&bitmap_icon_previous,	[&nav](){ nav.pop(); } } } );
+        add_items( { { "..", ui::Color::light_grey(),&bitmap_icon_previous , [&nav](){ nav.pop(); } } } );
     }
-   add_items( {
+    add_items( {
 		{ "ADS-B", 		ui::Color::green(),		&bitmap_icon_adsb,		[&nav](){ nav.push<ADSBRxView>(); }, },
 		//{ "ACARS", 		ui::Color::yellow(),	&bitmap_icon_adsb,		[&nav](){ nav.push<ACARSAppView>(); }, },
 		{ "AIS Boats",	ui::Color::green(),		&bitmap_icon_ais,		[&nav](){ nav.push<AISAppView>(); } },
@@ -498,7 +498,7 @@ ReceiversMenuView::ReceiversMenuView(NavigationView& nav) {
 TransmittersMenuView::TransmittersMenuView(NavigationView& nav) {
     if( portapack::persistent_memory::show_gui_return_icon() )
     {
-        add_items( { { "..", 		ui::Color::light_grey(),&bitmap_icon_previous,	[&nav](){ nav.pop(); } } } );
+        add_items( { { "..", ui::Color::light_grey(),&bitmap_icon_previous , [&nav](){ nav.pop(); } } } );
     }
     add_items({
 		{ "ADS-B [S]",		ui::Color::yellow(), 	&bitmap_icon_adsb,		[&nav](){ nav.push<ADSBTxView>(); } },
@@ -527,7 +527,7 @@ TransmittersMenuView::TransmittersMenuView(NavigationView& nav) {
 UtilitiesMenuView::UtilitiesMenuView(NavigationView& nav) {
     if( portapack::persistent_memory::show_gui_return_icon() )
     {
-        add_items( { { "..", 		ui::Color::light_grey(),&bitmap_icon_previous,	[&nav](){ nav.pop(); } } } );
+        add_items( { { "..", ui::Color::light_grey(),&bitmap_icon_previous , [&nav](){ nav.pop(); } } } );
     }
 	add_items({
 		//{ "Test app", 		ui::Color::dark_grey(),	nullptr,				[&nav](){ nav.push<TestView>(); } },

--- a/firmware/application/ui_navigation.cpp
+++ b/firmware/application/ui_navigation.cpp
@@ -464,8 +464,11 @@ void NavigationView::focus() {
 /* ReceiversMenuView *****************************************************/
 
 ReceiversMenuView::ReceiversMenuView(NavigationView& nav) {
-	add_items({
-		//{ "..", 		ui::Color::light_grey(),&bitmap_icon_previous,	[&nav](){ nav.pop(); } },
+    if( portapack::persistent_memory::show_gui_return_icon() )
+    {
+        add_items( { { "..", 		ui::Color::light_grey(),&bitmap_icon_previous,	[&nav](){ nav.pop(); } } } );
+    }
+   add_items( {
 		{ "ADS-B", 		ui::Color::green(),		&bitmap_icon_adsb,		[&nav](){ nav.push<ADSBRxView>(); }, },
 		//{ "ACARS", 		ui::Color::yellow(),	&bitmap_icon_adsb,		[&nav](){ nav.push<ACARSAppView>(); }, },
 		{ "AIS Boats",	ui::Color::green(),		&bitmap_icon_ais,		[&nav](){ nav.push<AISAppView>(); } },
@@ -485,16 +488,19 @@ ReceiversMenuView::ReceiversMenuView(NavigationView& nav) {
 		{ "LoRa", 		ui::Color::dark_grey(),	&bitmap_icon_lora,		[&nav](){ nav.push<NotImplementedView>(); } },
 		{ "SSTV", 		ui::Color::dark_grey(), &bitmap_icon_sstv,		[&nav](){ nav.push<NotImplementedView>(); } },
 		{ "TETRA", 		ui::Color::dark_grey(),	&bitmap_icon_tetra,		[&nav](){ nav.push<NotImplementedView>(); } },*/
-	});
-	
-	//set_highlighted(4);		// Default selection is "Audio"
+	} );
+
+	//set_highlighted(0);		// Default selection is "Audio"
 }
 
 /* TransmittersMenuView **************************************************/
 
 TransmittersMenuView::TransmittersMenuView(NavigationView& nav) {
-	add_items({
-		//{ "..",				ui::Color::light_grey(),&bitmap_icon_previous,	[&nav](){ nav.pop(); } },
+    if( portapack::persistent_memory::show_gui_return_icon() )
+    {
+        add_items( { { "..", 		ui::Color::light_grey(),&bitmap_icon_previous,	[&nav](){ nav.pop(); } } } );
+    }
+    add_items({
 		{ "ADS-B [S]",		ui::Color::yellow(), 	&bitmap_icon_adsb,		[&nav](){ nav.push<ADSBTxView>(); } },
 		{ "APRS", 			ui::Color::green(),		&bitmap_icon_aprs,		[&nav](){ nav.push<APRSTXView>(); } },
 		{ "BHT Xy/EP", 		ui::Color::green(), 	&bitmap_icon_bht,		[&nav](){ nav.push<BHTView>(); } },
@@ -519,9 +525,12 @@ TransmittersMenuView::TransmittersMenuView(NavigationView& nav) {
 /* UtilitiesMenuView *****************************************************/
 
 UtilitiesMenuView::UtilitiesMenuView(NavigationView& nav) {
+    if( portapack::persistent_memory::show_gui_return_icon() )
+    {
+        add_items( { { "..", 		ui::Color::light_grey(),&bitmap_icon_previous,	[&nav](){ nav.pop(); } } } );
+    }
 	add_items({
 		//{ "Test app", 		ui::Color::dark_grey(),	nullptr,				[&nav](){ nav.push<TestView>(); } },
-		//{ "..", 			ui::Color::light_grey(),&bitmap_icon_previous,		[&nav](){ nav.pop(); } },
 		{ "Freq. manager",	ui::Color::green(), 	&bitmap_icon_freqman,		[&nav](){ nav.push<FrequencyManagerView>(); } },
 		{ "File manager", 	ui::Color::yellow(),	&bitmap_icon_dir,			[&nav](){ nav.push<FileManagerView>(); } },
 		//{ "Notepad",		ui::Color::dark_grey(),	&bitmap_icon_notepad,		[&nav](){ nav.push<NotImplementedView>(); } },

--- a/firmware/common/portapack_persistent_memory.cpp
+++ b/firmware/common/portapack_persistent_memory.cpp
@@ -200,13 +200,16 @@ void set_serial_format(const serial_format_t new_value) {
 	data->serial_format = new_value;
 }
 
-bool show_gui_return_icon(){ // add return icon in touchscreen menue
-return data->ui_config & (1 << 20);
-
 // ui_config is an uint32_t var storing information bitwise
 // bits 0-2 store the backlight timer
 // bits 4-19 (16 bits) store the clkout frequency
 // bits 21-31 store the different single bit configs depicted below
+// bit 20 store the display state of the gui return icon, hidden (0) or shown (1)
+
+bool show_gui_return_icon(){ // add return icon in touchscreen menue
+return data->ui_config & (1 << 20);
+}
+
 bool load_app_settings() { // load (last saved) app settings on startup of app
 	return data->ui_config & (1 << 21);
 }
@@ -261,6 +264,7 @@ uint32_t config_backlight_timer() {
 
 void set_gui_return_icon(bool v) {
 	data->ui_config = (data->ui_config & ~(1 << 20)) | (v << 20);
+}
 
 void set_load_app_settings(bool v) {
 	data->ui_config = (data->ui_config & ~(1 << 21)) | (v << 21);

--- a/firmware/common/portapack_persistent_memory.cpp
+++ b/firmware/common/portapack_persistent_memory.cpp
@@ -230,12 +230,17 @@ void set_playdead_sequence(const uint32_t new_value) {
 // bits 31, 30,29,28,27, 26, 25, 24 stores the different single bit configs depicted below
 // bits on position 4 to 19 (16 bits) store the clkout frequency
 
-bool disable_touchscreen() { // Option to disable touch screen
-	return data->ui_config & (1 << 24);
+
+bool show_gui_return_icon(){ // add return icon in touchscreen menue
+	return data->ui_config & (1 << 22);
 }
   
 bool show_bigger_qr_code() { // show bigger QR code
 	return data->ui_config & (1 << 23);
+}
+
+bool disable_touchscreen() { // Option to disable touch screen
+	return data->ui_config & (1 << 24);
 }
 
 bool hide_clock() { // clock hidden from main menu
@@ -274,12 +279,16 @@ uint32_t config_backlight_timer() {
 	return timer_seconds[data->ui_config & 7]; //first three bits, 8 possible values
 }
 
-void set_disable_touchscreen(bool v) {
-	data->ui_config = (data->ui_config & ~(1 << 24)) | (v << 24);
+void set_gui_return_icon(bool v) {
+	data->ui_config = (data->ui_config & ~(1 << 22)) | (v << 22);
 }
   
 void set_show_bigger_qr_code(bool v) {
 	data->ui_config = (data->ui_config & ~(1 << 23)) | (v << 23);
+}
+
+void set_disable_touchscreen(bool v) {
+	data->ui_config = (data->ui_config & ~(1 << 24)) | (v << 24);
 }
 
 void set_clock_hidden(bool v) {

--- a/firmware/common/portapack_persistent_memory.hpp
+++ b/firmware/common/portapack_persistent_memory.hpp
@@ -78,6 +78,7 @@ uint8_t config_cpld();
 void set_config_cpld(uint8_t i);
 
 bool config_splash();
+bool show_gui_return_icon();
 bool show_bigger_qr_code();
 bool hide_clock();
 bool clock_with_date();
@@ -86,8 +87,9 @@ bool config_speaker();
 uint32_t config_backlight_timer();
 bool disable_touchscreen();
 
-void set_config_splash(bool v);
+void set_gui_return_icon(bool v);
 void set_show_bigger_qr_code(bool v);
+void set_config_splash(bool v);
 void set_clock_hidden(bool v);
 void set_clock_with_date(bool v);
 void set_config_login(bool v);


### PR DESCRIPTION
In Settings/User Interface I added a checkbox "add return icon in GUI" which add a big ".." icon in each menu, or not.

It's saved in persistent memory and just require to get out of the settings menu to be showing or not the menues.

I checked the ui_menu code and add_items is not destructive, hence we can easily make configurable menues with flags.