### PR TITLE
fixed hackrf mode for portapacks with TQFP100 CPLD

### DIFF
--- a/firmware/baseband/CMakeLists.txt
+++ b/firmware/baseband/CMakeLists.txt
@@ -564,11 +564,19 @@ DeclareTargets(PUSB sd_over_usb)
 
 ### HackRF "factory" firmware
 
+add_custom_target(
+	portapack_mod
+	WORKING_DIRECTORY ${HACKRF_PATH}
+	COMMAND git checkout -- firmware/common/portapack.c
+	COMMAND sed -i 's/return jtag_pp_idcode\(\)/const uint32_t idcode = jtag_pp_idcode\(\)\; return idcode == 0x00025610 || idcode/g' firmware/common/portapack.c
+)
+
 add_custom_command(
 	OUTPUT hackrf.img
 	COMMAND ${LZ4} -f -9 ${HACKRF_FIRMWARE_BIN_IMAGE} hackrf.lz4
 	COMMAND ${MAKE_IMAGE_CHUNK} hackrf.lz4 HRF1 hackrf.img
-	DEPENDS ${HACKRF_FIRMWARE_BIN_FILENAME} ${MAKE_IMAGE_CHUNK}
+	COMMAND git -C ${HACKRF_PATH} checkout -- firmware/common/portapack.c
+	DEPENDS portapack_mod ${HACKRF_FIRMWARE_BIN_FILENAME} ${MAKE_IMAGE_CHUNK}
 	VERBATIM
 )
 


### PR DESCRIPTION
This pull request adds the hardware id of the TQFP100 CPLD to the portapack check in the hackrf mode, enabling it where the screen stayed black.

Since it is a change in the submodule hackrf it is only active while building.

![grafik](https://user-images.githubusercontent.com/13151053/230376095-523a4e55-816c-47a8-939d-425b1bacbd87.png)
