### PR TITLE
Quoted restore frequency at start for audio app

### DIFF
--- a/firmware/application/apps/analog_audio_app.cpp
+++ b/firmware/application/apps/analog_audio_app.cpp
@@ -140,7 +140,7 @@ AnalogAudioView::AnalogAudioView(
 		field_lna.set_value(app_settings.lna);
 		field_vga.set_value(app_settings.vga);
 		receiver_model.set_rf_amp(app_settings.rx_amp);
-		field_frequency.set_value(app_settings.rx_frequency);
+		// field_frequency.set_value(app_settings.rx_frequency);
 		receiver_model.set_configuration_without_init(static_cast<ReceiverModel::Mode>(app_settings.modulation), app_settings.step, app_settings.am_config_index, app_settings.nbfm_config_index, app_settings.wfm_config_index, app_settings.squelch);
 	}
 	else field_frequency.set_value(receiver_model.tuning_frequency());


### PR DESCRIPTION
Quoted restore frequency at start for a good interactions with other apps calling audio app
Suggested by @loewal