### PR TITLE
added frame drop rate for m4 signal processing

### DIFF
--- a/firmware/application/apps/ui_dfu_menu.cpp
+++ b/firmware/application/apps/ui_dfu_menu.cpp
@@ -35,7 +35,8 @@ DfuMenu::DfuMenu(NavigationView& nav) : nav_ (nav) {
 		&text_info_line_4,
 		&text_info_line_5,
 		&text_info_line_6,
-		&text_info_line_7
+		&text_info_line_7,
+		&text_info_line_8
 	});
 }
 
@@ -48,14 +49,16 @@ void DfuMenu::paint(Painter& painter) {
 	text_info_line_4.set(to_string_dec_uint(shared_memory.m4_heap_usage, 6));
 	text_info_line_5.set(to_string_dec_uint(shared_memory.m4_stack_usage, 6));
 	text_info_line_6.set(to_string_dec_uint(shared_memory.m4_cpu_usage, 6));
-	text_info_line_7.set(to_string_dec_uint(chTimeNow()/1000, 6));
+	text_info_line_7.set(to_string_dec_uint(shared_memory.m4_buffer_missed, 6));
+	text_info_line_8.set(to_string_dec_uint(chTimeNow()/1000, 6));
 
 	constexpr auto margin = 5;
+	constexpr auto lines = 8 + 2;
 
 	painter.fill_rectangle(
 		{
 			{6 * CHARACTER_WIDTH - margin, 3 * LINE_HEIGHT - margin},
-			{15 * CHARACTER_WIDTH + margin * 2, 9 * LINE_HEIGHT + margin * 2}
+			{15 * CHARACTER_WIDTH + margin * 2, lines * LINE_HEIGHT + margin * 2}
 		},
 		ui::Color::black()
 	);
@@ -63,7 +66,7 @@ void DfuMenu::paint(Painter& painter) {
 	painter.fill_rectangle(
 		{
 			{5 * CHARACTER_WIDTH - margin, 3 * LINE_HEIGHT - margin},
-			{CHARACTER_WIDTH, 9 * LINE_HEIGHT + margin * 2}
+			{CHARACTER_WIDTH, lines * LINE_HEIGHT + margin * 2}
 		},
 		ui::Color::dark_cyan()
 	);
@@ -71,7 +74,7 @@ void DfuMenu::paint(Painter& painter) {
 	painter.fill_rectangle(
 		{
 			{21 * CHARACTER_WIDTH + margin, 3 * LINE_HEIGHT - margin},
-			{CHARACTER_WIDTH, 9 * LINE_HEIGHT + margin * 2}
+			{CHARACTER_WIDTH, lines * LINE_HEIGHT + margin * 2}
 		},
 		ui::Color::dark_cyan()
 	);
@@ -86,7 +89,7 @@ void DfuMenu::paint(Painter& painter) {
 
 	painter.fill_rectangle(
 		{
-			{5 * CHARACTER_WIDTH - margin, 12 * LINE_HEIGHT + margin},
+			{5 * CHARACTER_WIDTH - margin, (lines+3) * LINE_HEIGHT + margin},
 			{17 * CHARACTER_WIDTH + margin * 2, 8}
 		},
 		ui::Color::dark_cyan()

--- a/firmware/application/apps/ui_dfu_menu.hpp
+++ b/firmware/application/apps/ui_dfu_menu.hpp
@@ -54,7 +54,8 @@ private:
 		{ { 6 * CHARACTER_WIDTH, 8 * LINE_HEIGHT }, "M4 heap:", Color::dark_cyan() },
 		{ { 6 * CHARACTER_WIDTH, 9 * LINE_HEIGHT }, "M4 stack:", Color::dark_cyan() },
 		{ { 6 * CHARACTER_WIDTH,10 * LINE_HEIGHT }, "M4 cpu %:", Color::dark_cyan() },
-		{ { 6 * CHARACTER_WIDTH,11 * LINE_HEIGHT }, "uptime:", Color::dark_cyan() }
+		{ { 6 * CHARACTER_WIDTH,11 * LINE_HEIGHT }, "M4 miss:", Color::dark_cyan() },
+		{ { 6 * CHARACTER_WIDTH,12 * LINE_HEIGHT }, "uptime:", Color::dark_cyan() }
 	};
 
 	Text text_info_line_1 {{ 15 * CHARACTER_WIDTH, 5 * LINE_HEIGHT, 5 * CHARACTER_WIDTH, 1 * LINE_HEIGHT }, ""};
@@ -64,6 +65,7 @@ private:
 	Text text_info_line_5 {{ 15 * CHARACTER_WIDTH, 9 * LINE_HEIGHT, 5 * CHARACTER_WIDTH, 1 * LINE_HEIGHT }, ""};
 	Text text_info_line_6 {{ 15 * CHARACTER_WIDTH,10 * LINE_HEIGHT, 5 * CHARACTER_WIDTH, 1 * LINE_HEIGHT }, ""};
 	Text text_info_line_7 {{ 15 * CHARACTER_WIDTH,11 * LINE_HEIGHT, 5 * CHARACTER_WIDTH, 1 * LINE_HEIGHT }, ""};
+	Text text_info_line_8 {{ 15 * CHARACTER_WIDTH,12 * LINE_HEIGHT, 5 * CHARACTER_WIDTH, 1 * LINE_HEIGHT }, ""};
 };
 
 } /* namespace ui */

--- a/firmware/common/portapack_shared_memory.hpp
+++ b/firmware/common/portapack_shared_memory.hpp
@@ -69,6 +69,7 @@ struct SharedMemory {
 	uint8_t volatile m4_cpu_usage{ 0 };
 	uint16_t volatile m4_stack_usage{ 0 };
 	uint16_t volatile m4_heap_usage{ 0 };
+	uint16_t volatile m4_buffer_missed{ 0 };
 };
 
 extern SharedMemory& shared_memory;


### PR DESCRIPTION
This pull request adds the frame drop rate (buffer overflow / underflow) for m4 signal processing.

![SCR_0024](https://user-images.githubusercontent.com/13151053/234866387-8e2595a9-a56e-4eee-8c2e-9d06c62a52d3.PNG)

Depending on the sampling rate, signal data is always coming in at a constant rate. When processing for one frame takes longer than the length of the frame, the next one will be dropped.

Example for some dropped data (will still work most of the time):
![SCR_0022](https://user-images.githubusercontent.com/13151053/234866362-e54c4e70-46c1-4504-a298-f199629bf8a6.PNG)

Example for lots of dropped data:
![SCR_0023](https://user-images.githubusercontent.com/13151053/234866382-261f19cd-b1fb-42b9-8188-376929aefee6.PNG)

