### PR TITLE
TPMS app enhancement to support Celsius/Fahrenheit toggling #873

### DIFF
--- a/firmware/application/apps/tpms_app.hpp
+++ b/firmware/application/apps/tpms_app.hpp
@@ -144,12 +144,21 @@ private:
 		}
 	};
 
-	OptionsField options_type {
+	OptionsField options_pressure {
 		{ 5 * 8, 0 * 16 },
 		3,
 		{
 			{ "kPa", 0 },
 			{ "PSI", 1 }
+		}
+	};
+
+	OptionsField options_temperature {
+		{ 9 * 8, 0 * 16 },
+		1,
+		{
+			{ "C", 0 },
+			{ "F", 1 }
 		}
 	};
 
@@ -168,31 +177,21 @@ private:
 	TPMSRecentEntries recent { };
 	std::unique_ptr<TPMSLogger> logger { };
 
-	const RecentEntriesColumns columns_kpa { {
+	const RecentEntriesColumns columns { {
 		{ "Tp", 2 },
 		{ "ID", 8 },
-		{ "kPa", 3 },
-		{ "C", 3 },
+		{ "Pres", 4 },
+		{ "Temp", 4 },
 		{ "Cnt", 3 },
 		{ "Fl", 2 },
 	} };
-	TPMSRecentEntriesView recent_entries_view_kpa { columns_kpa, recent };
-
-	const RecentEntriesColumns columns_psi { {
-		{ "Tp", 2 },
-		{ "ID", 8 },
-		{ "PSI", 3 },
-		{ "C", 3 },
-		{ "Cnt", 3 },
-		{ "Fl", 2 },
-	} };
-	TPMSRecentEntriesView recent_entries_view_psi { columns_psi, recent };
+	TPMSRecentEntriesView recent_entries_view { columns, recent };
 
 	uint32_t target_frequency_ = initial_target_frequency;
 
 	void on_packet(const tpms::Packet& packet);
 	void on_show_list();
-	void update_type();
+	void update_view();
 
 	void on_band_changed(const uint32_t new_band_frequency);
 


### PR DESCRIPTION
I propose to modify the TPMS app to support switching between Celsius & Fahrenheit temperature display, similar to the existing support for switching between kPA & PSI pressure.  The USA still uses the Fahrenheit temperature scale primarily.

For code simplification, I additionally propose to display "Pres & Temp" column headings in all cases, versus switching the column heading when units are changed.  Note that the units, kPA/PSI and C/F, will be displayed at the top of the screen already.

I have already implemented and tested this change in the https://github.com/NotherNgineer/portapack-mayhem branch (filing this Enhancement request for tracking purposes).  Two files are affected by this change:  tpms_app.cpp, tpms_app.hpp

Example screen-shot with this change is attached to the enhancement request https://github.com/eried/portapack-mayhem/issues/873