### PR TITLE
(MINOR IMPROV Replay App) - Extending previous  "ghost interf. signal" c/m to Replay App

### DIFF
--- a/firmware/application/apps/replay_app.cpp
+++ b/firmware/application/apps/replay_app.cpp
@@ -26,7 +26,7 @@
 
 #include "ui_fileman.hpp"
 #include "io_file.hpp"
-
+#include "cpld_update.hpp"
 #include "baseband_api.hpp"
 #include "portapack.hpp"
 #include "portapack_persistent_memory.hpp"
@@ -258,7 +258,12 @@ ReplayAppView::ReplayAppView(
 
 ReplayAppView::~ReplayAppView() {
 	radio::disable();
-	baseband::shutdown();
+ 
+ 	display.fill_rectangle({ 0,0,240, 320 },Color::black()); //Solving sometimes visible bottom waterfall artifacts, clearing all LCD  pixels. 
+	chThdSleepMilliseconds(40);	// (that happened sometimes if we interrupt the waterfall play at the beggining of the play  around 25% and exit )  
+	hackrf::cpld::load_sram_no_verify();  // to leave all  RX reception ok, without "ghost interference signal problem" at the exit .
+
+	baseband::shutdown(); // better this function at the end, after load_sram(). If not , sometimes produced hang up (now not , it is ok).
 }
 
 void ReplayAppView::on_hide() {


### PR DESCRIPTION
Hi,  this PR is a minor improving of  Replay App. 
(avoiding to produce  "ghost signal interference"  problem to all receivers , after using "play" in that Replay app.)

When I released the previous PR #707 ,   I  added the c/m to all  Transmitter App group  , but I forgot to add it in that  Replay App, that is also a transmitter ... .and actually I could  detect that after using the play TX in the Replay App ,  later on ,  the ADSB airplane reception was very poor and in the Audio receiver App or  Capture App ,  I could see all the previous "ghost interferences".  (already described in the issue #637 )

So this PR , is  just adding the same previous c/m  to the exit of the Replay App, --> to guarantee a clean reception in the rest of Receiver Applicatons . (same as booting) .

But I also added an small  "clear LCD screen" -before the c/m-  , when exiting , because I realised that  if we interrupted the "play" just at the begigging of the waterfall <25-40% (left below picture) , sometimes we had an strange image artifact for a few hundred of milisegs.  in the bottom LCD part  (right picture)  ,(now is fixed)
![image](https://user-images.githubusercontent.com/86470699/198892106-34811597-ff01-44e1-9300-2f3391f3501b.png)

I tested in AK H1 and WM H2+.and it seems no side effect about that PR ,

Note : I think due to my local compiler issue and the SD problems  ,  beside that change , In AK H1 , sometimes , I can  not "open files" , two consecutive times inside Replay App  without exiting the app . (But if we exit the app, and enter again , "open files" works well) . In the WM H2+ seems OK, not failing . (but   using  yesterday nightly version 30th of Oct ,  ,both platforms   works well, so it should be my local compiler issue and the SD card . I will check next nightly with that PR again ) . 

Cheers, 