### PR TITLE
Fileman UI and Perf Fixes

### DIFF
--- a/firmware/application/apps/soundboard_app.cpp
+++ b/firmware/application/apps/soundboard_app.cpp
@@ -206,7 +206,7 @@ void SoundBoardView::refresh_list() {
 				file_list[n].string().substr(0, 30),
 				ui::Color::white(),
 				nullptr,
-				[this](){
+				[this](KeyEvent){
 					on_select_entry();
 				}
 			});

--- a/firmware/application/apps/ui_fileman.hpp
+++ b/firmware/application/apps/ui_fileman.hpp
@@ -163,12 +163,12 @@ private:
 	};
 
 	Button button_rename {
-		{ 0 * 8, 29 * 8, 9 * 8, 32 },
+		{ 0 * 8, 29 * 8, 14 * 8, 32 },
 		"Rename"
 	};
 
 	Button button_delete {
-		{ 21 * 8, 29 * 8, 9 * 8, 32 },
+		{ 16 * 8, 29 * 8, 14 * 8, 32 },
 		"Delete"
 	};
 

--- a/firmware/application/apps/ui_fileman.hpp
+++ b/firmware/application/apps/ui_fileman.hpp
@@ -52,15 +52,13 @@ public:
 	std::string title() const override { return "Fileman"; };
 	
 protected:
-	static constexpr size_t max_filename_length = 64 - 2; // Necessary?
+	static constexpr size_t max_filename_length = 64; // Necessary?
 
 	struct file_assoc_t {
 		std::filesystem::path extension;
 		const Bitmap* icon;
 		ui::Color color;
 	};
-
-	const std::string suffix[5] = { "B", "kB", "MB", "GB", "??" };
 	
 	const std::vector<file_assoc_t> file_types = {
 		{ u".TXT", &bitmap_icon_file_text, ui::Color::white() },
@@ -82,6 +80,7 @@ protected:
 	std::function<void(bool)> on_refresh_widgets { nullptr };
 	
 	std::vector<fileman_entry> entry_list { };
+	const std::filesystem::path parent_dir_path { u".." };
 	std::filesystem::path current_path { u"" };
 	std::filesystem::path extension_filter { u"" };
 	
@@ -148,9 +147,9 @@ private:
 	std::string extension_buffer { };
 	
 	void refresh_widgets(const bool v);
-	void on_rename(NavigationView& nav);
-	//void on_refactor(NavigationView& nav);
+	void on_rename();
 	void on_delete();
+	void on_new_dir();
 	
 	Labels labels {
 		{ { 0, 26 * 8 }, "Created ", Color::light_grey() }
@@ -166,7 +165,7 @@ private:
 		"Rename"
 	};
 
-	Button button_copy {
+	/*Button button_copy {
 		{ 10 * 8, 29 * 8, 10 * 8, 32 },
 		"Copy"
 	};
@@ -174,7 +173,7 @@ private:
 	Button button_move {
 		{ 10 * 8, 29 * 8, 10 * 8, 32 },
 		"Move"
-	};
+	};*/
 
 	Button button_delete {
 		{ 21 * 8, 29 * 8, 9 * 8, 32 },
@@ -190,7 +189,6 @@ private:
 		{ 0 * 8, 34 * 8, 14 * 8, 32 },
 		"New Dir"
 	};
-	
 };
 
 } /* namespace ui */

--- a/firmware/application/apps/ui_fileman.hpp
+++ b/firmware/application/apps/ui_fileman.hpp
@@ -43,16 +43,11 @@ public:
 		std::string filter
 	);
 
-	void focus() override;
-	
-	void load_directory_contents(const std::filesystem::path& dir_path);
-	std::filesystem::path get_selected_full_path() const;
-	const fileman_entry& get_selected_entry() const;
-	
+	void focus() override;	
 	std::string title() const override { return "Fileman"; };
 	
 protected:
