### PR TITLE
Scanner BW label corrections

### DIFF
--- a/firmware/application/apps/ui_scanner.cpp
+++ b/firmware/application/apps/ui_scanner.cpp
@@ -584,9 +584,9 @@ size_t ScannerView::change_mode(uint8_t new_mod) { //Before this, do a scan_thre
 
 	switch (new_mod) {
 	case NFM:	//bw 16k (2) default
-		bw.emplace_back("8k5", 0);
-		bw.emplace_back("11k", 0);
-		bw.emplace_back("16k", 0);			
+		bw.emplace_back("8k5   ", 0);
+		bw.emplace_back("11k   ", 0);
+		bw.emplace_back("16k   ", 0);			
 		field_bw.set_options(bw);
 
 		baseband::run_image(portapack::spi_flash::image_tag_nfm_audio);
@@ -613,7 +613,7 @@ size_t ScannerView::change_mode(uint8_t new_mod) { //Before this, do a scan_thre
 		receiver_model.set_sampling_rate(3072000);	receiver_model.set_baseband_bandwidth(1750000); 
 		break;
 	case WFM:
-		bw.emplace_back("200k", 0);
+		bw.emplace_back("200k  ", 0);
 		field_bw.set_options(bw);
 
 		baseband::run_image(portapack::spi_flash::image_tag_wfm_audio);


### PR DESCRIPTION
(very minor UI  correction in Scanner App) 
It is only changed the BW field character space in the Scanner App
 , adding blank space at the end, to communize all labels , same size. (to have a clean label refresh at each option change.)

No risk of side effects,  it is just label BW update, error correction.

Already compiled and validated in the Scanner app. 
 