### PR TITLE
#868 TPMS app displays incorrect readings for Type 5 sensors

### DIFF
--- a/firmware/common/tpms_packet.cpp
+++ b/firmware/common/tpms_packet.cpp
@@ -123,7 +123,7 @@ Optional<Reading> Packet::reading_ook_8k4_schrader() const {
 		return Reading {
 			Reading::Type::GMC_96,
 			(uint32_t)id,
-			Pressure { static_cast<int>(value_0) * 8 / 3 },
+			Pressure { static_cast<int>(value_0) * 11 / 4 },
 			Temperature { static_cast<int>(value_1) - 61 }
 		};
 	} else {

--- a/firmware/common/tpms_packet.cpp
+++ b/firmware/common/tpms_packet.cpp
@@ -100,8 +100,8 @@ Optional<Reading> Packet::reading_ook_8k4_schrader() const {
 	 * Preamble: 01*40
 	 * System ID: 01100101, ??*20 (not really sure what this data is)
 	 * ID: 32 Manchester symbols
-	 * Value: 8 Manchester symbols (temperature?)
-	 * Value: 8 Manchester symbols (pressure?)
+	 * Value: 8 Manchester symbols (pressure)
+	 * Value: 8 Manchester symbols (temperature)
 	 * Checksum: 8 Manchester symbols (uint8_t sum of bytes starting with system ID)
 	 */
 	/* NOTE: First four bits of packet are consumed in preamble detection.
@@ -123,8 +123,8 @@ Optional<Reading> Packet::reading_ook_8k4_schrader() const {
 		return Reading {
 			Reading::Type::GMC_96,
 			(uint32_t)id,
-			Pressure { static_cast<int>(value_1) * 4 / 3 },
-			Temperature { static_cast<int>(value_0) - 56 }
+			Pressure { static_cast<int>(value_0) * 8 / 3 },
+			Temperature { static_cast<int>(value_1) - 61 }
 		};
 	} else {
 		return { };


### PR DESCRIPTION
Fixes issue with TPMS app displaying incorrect Temperature & Pressure values for Type 5 (OOK Schrader 8400) sensors only.  Please refer to issue https://github.com/eried/portapack-mayhem/issues/868