### PR TITLE
Freq disp fix

### DIFF
--- a/firmware/application/apps/ui_level.hpp
+++ b/firmware/application/apps/ui_level.hpp
@@ -48,8 +48,6 @@ namespace ui {
 
 			void focus() override;
 
-			void big_display_freq( int64_t f );
-
 			const Style style_grey {		// level
 				.font = font::fixed_8x16,
 					.background = Color::black(),

--- a/firmware/application/apps/ui_recon.cpp
+++ b/firmware/application/apps/ui_recon.cpp
@@ -443,9 +443,7 @@ namespace ui {
 
 	void ReconView::set_display_freq( int64_t freq )
 	{
-		int64_t freqMHz = ( freq / 1000000 );
-		int64_t freqMhzFloatingPart = ( freq - ( 1000000 * freqMHz ) ) / 100 ;
-		big_display.set( "FREQ: "+to_string_dec_int( freqMHz )+"."+to_string_dec_int( freqMhzFloatingPart )+" MHz" );
+		big_display.set( "FREQ: "+to_string_short_freq( freq )+" MHz" );
 	}
 
 	void ReconView::handle_retune( int64_t freq , uint32_t index ) {

--- a/firmware/application/apps/ui_recon.hpp
+++ b/firmware/application/apps/ui_recon.hpp
@@ -118,8 +118,6 @@ namespace ui {
 
 			void focus() override;
 
-			void big_display_freq( int64_t f );
-
 			const Style style_grey {		// recon
 				.font = font::fixed_8x16,
 					.background = Color::black(),

--- a/firmware/application/apps/ui_scanner.hpp
+++ b/firmware/application/apps/ui_scanner.hpp
@@ -88,8 +88,6 @@ public:
 	
 	void focus() override;
 
-	void big_display_freq(rf::Frequency f);
-
 	const Style style_grey {		// scanning
 		.font = font::fixed_8x16,
 		.background = Color::black(),


### PR DESCRIPTION
Fix issue 928 , [Recon Frequency field doesn't display frequencies correctly if there are leading zeros in floating part](https://github.com/eried/portapack-mayhem/issues/928)