### PR TITLE
Support for ERT SCM+ meter protocol

### DIFF
--- a/firmware/application/apps/ert_app.cpp
+++ b/firmware/application/apps/ert_app.cpp
@@ -38,9 +38,9 @@ namespace format {
 std::string type(Packet::Type value) {
 	switch(value) {
 	default:
-	case Packet::Type::Unknown:	return "??? ";
-	case Packet::Type::IDM:		return "IDM ";
-	case Packet::Type::SCM:		return "SCM ";
+	case Packet::Type::Unknown:	return "???";
+	case Packet::Type::IDM:		return "IDM";
+	case Packet::Type::SCM:		return "SCM";
 	case Packet::Type::SCMPLUS:	return "SCM+";
 	}
 }

--- a/firmware/application/apps/ert_app.cpp
+++ b/firmware/application/apps/ert_app.cpp
@@ -63,7 +63,8 @@ std::string commodity_type(CommodityType value) {
 
 void ERTLogger::on_packet(const ert::Packet& packet) {
 	const auto formatted = packet.symbols_formatted();
-	log_file.write_entry(packet.received_at(), formatted.data + "/" + formatted.errors);
+	std::string entry = ert::format::type(packet.type()) + " " + formatted.data + "/" + formatted.errors;
+	log_file.write_entry(packet.received_at(), entry);
 }
 
 const ERTRecentEntry::Key ERTRecentEntry::invalid_key { };

--- a/firmware/application/apps/ert_app.cpp
+++ b/firmware/application/apps/ert_app.cpp
@@ -38,9 +38,10 @@ namespace format {
 std::string type(Packet::Type value) {
 	switch(value) {
 	default:
-	case Packet::Type::Unknown:	return "???";
-	case Packet::Type::IDM:		return "IDM";
-	case Packet::Type::SCM:		return "SCM";
+	case Packet::Type::Unknown:	return "??? ";
+	case Packet::Type::IDM:		return "IDM ";
+	case Packet::Type::SCM:		return "SCM ";
+	case Packet::Type::SCMPLUS:	return "SCM+";
 	}
 }
 

--- a/firmware/baseband/proc_ert.cpp
+++ b/firmware/baseband/proc_ert.cpp
@@ -87,6 +87,7 @@ void ERTProcessor::consume_symbol(
 ) {
 	const uint_fast8_t sliced_symbol = (raw_symbol >= 0.0f) ? 1 : 0;
 	scm_builder.execute(sliced_symbol);
+	scmplus_builder.execute(sliced_symbol);
 	idm_builder.execute(sliced_symbol);
 }
 
@@ -94,6 +95,13 @@ void ERTProcessor::scm_handler(
 	const baseband::Packet& packet
 ) {
 	const ERTPacketMessage message { ert::Packet::Type::SCM, packet };
+	shared_memory.application_queue.push(message);
+}
+
+void ERTProcessor::scmplus_handler(
+	const baseband::Packet& packet
+) {
+	const ERTPacketMessage message { ert::Packet::Type::SCMPLUS, packet };
 	shared_memory.application_queue.push(message);
 }
 

--- a/firmware/baseband/proc_ert.hpp
+++ b/firmware/baseband/proc_ert.hpp
@@ -44,10 +44,14 @@ constexpr uint64_t scm_preamble_and_sync_manchester { 0b101010101001011001100110
 constexpr size_t scm_preamble_and_sync_length { 42 - 10 };
 constexpr size_t scm_payload_length_max { 150 };
 
+// ''.join(['%d%d' % (c, 1-c) for c in map(int, bin(0x16a3)[2:].zfill(16))])
+constexpr uint64_t scmplus_preamble_and_sync_manchester { 0b01010110011010011001100101011010 };
+constexpr size_t scmplus_preamble_and_sync_length { 32 - 0 };
+constexpr size_t scmplus_payload_length_max { 224 };
+
 // ''.join(['%d%d' % (c, 1-c) for c in map(int, bin(0x555516a3)[2:].zfill(32))])
 constexpr uint64_t idm_preamble_and_sync_manchester { 0b0110011001100110011001100110011001010110011010011001100101011010 };
 constexpr size_t idm_preamble_and_sync_length { 64 - 16 };
-
 constexpr size_t idm_payload_length_max { 1408 };
 
 class ERTProcessor : public BasebandProcessor {
@@ -80,6 +84,15 @@ private:
 		}
 	};
 
+	PacketBuilder<BitPattern, NeverMatch, FixedLength> scmplus_builder {
+		{ scmplus_preamble_and_sync_manchester, scmplus_preamble_and_sync_length, 1 },
+		{ },
+		{ scmplus_payload_length_max },
+		[this](const baseband::Packet& packet) {
+			this->scmplus_handler(packet);
+		}
+	};
+	
 	PacketBuilder<BitPattern, NeverMatch, FixedLength> idm_builder {
 		{ idm_preamble_and_sync_manchester, idm_preamble_and_sync_length, 1 },
 		{ },
@@ -91,6 +104,7 @@ private:
 
 	void consume_symbol(const float symbol);
 	void scm_handler(const baseband::Packet& packet);
+	void scmplus_handler(const baseband::Packet& packet);
 	void idm_handler(const baseband::Packet& packet);
 
 	float sum_half_period[2];

--- a/firmware/common/ert_packet.hpp
+++ b/firmware/common/ert_packet.hpp
@@ -45,6 +45,7 @@ public:
 		Unknown = 0,
 		IDM = 1,
 		SCM = 2,
+		SCMPLUS = 3,
 	};
 
 	Packet(
@@ -80,7 +81,7 @@ private:
 	const Reader reader_;
 	const Type type_;
 
-	bool crc_ok_idm() const;
+	bool crc_ok_ccitt() const;
 	bool crc_ok_scm() const;
 };
 


### PR DESCRIPTION
Coded & tested support for the SCM+ meter protocol.  More details on this protocol format is described here: https://github.com/bemasher/rtlamr/wiki/Protocol

The reason I implemented this is that our 2-year-old gas meter was not showing up in the ERT app or in the ert.txt logs, and I eventually figured out that it uses the SCM+ protocol (versus our neighbors' older gas meters that use SCM and were showing up in the app).

Please let me know if I should file an enhancement ticket for tracking purposes prior to submitting a Pull request.