### PR TITLE
Dfu menu

### DIFF
--- a/firmware/application/CMakeLists.txt
+++ b/firmware/application/CMakeLists.txt
@@ -230,6 +230,7 @@ set(CPPSRC
 	apps/ui_nrf_rx.cpp
 	apps/ui_aprs_tx.cpp
 	apps/ui_bht_tx.cpp
+	apps/ui_dfu_menu.cpp
 	apps/ui_coasterp.cpp
 	apps/ui_debug.cpp
 	apps/ui_encoders.cpp

--- a/firmware/application/apps/ui_dfu_menu.cpp
+++ b/firmware/application/apps/ui_dfu_menu.cpp
@@ -39,9 +39,6 @@ DfuMenu::DfuMenu(NavigationView& nav) : nav_ (nav) {
 }
 
 void DfuMenu::paint(Painter& painter) {
-	//update child values
-	//   if (chThdSelf() == chSysGetIdleThread()) { chThdGetTicks(chThdSelf()) }   
-
 	auto now = chTimeNow();
 	auto idle_ticks = chThdGetTicks(chSysGetIdleThread());
 	
@@ -57,19 +54,51 @@ void DfuMenu::paint(Painter& painter) {
 	text_info_line_1.set(to_string_dec_uint(chCoreStatus(), 6));
 	text_info_line_2.set(to_string_dec_uint((uint32_t)get_free_stack_space(), 6));
 	text_info_line_3.set(to_string_dec_uint((time_elapsed - idle_elapsed) / 10, 6));
-	text_info_line_4.set("M4 heap");
-	text_info_line_5.set("M4 stack");
-	text_info_line_6.set("M4 cpu");
+	text_info_line_4.set(to_string_dec_uint(shared_memory.m4_heap_usage, 6));
+	text_info_line_5.set(to_string_dec_uint(shared_memory.m4_stack_usage, 6));
+	text_info_line_6.set(to_string_dec_uint(shared_memory.m4_cpu_usage, 6));
 	text_info_line_7.set(to_string_dec_uint(chTimeNow()/1000, 6));
 
-	auto screen_size = portapack::display.screen_rect().size();
-	
+	constexpr auto margin = 5;
+
 	painter.fill_rectangle(
 		{
-			{6 * CHARACTER_WIDTH, 3 * LINE_HEIGHT},
-			{screen_size.width() - 12 * CHARACTER_WIDTH, screen_size.height() - 6 * LINE_HEIGHT}
+			{6 * CHARACTER_WIDTH - margin, 3 * LINE_HEIGHT - margin},
+			{15 * CHARACTER_WIDTH + margin * 2, 9 * LINE_HEIGHT + margin * 2}
 		},
 		ui::Color::black()
+	);
+
+	painter.fill_rectangle(
+		{
+			{5 * CHARACTER_WIDTH - margin, 3 * LINE_HEIGHT - margin},
+			{CHARACTER_WIDTH, 9 * LINE_HEIGHT + margin * 2}
+		},
+		ui::Color::dark_cyan()
+	);
+
+	painter.fill_rectangle(
+		{
+			{21 * CHARACTER_WIDTH + margin, 3 * LINE_HEIGHT - margin},
+			{CHARACTER_WIDTH, 9 * LINE_HEIGHT + margin * 2}
+		},
+		ui::Color::dark_cyan()
+	);
+
+	painter.fill_rectangle(
+		{
+			{5 * CHARACTER_WIDTH - margin, 3 * LINE_HEIGHT - margin - 8},
+			{17 * CHARACTER_WIDTH + margin * 2, 8}
+		},
+		ui::Color::dark_cyan()
+	);
+
+	painter.fill_rectangle(
+		{
+			{5 * CHARACTER_WIDTH - margin, 12 * LINE_HEIGHT + margin},
+			{17 * CHARACTER_WIDTH + margin * 2, 8}
+		},
+		ui::Color::dark_cyan()
 	);
 }
 

--- a/firmware/application/apps/ui_dfu_menu.cpp
+++ b/firmware/application/apps/ui_dfu_menu.cpp
@@ -26,20 +26,50 @@ namespace ui {
 
 DfuMenu::DfuMenu(NavigationView& nav) : nav_ (nav) {
 	add_children({
-		&text_info,
-		&progress,
-		&dummy,
+		&text_head,
+		&labels,
+		&text_info_line_1,
+		&text_info_line_2,
+		&text_info_line_3,
+		&text_info_line_4,
+		&text_info_line_5,
+		&text_info_line_6,
+		&text_info_line_7
 	});
 }
 
-void DfuMenu::focus() {
-	dummy.focus();
-}
-
 void DfuMenu::paint(Painter& painter) {
+	//update child values
+	//   if (chThdSelf() == chSysGetIdleThread()) { chThdGetTicks(chThdSelf()) }   
+
+	auto now = chTimeNow();
+	auto idle_ticks = chThdGetTicks(chSysGetIdleThread());
+	
+	static systime_t last_time;
+	static systime_t last_last_time;
+
+	auto time_elapsed = now - last_time;
+	auto idle_elapsed = idle_ticks - last_last_time;
+
+	last_time = now;
+	last_last_time = idle_ticks;
+
+	text_info_line_1.set(to_string_dec_uint(chCoreStatus(), 6));
+	text_info_line_2.set(to_string_dec_uint((uint32_t)get_free_stack_space(), 6));
+	text_info_line_3.set(to_string_dec_uint((time_elapsed - idle_elapsed) / 10, 6));
+	text_info_line_4.set("M4 heap");
+	text_info_line_5.set("M4 stack");
+	text_info_line_6.set("M4 cpu");
+	text_info_line_7.set(to_string_dec_uint(chTimeNow()/1000, 6));
+
+	auto screen_size = portapack::display.screen_rect().size();
+	
 	painter.fill_rectangle(
-		{{50,50} , {50 , 50}},
-		ui::Color::blue()
+		{
+			{6 * CHARACTER_WIDTH, 3 * LINE_HEIGHT},
+			{screen_size.width() - 12 * CHARACTER_WIDTH, screen_size.height() - 6 * LINE_HEIGHT}
+		},
+		ui::Color::black()
 	);
 }
 

--- a/firmware/application/apps/ui_dfu_menu.cpp
+++ b/firmware/application/apps/ui_dfu_menu.cpp
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2023 Bernd Herzog
+ *
+ * This file is part of PortaPack.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#include "ui_dfu_menu.hpp"
+#include "portapack_shared_memory.hpp"
+
+namespace ui {
+
+DfuMenu::DfuMenu(NavigationView& nav) : nav_ (nav) {
+	add_children({
+		&text_info,
+		&progress,
+		&dummy,
+	});
+}
+
+void DfuMenu::focus() {
+	dummy.focus();
+}
+
+void DfuMenu::paint(Painter& painter) {
+	painter.fill_rectangle(
+		{{50,50} , {50 , 50}},
+		ui::Color::blue()
+	);
+}
+
+} /* namespace ui */

--- a/firmware/application/apps/ui_dfu_menu.hpp
+++ b/firmware/application/apps/ui_dfu_menu.hpp
@@ -45,29 +45,25 @@ public:
 private:
 	NavigationView& nav_;
 	
-	Text text_head {{ 6 * CHARACTER_WIDTH, 3 * LINE_HEIGHT, 10 * CHARACTER_WIDTH, 1 * LINE_HEIGHT }, "DFU Menu"};
+	Text text_head {{ 6 * CHARACTER_WIDTH, 3 * LINE_HEIGHT, 11 * CHARACTER_WIDTH, 1 * LINE_HEIGHT }, "Performance"};
 
 	Labels labels {
-		{ { 6 * CHARACTER_WIDTH, 5 * LINE_HEIGHT }, "M0 heap:", Color::light_grey() },
-		{ { 6 * CHARACTER_WIDTH, 6 * LINE_HEIGHT }, "M0 stack:", Color::light_grey() },
-		{ { 6 * CHARACTER_WIDTH, 7 * LINE_HEIGHT }, "M0 cpu %:", Color::light_grey() },
-		{ { 6 * CHARACTER_WIDTH, 8 * LINE_HEIGHT }, "M4 heap:", Color::light_grey() },
-		{ { 6 * CHARACTER_WIDTH, 9 * LINE_HEIGHT }, "M4 stack:", Color::light_grey() },
-		{ { 6 * CHARACTER_WIDTH,10 * LINE_HEIGHT }, "M4 cpu %:", Color::light_grey() },
-		{ { 6 * CHARACTER_WIDTH,11 * LINE_HEIGHT }, "uptime:", Color::light_grey() }
+		{ { 6 * CHARACTER_WIDTH, 5 * LINE_HEIGHT }, "M0 heap:", Color::dark_cyan() },
+		{ { 6 * CHARACTER_WIDTH, 6 * LINE_HEIGHT }, "M0 stack:", Color::dark_cyan() },
+		{ { 6 * CHARACTER_WIDTH, 7 * LINE_HEIGHT }, "M0 cpu %:", Color::dark_cyan() },
+		{ { 6 * CHARACTER_WIDTH, 8 * LINE_HEIGHT }, "M4 heap:", Color::dark_cyan() },
+		{ { 6 * CHARACTER_WIDTH, 9 * LINE_HEIGHT }, "M4 stack:", Color::dark_cyan() },
+		{ { 6 * CHARACTER_WIDTH,10 * LINE_HEIGHT }, "M4 cpu %:", Color::dark_cyan() },
+		{ { 6 * CHARACTER_WIDTH,11 * LINE_HEIGHT }, "uptime:", Color::dark_cyan() }
 	};
 
-	Text text_info_line_1 {{ 16 * CHARACTER_WIDTH, 5 * LINE_HEIGHT, 10 * CHARACTER_WIDTH, 1 * LINE_HEIGHT }, ""};
-	Text text_info_line_2 {{ 16 * CHARACTER_WIDTH, 6 * LINE_HEIGHT, 10 * CHARACTER_WIDTH, 1 * LINE_HEIGHT }, ""};
-	Text text_info_line_3 {{ 16 * CHARACTER_WIDTH, 7 * LINE_HEIGHT, 10 * CHARACTER_WIDTH, 1 * LINE_HEIGHT }, ""};
-	Text text_info_line_4 {{ 16 * CHARACTER_WIDTH, 8 * LINE_HEIGHT, 10 * CHARACTER_WIDTH, 1 * LINE_HEIGHT }, ""};
-	Text text_info_line_5 {{ 16 * CHARACTER_WIDTH, 9 * LINE_HEIGHT, 10 * CHARACTER_WIDTH, 1 * LINE_HEIGHT }, ""};
-	Text text_info_line_6 {{ 16 * CHARACTER_WIDTH,10 * LINE_HEIGHT, 10 * CHARACTER_WIDTH, 1 * LINE_HEIGHT }, ""};
-	Text text_info_line_7 {{ 16 * CHARACTER_WIDTH,11 * LINE_HEIGHT, 10 * CHARACTER_WIDTH, 1 * LINE_HEIGHT }, ""};
-	
-	// ProgressBar progress {
-	// 	{ 6 * CHARACTER_WIDTH, 5 * LINE_HEIGHT, 16 * CHARACTER_WIDTH, 24 }
-	// };
+	Text text_info_line_1 {{ 15 * CHARACTER_WIDTH, 5 * LINE_HEIGHT, 5 * CHARACTER_WIDTH, 1 * LINE_HEIGHT }, ""};
+	Text text_info_line_2 {{ 15 * CHARACTER_WIDTH, 6 * LINE_HEIGHT, 5 * CHARACTER_WIDTH, 1 * LINE_HEIGHT }, ""};
+	Text text_info_line_3 {{ 15 * CHARACTER_WIDTH, 7 * LINE_HEIGHT, 5 * CHARACTER_WIDTH, 1 * LINE_HEIGHT }, ""};
+	Text text_info_line_4 {{ 15 * CHARACTER_WIDTH, 8 * LINE_HEIGHT, 5 * CHARACTER_WIDTH, 1 * LINE_HEIGHT }, ""};
+	Text text_info_line_5 {{ 15 * CHARACTER_WIDTH, 9 * LINE_HEIGHT, 5 * CHARACTER_WIDTH, 1 * LINE_HEIGHT }, ""};
+	Text text_info_line_6 {{ 15 * CHARACTER_WIDTH,10 * LINE_HEIGHT, 5 * CHARACTER_WIDTH, 1 * LINE_HEIGHT }, ""};
+	Text text_info_line_7 {{ 15 * CHARACTER_WIDTH,11 * LINE_HEIGHT, 5 * CHARACTER_WIDTH, 1 * LINE_HEIGHT }, ""};
 };
 
 } /* namespace ui */

--- a/firmware/application/apps/ui_dfu_menu.hpp
+++ b/firmware/application/apps/ui_dfu_menu.hpp
@@ -26,6 +26,11 @@
 
 #include "ui_widget.hpp"
 #include "event_m0.hpp"
+#include "debug.hpp"
+#include "string_format.hpp"
+
+#define LINE_HEIGHT 16
+#define CHARACTER_WIDTH 8
 
 namespace ui {
 class NavigationView;
@@ -35,27 +40,34 @@ public:
 	DfuMenu(NavigationView& nav);
 	~DfuMenu() = default;
 
-	void focus() override;
 	void paint(Painter& painter) override;
-
-	std::string title() const override { return "DFU Menu"; };	
 
 private:
 	NavigationView& nav_;
 	
-	Text text_info {
-		{ 10 * 8, 16 * 8, 10 * 8, 16 },
-		"Working..."
+	Text text_head {{ 6 * CHARACTER_WIDTH, 3 * LINE_HEIGHT, 10 * CHARACTER_WIDTH, 1 * LINE_HEIGHT }, "DFU Menu"};
+
+	Labels labels {
+		{ { 6 * CHARACTER_WIDTH, 5 * LINE_HEIGHT }, "M0 heap:", Color::light_grey() },
+		{ { 6 * CHARACTER_WIDTH, 6 * LINE_HEIGHT }, "M0 stack:", Color::light_grey() },
+		{ { 6 * CHARACTER_WIDTH, 7 * LINE_HEIGHT }, "M0 cpu %:", Color::light_grey() },
+		{ { 6 * CHARACTER_WIDTH, 8 * LINE_HEIGHT }, "M4 heap:", Color::light_grey() },
+		{ { 6 * CHARACTER_WIDTH, 9 * LINE_HEIGHT }, "M4 stack:", Color::light_grey() },
+		{ { 6 * CHARACTER_WIDTH,10 * LINE_HEIGHT }, "M4 cpu %:", Color::light_grey() },
+		{ { 6 * CHARACTER_WIDTH,11 * LINE_HEIGHT }, "uptime:", Color::light_grey() }
 	};
+
+	Text text_info_line_1 {{ 16 * CHARACTER_WIDTH, 5 * LINE_HEIGHT, 10 * CHARACTER_WIDTH, 1 * LINE_HEIGHT }, ""};
+	Text text_info_line_2 {{ 16 * CHARACTER_WIDTH, 6 * LINE_HEIGHT, 10 * CHARACTER_WIDTH, 1 * LINE_HEIGHT }, ""};
+	Text text_info_line_3 {{ 16 * CHARACTER_WIDTH, 7 * LINE_HEIGHT, 10 * CHARACTER_WIDTH, 1 * LINE_HEIGHT }, ""};
+	Text text_info_line_4 {{ 16 * CHARACTER_WIDTH, 8 * LINE_HEIGHT, 10 * CHARACTER_WIDTH, 1 * LINE_HEIGHT }, ""};
+	Text text_info_line_5 {{ 16 * CHARACTER_WIDTH, 9 * LINE_HEIGHT, 10 * CHARACTER_WIDTH, 1 * LINE_HEIGHT }, ""};
+	Text text_info_line_6 {{ 16 * CHARACTER_WIDTH,10 * LINE_HEIGHT, 10 * CHARACTER_WIDTH, 1 * LINE_HEIGHT }, ""};
+	Text text_info_line_7 {{ 16 * CHARACTER_WIDTH,11 * LINE_HEIGHT, 10 * CHARACTER_WIDTH, 1 * LINE_HEIGHT }, ""};
 	
-	ProgressBar progress {
-		{ 2 * 8, 19 * 8, 26 * 8, 24 }
-	};
-	
-	Button dummy {
-		{ 240, 0, 0, 0 },
-		""
-	};
+	// ProgressBar progress {
+	// 	{ 6 * CHARACTER_WIDTH, 5 * LINE_HEIGHT, 16 * CHARACTER_WIDTH, 24 }
+	// };
 };
 
 } /* namespace ui */

--- a/firmware/application/apps/ui_dfu_menu.hpp
+++ b/firmware/application/apps/ui_dfu_menu.hpp
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2023 Bernd Herzog
+ *
+ * This file is part of PortaPack.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#ifndef __UI_DFU_MENU_H__
+#define __UI_DFU_MENU_H__
+
+#include <cstdint>
+
+#include "ui_widget.hpp"
+#include "event_m0.hpp"
+
+namespace ui {
+class NavigationView;
+
+class DfuMenu : public View {
+public:
+	DfuMenu(NavigationView& nav);
+	~DfuMenu() = default;
+
+	void focus() override;
+	void paint(Painter& painter) override;
+
+	std::string title() const override { return "DFU Menu"; };	
+
+private:
+	NavigationView& nav_;
+	
+	Text text_info {
+		{ 10 * 8, 16 * 8, 10 * 8, 16 },
+		"Working..."
+	};
+	
+	ProgressBar progress {
+		{ 2 * 8, 19 * 8, 26 * 8, 24 }
+	};
+	
+	Button dummy {
+		{ 240, 0, 0, 0 },
+		""
+	};
+};
+
+} /* namespace ui */
+
+#endif/*__UI_DFU_MENU_H__*/

--- a/firmware/application/event_m0.cpp
+++ b/firmware/application/event_m0.cpp
@@ -43,6 +43,7 @@ using namespace lpc43xx;
 #include <array>
 
 #include "ui_font_fixed_8x16.hpp"
+#include "ui_navigation.hpp"
 
 extern "C" {
 
@@ -262,6 +263,8 @@ void EventDispatcher::on_touch_event(ui::TouchEvent event) {
 void EventDispatcher::handle_lcd_frame_sync() {
 	DisplayFrameSyncMessage message;
 	message_map.send(&message);
+
+	static_cast<ui::SystemView *>(top_widget)->paint_overlay();
 	painter.paint_widget_tree(top_widget);
 
 	portapack::backlight()->on();
@@ -304,7 +307,12 @@ void EventDispatcher::handle_switches() {
 		if( switches_state[i] ) {
 			const auto event = static_cast<ui::KeyEvent>(i);
 			if( !event_bubble_key(event) ) {
-				context.focus_manager().update(top_widget, event);
+				if (switches_state[(size_t)ui::KeyEvent::Dfu]) {
+					static_cast<ui::SystemView *>(top_widget)->toggle_overlay();
+				}
+				else {
+					context.focus_manager().update(top_widget, event);
+				}
 			}
 
 			in_key_event = true;

--- a/firmware/application/main.cpp
+++ b/firmware/application/main.cpp
@@ -145,14 +145,14 @@ Continuous (Fox-oring)
 rffc507x::RFFC507x first_if;
 
 static void event_loop() {
-	ui::Context context;
-	ui::SystemView system_view {
+	static ui::Context context;
+	static ui::SystemView system_view {
 		context,
 		portapack::display.screen_rect()
 	};
 
 	EventDispatcher event_dispatcher { &system_view, context };
-	MessageHandlerRegistration message_handler_display_sleep {
+	static MessageHandlerRegistration message_handler_display_sleep {
 		Message::ID::DisplaySleep,
 		[&event_dispatcher](const Message* const) {
 			event_dispatcher.set_display_sleep(true);

--- a/firmware/application/ui_navigation.cpp
+++ b/firmware/application/ui_navigation.cpp
@@ -761,7 +761,13 @@ void SystemView::toggle_overlay() {
 }
 
 void SystemView::paint_overlay() {
+	static bool last_paint_state = false;
 	if (overlay_active){
+		// paint background only every other second
+		if ((((chTimeNow()>>10) & 0x01) == 0x01) == last_paint_state)
+			return;
+
+		last_paint_state = !last_paint_state;
 		this->overlay.set_dirty();
 	}
 }

--- a/firmware/application/ui_navigation.cpp
+++ b/firmware/application/ui_navigation.cpp
@@ -29,6 +29,7 @@
 #include "bmp_splash.hpp"
 #include "bmp_modal_warning.hpp"
 #include "portapack_persistent_memory.hpp"
+#include "portapack_shared_memory.hpp"
 
 #include "ui_about_simple.hpp"
 #include "ui_adsb_rx.hpp"
@@ -752,11 +753,14 @@ void SystemView::toggle_overlay() {
 	if (overlay_active){
 		this->remove_child(&this->overlay);
 		this->set_dirty();
+		shared_memory.request_m4_performance_counter = 0;
 	}
 	else{
 		this->add_child(&this->overlay);
 		this->set_dirty();
+		shared_memory.request_m4_performance_counter = 1;
 	}
+
 	overlay_active = !overlay_active;
 }
 

--- a/firmware/application/ui_navigation.cpp
+++ b/firmware/application/ui_navigation.cpp
@@ -748,6 +748,24 @@ Context& SystemView::context() const {
 	return context_;
 }
 
+void SystemView::toggle_overlay() {
+	if (overlay_active){
+		this->remove_child(&this->overlay);
+		this->set_dirty();
+	}
+	else{
+		this->add_child(&this->overlay);
+		this->set_dirty();
+	}
+	overlay_active = !overlay_active;
+}
+
+void SystemView::paint_overlay() {
+	if (overlay_active){
+		this->overlay.set_dirty();
+	}
+}
+
 /* ***********************************************************************/
 
 void BMPView::focus() {

--- a/firmware/application/ui_navigation.cpp
+++ b/firmware/application/ui_navigation.cpp
@@ -759,6 +759,9 @@ void SystemView::toggle_overlay() {
 		this->add_child(&this->overlay);
 		this->set_dirty();
 		shared_memory.request_m4_performance_counter = 1;
+		shared_memory.m4_cpu_usage = 0;
+		shared_memory.m4_heap_usage = 0;
+		shared_memory.m4_stack_usage = 0;
 	}
 
 	overlay_active = !overlay_active;

--- a/firmware/application/ui_navigation.hpp
+++ b/firmware/application/ui_navigation.hpp
@@ -33,6 +33,7 @@
 #include "ui_channel.hpp"
 #include "ui_audio.hpp"
 #include "ui_sd_card_status_view.hpp"
+#include "ui_dfu_menu.hpp"
 
 #include "bitmap.hpp"
 #include "ff.h"
@@ -290,10 +291,15 @@ namespace ui
 			const Rect parent_rect);
 
 		Context &context() const override;
+		void toggle_overlay();
+		void paint_overlay();
 
 	private:
+		bool overlay_active {false};
+
 		SystemStatusView status_view{navigation_view};
 		InformationView info_view{navigation_view};
+		DfuMenu overlay{navigation_view};
 		NavigationView navigation_view{};
 		Context &context_;
 	};

--- a/firmware/baseband/chconf.h
+++ b/firmware/baseband/chconf.h
@@ -508,6 +508,8 @@
 }
 #endif
 
+
+
 /**
  * @brief   System tick event hook.
  * @details This hook is invoked in the system tick handler immediately
@@ -516,6 +518,8 @@
 #if !defined(SYSTEM_TICK_EVENT_HOOK) || defined(__DOXYGEN__)
 #define SYSTEM_TICK_EVENT_HOOK() {                                          \
   /* System tick event code here.*/                                         \
+  extern void update_performance_counters();  \
+  update_performance_counters();  \
 }
 #endif
 

--- a/firmware/baseband/event_m4.cpp
+++ b/firmware/baseband/event_m4.cpp
@@ -87,10 +87,6 @@ void EventDispatcher::dispatch(const eventmask_t events) {
 	if( events & EVT_MASK_SPECTRUM ) {
 		handle_spectrum();
 	}
-
-	if (shared_memory.request_m4_performance_counter == 0x01) {
-		update_performance_counters();
-	}
 }
 
 void EventDispatcher::handle_baseband_queue() {
@@ -98,34 +94,6 @@ void EventDispatcher::handle_baseband_queue() {
 	if( message ) {
 		on_message(message);
 	}
-}
-
-void EventDispatcher::update_performance_counters() {
-	static bool last_paint_state = false;
-	if ((((chTimeNow()>>10) & 0x01) == 0x01) == last_paint_state)
-		return;
-
-	last_paint_state = !last_paint_state;
-
-	auto now = chTimeNow();
-	auto idle_ticks = chThdGetTicks(chSysGetIdleThread());
-	
-	static systime_t last_time;
-	static systime_t last_last_time;
-
-	auto time_elapsed = now - last_time;
-	auto idle_elapsed = idle_ticks - last_last_time;
-
-	last_time = now;
-	last_last_time = idle_ticks;
-
-	auto cpu_usage = (time_elapsed - idle_elapsed) / 10;
-	auto free_stack = (uint32_t)get_free_stack_space();
-	auto free_heap = chCoreStatus();
-
-	shared_memory.m4_cpu_usage = cpu_usage;
-	shared_memory.m4_stack_usage = free_stack;
-	shared_memory.m4_heap_usage = free_heap;
 }
 
 void EventDispatcher::on_message(const Message* const message) {
@@ -153,3 +121,4 @@ void EventDispatcher::handle_spectrum() {
 	const UpdateSpectrumMessage message;
 	baseband_processor->on_message(&message);
 }
+

--- a/firmware/baseband/event_m4.cpp
+++ b/firmware/baseband/event_m4.cpp
@@ -20,6 +20,7 @@
  */
 
 #include "event_m4.hpp"
+#include "debug.hpp"
 
 #include "portapack_shared_memory.hpp"
 
@@ -86,6 +87,10 @@ void EventDispatcher::dispatch(const eventmask_t events) {
 	if( events & EVT_MASK_SPECTRUM ) {
 		handle_spectrum();
 	}
+
+	if (shared_memory.request_m4_performance_counter == 0x01) {
+		update_performance_counters();
+	}
 }
 
 void EventDispatcher::handle_baseband_queue() {
@@ -93,6 +98,34 @@ void EventDispatcher::handle_baseband_queue() {
 	if( message ) {
 		on_message(message);
 	}
+}
+
+void EventDispatcher::update_performance_counters() {
+	static bool last_paint_state = false;
+	if ((((chTimeNow()>>10) & 0x01) == 0x01) == last_paint_state)
+		return;
+
+	last_paint_state = !last_paint_state;
+
+	auto now = chTimeNow();
+	auto idle_ticks = chThdGetTicks(chSysGetIdleThread());
+	
+	static systime_t last_time;
+	static systime_t last_last_time;
+
+	auto time_elapsed = now - last_time;
+	auto idle_elapsed = idle_ticks - last_last_time;
+
+	last_time = now;
+	last_last_time = idle_ticks;
+
+	auto cpu_usage = (time_elapsed - idle_elapsed) / 10;
+	auto free_stack = (uint32_t)get_free_stack_space();
+	auto free_heap = chCoreStatus();
+
+	shared_memory.m4_cpu_usage = cpu_usage;
+	shared_memory.m4_stack_usage = free_stack;
+	shared_memory.m4_heap_usage = free_heap;
 }
 
 void EventDispatcher::on_message(const Message* const message) {

--- a/firmware/baseband/event_m4.hpp
+++ b/firmware/baseband/event_m4.hpp
@@ -61,7 +61,6 @@ private:
 	void dispatch(const eventmask_t events);
 
 	void handle_baseband_queue();
-	void update_performance_counters();
 
 	void on_message(const Message* const message);
 	void on_message_shutdown(const ShutdownMessage&);

--- a/firmware/baseband/event_m4.hpp
+++ b/firmware/baseband/event_m4.hpp
@@ -61,6 +61,7 @@ private:
 	void dispatch(const eventmask_t events);
 
 	void handle_baseband_queue();
+	void update_performance_counters();
 
 	void on_message(const Message* const message);
 	void on_message_shutdown(const ShutdownMessage&);

--- a/firmware/baseband/sd_over_usb/proc_sd_over_usb.cpp
+++ b/firmware/baseband/sd_over_usb/proc_sd_over_usb.cpp
@@ -45,3 +45,5 @@ int main() {
 
 	return 0;
 }
+
+void update_performance_counters() {}

--- a/firmware/common/portapack_shared_memory.hpp
+++ b/firmware/common/portapack_shared_memory.hpp
@@ -64,6 +64,11 @@ struct SharedMemory {
 		JammerChannel jammer_channels[24];
 		uint8_t data[512];
 	} bb_data { { { { 0, 0 } }, 0, { 0 } } };
+
+	uint8_t request_m4_performance_counter{ 0 };
+	uint8_t m4_cpu_usage{ 0 };
+	uint16_t m4_stack_usage{ 0 };
+	uint16_t m4_heap_usage{ 0 };
 };
 
 extern SharedMemory& shared_memory;

--- a/firmware/common/portapack_shared_memory.hpp
+++ b/firmware/common/portapack_shared_memory.hpp
@@ -65,10 +65,10 @@ struct SharedMemory {
 		uint8_t data[512];
 	} bb_data { { { { 0, 0 } }, 0, { 0 } } };
 
-	uint8_t request_m4_performance_counter{ 0 };
-	uint8_t m4_cpu_usage{ 0 };
-	uint16_t m4_stack_usage{ 0 };
-	uint16_t m4_heap_usage{ 0 };
+	uint8_t volatile request_m4_performance_counter{ 0 };
+	uint8_t volatile m4_cpu_usage{ 0 };
+	uint16_t volatile m4_stack_usage{ 0 };
+	uint16_t volatile m4_heap_usage{ 0 };
 };
 
 extern SharedMemory& shared_memory;


### PR DESCRIPTION
This pull request adds an overlay for current system performance statistics.

* It is bound to the DFU button

![SCR_0018](https://user-images.githubusercontent.com/13151053/233868121-be63615c-43a9-4687-8703-4f068fcfc121.PNG) ![SCR_0019](https://user-images.githubusercontent.com/13151053/233868127-e12736fa-278e-4e59-8a9f-9360e42f496e.PNG)

* "heap" is the current free memory for dynamic allocation
* "stack" is the all time highest usage of the stack.
* "cpu %" is current cpu utilisation
* "uptime" is in seconds

The ui framework does not support overlapping elements. Most apps will interfere with the overlay:
![SCR_0020](https://user-images.githubusercontent.com/13151053/233868285-5612c7e5-9a25-4fb8-b301-7f564d602ea5.PNG) ![SCR_0021](https://user-images.githubusercontent.com/13151053/233868293-53346cb9-3a4c-4623-93e2-367010936315.PNG)

* In most cases the information can still be read/used.