### PR TITLE
Automatically reduce rssi graph history

### DIFF
--- a/firmware/application/ui/ui_rssi.cpp
+++ b/firmware/application/ui/ui_rssi.cpp
@@ -434,6 +434,23 @@ namespace ui {
     void RSSIGraph::set_nb_columns( int16_t nb )
     {
         nb_columns = nb ;
+        while( graph_list.size() >  nb_columns )
+        {
+            graph_list.erase( graph_list.begin() );
+        }
+    }
+
+    void RSSIGraph::on_hide() {
+        nb_columns_before_hide = nb_columns ;
+        nb_columns = 1 ;
+        while( graph_list.size() >  nb_columns )
+        {
+            graph_list.erase( graph_list.begin() );
+        }
+    }
+
+    void RSSIGraph::on_show() {
+        nb_columns = nb_columns_before_hide ;
     }
 
     void RSSI::on_focus() {

--- a/firmware/application/ui/ui_rssi.hpp
+++ b/firmware/application/ui/ui_rssi.hpp
@@ -115,8 +115,12 @@ namespace ui {
             void paint(Painter& painter) override;
             void add_values(int16_t rssi_min, int16_t rssi_avg, int16_t rssi_max, int16_t db );
             void set_nb_columns( int16_t nb );
+            
+            void on_hide() override ;
+            void on_show() override ;
 
         private:
+            uint16_t nb_columns_before_hide = 16 ;
             uint16_t nb_columns = 16 ;
             RSSIGraphList graph_list { } ;
     };


### PR DESCRIPTION
Automatically reduce rssi graph history when hidden and restore size when shown.
Prevent Memory exhaustion in apps like 'Level' or any app eating a bit too much mem before launching a  FrequencyPadView