### PR TITLE
Fix  the initialisation of frquency when apps are launched

### DIFF
--- a/firmware/application/apps/analog_audio_app.cpp
+++ b/firmware/application/apps/analog_audio_app.cpp
@@ -129,6 +129,11 @@ AnalogAudioView::AnalogAudioView(
 		&waterfall
 	});
 
+	// Set on_change before initialising the field
+	field_frequency.on_change = [this](rf::Frequency f) {
+		this->on_tuning_frequency_changed(f);
+	};
+
 	// load app settings
 	auto rc = settings.load("rx_audio", &app_settings);
 	if(rc == SETTINGS_OK) {
@@ -144,9 +149,6 @@ AnalogAudioView::AnalogAudioView(
 	record_view.set_filename_date_frequency(true);
 
 	field_frequency.set_step(receiver_model.frequency_step());
-	field_frequency.on_change = [this](rf::Frequency f) {
-		this->on_tuning_frequency_changed(f);
-	};
 	field_frequency.on_edit = [this, &nav]() {
 		// TODO: Provide separate modal method/scheme?
 		auto new_view = nav.push<FrequencyKeypadView>(receiver_model.tuning_frequency());

--- a/firmware/application/apps/analog_tv_app.cpp
+++ b/firmware/application/apps/analog_tv_app.cpp
@@ -57,6 +57,10 @@ AnalogTvView::AnalogTvView(
 		&tv
 	});
 
+	// Set on_change before initialising the field
+	field_frequency.on_change = [this](rf::Frequency f) {
+		this->on_tuning_frequency_changed(f);
+	};
 
 	// load app settings
 	auto rc = settings.load("rx_tv", &app_settings);
@@ -70,9 +74,6 @@ AnalogTvView::AnalogTvView(
 
 
 	field_frequency.set_step(receiver_model.frequency_step());
-	field_frequency.on_change = [this](rf::Frequency f) {
-		this->on_tuning_frequency_changed(f);
-	};
 	field_frequency.on_edit = [this, &nav]() {
 		// TODO: Provide separate modal method/scheme?
 		auto new_view = nav.push<FrequencyKeypadView>(receiver_model.tuning_frequency());

--- a/firmware/application/apps/pocsag_app.cpp
+++ b/firmware/application/apps/pocsag_app.cpp
@@ -77,6 +77,11 @@ POCSAGAppView::POCSAGAppView(NavigationView& nav) {
 		&console
 	});
 	
+	// Set on_change before initialising the field
+	field_frequency.on_change = [this](rf::Frequency f) {
+		update_freq(f);
+	};
+
 	// load app settings
 	auto rc = settings.load("rx_pocsag", &app_settings);
 	if(rc == SETTINGS_OK) {
@@ -94,9 +99,6 @@ POCSAGAppView::POCSAGAppView(NavigationView& nav) {
 	receiver_model.enable();
 	
 	field_frequency.set_step(receiver_model.frequency_step());
-	field_frequency.on_change = [this](rf::Frequency f) {
-		update_freq(f);
-	};
 	field_frequency.on_edit = [this, &nav]() {
 		// TODO: Provide separate modal method/scheme?
 		auto new_view = nav.push<FrequencyKeypadView>(receiver_model.tuning_frequency());


### PR DESCRIPTION
This is a fix for issue #816 

The frequency field was being set from the settings, but never written into the radio.  Attaching the on_change before the field is set causes the normal on_change to occur when the value is written.  There is no additional code, just a different order.