### PR TITLE
Add a TextField widget that supports a cursor.

### DIFF
--- a/firmware/application/ui/ui_alphanum.cpp
+++ b/firmware/application/ui/ui_alphanum.cpp
@@ -30,10 +30,6 @@
 
 namespace ui {
 
-void AlphanumView::paint(Painter&) {
-	draw_cursor();
-}
-
 AlphanumView::AlphanumView(
 	NavigationView& nav,
 	std::string& str,
@@ -41,7 +37,7 @@ AlphanumView::AlphanumView(
 ) : TextEntryView(nav, str, max_length)
 {
 	size_t n;
-	
+
 	add_children({
 		&button_mode,
 		&text_raw,
@@ -77,16 +73,7 @@ AlphanumView::AlphanumView(
 	field_raw.set_value('0');
 	field_raw.on_select = [this](NumberField&) {
 		char_add(field_raw.value());
-		update_text();
 	};
-
-	button_ok.on_select = [this, &nav](Button&) {
-		if (on_changed)
-			on_changed(_str);
-		nav.pop();
-	};
-
-	update_text();
 }
 
 void AlphanumView::set_mode(const uint32_t new_mode) {
@@ -120,8 +107,6 @@ void AlphanumView::on_button(Button& button) {
 		char_delete();
 	else
 		char_add(c);
-	
-	update_text();
 }
 
 bool AlphanumView::on_encoder(const EncoderEvent delta) {

--- a/firmware/application/ui/ui_alphanum.hpp
+++ b/firmware/application/ui/ui_alphanum.hpp
@@ -40,7 +40,6 @@ public:
 	AlphanumView& operator=(const AlphanumView&) = delete;
 	AlphanumView& operator=(AlphanumView&&) = delete;
 
-	void paint(Painter& painter) override;
 	bool on_encoder(const EncoderEvent delta) override;
 
 private:

--- a/firmware/application/ui/ui_textentry.hpp
+++ b/firmware/application/ui/ui_textentry.hpp
@@ -28,6 +28,54 @@
 
 namespace ui {
 
+// A TextField is bound to a string reference and allows the string
+// to be manipulated. The field itself does not provide the UI for
+// setting the value. It provides the UI of rendering the text,
+// a cursor, and an API to edit the string content.
+class TextField : public Widget {
+public:
+	TextField(std::string& str, Point position, uint32_t length = 30)
+		: TextField{str, 64, position, length} { }
+
+	// Str: the string containing the content to edit.
+	// Max_length: max length the string is allowed to use.
+	// Position: the top-left corner of the control.
+	// Length: the number of characters to display.
+	//   - Characters are 8 pixels wide.
+	//   - The screen can show 30 characters max.
+	//   - The control is 16 pixels tall.
+	TextField(std::string& str, size_t max_length, Point position, uint32_t length = 30);
+
+	TextField(const TextField&) = delete;
+	TextField(TextField&&) = delete;
+	TextField& operator=(const TextField&) = delete;
+	TextField& operator=(TextField&&) = delete;
+
+	const std::string& value() const;
+
+	void set(const std::string& str);
+	void set_cursor(uint32_t pos);
+	void set_max_length(size_t max_length);
+	void set_insert_mode();
+	void set_overwrite_mode();
+
+	void char_add(char c);
+	void char_delete();
+
+	void paint(Painter& painter) override;
+
+	bool on_key(const KeyEvent key) override;
+	bool on_encoder(const EncoderEvent delta) override;
+	bool on_touch(const TouchEvent event) override;
+
+protected:
+	std::string&   text_;
+	size_t         max_length_;
+	uint32_t       char_count_;
+	uint32_t       cursor_pos_;
+	bool           insert_mode_;
+};
+
 class TextEntryView : public View {
 public:
 	std::function<void(std::string&)> on_changed { };
@@ -45,17 +93,8 @@ protected:
 
 	void char_add(const char c);
 	void char_delete();
-	void draw_cursor();
-	void update_text();
 	
-	std::string& _str;
-	size_t _max_length;
-	uint32_t cursor_pos { 0 };
-	
-	Text text_input {
-		{ 0, 0, 240, 16 }
-	};
-	
+	TextField text_input;
 	Button button_ok {
 		{ 10 * 8, 33 * 8, 9 * 8, 32 },
 		"OK"

--- a/firmware/common/ui_painter.cpp
+++ b/firmware/common/ui_painter.cpp
@@ -43,7 +43,7 @@ int Painter::draw_char(const Point p, const Style& style, const char c) {
 }
 
 int Painter::draw_string(Point p, const Font& font, const Color foreground,
-	const Color background, const std::string text) {
+	const Color background, const std::string& text) {
 	
 	bool escape = false;
 	size_t width = 0;
@@ -71,7 +71,7 @@ int Painter::draw_string(Point p, const Font& font, const Color foreground,
 	return width;
 }
 
-int Painter::draw_string(Point p, const Style& style, const std::string text) {
+int Painter::draw_string(Point p, const Style& style, const std::string& text) {
 	return draw_string(p, style.font, style.foreground, style.background, text);
 }
 

--- a/firmware/common/ui_painter.hpp
+++ b/firmware/common/ui_painter.hpp
@@ -49,8 +49,8 @@ public:
 	int draw_char(const Point p, const Style& style, const char c);
 
 	int draw_string(Point p, const Font& font, const Color foreground,
-		const Color background, const std::string text);
-	int draw_string(Point p, const Style& style, const std::string text);
+		const Color background, const std::string& text);
+	int draw_string(Point p, const Style& style, const std::string& text);
 
 	void draw_bitmap(const Point p, const Bitmap& bitmap, const Color background, const Color foreground);
 


### PR DESCRIPTION
This extracts a TextField Widget from the TextEntryView.
TextField supports a cursor an is more memory efficient because it doesn't need to copy to the Text widget for display.
TextField supports insert and overwrite modes.

I kept the Widget code close to the TextViewEntry mainly because the Widget relies on the TextEntryView to handle the text input, but I could just as well move the code to ui_widget if that makes more sense.

There are a few functional changes from the previous behavior.
1) The control does not right trim whitespace. This feels like something the caller should be doing, vs something the control should do.
2) The old control displayed a "<" if the text exceeded the width. Now that you can use the encoder or the dpad to move the cursor, this seemed unnecessary.
3) The text field is now a tab stop on the TextEntryView so that it can be interacted with. Given that, the default control when the TextEntryView loads is now the text field instead of the OK button.

I verified this works with the encoder, the dpad, and with touch. I tried entry with Fileman, Freqman, and Recon.

https://user-images.githubusercontent.com/3761006/235280474-891e7abf-8e18-4a7a-8450-ee16d6af6ee7.mp4

