### PR TITLE
Fix OOK app

### DIFF
--- a/firmware/application/apps/ui_encoders.cpp
+++ b/firmware/application/apps/ui_encoders.cpp
@@ -156,6 +156,8 @@ void EncodersConfigView::generate_frame() {
 	for (auto c : encoder_def->word_format) {
 		if (c == 'S')
 			frame_fragments += encoder_def->sync;
+		else if (!c)
+			break;
 		else
 			frame_fragments += encoder_def->bit_format[symfield_word.get_sym(i++)];
 	}
@@ -252,7 +254,8 @@ void EncodersView::start_tx(const bool scan) {
 		scan_width = view_scan.field_length.value();
 		samples_per_bit =
 			((view_scan.bit_length_10.value() * 10 + view_scan.bit_length.value()) * OOK_SAMPLERATE) / 1000000UL;
-		const uint32_t seq_len = ((1 << (scan_width - 1)) * 2) * ((uint64_t) samples_per_bit) / 2048UL;
+		constexpr auto sym_len = 4;
+		const uint32_t seq_len = ((1 << (scan_width - 1)) * 2) * ((uint64_t) samples_per_bit) * sym_len / 2048UL;
 		progressbar.set_max(seq_len);
 		repeat_min = seq_len;
 	} else {

--- a/firmware/application/protocols/encoders.hpp
+++ b/firmware/application/protocols/encoders.hpp
@@ -28,12 +28,12 @@
 #define __ENCODERS_H__
 
 namespace encoders {
-	
+
 	#define ENC_TYPES_COUNT 14
 	#define OOK_SAMPLERATE	2280000U
-	
+
 	#define ENCODER_UM3750	8
-	
+
 	size_t make_bitstream(std::string& fragments);
 	void bitstream_append(size_t& bitstream_length, uint32_t bit_count, uint32_t bits);
 
@@ -65,7 +65,7 @@ namespace encoders {
 			150000,	2,
 			0
 		},
-		
+
 		// PT2260-R4
 		{
 			"2260-R4",
@@ -77,7 +77,7 @@ namespace encoders {
 			150000,	2,
 			0
 		},
-		
+
 		// PT2262
 		{
 			"2262   ",
@@ -89,7 +89,7 @@ namespace encoders {
 			20000,	4,
 			0
 		},
-		
+
 		// 16-bit ?
 		{
 			"16-bit ",
@@ -101,7 +101,7 @@ namespace encoders {
 			25000,	50,
 			0	// ?
 		},
-		
+
 		// RT1527
 		{
 			"1527   ",
@@ -111,9 +111,9 @@ namespace encoders {
 			24,	"SAAAAAAAAAAAAAAAAAAAADDDD",
 			"10000000000000000000000000000000",
 			100000,	4,
-			10	// ?
+			0
 		},
-		
+
 		// HK526E
 		{
 			"526E   ",
@@ -125,7 +125,7 @@ namespace encoders {
 			20000, 4,
 			10	// ?
 		},
-		
+
 		// HT12E
 		{
 			"12E    ",
@@ -137,7 +137,7 @@ namespace encoders {
 			3000, 4,
 			10	// ?
 		},
-			
+
 		// VD5026 13 bits ?
 		{
 			"5026   ",
@@ -149,7 +149,7 @@ namespace encoders {
 			100000,	4,
 			10	// ?
 		},
-		
+
 		// UM3750
 		{
 			"UM3750 ",
@@ -161,7 +161,7 @@ namespace encoders {
 			100000,	4,
 			(3 * 12) - 6	// Compensates for pause delay bug in proc_ook
 		},
-		
+
 		// UM3758
 		{
 			"UM3758 ",
@@ -173,7 +173,7 @@ namespace encoders {
 			160000,	4,
 			10	// ?
 		},
-		
+
 		// BA5104
 		{
 			"BA5104 ",
@@ -185,7 +185,7 @@ namespace encoders {
 			455000,	4,
 			10	// ?
 		},
-			
+
 		// MC145026
 		{
 			"145026 ",
@@ -197,7 +197,7 @@ namespace encoders {
 			455000,	2,
 			2
 		},
-		
+
 		// HT6*** TODO: Add individual variations
 		{
 			"HT6*** ",
@@ -209,7 +209,7 @@ namespace encoders {
 			80000,	3,
 			10	// ?
 		},
-		
+
 		// TC9148
 		{
 			"TC9148 ",

--- a/firmware/baseband/proc_ook.hpp
+++ b/firmware/baseband/proc_ook.hpp
@@ -46,9 +46,9 @@ private:
 	uint32_t pause_counter { 0 };
 	uint8_t repeat_counter { 0 };
 	uint8_t s { 0 };
-    uint16_t bit_pos { 0 };
-    uint8_t cur_bit { 0 };
-    uint32_t sample_count { 0 };
+	uint16_t bit_pos { 0 };
+	uint8_t cur_bit { 0 };
+	uint32_t sample_count { 0 };
 	uint32_t tone_phase { 0 }, phase { 0 }, sphase { 0 };
 	int32_t tone_sample { 0 }, sig { 0 }, frq { 0 };
 
@@ -56,14 +56,22 @@ private:
 
 	static constexpr auto MAX_DE_BRUIJN_ORDER = 24;
 	uint8_t v[MAX_DE_BRUIJN_ORDER];
+	uint8_t v_tmp[MAX_DE_BRUIJN_ORDER];
 	unsigned int idx { 0 };
 	unsigned int k { 0 };
-	size_t bit_ptr{ 0 };
+	unsigned int duval_symbols { 0 };
+	unsigned int duval_length { 0 };
+	unsigned int duval_bit { 0 };
+	unsigned int duval_sample_bit { 0 };
+	unsigned int duval_symbol { 0 };
 	size_t scan_progress{ 0 };
 	uint8_t scan_done { true };
 
+	size_t duval_algo_step();
+	void scan_process(const buffer_c8_t& buffer);
+	bool scan_init(unsigned int order);
+	bool scan_encode(const buffer_c8_t& buffer, size_t& buf_ptr);
 	void write_sample(const buffer_c8_t& buffer, uint8_t bit_value, size_t i);
-	void duval_algo(const buffer_c8_t& buffer);
 };
 
 #endif


### PR DESCRIPTION
This PR addresses the following issues:

- Broken encoding in OOK app.

This can be reproduced by selecting an encoder and setting last bit to 1 - we're still seeing some zeroes at the end that shouldn't be there.
![SCR_0001](https://user-images.githubusercontent.com/9296247/216379909-af0c0f5b-2348-46ca-9ff9-52374ec8ad4e.PNG)
These symbols are also present in the transmitted packet:
![hackrf_bad_tx](https://user-images.githubusercontent.com/9296247/216381826-cd7b0197-f5b9-43c4-8295-5e026f2db5eb.png)

This is caused by the initialization of `word_format[32]` inside `encoder_def_t` and affects all the encoders. Fixed by checking for null-terminator when parsing the string.
![SCR_0002](https://user-images.githubusercontent.com/9296247/216394526-b2ab4cc2-3f31-4f30-8d85-3a5c4dc0c875.PNG)
![hackrf_expected_tx](https://user-images.githubusercontent.com/9296247/216394541-f6af8e14-3b3e-4bbd-b610-6d963d415ba9.png)

Also `pause_symbols` was changed from 10 to 0 for 1527 encoder - it's not mentioned anywhere in the documentation and the module that I used for testing refused to detect the packet with this pause.

- Missing encoding in scan

For some reason I was being stupid and forgot to add the actual encoding when I implemented scan feature. For now the encoding is hard-coded ( 0 -> 1000, 1 -> 1110), but I might re-visit this and make encoding user-adjustable in the future when the modules I ordered for testing arrive. I'll also add support for ternary encoders when I get my hands on one. The code already supports it and it's simply a matter of making `duval_symbols` and `sym[]` user configurable.