### PR TITLE
fix last commit aka fileman refactor exception

### DIFF
--- a/firmware/application/apps/ui_fileman.cpp
+++ b/firmware/application/apps/ui_fileman.cpp
@@ -357,10 +357,10 @@ FileManagerView::FileManagerView(
 			on_rename(nav);
 		};
 
-        button_refactor.on_select = [this, &nav](Button&) {
-            name_buffer = entry_list[menu_view.highlighted_index()].entry_path.filename().string().substr(0, max_filename_length);
-            on_refactor(nav);
-        };
+		button_refactor.on_select = [this, &nav](Button&) {
+			name_buffer = entry_list[menu_view.highlighted_index()].entry_path.filename().string().substr(0, max_filename_length);
+			on_refactor(nav);
+		};
 
 		button_delete.on_select = [this, &nav](Button&) {
 			// Use display_modal ?

--- a/firmware/application/apps/ui_fileman.cpp
+++ b/firmware/application/apps/ui_fileman.cpp
@@ -263,28 +263,32 @@ void FileManagerView::on_rename(NavigationView& nav) {
 }
 
 void FileManagerView::on_refactor(NavigationView& nav) {
-    text_prompt(nav, name_buffer, max_filename_length, [this](std::string& buffer) {
-        std::string destination_path = current_path.string();
-        if (destination_path.back() != '/')
-            destination_path += '/';
-        destination_path = destination_path + buffer;
-        rename_file(get_selected_path(), destination_path);  //rename the selected file
+	text_prompt(nav, name_buffer, max_filename_length, [this](std::string& buffer) {
+		std::string destination_path = current_path.string();
+		if (destination_path.back() != '/')
+			destination_path += '/';
+		destination_path = destination_path + buffer;
 
-        if (get_selected_path().extension().string().substr(1) == "C16") {//rename it's partner ( C16 <-> TXT ) file.
-            auto selected_path = get_selected_path();
-            auto partner_file_path = selected_path.string().substr(0, selected_path.string().size()-4) + ".TXT";
-            destination_path = destination_path.substr(0, destination_path.size()-4) + ".TXT";
-            rename_file(partner_file_path, destination_path);
-        }else if (get_selected_path().extension().string().substr(1) == "TXT") {//If the file user choose is a TXT file
-            auto selected_path = get_selected_path();
-            auto partner_file_path = selected_path.string().substr(0, selected_path.string().size()-4) + ".C16";
-            destination_path = destination_path.substr(0, destination_path.size()-4) + ".C16";
-            rename_file(partner_file_path, destination_path);
-        }
+		rename_file(get_selected_path(), destination_path);  //rename the selected file
 
-        load_directory_contents(current_path);
-        refresh_list();
-    });
+		auto selected_path = get_selected_path();
+		auto extension = selected_path.extension().string();
+
+		if (!extension.empty() && selected_path.string().back() != '/' && extension.substr(1) == "C16") {
+			// Rename its partner ( C16 <-> TXT ) file.
+			auto partner_file_path = selected_path.string().substr(0, selected_path.string().size() - 4) + ".TXT";
+			destination_path = destination_path.substr(0, destination_path.size() - 4) + ".TXT";
+			rename_file(partner_file_path, destination_path);
+		} else if (!extension.empty() && selected_path.string().back() != '/' && extension.substr(1) == "TXT") {
+			// If the file user choose is a TXT file.
+			auto partner_file_path = selected_path.string().substr(0, selected_path.string().size() - 4) + ".C16";
+			destination_path = destination_path.substr(0, destination_path.size() - 4) + ".C16";
+			rename_file(partner_file_path, destination_path);
+		}
+
+		load_directory_contents(current_path);
+		refresh_list();
+	});
 }
 
 void FileManagerView::on_delete() {
@@ -353,10 +357,10 @@ FileManagerView::FileManagerView(
 			on_rename(nav);
 		};
 
-		button_refactor.on_select = [this, &nav](Button&) {
-			name_buffer = entry_list[menu_view.highlighted_index()].entry_path.filename().string().substr(0, max_filename_length);
-			on_refactor(nav);
-		};
+        button_refactor.on_select = [this, &nav](Button&) {
+            name_buffer = entry_list[menu_view.highlighted_index()].entry_path.filename().string().substr(0, max_filename_length);
+            on_refactor(nav);
+        };
 
 		button_delete.on_select = [this, &nav](Button&) {
 			// Use display_modal ?

--- a/firmware/application/apps/ui_fileman.hpp
+++ b/firmware/application/apps/ui_fileman.hpp
@@ -159,7 +159,7 @@ private:
 	};
 
 	Button button_rename {
-		{ 0 * 8, 29 * 8, 10 * 8, 32 },
+		{ 0 * 8, 29 * 8, 9 * 8, 32 },
 		"Rename"
 	};
 
@@ -169,7 +169,7 @@ private:
 	};
 
 	Button button_delete {
-		{ 20 * 8, 29 * 8, 10 * 8, 32 },
+		{ 21 * 8, 29 * 8, 9 * 8, 32 },
 		"Delete"
 	};
 	


### PR DESCRIPTION
# #905 
hello, at today's playing i found that my last commit has a bug so in this pr i fixed it:
>when user trying to refactor a dir, the m0 exception tripped.

i used `auto selected_path = get_selected_path();`
and
`!extension.empty() && selected_path.string().back() != '/' && extension.substr(1) == "C16"`
and
`!extension.empty() && selected_path.string().back() != '/' && extension.substr(1) == "TXT")`
to make sure only execute refactor when user are actually choosing a file instead of a dir.



also adjusted the buttons to make it looks better.



im so sorry for my omission.


bin ->
[portapack-h1_h2-mayhem.zip](https://github.com/eried/portapack-mayhem/files/11301626/portapack-h1_h2-mayhem.zip)

