### PR TITLE
Very minor change , add 10 & 50Hz freq. steps , SSB  in HF and Qo-100_sat_#669

### DIFF
--- a/firmware/application/ui/ui_receiver.hpp
+++ b/firmware/application/ui/ui_receiver.hpp
@@ -247,6 +247,8 @@ public:
 			parent_pos,
 			5,
 			{
+				{ "   10",       10 },  /* Fine tuning SSB voice pitch,in HF and QO-100 sat #669 */
+				{ "   50",       50 },	/* added 50Hz/10Hz,but we do not increase GUI digit decimal */
 				{ "  100",      100 },
 				{ "  1k ",     1000 },
 				{ "  3k ",     3000 },	/* Approximate SSB bandwidth */


### PR DESCRIPTION
Very minor change ,   
Just adding  10  and 50Hz  in the  freq. step,as suggested by @devop-mike (issue #669). ,  for better voice pitch fine tunning in the  SSB  in HF and Qo-100_sat_#669

* Currently our min.  step is 100Hz,  but in some cases, the decoded SSB voice pitch  is not natural . 
*  We are adding in this PR,   10 and 50Hz step below 100Hz , to have better accurate SSB voice pitch fine tuning .

Note , to make it simple ,  we will not add 1 x more Freq. selection DIGIT display  , then we will see how the 100Hz digit will change every two 2x steps increase/decrease  ,( when we have selected step =50 hz) , and every x 10 ,  (when we select 10 Hz.)
  
So user , can select example in the Receiver App the freq- STEP  that he wants ,  and in all other aplications  that use  Freq. display selection ,==> we  will have those steps in real freq-  , but we are not changing the display decimal digits  .., (but it is not a major problem , because the main benefit will be ,  correct hear adjustment of the  voice pitch fine tuning ,  in decoded SSB voice .


.

