### PR TITLE
make the title touchable, and back/return when touch it

### DIFF
--- a/firmware/application/ui_navigation.hpp
+++ b/firmware/application/ui_navigation.hpp
@@ -125,7 +125,7 @@ namespace ui
 			Color::dark_grey()};
 
 		ImageButton button_back{
-			{2, 0 * 16, 16, 16},
+			{0, 0 * 16, 16 * 8, 16},//back button is long enough to cover the title area to make it easier to touch
 			&bitmap_icon_previous,
 			Color::white(),
 			Color::dark_grey()};

--- a/firmware/application/ui_navigation.hpp
+++ b/firmware/application/ui_navigation.hpp
@@ -125,7 +125,7 @@ namespace ui
 			Color::dark_grey()};
 
 		ImageButton button_back{
-			{0, 0 * 16, 16 * 8, 16},//back button is long enough to cover the title area to make it easier to touch
+			{0, 0 * 16, 15 * 8, 16},//back button is long enough to cover the title area to make it easier to touch
 			&bitmap_icon_previous,
 			Color::white(),
 			Color::dark_grey()};

--- a/firmware/application/ui_navigation.hpp
+++ b/firmware/application/ui_navigation.hpp
@@ -125,7 +125,7 @@ namespace ui
 			Color::dark_grey()};
 
 		ImageButton button_back{
-			{0, 0 * 16, 15 * 8, 16},//back button is long enough to cover the title area to make it easier to touch
+			{0, 0 * 16, 12 * 8, 16},//back button is long enough to cover the title area to make it easier to touch
 			&bitmap_icon_previous,
 			Color::white(),
 			Color::dark_grey()};


### PR DESCRIPTION
Since the back button is too small to touch (and in the corner).
This change made the `title` touchable and when touch it, it backs.
I have imagined several ways to implement it, but it turns out the 3rd way is best...
>  1. Replace the `title` text widget with a button:
	But the text shown in the button is not changeable using `set` member function.
	It's ugly.


>  2. Implement the select/touch event for `text` widget (since the text is not selectable nor touchable for now):
	It might influence many other apps.


>  3. Just make the back image_button larger, with 1 line code changing
	Not that elegant but safe and simple and it works...
The only thing need to be taken care is that next time if there's new icon would appear on the status bar, this value needs to be changed...

So here it is, how do you think? Feel free to revise if there's any more elegant ways...
Here is a vid.


https://user-images.githubusercontent.com/24917424/233654954-9b029ec1-1b39-4a6c-b575-aa1b94efe795.mov

