### PR TITLE
Solving Noise generation in Signal gen App

### DIFF
--- a/firmware/application/apps/ui_siggen.hpp
+++ b/firmware/application/apps/ui_siggen.hpp
@@ -48,14 +48,16 @@ private:
 	void update_tone();
 	void on_tx_progress(const uint32_t progress, const bool done);
 	
-	const std::string shape_strings[7] = {
-		"CW",
-		"Sine",
-		"Triangle",
-		"Saw up",
-		"Saw down",
-		"Square",
-		"Noise"
+	const std::string shape_strings[9] = {
+		"CW          ",
+		"Sine        ",
+		"Triangle    ",
+		"Saw up      ",
+		"Saw down    ",
+		"Square      ",
+		"Noise n20Khz",
+		"Noise n10khz",
+		"Noise n5khz "
 	};
 	
 	bool auto_update { false };
@@ -78,7 +80,9 @@ private:
 			{ &bitmap_sig_saw_up, 3 },
 			{ &bitmap_sig_saw_down, 4 },
 			{ &bitmap_sig_square, 5 },
-			{ &bitmap_sig_noise, 6 }
+			{ &bitmap_sig_noise, 6 },
+			{ &bitmap_sig_noise, 7 },
+			{ &bitmap_sig_noise, 8 }
 		}
 	};
 	

--- a/firmware/baseband/proc_siggen.hpp
+++ b/firmware/baseband/proc_siggen.hpp
@@ -38,13 +38,14 @@ private:
 	
 	BasebandThread baseband_thread { 1536000, this, NORMALPRIO + 20, baseband::Direction::Transmit };
 	
-	uint32_t tone_delta { 0 }, fm_delta { };
-	uint32_t lfsr { }, feedback { }, tone_shape { };
+	uint32_t tone_delta { 0 }, fm_delta { },tone_phase { 0 };
+	uint8_t tone_shape { };
     uint32_t sample_count { 0 };
     bool auto_off { };
-	uint32_t tone_phase { 0 }, phase { 0 }, delta { 0 }, sphase { 0 };
-	int8_t sample { 0 };
-	int8_t re { 0 }, im { 0 };
+	int32_t phase { 0 }, sphase { 0 }, delta { 0 }; 	// they may have sign .
+	int8_t  sample { 0 }, re { 0 }, im { 0 };			// they may have sign .
+    uint8_t seed_value = {0x56};   						// seed : any nonzero start state will work. 
+	uint8_t lfsr { }, bit { };  						// bit must be 8-bit to allow bit<<7 later in the code */
 	
 	TXProgressMessage txprogress_message { };
 };


### PR DESCRIPTION
Due to issue #923 , it was found that the White Noise generator was not working in the Signal Generator App. (inside utiilities) 
Thanks to @bernd-herzog ,  I could debug properly following his guide and his support .

I have played a lot , trying to make it work , the original 32 bits polynomial and others of 16 bits without succeed.
Therefore , we are replacing previous LFSR polynomial of  32 bits, with 3 variants of 8 bits LFSR .
(but no problem at all, because in fact, each sample var to be send to the RF I,Q  modulator  ,  only has 8 bits) 

Basically I followed this [link ](https://en.wikipedia.org/wiki/Linear-feedback_shift_register).
With this PR,  we are applying the last  3 polynomial of  6, 7, 8 bits 
![image](https://user-images.githubusercontent.com/86470699/235361335-eb40d21e-c997-4baa-a544-dd9ba674cde7.png)

Confirmation , checking the spectrum of the FM generated , with all options, : 

![image](https://user-images.githubusercontent.com/86470699/235361398-987514b0-6589-4df4-bd80-038c8fa7ace0.png)

![image](https://user-images.githubusercontent.com/86470699/235361412-0a766313-a17e-48de-ae7a-777afae58a6c.png)

![image](https://user-images.githubusercontent.com/86470699/235361429-69a9e2d0-0e94-46ac-845d-96be780a79c9.png)


  


    