### PR TITLE
Set usable persistent memory defaults for Recon 

### DIFF
--- a/firmware/common/portapack_persistent_memory.cpp
+++ b/firmware/common/portapack_persistent_memory.cpp
@@ -400,16 +400,16 @@ namespace cache {
 void defaults() {
 	cached_backup_ram = backup_ram_t();
 
-    // defaults values for recon app
-    set_recon_autosave_freqs( false );
-    set_recon_autostart_recon( true );
-    set_recon_continuous( true );
-    set_recon_clear_output( false );
-    set_recon_load_freqs( true );
-    set_recon_load_ranges( true );
-    set_recon_update_ranges_when_recon( true );
-    set_recon_load_hamradios( true );
-    set_recon_match_mode( 0 );
+	// defaults values for recon app
+	set_recon_autosave_freqs( false );
+	set_recon_autostart_recon( true );
+	set_recon_continuous( true );
+	set_recon_clear_output( false );
+	set_recon_load_freqs( true );
+	set_recon_load_ranges( true );
+	set_recon_update_ranges_when_recon( true );
+	set_recon_load_hamradios( true );
+	set_recon_match_mode( 0 );
 }
 
 void init() {

--- a/firmware/common/portapack_persistent_memory.cpp
+++ b/firmware/common/portapack_persistent_memory.cpp
@@ -399,6 +399,18 @@ namespace cache {
 
 void defaults() {
 	cached_backup_ram = backup_ram_t();
+
+    // defaults values for recon app
+    set_recon_autosave_freqs( false );
+    set_recon_autostart_recon( true );
+    set_recon_continuous( true );
+    set_recon_clear_output( false );
+    set_recon_load_freqs( true );
+    set_recon_load_ranges( true );
+    set_recon_update_ranges_when_recon( true );
+    set_recon_load_hamradios( true );
+    set_recon_match_mode( 0 );
+
 }
 
 void init() {

--- a/firmware/common/portapack_persistent_memory.cpp
+++ b/firmware/common/portapack_persistent_memory.cpp
@@ -410,7 +410,6 @@ void defaults() {
     set_recon_update_ranges_when_recon( true );
     set_recon_load_hamradios( true );
     set_recon_match_mode( 0 );
-
 }
 
 void init() {


### PR DESCRIPTION
When no battery button is installed or the one is dead, defaults are restored for the persistent memory.
This add a couple of default settings for the Recon App, so one can start scanning / loading without bad surprises.
It makes the app more intuitive for people who can not save their settings.