-	static constexpr size_t max_filename_length = 64; // Necessary?
+	static constexpr size_t max_filename_length = 50;
 
 	struct file_assoc_t {
 		std::filesystem::path extension;
@@ -70,19 +65,26 @@ protected:
 		{ u"", &bitmap_icon_file, ui::Color::light_grey() } // NB: Must be last.
 	};
 
+
+	std::filesystem::path get_selected_full_path() const;
+	const fileman_entry& get_selected_entry() const;
+
 	void refresh_list();
+	void reload_current();
+	void load_directory_contents(const std::filesystem::path& dir_path);
 	const file_assoc_t& get_assoc(const std::filesystem::path& ext) const;
 
 	NavigationView& nav_;
 
 	bool empty_root { false };
-	std::function<void(void)> on_select_entry { nullptr };
+	std::function<void(KeyEvent)> on_select_entry { nullptr };
 	std::function<void(bool)> on_refresh_widgets { nullptr };
-	
-	std::vector<fileman_entry> entry_list { };
+
 	const std::filesystem::path parent_dir_path { u".." };
 	std::filesystem::path current_path { u"" };
 	std::filesystem::path extension_filter { u"" };
+
+	std::vector<fileman_entry> entry_list { };
 	
 	Labels labels {
 		{ { 0, 0 }, "Path:", Color::light_grey() }
@@ -143,8 +145,8 @@ public:
 	~FileManagerView();
 
 private:
+	// Passed by ref to other views needing lifetime extension.
 	std::string name_buffer { };
-	std::string extension_buffer { };
 	
 	void refresh_widgets(const bool v);
 	void on_rename();
@@ -165,25 +167,10 @@ private:
 		"Rename"
 	};
 
-	/*Button button_copy {
-		{ 10 * 8, 29 * 8, 10 * 8, 32 },
-		"Copy"
-	};
-
-	Button button_move {
-		{ 10 * 8, 29 * 8, 10 * 8, 32 },
-		"Move"
-	};*/
-
 	Button button_delete {
 		{ 21 * 8, 29 * 8, 9 * 8, 32 },
 		"Delete"
 	};
