### PR TITLE
forcing input freq to be set in all cases

### DIFF
--- a/firmware/application/apps/analog_audio_app.cpp
+++ b/firmware/application/apps/analog_audio_app.cpp
@@ -143,7 +143,7 @@ AnalogAudioView::AnalogAudioView(
 		// field_frequency.set_value(app_settings.rx_frequency);
 		receiver_model.set_configuration_without_init(static_cast<ReceiverModel::Mode>(app_settings.modulation), app_settings.step, app_settings.am_config_index, app_settings.nbfm_config_index, app_settings.wfm_config_index, app_settings.squelch);
 	}
-	else field_frequency.set_value(receiver_model.tuning_frequency());
+	field_frequency.set_value(receiver_model.tuning_frequency());
 	
 	//Filename Datetime and Frequency
 	record_view.set_filename_date_frequency(true);


### PR DESCRIPTION
Tested against save/load app settings on and off. 
Audio app keeps the last tuned frequency at start so it's usefull when started from other apps.