### PR TITLE
implemented issue#917

### DIFF
--- a/firmware/application/apps/ui_fileman.cpp
+++ b/firmware/application/apps/ui_fileman.cpp
@@ -264,11 +264,16 @@ void FileManagerView::on_rename(NavigationView& nav) {
 
 void FileManagerView::on_refactor(NavigationView& nav) {
 	text_prompt(nav, name_buffer, max_filename_length, [this](std::string& buffer) {
+
 		std::string destination_path = current_path.string();
 		if (destination_path.back() != '/')
 			destination_path += '/';
 
-		destination_path = get_selected_path().string().back() != '/' ? destination_path + buffer + extension_buffer : destination_path + buffer;
+		if(get_selected_path().string().back() != '/'){
+			destination_path = destination_path + buffer + extension_buffer;
+		}else if(get_selected_path().string().back() == '/'){
+			destination_path = destination_path + buffer;
+		}
 
 		rename_file(get_selected_path(), destination_path);  //rename the selected file
 
@@ -289,9 +294,9 @@ void FileManagerView::on_refactor(NavigationView& nav) {
 
 		load_directory_contents(current_path);
 		refresh_list();
-		extension_buffer.clear();
-		destination_path.clear();
+
 	});
+
 }
 
 void FileManagerView::on_delete() {

--- a/firmware/application/apps/ui_fileman.cpp
+++ b/firmware/application/apps/ui_fileman.cpp
@@ -289,6 +289,8 @@ void FileManagerView::on_refactor(NavigationView& nav) {
 
 		load_directory_contents(current_path);
 		refresh_list();
+		extension_buffer.clear();
+		destination_path.clear();
 	});
 }
 

--- a/firmware/application/apps/ui_fileman.cpp
+++ b/firmware/application/apps/ui_fileman.cpp
@@ -267,14 +267,15 @@ void FileManagerView::on_refactor(NavigationView& nav) {
 		std::string destination_path = current_path.string();
 		if (destination_path.back() != '/')
 			destination_path += '/';
-		destination_path = destination_path + buffer;
+
+		destination_path = get_selected_path().string().back() != '/' ? destination_path + buffer + extension_buffer : destination_path + buffer;
 
 		rename_file(get_selected_path(), destination_path);  //rename the selected file
 
 		auto selected_path = get_selected_path();
 		auto extension = selected_path.extension().string();
 
-		if (!extension.empty() && selected_path.string().back() != '/' && extension.substr(1) == "C16") {
+		if (!extension.empty() && selected_path.string().back() != '/' && extension.substr(1) == "C16") { //substr(1) is for ignore the dot
 			// Rename its partner ( C16 <-> TXT ) file.
 			auto partner_file_path = selected_path.string().substr(0, selected_path.string().size() - 4) + ".TXT";
 			destination_path = destination_path.substr(0, destination_path.size() - 4) + ".TXT";
@@ -359,6 +360,13 @@ FileManagerView::FileManagerView(
 
 		button_refactor.on_select = [this, &nav](Button&) {
 			name_buffer = entry_list[menu_view.highlighted_index()].entry_path.filename().string().substr(0, max_filename_length);
+			size_t pos = name_buffer.find_last_of(".");
+
+			if (pos != std::string::npos) {
+				extension_buffer = name_buffer.substr(pos);
+				name_buffer = name_buffer.substr(0, pos);
+			}
+
 			on_refactor(nav);
 		};
 

--- a/firmware/application/apps/ui_fileman.cpp
+++ b/firmware/application/apps/ui_fileman.cpp
@@ -266,19 +266,20 @@ void FileManagerView::on_refactor(NavigationView& nav) {
 	text_prompt(nav, name_buffer, max_filename_length, [this](std::string& buffer) {
 
 		std::string destination_path = current_path.string();
-		if (destination_path.back() != '/')
+		if (destination_path.back() != '/')//if the path is not ended with '/', add '/'
 			destination_path += '/';
-
-		if(get_selected_path().string().back() != '/'){
-			destination_path = destination_path + buffer + extension_buffer;
-		}else if(get_selected_path().string().back() == '/'){
-			destination_path = destination_path + buffer;
-		}
-
-		rename_file(get_selected_path(), destination_path);  //rename the selected file
 
 		auto selected_path = get_selected_path();
 		auto extension = selected_path.extension().string();
+
+		if(extension.empty()){// Is Dir
+			destination_path = destination_path + buffer;
+			extension_buffer = "";
+		}else{//is File
+			destination_path = destination_path + buffer + extension_buffer;
+		}
+
+		rename_file(get_selected_path(), destination_path);  //rename the selected file
 
 		if (!extension.empty() && selected_path.string().back() != '/' && extension.substr(1) == "C16") { //substr(1) is for ignore the dot
 			// Rename its partner ( C16 <-> TXT ) file.

--- a/firmware/application/apps/ui_fileman.hpp
+++ b/firmware/application/apps/ui_fileman.hpp
@@ -143,6 +143,7 @@ public:
 
 private:
 	std::string name_buffer { };
+	std::string extension_buffer { };
 	
 	void refresh_widgets(const bool v);
 	void on_rename(NavigationView& nav);


### PR DESCRIPTION
I also noticed issue#916, but i did a test and it seems there's no much more memory were taken even if i decleared a new variable....   
When rename a file, just cut the extension from name_buffer, and when the keypad return the buffer, just add the extension back so user wouldn't need to delete the extension and type it again....   
it is implemented in "refactor" button so user can still rename the extension with "rename" if they need.    
considering record and replay is the the main feature of pp so i think it worth to waste SPI flash memory within 11 line code to implement it...   