### PR TITLE
Mic App: DSB RX distortion c/m + minor improv.

### DIFF
--- a/firmware/application/apps/ui_mictx.hpp
+++ b/firmware/application/apps/ui_mictx.hpp
@@ -123,7 +123,7 @@ private:
 		{ {20 * 8, 10 * 8 }, "DEC:", Color::light_grey() },
 		{ { 4 * 8, ( 13 * 8 ) - 2 }, "TONE KEY:", Color::light_grey() },
 		{ { 7 * 8, 23 * 8 }, "VOL:", Color::light_grey() },
-		{ {14 * 8, 23 * 8 }, "FM RXBW:", Color::light_grey() },
+		{ {14 * 8, 23 * 8 }, "RXBW:", Color::light_grey() },				//we remove the label "FM" because we will display all MOD types RX_BW.
 		{ {17 * 8, 25 * 8 }, "SQ:", Color::light_grey() },
 		{ { 5 * 8, 25 * 8 }, "F:", Color::light_grey() },
 		{ { 5 * 8, 27 * 8 }, "LNA:", Color::light_grey()},
@@ -144,7 +144,7 @@ private:
 		{ {20 * 8, 10 * 8 }, "DEC:", Color::light_grey() },
 		{ { 4 * 8, ( 13 * 8 ) - 2 }, "TONE KEY:", Color::light_grey() },
 		{ { (6 * 8)+4, 23 * 8 }, "VOL:", Color::light_grey() },
-		{ {14 * 8, 23 * 8 }, "FM RXBW:", Color::light_grey() },
+		{ {14 * 8, 23 * 8 }, "RXBW:", Color::light_grey() },			//we remove the label "FM" because we will display all MOD types RX_BW.
 		{ {17 * 8, 25 * 8 }, "SQ:", Color::light_grey() },
 		{ { 5 * 8, 25 * 8 }, "F:", Color::light_grey() },
 		{ { 5 * 8, 27 * 8 }, "LNA:", Color::light_grey()},
@@ -233,10 +233,10 @@ OptionsField options_wm8731_boost_mode {
 		{
 			{ "NFM/FM", 0 },
 			{ " WFM  ", 1 },
-			{ "  AM  ", 2 },
+			{ "  AM  ", 2 },			// in fact that TX mode = AM -DSB with carrier .
 			{ " USB  ", 3 },
 			{ " LSB  ", 4 },
-			{ " DSB  ", 5 }
+			{ "DSB-SC", 5 }				// We are TX Double Side AM Band with suppressed carrier, and allowing in RX both indep SSB lateral band (USB/LSB).  
 		}
 	};
 	/*
@@ -309,12 +309,12 @@ OptionsField options_wm8731_boost_mode {
 	};
 	
 	OptionsField field_rxbw {
-	       { 22* 8, 23 * 8},
+	       { 19* 8, 23 * 8},
 	       3,
 	       {
-	       		{"8k5-NFM", 0},
-	       		{"11k-NFM", 1},
-	       		{"16k-FM ", 2},
+	       		{" NFM1:8k5  ", 0},
+	       		{" NFM2:11k  ", 1},
+	       		{" FM  :16k  ", 2},
 		   	}
 	};
 	


### PR DESCRIPTION
(MINOR CORRECTIONS and  IMPROVEMENTS to RX  of the MIC -APP) 
In previous fw PR #727  , I could realise that the audio demodulated of the MOD:  DSB reception, was distorted.
After debugging and testing I could confirm that I wrongly activated RX  AM DSB-C (with carrier) demodulation, but when we transmit a signal AM suppressing the carrier , (DSB-SC) actually it was just decoding  incorrect distorted  audio.

With this minor  PR , we apply following minor changes, : 
i-) To avoid missunderstanding , and be more accurate , we changed in the main MOD Types label :  DSB label --> DSB-SC  (previous label : DSB was to general better specify that in that mode we are  really TX DSB-SC, because actually in that mode , we are transmitting both lateral side bands , but with suppressed central carrier .

ii-) Add in the below RX part ,when we activate the MOD : DSB-SC , in  the below  submenu, the user will have the choice to select the lateral demod. part , USB or LSB.

iii-) I am removing in below line the "FM" word,   "FM RXBW" --> "RXBW", and now we are displaying the selected reception bandwith of each selected mode.    (in all modes,  not only  FM ) .

iv-) Other minor GUI issues,  adding 1,2 in the  RXBW labels that has several options,  example NFM1, NFM2, SSB1, SSB2, then user can better recognise wich MODES has additional RX sub-options or not .
![image](https://user-images.githubusercontent.com/86470699/198836225-a0881439-f04e-4e64-b8f2-61e6cb46c5dd.png)


v-) some internal code comments corrections , and  code  improvements.

I already validated in both platforms , AK4951 H1 ,  WM8731 H2+ , transmitting AM /DSB-SC / USB / LSB from  GNURADIO.

Cheers, 
 