### PR TITLE
Increase max OOK clock

### DIFF
--- a/firmware/application/apps/ui_encoders.cpp
+++ b/firmware/application/apps/ui_encoders.cpp
@@ -46,7 +46,9 @@ EncodersConfigView::EncodersConfigView(
 		&labels,
 		&options_enctype,
 		&field_clk,
+		&field_clk_step,
 		&field_frameduration,
+		&field_frameduration_step,
 		&symfield_word,
 		&text_format,
 		&waveform
@@ -74,6 +76,10 @@ EncodersConfigView::EncodersConfigView(
 		if (new_value != field_frameduration.value())
 			field_frameduration.set_value(new_value * encoder_def->word_length, false);
 	};
+
+	field_clk_step.on_change = [this](size_t, int32_t value) {
+		field_clk.set_step(value);
+	};
 	
 	// Selecting word duration changes input clock and symbol duration
 	field_frameduration.on_change = [this](int32_t value) {
@@ -81,6 +87,10 @@ EncodersConfigView::EncodersConfigView(
 		int32_t new_value = (value * 1000) / (encoder_def->word_length * encoder_def->clk_per_symbol);
 		if (new_value != field_clk.value())
 			field_clk.set_value(1000000 / new_value, false);
+	};
+
+	field_frameduration_step.on_change = [this](size_t, int32_t value) {
+		field_frameduration.set_step(value);
 	};
 }
 

--- a/firmware/application/apps/ui_encoders.hpp
+++ b/firmware/application/apps/ui_encoders.hpp
@@ -66,12 +66,14 @@ private:
 	
 	Labels labels {
 		{ { 1 * 8, 0 }, "Type:", Color::light_grey() },
-		{ { 16 * 8, 0 }, "Clk:", Color::light_grey() },
-		{ { 25 * 8, 0 }, "kHz", Color::light_grey() },
-		{ { 14 * 8, 2 * 8 }, "Frame:", Color::light_grey() },
-		{ { 26 * 8, 2 * 8 }, "us", Color::light_grey() },
-		{ { 2 * 8, 4 * 8 }, "Symbols:", Color::light_grey() },
-		{ { 1 * 8, 11 * 8 }, "Waveform:", Color::light_grey() }
+		{ { 1 * 8, 2 * 8 }, "Clk:", Color::light_grey() },
+		{ { 10 * 8, 2 * 8 }, "kHz", Color::light_grey() },
+        { { 17 * 8, 2 * 8 }, "Step:", Color::light_grey() },
+		{ { 1 * 8, 4 * 8 }, "Frame:", Color::light_grey() },
+		{ { 13 * 8, 4 * 8 }, "us", Color::light_grey() },		
+		{ { 17 * 8, 4 * 8 }, "Step", Color::light_grey() },
+		{ { 2 * 8, 7 * 8 }, "Symbols:", Color::light_grey() },
+		{ { 1 * 8, 14 * 8 }, "Waveform:", Color::light_grey() }
 	};
 
 	OptionsField options_enctype {		// Options are loaded at runtime
@@ -82,34 +84,55 @@ private:
 	};
 
 	NumberField field_clk {
-		{ 21 * 8, 0 },
+		{ 5 * 8, 2 * 8 },
 		4,
 		{ 1, 1000 },
 		1,
 		' '
 	};
 
+	OptionsField field_clk_step {
+		{ 22 * 8, 2 * 8 },
+		7,
+		{
+			{ "1", 1 },
+			{ "10", 10 },
+			{ "100", 100 }
+		}
+	};
+
 	NumberField field_frameduration {
-		{ 21 * 8, 2 * 8 },
+		{ 7 * 8, 4 * 8 },
 		5,
 		{ 300, 99999 },
 		100,
 		' '
 	};
+
+	OptionsField field_frameduration_step {
+		{ 22 * 8, 4 * 8 },
+		7,
+		{
+			{ "1", 1 },
+			{ "10", 10 },
+			{ "100", 100 },
+			{ "1000", 1000 }
+		}
+	};
 	
 	SymField symfield_word {
-		{ 2 * 8, 6 * 8 },
+		{ 2 * 8, 9 * 8 },
 		20,
 		SymField::SYMFIELD_DEF
 	};
 	
 	Text text_format {
-		{ 2 * 8, 8 * 8, 24 * 8, 16 },
+		{ 2 * 8, 11 * 8, 24 * 8, 16 },
 		""
 	};
 	
 	Waveform waveform {
-		{ 0, 14 * 8, 240, 32 },
+		{ 0, 17 * 8, 240, 32 },
 		waveform_buffer,
 		0,
 		0,

--- a/firmware/application/apps/ui_encoders.hpp
+++ b/firmware/application/apps/ui_encoders.hpp
@@ -67,7 +67,7 @@ private:
 	Labels labels {
 		{ { 1 * 8, 0 }, "Type:", Color::light_grey() },
 		{ { 16 * 8, 0 }, "Clk:", Color::light_grey() },
-		{ { 24 * 8, 0 }, "kHz", Color::light_grey() },
+		{ { 25 * 8, 0 }, "kHz", Color::light_grey() },
 		{ { 14 * 8, 2 * 8 }, "Frame:", Color::light_grey() },
 		{ { 26 * 8, 2 * 8 }, "us", Color::light_grey() },
 		{ { 2 * 8, 4 * 8 }, "Symbols:", Color::light_grey() },
@@ -83,8 +83,8 @@ private:
 
 	NumberField field_clk {
 		{ 21 * 8, 0 },
-		3,
-		{ 1, 500 },
+		4,
+		{ 1, 1000 },
 		1,
 		' '
 	};

--- a/firmware/application/apps/ui_encoders.hpp
+++ b/firmware/application/apps/ui_encoders.hpp
@@ -68,7 +68,7 @@ private:
 		{ { 1 * 8, 0 }, "Type:", Color::light_grey() },
 		{ { 1 * 8, 2 * 8 }, "Clk:", Color::light_grey() },
 		{ { 10 * 8, 2 * 8 }, "kHz", Color::light_grey() },
-        { { 17 * 8, 2 * 8 }, "Step:", Color::light_grey() },
+                { { 17 * 8, 2 * 8 }, "Step:", Color::light_grey() },
 		{ { 1 * 8, 4 * 8 }, "Frame:", Color::light_grey() },
 		{ { 13 * 8, 4 * 8 }, "us", Color::light_grey() },		
 		{ { 17 * 8, 4 * 8 }, "Step", Color::light_grey() },


### PR DESCRIPTION
I've seen PR refactoring OOK, which is in progress. 
https://github.com/eried/portapack-mayhem/pull/572
Not sure, when it will be finished, but I'd like to propose this change.

I found the car key fob with PT2260, which transmits with ~1000 kHz clock. In attempt to use with portapack-mayhem, I did this:
- increase max allowed clock to 1000 kHz
- add steps options for clock and frame duration to make adjusting easier