### PR TITLE
#910 Brighter color for .C8/.C16 files in fileman

### DIFF
--- a/firmware/application/apps/ui_fileman.hpp
+++ b/firmware/application/apps/ui_fileman.hpp
@@ -67,8 +67,8 @@ protected:
 		{ ".TXT", &bitmap_icon_file_text, ui::Color::white() },
 		{ ".PNG", &bitmap_icon_file_image, ui::Color::green() },
 		{ ".BMP", &bitmap_icon_file_image, ui::Color::green() },
-		{ ".C8",  &bitmap_icon_file_iq, ui::Color::blue() },
-		{ ".C16", &bitmap_icon_file_iq, ui::Color::blue() },
+		{ ".C8",  &bitmap_icon_file_iq, ui::Color::dark_cyan() },
+		{ ".C16", &bitmap_icon_file_iq, ui::Color::dark_cyan() },
 		{ ".WAV", &bitmap_icon_file_wav, ui::Color::dark_magenta() },
 		{ "", &bitmap_icon_file, ui::Color::light_grey() }
 	};


### PR DESCRIPTION
Proposed color change for higher visibility of .C8/.C16 files in fileman per #910
 
![SCR_0001](https://user-images.githubusercontent.com/129641948/234497836-709365bf-d90b-4cbc-9a83-c7e48c5d0571.PNG)
