### PR TITLE
improved runtime error details in guru meditation 

### DIFF
--- a/firmware/application/debug.hpp
+++ b/firmware/application/debug.hpp
@@ -26,6 +26,18 @@
 #include "hackrf_gpio.hpp"
 
 extern void draw_guru_meditation(uint8_t, const char *);
-extern void draw_guru_meditation(uint8_t, const char *, struct extctx *);
+extern void draw_guru_meditation(uint8_t, const char *, struct extctx *, uint32_t);
+
+extern uint32_t __process_stack_base__;
+extern uint32_t __process_stack_end__;
+#define CRT0_STACKS_FILL_PATTERN    0x55555555
+
+inline uint32_t get_free_stack_space(){
+    uint32_t *p;
+    for (p = &__process_stack_base__; *p == CRT0_STACKS_FILL_PATTERN && p < &__process_stack_end__; p++);
+    auto stack_space_left = p - &__process_stack_base__;
+
+    return stack_space_left;
+}
 
 #endif/*__DEBUG_H__*/

--- a/firmware/application/event_m0.cpp
+++ b/firmware/application/event_m0.cpp
@@ -145,7 +145,11 @@ void EventDispatcher::dispatch(const eventmask_t events) {
 		if (shared_memory.bb_data.data[0] == 0)
 			draw_guru_meditation(CORTEX_M4, shared_memory.m4_panic_msg);
 		else
-			draw_guru_meditation(CORTEX_M4, shared_memory.m4_panic_msg, (struct extctx *)&shared_memory.bb_data.data[4]);
+			draw_guru_meditation(
+				CORTEX_M4,
+				shared_memory.m4_panic_msg,
+				(struct extctx *)&shared_memory.bb_data.data[8],
+				*(uint32_t *)&shared_memory.bb_data.data[4]);
 	}
 
 	if( events & EVT_MASK_APPLICATION ) {

--- a/firmware/baseband/debug.hpp
+++ b/firmware/baseband/debug.hpp
@@ -22,4 +22,25 @@
 #ifndef __DEBUG_H__
 #define __DEBUG_H__
 
+#include <ch.h>
+
+extern uint32_t __process_stack_base__;
+extern uint32_t __process_stack_end__;
+#define CRT0_STACKS_FILL_PATTERN    0x55555555
+
+inline uint32_t get_free_stack_space(){
+    uint32_t *p;
+    for (p = &__process_stack_base__; *p == CRT0_STACKS_FILL_PATTERN && p < &__process_stack_end__; p++);
+    auto stack_space_left = p - &__process_stack_base__;
+
+    return stack_space_left;
+}
+
+#define HALT_IF_DEBUGGING()                              \
+  do {                                                   \
+    if ((*(volatile uint32_t *)0xE000EDF0) & (1 << 0)) { \
+      __asm__ __volatile__("bkpt 1");                    \
+    }                                                    \
+} while (0)
+
 #endif/*__DEBUG_H__*/

--- a/firmware/common/chibios_cpp.cpp
+++ b/firmware/common/chibios_cpp.cpp
@@ -26,11 +26,17 @@
 #include <ch.h>
 
 void* operator new(size_t size) {
-	return chHeapAlloc(0x0, size);
+	void *p = chHeapAlloc(0x0, size);
+	if (p == nullptr)
+		chDbgPanic("Out of Memory");
+	return p;
 }
 
 void* operator new[](size_t size) {
-	return chHeapAlloc(0x0, size);
+	void *p = chHeapAlloc(0x0, size);
+	if (p == nullptr)
+		chDbgPanic("Out of Memory");
+	return p;
 }
 
 void operator delete(void* p) noexcept {


### PR DESCRIPTION
follow up on https://github.com/eried/portapack-mayhem/pull/830

* added detection of stack overflow (M0 and M4)
* added detection of out of memory (M0 only)
* added break point for JTAG debugging (M4 only)
* added cfsr output (M4 only)
* removed code duplication number_to_hex_string