### PR TITLE
Save and recall all receiver settings of the Audio RX app

### DIFF
--- a/firmware/application/app_settings.cpp
+++ b/firmware/application/app_settings.cpp
@@ -68,7 +68,7 @@ int app_settings::load(std::string application, AppSettings* settings) {
 
 int app_settings::save(std::string application, AppSettings* settings) {
 
-	if (portapack::persistent_memory::save_app_settings()) {        
+	if (portapack::persistent_memory::save_app_settings()) {
 		file_path = folder+"/"+application+".ini";
 		make_new_directory(folder);
 

--- a/firmware/application/app_settings.cpp
+++ b/firmware/application/app_settings.cpp
@@ -52,6 +52,12 @@ int app_settings::load(std::string application, AppSettings* settings) {
 			settings->tx_frequency=std::app_settings::read_long_long(file_content, "tx_frequency=");
 			settings->tx_gain=std::app_settings::read_long_long(file_content, "tx_gain=");
 			settings->step=std::app_settings::read_long_long(file_content, "step=");
+			settings->modulation=std::app_settings::read_long_long(file_content, "modulation=");
+			settings->am_config_index=std::app_settings::read_long_long(file_content, "am_config_index=");
+			settings->nbfm_config_index=std::app_settings::read_long_long(file_content, "nbfm_config_index=");
+			settings->wfm_config_index=std::app_settings::read_long_long(file_content, "wfm_config_index=");
+			settings->squelch=std::app_settings::read_long_long(file_content, "squelch=");
+
 			rc = SETTINGS_OK;
 		}
 		else rc = SETTINGS_UNABLE_TO_LOAD;
@@ -81,6 +87,11 @@ int app_settings::save(std::string application, AppSettings* settings) {
 			settings_file.write_line("rx_frequency="+to_string_dec_uint(settings->rx_frequency));
 			settings_file.write_line("tx_frequency="+to_string_dec_uint(settings->tx_frequency));
 			settings_file.write_line("step="+to_string_dec_uint(settings->step));
+			settings_file.write_line("modulation="+to_string_dec_uint(settings->modulation));
+			settings_file.write_line("am_config_index="+to_string_dec_uint(settings->am_config_index));
+			settings_file.write_line("nbfm_config_index="+to_string_dec_uint(settings->nbfm_config_index));
+			settings_file.write_line("wfm_config_index="+to_string_dec_uint(settings->wfm_config_index));
+			settings_file.write_line("squelch="+to_string_dec_uint(settings->squelch));
 
 			rc = SETTINGS_OK;
 		}

--- a/firmware/application/app_settings.cpp
+++ b/firmware/application/app_settings.cpp
@@ -51,6 +51,7 @@ int app_settings::load(std::string application, AppSettings* settings) {
 			settings->tx_amp=std::app_settings::read_long_long(file_content, "tx_amp=");
 			settings->tx_frequency=std::app_settings::read_long_long(file_content, "tx_frequency=");
 			settings->tx_gain=std::app_settings::read_long_long(file_content, "tx_gain=");
+			settings->step=std::app_settings::read_long_long(file_content, "step=");
 			rc = SETTINGS_OK;
 		}
 		else rc = SETTINGS_UNABLE_TO_LOAD;
@@ -79,6 +80,7 @@ int app_settings::save(std::string application, AppSettings* settings) {
 			// Save other settings from struct
 			settings_file.write_line("rx_frequency="+to_string_dec_uint(settings->rx_frequency));
 			settings_file.write_line("tx_frequency="+to_string_dec_uint(settings->tx_frequency));
+			settings_file.write_line("step="+to_string_dec_uint(settings->step));
 
 			rc = SETTINGS_OK;
 		}

--- a/firmware/application/app_settings.hpp
+++ b/firmware/application/app_settings.hpp
@@ -60,6 +60,10 @@ public:
 		uint8_t 	tx_gain;
 		uint8_t 	vga;
 		uint32_t 	step;
+		uint8_t 	am_config_index;
+		uint8_t 	nbfm_config_index;
+		uint8_t 	wfm_config_index;
+		uint8_t 	squelch;
 	};
 
 	int load(std::string application, AppSettings* settings);

--- a/firmware/application/app_settings.hpp
+++ b/firmware/application/app_settings.hpp
@@ -59,6 +59,7 @@ public:
 		uint32_t 	tx_frequency;
 		uint8_t 	tx_gain;
 		uint8_t 	vga;
+		uint32_t 	step;
 	};
 
 	int load(std::string application, AppSettings* settings);

--- a/firmware/application/apps/analog_audio_app.cpp
+++ b/firmware/application/apps/analog_audio_app.cpp
@@ -194,30 +194,30 @@ AnalogAudioView::AnalogAudioView(
 	audio::output::start();
 
 	update_modulation(static_cast<ReceiverModel::Mode>(modulation));
-    on_modulation_changed(static_cast<ReceiverModel::Mode>(modulation));
+	on_modulation_changed(static_cast<ReceiverModel::Mode>(modulation));
 }
 
 size_t AnalogAudioView::get_spec_bw_index() {
-    return spec_bw_index;
+	return spec_bw_index;
 }
 
 void AnalogAudioView::set_spec_bw(size_t index, uint32_t bw) {
-    spec_bw_index = index;
-    spec_bw = bw;
+	spec_bw_index = index;
+	spec_bw = bw;
 
-    baseband::set_spectrum(bw, spec_trigger);
-    receiver_model.set_sampling_rate(bw);
-    receiver_model.set_baseband_bandwidth(bw/2);
+	baseband::set_spectrum(bw, spec_trigger);
+	receiver_model.set_sampling_rate(bw);
+	receiver_model.set_baseband_bandwidth(bw/2);
 }
 
 uint16_t AnalogAudioView::get_spec_trigger() {
-    return spec_trigger;
+	return spec_trigger;
 }
 
 void AnalogAudioView::set_spec_trigger(uint16_t trigger) {
-    spec_trigger = trigger;
+	spec_trigger = trigger;
 
-    baseband::set_spectrum(spec_bw, spec_trigger);
+	baseband::set_spectrum(spec_bw, spec_trigger);
 }
 
 AnalogAudioView::~AnalogAudioView() {

--- a/firmware/application/apps/analog_audio_app.cpp
+++ b/firmware/application/apps/analog_audio_app.cpp
@@ -136,6 +136,7 @@ AnalogAudioView::AnalogAudioView(
 		field_vga.set_value(app_settings.vga);
 		receiver_model.set_rf_amp(app_settings.rx_amp);
 		field_frequency.set_value(app_settings.rx_frequency);
+		receiver_model.set_configuration_without_init(static_cast<ReceiverModel::Mode>(app_settings.modulation), app_settings.step, app_settings.am_config_index, app_settings.nbfm_config_index, app_settings.wfm_config_index, app_settings.squelch);
 	}
 	else field_frequency.set_value(receiver_model.tuning_frequency());
 	
@@ -193,7 +194,7 @@ AnalogAudioView::AnalogAudioView(
 	audio::output::start();
 
 	update_modulation(static_cast<ReceiverModel::Mode>(modulation));
-    	on_modulation_changed(static_cast<ReceiverModel::Mode>(modulation));
+    on_modulation_changed(static_cast<ReceiverModel::Mode>(modulation));
 }
 
 size_t AnalogAudioView::get_spec_bw_index() {
@@ -223,6 +224,15 @@ AnalogAudioView::~AnalogAudioView() {
 
 	// save app settings
 	app_settings.rx_frequency = field_frequency.value();
+	app_settings.lna = receiver_model.lna();
+	app_settings.vga = receiver_model.vga();
+	app_settings.rx_amp = receiver_model.rf_amp();
+	app_settings.step = receiver_model.frequency_step();
+	app_settings.modulation = (uint8_t)receiver_model.modulation();
+	app_settings.am_config_index = receiver_model.am_configuration();
+	app_settings.nbfm_config_index = receiver_model.nbfm_configuration();
+	app_settings.wfm_config_index = receiver_model.wfm_configuration();
+	app_settings.squelch = receiver_model.squelch_level();
 	settings.save("rx_audio", &app_settings);
 
 	// TODO: Manipulating audio codec here, and in ui_receiver.cpp. Good to do

--- a/firmware/application/receiver_model.cpp
+++ b/firmware/application/receiver_model.cpp
@@ -313,3 +313,12 @@ size_t ReceiverModel::wfm_configuration() const {
 void ReceiverModel::update_wfm_configuration() {
 	wfm_configs[wfm_config_index].apply();
 }
+
+void ReceiverModel::set_configuration_without_init(const Mode new_mode, const rf::Frequency new_frequency_step, const size_t new_am_config_index, const size_t new_nbfm_config_index, const size_t new_wfm_config_index, uint8_t new_squelch_level) {
+	mode_ = new_mode;
+	frequency_step_ = new_frequency_step;
+	am_config_index = new_am_config_index;
+	nbfm_config_index = new_nbfm_config_index;
+	wfm_config_index = new_wfm_config_index;
+	squelch_level_ = new_squelch_level;
+}

--- a/firmware/application/receiver_model.hpp
+++ b/firmware/application/receiver_model.hpp
@@ -87,6 +87,8 @@ public:
 	size_t wfm_configuration() const;
 	void set_wfm_configuration(const size_t n);
 
+	void set_configuration_without_init(const Mode new_mode, const rf::Frequency new_frequency_step, const size_t new_am_config_index, const size_t new_nbfm_config_index, const size_t new_wfm_config_index, uint8_t new_squelch_level);
+
 private:
 	rf::Frequency frequency_step_ { 25000 };
 	bool enabled_ { false };


### PR DESCRIPTION
These changes let the Audio RX app resume at the exact state where you left it last time.

- [x] Frequency
- [x] LNA/VGA/Amp
- [x] Modulation
- [x] Modulation sub-config
- [x] Step size
- [x] Squelch