-	
-	/*Button button_new_file {
-		{ 0 * 8, 34 * 8, 14 * 8, 32 },
-		"New File"
-	};*/
 
 	Button button_new_dir {
 		{ 0 * 8, 34 * 8, 14 * 8, 32 },

--- a/firmware/application/apps/ui_fileman.hpp
+++ b/firmware/application/apps/ui_fileman.hpp
@@ -31,7 +31,7 @@
 namespace ui {
 
 struct fileman_entry {
-	std::filesystem::path entry_path { };
+	std::filesystem::path path { };
 	uint32_t size { };
 	bool is_directory { };
 };
@@ -46,47 +46,49 @@ public:
 	void focus() override;
 	
 	void load_directory_contents(const std::filesystem::path& dir_path);
-	std::filesystem::path get_selected_path();
+	std::filesystem::path get_selected_full_path() const;
+	const fileman_entry& get_selected_entry() const;
 	
 	std::string title() const override { return "Fileman"; };
 	
 protected:
-	NavigationView& nav_;
-	
-	static constexpr size_t max_filename_length = 30 - 2;
-	
-	const std::string suffix[5] = { "B", "kB", "MB", "GB", "??" };
-	
+	static constexpr size_t max_filename_length = 64 - 2; // Necessary?
+
 	struct file_assoc_t {
-		std::string extension;
+		std::filesystem::path extension;
 		const Bitmap* icon;
 		ui::Color color;
 	};
+
+	const std::string suffix[5] = { "B", "kB", "MB", "GB", "??" };
 	
 	const std::vector<file_assoc_t> file_types = {
-		{ ".TXT", &bitmap_icon_file_text, ui::Color::white() },
-		{ ".PNG", &bitmap_icon_file_image, ui::Color::green() },
-		{ ".BMP", &bitmap_icon_file_image, ui::Color::green() },
-		{ ".C8",  &bitmap_icon_file_iq, ui::Color::dark_cyan() },
-		{ ".C16", &bitmap_icon_file_iq, ui::Color::dark_cyan() },
-		{ ".WAV", &bitmap_icon_file_wav, ui::Color::dark_magenta() },
-		{ "", &bitmap_icon_file, ui::Color::light_grey() }
+		{ u".TXT", &bitmap_icon_file_text, ui::Color::white() },
+		{ u".PNG", &bitmap_icon_file_image, ui::Color::green() },
+		{ u".BMP", &bitmap_icon_file_image, ui::Color::green() },
+		{ u".C8",  &bitmap_icon_file_iq, ui::Color::dark_cyan() },
+		{ u".C16", &bitmap_icon_file_iq, ui::Color::dark_cyan() },
+		{ u".WAV", &bitmap_icon_file_wav, ui::Color::dark_magenta() },
+		{ u"", &bitmap_icon_file, ui::Color::light_grey() } // NB: Must be last.
 	};
-	
+
+	void refresh_list();
+	const file_assoc_t& get_assoc(const std::filesystem::path& ext) const;
+
+	NavigationView& nav_;
+
 	bool empty_root { false };
 	std::function<void(void)> on_select_entry { nullptr };
 	std::function<void(bool)> on_refresh_widgets { nullptr };
+	
 	std::vector<fileman_entry> entry_list { };
 	std::filesystem::path current_path { u"" };
-	std::string extension_filter { "" };
-	
-	void change_category(int32_t category_id);
-	std::filesystem::path get_parent_dir();
-	void refresh_list();
+	std::filesystem::path extension_filter { u"" };
 	
 	Labels labels {
 		{ { 0, 0 }, "Path:", Color::light_grey() }
 	};
+
 	Text text_current {
 		{ 6 * 8, 0 * 8, 24 * 8, 16 },
 		"",
@@ -147,7 +149,7 @@ private:
 	
 	void refresh_widgets(const bool v);
 	void on_rename(NavigationView& nav);
-	void on_refactor(NavigationView& nav);
+	//void on_refactor(NavigationView& nav);
 	void on_delete();
 	
 	Labels labels {
@@ -164,9 +166,14 @@ private:
 		"Rename"
 	};
 
-	Button button_refactor{
+	Button button_copy {
 		{ 10 * 8, 29 * 8, 10 * 8, 32 },
-		"Refactor"
+		"Copy"
+	};
+
+	Button button_move {
+		{ 10 * 8, 29 * 8, 10 * 8, 32 },
+		"Move"
 	};
 
 	Button button_delete {
@@ -174,9 +181,14 @@ private:
 		"Delete"
 	};
 	
+	/*Button button_new_file {
+		{ 0 * 8, 34 * 8, 14 * 8, 32 },
+		"New File"
+	};*/
+
 	Button button_new_dir {
 		{ 0 * 8, 34 * 8, 14 * 8, 32 },
-		"New dir"
+		"New Dir"
 	};
 	
 };

--- a/firmware/application/apps/ui_flash_utility.cpp
+++ b/firmware/application/apps/ui_flash_utility.cpp
@@ -44,7 +44,7 @@ FlashUtilityView::FlashUtilityView(NavigationView& nav) : nav_ (nav) {
 			filename.string().substr(0, max_filename_length),
 			ui::Color::red(),
 			&bitmap_icon_temperature,
-			[this, path]() {
+			[this, path](KeyEvent) {
 				this->firmware_selected(path);
 			}
 		});

--- a/firmware/application/apps/ui_freqman.cpp
+++ b/firmware/application/apps/ui_freqman.cpp
@@ -120,7 +120,7 @@ void FreqManBaseView::refresh_list() {
 				freqman_item_string(database[n], 30),
 				ui::Color::white(),
 				nullptr,
-				[this](){
+				[this](KeyEvent){
 					if (on_select_frequency)
 						on_select_frequency();
 				}

--- a/firmware/application/file.cpp
+++ b/firmware/application/file.cpp
@@ -197,6 +197,13 @@ std::vector<std::filesystem::path> scan_root_directories(const std::filesystem::
 	return directory_list;
 }
 
+bool file_exists(const std::filesystem::path& file_path) {
+	FILINFO filinfo;
+	auto fr = f_stat(reinterpret_cast<const TCHAR*>(file_path.c_str()), &filinfo);
+	
+	return fr == FR_OK;
+}
+
 uint32_t delete_file(const std::filesystem::path& file_path) {
 	return f_unlink(reinterpret_cast<const TCHAR*>(file_path.c_str()));
 }
@@ -251,12 +258,11 @@ std::string filesystem_error::what() const {
 }
 
 path path::parent_path() const {
-	const auto t = filename().native();
-	const auto index = t.find_last_of(preferred_separator);
-	if( index == t.npos ) {
-		return *this;
+	const auto index = _s.find_last_of(preferred_separator);
+	if( index == _s.npos ) {
+		return { }; // NB: Deviation from STL.
 	} else {
-		return t.substr(0, index);
+		return _s.substr(0, index);
 	}
 }
 
@@ -316,6 +322,12 @@ bool operator<(const path& lhs, const path& rhs) {
 
 bool operator>(const path& lhs, const path& rhs) {
 	return lhs.native() > rhs.native();
+}
+
+path operator+(const path& lhs, const path& rhs) {
+	path result = lhs;
+	result += rhs;
+	return result;
 }
 
 path operator/(const path& lhs, const path& rhs) {

--- a/firmware/application/file.cpp
+++ b/firmware/application/file.cpp
@@ -250,6 +250,16 @@ std::string filesystem_error::what() const {
 	}
 }
 
+path path::parent_path() const {
+	const auto t = filename().native();
+	const auto index = t.find_last_of(preferred_separator);
+	if( index == t.npos ) {
+		return *this;
+	} else {
+		return t.substr(0, index);
+	}
+}
+
 path path::extension() const {
 	const auto t = filename().native();
 	const auto index = t.find_last_of(u'.');
@@ -296,12 +306,22 @@ path& path::replace_extension(const path& replacement) {
 	return *this;
 }
 
+bool operator==(const path& lhs, const path& rhs) {
+	return lhs.native() == rhs.native();
+}
+
 bool operator<(const path& lhs, const path& rhs) {
 	return lhs.native() < rhs.native();
 }
 
 bool operator>(const path& lhs, const path& rhs) {
 	return lhs.native() > rhs.native();
+}
+
+path operator/(const path& lhs, const path& rhs) {
+	path result = lhs;
+	result /= rhs;
+	return result;
 }
 
 directory_iterator::directory_iterator(

--- a/firmware/application/file.hpp
+++ b/firmware/application/file.hpp
@@ -154,7 +154,7 @@ struct path {
 
 	path& operator/=(const path& p) {
 		if (_s.back() != preferred_separator)
-			_s + preferred_separator;
+			_s += preferred_separator;
 		_s += p._s;
 		return *this;
 	}

--- a/firmware/application/file.hpp
+++ b/firmware/application/file.hpp
@@ -123,6 +123,7 @@ struct path {
 		return *this;
 	}
 
+	path parent_path() const;
 	path extension() const;
 	path filename() const;
 	path stem() const;
@@ -151,14 +152,23 @@ struct path {
 		return *this;
 	}
 
+	path& operator/=(const path& p) {
+		if (_s.back() != preferred_separator)
+			_s + preferred_separator;
+		_s += p._s;
+		return *this;
+	}
+
 	path& replace_extension(const path& replacement = path());
 
 private:
 	string_type _s;
 };
 
+bool operator==(const path& lhs, const path& rhs);
 bool operator<(const path& lhs, const path& rhs);
 bool operator>(const path& lhs, const path& rhs);
+path operator/(const path& lhs, const path& rhs);
 
 using file_status = BYTE;
 

--- a/firmware/application/file.hpp
+++ b/firmware/application/file.hpp
@@ -168,6 +168,7 @@ private:
 bool operator==(const path& lhs, const path& rhs);
 bool operator<(const path& lhs, const path& rhs);
 bool operator>(const path& lhs, const path& rhs);
+path operator+(const path& lhs, const path& rhs);
 path operator/(const path& lhs, const path& rhs);
 
 using file_status = BYTE;
@@ -248,6 +249,7 @@ struct FATTimestamp {
 	uint16_t FAT_time;
 };
 
+bool file_exists(const std::filesystem::path& file_path);
 uint32_t delete_file(const std::filesystem::path& file_path);
 uint32_t rename_file(const std::filesystem::path& file_path, const std::filesystem::path& new_name);
 FATTimestamp file_created_date(const std::filesystem::path& file_path);
@@ -255,6 +257,8 @@ uint32_t make_new_directory(const std::filesystem::path& dir_path);
 
 std::vector<std::filesystem::path> scan_root_files(const std::filesystem::path& directory, const std::filesystem::path& extension);
 std::vector<std::filesystem::path> scan_root_directories(const std::filesystem::path& directory);
+
+/* Gets an auto incrementing filename. */
 std::filesystem::path next_filename_stem_matching_pattern(std::filesystem::path filename_stem_pattern);
 
 /* Values added to FatFs FRESULT enum, values outside the FRESULT data type */

--- a/firmware/application/ui/ui_menu.cpp
+++ b/firmware/application/ui/ui_menu.cpp
@@ -262,7 +262,7 @@ bool MenuView::on_key(const KeyEvent key) {
 	case KeyEvent::Select:
 	case KeyEvent::Right:
 		if( menu_items[highlighted_item].on_select ) {
-			menu_items[highlighted_item].on_select();
+			menu_items[highlighted_item].on_select(key);
 		}
 		return true;
 

--- a/firmware/application/ui/ui_menu.cpp
+++ b/firmware/application/ui/ui_menu.cpp
@@ -238,7 +238,7 @@ bool MenuView::set_highlighted(int32_t new_value) {
 	return true;
 }
 
-uint32_t MenuView::highlighted_index() {
+uint32_t MenuView::highlighted_index() const {
 	return highlighted_item;
 }
 

--- a/firmware/application/ui/ui_menu.hpp
+++ b/firmware/application/ui/ui_menu.hpp
@@ -39,7 +39,7 @@ struct MenuItem {
 	std::string text;
 	ui::Color color;
 	const Bitmap* bitmap;
-	std::function<void(void)> on_select;
+	std::function<void(KeyEvent)> on_select;
 
 	// TODO: Prevent default-constructed MenuItems.
 	// I managed to construct a menu with three extra, unspecified menu items

--- a/firmware/application/ui/ui_menu.hpp
+++ b/firmware/application/ui/ui_menu.hpp
@@ -87,7 +87,7 @@ public:
 	MenuItemView* item_view(size_t index) const;
 
 	bool set_highlighted(int32_t new_value);
-	uint32_t highlighted_index();
+	uint32_t highlighted_index() const;
 
 	void set_parent_rect(const Rect new_parent_rect) override;
 	void on_focus() override;

--- a/firmware/application/ui/ui_textentry.cpp
+++ b/firmware/application/ui/ui_textentry.cpp
@@ -29,9 +29,25 @@ using namespace portapack;
 
 namespace ui {
 
-void text_prompt(NavigationView& nav, std::string& str, const size_t max_length, const std::function<void(std::string&)> on_done) {
+void text_prompt(
+	NavigationView& nav,
+	std::string& str,
+	const size_t max_length,
+	const std::function<void(std::string&)> on_done
+) {
+	text_prompt(nav, str, str.length(), max_length, on_done);
+}
+
+void text_prompt(
+	NavigationView& nav,
+	std::string& str,
+	uint32_t cursor_pos,
+	const size_t max_length,
+	const std::function<void(std::string&)> on_done
+) {
 	//if (persistent_memory::ui_config_textentry() == 0) {
 		auto te_view = nav.push<AlphanumView>(str, max_length);
+		te_view->set_cursor(cursor_pos);
 		te_view->on_changed = [on_done](std::string& value) {
 			if (on_done)
 				on_done(value);
@@ -209,6 +225,10 @@ void TextEntryView::char_delete() {
 
 void TextEntryView::char_add(const char c) {
 	text_input.char_add(c);
+}
+
+void TextEntryView::set_cursor(uint32_t pos) {
+	text_input.set_cursor(pos);
 }
 
 void TextEntryView::focus() {

--- a/firmware/application/ui/ui_textentry.cpp
+++ b/firmware/application/ui/ui_textentry.cpp
@@ -32,8 +32,8 @@ namespace ui {
 void text_prompt(
 	NavigationView& nav,
 	std::string& str,
-	const size_t max_length,
-	const std::function<void(std::string&)> on_done
+	size_t max_length,
+	std::function<void(std::string&)> on_done
 ) {
 	text_prompt(nav, str, str.length(), max_length, on_done);
 }
@@ -42,8 +42,8 @@ void text_prompt(
 	NavigationView& nav,
 	std::string& str,
 	uint32_t cursor_pos,
-	const size_t max_length,
-	const std::function<void(std::string&)> on_done
+	size_t max_length,
+	std::function<void(std::string&)> on_done
 ) {
 	//if (persistent_memory::ui_config_textentry() == 0) {
 		auto te_view = nav.push<AlphanumView>(str, max_length);
@@ -70,7 +70,7 @@ TextField::TextField(
 	uint32_t length
 ) : Widget{ { position, { 8 * static_cast<int>(length), 16 } } },
 	text_{ str },
-	max_length_{ std::max<size_t>(max_length, 1) },
+	max_length_{ std::max<size_t>(max_length, str.length()) },
 	char_count_{ std::max<uint32_t>(length, 1) },
 	cursor_pos_{ text_.length() },
 	insert_mode_{ true }
@@ -82,34 +82,9 @@ const std::string& TextField::value() const {
 	return text_;
 }
 
-void TextField::set(const std::string& str) {
-	// Assume that setting the string implies we want the whole thing.
-	max_length_ = std::max(max_length_, str.length());
-
-	text_ = str;
-	cursor_pos_ = str.length();
-	set_cursor(str.length());
-}
-
 void TextField::set_cursor(uint32_t pos) {
 	cursor_pos_ = std::min<size_t>(pos, text_.length());
 	set_dirty();
-}
-
-void TextField::set_max_length(size_t max_length) {
-	// Doesn't make sense, ignore.
-	if (max_length == 0)
-		return;
-
-	if (max_length < text_.length()) {
-		text_.erase(max_length - 1);
-		text_.shrink_to_fit();
-	} else {
-		text_.reserve(max_length);
-	}
-
-	max_length_ = max_length;
-	set_cursor(cursor_pos_);
 }
 
 void TextField::set_insert_mode() {
@@ -247,7 +222,6 @@ TextEntryView::TextEntryView(
 	});
 
 	button_ok.on_select = [this, &str, &nav](Button&) {
-		str.shrink_to_fit(); // NB: str is the TextField string.
 		if (on_changed)
 			on_changed(str);
 		nav.pop();

--- a/firmware/application/ui/ui_textentry.hpp
+++ b/firmware/application/ui/ui_textentry.hpp
@@ -53,9 +53,7 @@ public:
 
 	const std::string& value() const;
 
-	void set(const std::string& str);
 	void set_cursor(uint32_t pos);
-	void set_max_length(size_t max_length);
 	void set_insert_mode();
 	void set_overwrite_mode();
 
@@ -103,18 +101,22 @@ protected:
 	};
 };
 
+// Show the TextEntry view to receive keyboard input.
+// NB: This function returns immediately. 'str' is taken
+// by reference and its lifetime must be ensured by the
+// caller until the TextEntry view is dismissed.
 void text_prompt(
 	NavigationView& nav,
 	std::string& str,
 	size_t max_length,
-	const std::function<void(std::string&)> on_done = nullptr);
+	std::function<void(std::string&)> on_done = nullptr);
 
 void text_prompt(
 	NavigationView& nav,
 	std::string& str,
 	uint32_t cursor_pos,
 	size_t max_length,
-	const std::function<void(std::string&)> on_done = nullptr);
+	std::function<void(std::string&)> on_done = nullptr);
 
 } /* namespace ui */
 

--- a/firmware/application/ui/ui_textentry.hpp
+++ b/firmware/application/ui/ui_textentry.hpp
@@ -82,6 +82,8 @@ public:
 	
 	void focus() override;
 	std::string title() const override { return "Text entry"; };
+
+	void set_cursor(uint32_t pos);
 	
 protected:
 	TextEntryView(NavigationView& nav, std::string& str, size_t max_length);
@@ -101,7 +103,18 @@ protected:
 	};
 };
 
-void text_prompt(NavigationView& nav, std::string& str, size_t max_length, const std::function<void(std::string&)> on_done = nullptr);
+void text_prompt(
+	NavigationView& nav,
+	std::string& str,
+	size_t max_length,
+	const std::function<void(std::string&)> on_done = nullptr);
+
+void text_prompt(
+	NavigationView& nav,
+	std::string& str,
+	uint32_t cursor_pos,
+	size_t max_length,
+	const std::function<void(std::string&)> on_done = nullptr);
 
 } /* namespace ui */
 

--- a/firmware/application/ui_navigation.hpp
+++ b/firmware/application/ui_navigation.hpp
@@ -76,6 +76,15 @@ namespace ui
 		{
 			return reinterpret_cast<T *>(push_view(std::unique_ptr<View>(new T(*this, std::forward<Args>(args)...))));
 		}
+
+		// Pushes a new view under the current on the stack so the current view returns into this new one.
+		template <class T, class... Args>
+		void push_under_current(Args &&...args)
+		{
+			auto new_view = std::unique_ptr<View>(new T(*this, std::forward<Args>(args)...));
+			view_stack.insert(view_stack.end() - 1, std::move(new_view));
+		}
+
 		template <class T, class... Args>
 		T *replace(Args &&...args)
 		{


### PR DESCRIPTION
This removes the "Refactor" button and adds additional prompts to rename/delete partner files if found.

I noticed that path.string() was getting called all over the place and that's an expensive call. Refactoring the code to reduce the memory and CPU time needed for path handling.

Other changes:
- Pass KeyEvent to MenuEntry on_select so clients can differentiate between Right/Select keys. This enables button-only access to the menu for directories in Fileman. (Issue raised on discord).
- Adding more support for the filesystem::path implementation matching the STL when possible. This cleaned up path handling code in Fileman.
- `push_under_current` is a workaround for chaining modal views in the nav_stack. Needed to support the "partner file" modal.
- Removed a few unused methods on TextEntryView that made it slightly dangerous if used incorrectly.
- Files are listed in ASCII order now instead of whatever order they came from the filesystem enumeration.

[Video Link](https://kallanreed-my.sharepoint.com/:v:/p/kareed/EVOQRXpDcf9JtXWSwysHacIBuEZI3tGGUeZaHMz_1HlGBQ?e=fVBPqI)

![FolderMenus](https://user-images.githubusercontent.com/3761006/235834188-faacac8b-e1e5-4444-b9b5-708cb507fe48.gif)
![DeletePartner](https://user-images.githubusercontent.com/3761006/235834194-cc3dc213-b4f5-434f-a30f-4f917df28db2.gif)
![RenamePartner](https://user-images.githubusercontent.com/3761006/235834199-c14884cf-16e3-4b30-974a-792e1615f72c.gif)
