### PR TITLE
Fix for new H2+ devices

### DIFF
--- a/firmware/application/portapack.cpp
+++ b/firmware/application/portapack.cpp
@@ -215,7 +215,7 @@ static int load_config(){
 	static Optional<int> config_value;
 	if(!config_value.is_valid()){
 		int8_t value = portapack::persistent_memory::config_cpld();
-		if((value <= 0 || value >= 4) && sd_card::status() == sd_card::Status::Mounted){
+		if((value <= 0 || value >= 5) && sd_card::status() == sd_card::Status::Mounted){
 			int data = read_file("/hardware/settings.txt");
 			if(data != -1) {
 				config_value = data;
@@ -235,14 +235,19 @@ static PortaPackModel portapack_model() {
 		const auto switches_state = get_switches_state();
 		if (switches_state[(size_t)ui::KeyEvent::Up]){
 			save_config(1);
-			model = PortaPackModel::R2_20170522;
+			// model = PortaPackModel::R2_20170522; // Commented these out as they should be set down below anyway
 		}
 		else if (switches_state[(size_t)ui::KeyEvent::Down]){
 			save_config(2);
-			model = PortaPackModel::R1_20150901;
+			// model = PortaPackModel::R1_20150901;
 		}
 		else if (switches_state[(size_t)ui::KeyEvent::Left]){
 			save_config(3);
+			// model = PortaPackModel::R1_20150901;
+		}
+		else if (switches_state[(size_t)ui::KeyEvent::Right]){
+			save_config(4);
+			// model = PortaPackModel::R2_20170522;
 		}
 		else if (switches_state[(size_t)ui::KeyEvent::Select]){
 			save_config(0);
@@ -253,6 +258,10 @@ static PortaPackModel portapack_model() {
 			model = PortaPackModel::R2_20170522;
 		} else if (load_config() == 2) {
 			model = PortaPackModel::R1_20150901;
+		} else if (load_config() == 3) {
+			model = PortaPackModel::R1_20150901;
+		} else if (load_config() == 4) {
+			model = PortaPackModel::R2_20170522;
 		} else {
 			if( audio_codec_wm8731.detected() ) {
 				model = PortaPackModel::R1_20150901; // H1R1
@@ -478,7 +487,7 @@ bool init() {
 	if( !portapack::cpld::update_if_necessary(portapack_cpld_config()) ) {
 		chThdSleepMilliseconds(10);
 		// If using a "2021/12 QFP100", press and hold the left button while booting. Should only need to do once.
-		if (load_config() != 3){
+		if (load_config() != 3 && load_config() != 4){
 			shutdown_base();
 			return false;
 		}


### PR DESCRIPTION
Added a new option of booting with right key
So now we have the option of booting with 
Left, Right, Up, Down and center to reset the device.