### PR TITLE
update for python scripts so no python2.7 is needed

### DIFF
--- a/firmware/tools/extract_cpld_data.py
+++ b/firmware/tools/extract_cpld_data.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 #
 # Copyright (C) 2014 Jared Boone, ShareBrained Technology, Inc.
@@ -80,7 +80,7 @@ def print_block(block):
 	for n in range(0, len(block), 8):
 		chunk = block[n:n+8]
 		line = ['0x%04x,' % v for v in chunk]
-		print('\t%s' % ' '.join(line))
+		print(('\t%s' % ' '.join(line)))
 
 def crc32(blocks):
 	import zlib
@@ -92,7 +92,7 @@ def crc32(blocks):
 			crc_bytes.append((word >> 8) & 0xff)
 	return zlib.crc32(bytearray(crc_bytes)) & 0xffffffff
 
-print("""#include "portapack_cpld_data.hpp"
+print(("""#include "portapack_cpld_data.hpp"
 
 #include <cstdint>
 #include <array>
@@ -100,23 +100,23 @@ print("""#include "portapack_cpld_data.hpp"
 namespace portapack {
 namespace cpld {
 namespace %s {
-""" % revision_name)
+""" % revision_name))
 
-print('const std::array<uint16_t, %d> block_0 { {' % len(block_0))
+print(('const std::array<uint16_t, %d> block_0 { {' % len(block_0)))
 print_block(block_0)
 
 print("""} };
 """)
 
-print('const std::array<uint16_t, %d> block_1 { {' % len(block_1))
+print(('const std::array<uint16_t, %d> block_1 { {' % len(block_1)))
 print_block(block_1)
 
-print("""} };
+print(("""} };
 
 } /* namespace %s */
 } /* namespace cpld */
 } /* namespace portapack */
-""" % revision_name)
+""" % revision_name))
 
 if calculate_crc:
 	# Apply post-programming modification to make post-programming CRC correct:
@@ -124,4 +124,4 @@ if calculate_crc:
 	programmed_block_0[0] &= 0xfbff
 
 	crc = crc32((programmed_block_0, block_1))
-	print('%08x' % crc)
+	print(('%08x' % crc))

--- a/firmware/tools/fir_lpf.py
+++ b/firmware/tools/fir_lpf.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import math
 
 m = 64 - 1

--- a/firmware/tools/fir_lpf.py
+++ b/firmware/tools/fir_lpf.py
@@ -6,7 +6,7 @@ ft = 300.0 / 24000.0
 taps = []
 window = []
 
-print("Normalized ft = " + str(ft))
+print(("Normalized ft = " + str(ft)))
 
 for n in range(0, 64):
 	taps.append(math.sin(2 * math.pi * ft * (n - (m / 2.0))) / (math.pi * (n - (m / 2.0))))

--- a/firmware/tools/make_baseband_file.py
+++ b/firmware/tools/make_baseband_file.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright (C) 2016 Furrtek
 #

--- a/firmware/tools/make_bitmap.py
+++ b/firmware/tools/make_bitmap.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright (C) 2016 Furrtek
 #
@@ -42,7 +42,7 @@ def convert_png(file):
 	rgb_im = im.convert('RGBA')
 
 	if rgb_im.size[0] % 8 or rgb_im.size[1] % 8:
-		print(file + ": Size isn\'t a multiple of 8")
+		print((file + ": Size isn\'t a multiple of 8"))
 		sys.exit(-1)
 
 	name = path.basename(file).split(".")[0].lower();
@@ -112,4 +112,4 @@ f.write("\n")
 f.write("} /* namespace ui */\n\n")
 f.write("#endif/*__BITMAP_HPP__*/\n")
 
-print("Converted " + str(count) + " files")
+print(("Converted " + str(count) + " files"))

--- a/firmware/tools/make_dcs.py
+++ b/firmware/tools/make_dcs.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright (C) 2016 Furrtek
 #
@@ -40,4 +40,4 @@ for c in range (0, 0x200):		# DCS code is 9 bits
 	p10 = cb[3] ^ cb[5] ^ cb[6] ^ cb[8] ^ 1;
 	p11 = cb[0] ^ cb[1] ^ cb[2] ^ cb[3] ^ cb[6] ^ 1;
 	
-	print '	0b{0:011b}'.format((p11<<10) | (p10<<9) | (p9<<8) |(p8<<7) | (p7<<6) | (p6<<5) | (p5<<4) | (p4<<3) | (p3<<2) | (p2<<1) | (p1)) + ', 	// ' + str(c);
+	print('	0b{0:011b}'.format((p11<<10) | (p10<<9) | (p9<<8) |(p8<<7) | (p7<<6) | (p6<<5) | (p5<<4) | (p4<<3) | (p3<<2) | (p2<<1) | (p1)) + ', 	// ' + str(c));

--- a/firmware/tools/make_image_chunk.py
+++ b/firmware/tools/make_image_chunk.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 #
 # Copyright (C) 2015 Jared Boone, ShareBrained Technology, Inc.

--- a/firmware/tools/make_spi_image.py
+++ b/firmware/tools/make_spi_image.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 #
 # Copyright (C) 2015 Jared Boone, ShareBrained Technology, Inc.


### PR DESCRIPTION
As explained in [Issue 736](https://github.com/eried/portapack-mayhem/issues/736) there are python scripts which require python2.7.

These changes will remove this requirement and update all scripts to use python3 and use correct python3 syntax.