### PR TITLE
Add gain and amplifier controls in Jammer

### DIFF
--- a/firmware/application/apps/ui_jammer.cpp
+++ b/firmware/application/apps/ui_jammer.cpp
@@ -270,9 +270,9 @@ void JammerView::start_tx() {
 		button_transmit.set_text("STOP");
 		
 		transmitter_model.set_sampling_rate(3072000U);
-		transmitter_model.set_rf_amp(true);
+		transmitter_model.set_rf_amp(field_amp.value());
 		transmitter_model.set_baseband_bandwidth(3500000U);
-		transmitter_model.set_tx_gain(47);
+		transmitter_model.set_tx_gain(field_gain.value());
 		transmitter_model.enable();
 
 		baseband::set_jammer(true, (JammerType)options_type.selected_index(), options_speed.selected_index_value());
@@ -368,6 +368,8 @@ JammerView::JammerView(
 		&field_timetx,
 		&field_timepause,
 		&field_jitter,
+		&field_gain,
+		&field_amp,
 		&button_transmit
 	});
 	
@@ -382,6 +384,8 @@ JammerView::JammerView(
 
 	field_timetx.set_value(30);
 	field_timepause.set_value(1);
+	field_gain.set_value(transmitter_model.tx_gain());
+	field_amp.set_value(transmitter_model.rf_amp());
 
 	button_transmit.on_select = [this](Button&) {
 		if (jamming || cooling)

--- a/firmware/application/apps/ui_jammer.hpp
+++ b/firmware/application/apps/ui_jammer.hpp
@@ -156,7 +156,9 @@ private:
 		{ { 0 * 8, 33 * 8 }, "Jitter:", Color::light_grey() },	//Maybe the repository curator can keep the "mystype" for some versions. 
 		{ { 11 * 8, 29 * 8 }, "Secs.", Color::light_grey() }, 
 		{ { 11 * 8, 31 * 8 }, "Secs.", Color::light_grey() },
-		{ { 11 * 8, 33 * 8 }, "/60", Color::light_grey() }
+		{ { 11 * 8, 33 * 8 }, "/60", Color::light_grey() },
+		{ { 2 * 8, 35 * 8 }, "Gain:", Color::light_grey() },
+		{ { 11 * 8, 35 * 8 }, "A:", Color::light_grey() }
 	};
 	
 	OptionsField options_type {
@@ -229,8 +231,24 @@ private:
 		' ',
 	};
 
+	NumberField field_gain {
+		{ 8 * 8, 35 * 8 },
+		2,
+		{ 0, 47 },
+		1,
+		' ',
+	};
+
+	NumberField field_amp {
+		{ 13 * 8, 35 * 8 },
+		1,
+		{ 0, 1 },
+		1,
+		' ',
+	};
+
 	Button button_transmit {
-		{ 148, 212, 80, 80},
+		{ 148, 216, 80, 80},
 		"START"
 	};
 	


### PR DESCRIPTION
Allow user to adjust gain and control the amplifier. This is useful when external amplifier is used.

![SCR_0000](https://user-images.githubusercontent.com/9296247/199163811-35f2be91-4684-4658-839c-18378f701e59.PNG)
