### PR TITLE
Noise signal generator, adding  lfsr polynomial of 16 bits (now  almost continuous spectrum)

### DIFF
--- a/firmware/application/apps/ui_siggen.hpp
+++ b/firmware/application/apps/ui_siggen.hpp
@@ -49,12 +49,12 @@ private:
 	void on_tx_progress(const uint32_t progress, const bool done);
 	
 	const std::string shape_strings[10] = {
-		"CW-no mod",
-		"Sine     ",
-		"Triangle ",
-		"Saw up   ",
-		"Saw down ",
-		"Square        ",
+		"CW-just carrier",
+		"Sine signal    ",
+		"Triangle signal",
+		"Saw up signal  ",
+		"Saw down signal",
+		"Square signal  ",
 		"Noise 8-nx20Khz",	// using 8 bits LFSR register, 6 order polynomial feedback.
 		"Noise 8-nx10khz",	// using 8 bits LFSR register, 7 order polynomial feedback.
 		"Noise 8 -nx5khz ",	// using 8 bits LFSR register, 8 order polynomial feedback.

--- a/firmware/application/apps/ui_siggen.hpp
+++ b/firmware/application/apps/ui_siggen.hpp
@@ -48,29 +48,30 @@ private:
 	void update_tone();
 	void on_tx_progress(const uint32_t progress, const bool done);
 	
-	const std::string shape_strings[9] = {
-		"CW          ",
-		"Sine        ",
-		"Triangle    ",
-		"Saw up      ",
-		"Saw down    ",
-		"Square      ",
-		"Noise n20Khz",
-		"Noise n10khz",
-		"Noise n5khz "
+	const std::string shape_strings[10] = {
+		"CW-no mod",
+		"Sine     ",
+		"Triangle ",
+		"Saw up   ",
+		"Saw down ",
+		"Square        ",
+		"Noise 8-nx20Khz",	// using 8 bits LFSR register, 6 order polynomial feedback.
+		"Noise 8-nx10khz",	// using 8 bits LFSR register, 7 order polynomial feedback.
+		"Noise 8 -nx5khz ",	// using 8 bits LFSR register, 8 order polynomial feedback.
+		"Noise 16-nx1khz"	// using 16 bits LFSR register, 16 order polynomial feedback.
 	};
 	
 	bool auto_update { false };
 	
 	Labels labels {
-		{ { 6 * 8, 4 + 10 }, "Shape:", Color::light_grey() },
-		{ { 7 * 8, 7 * 8 }, "Tone:      Hz", Color::light_grey() },
+		{ { 3 * 8, 4 + 10 }, "Shape:", Color::light_grey() },
+		{ { 6 * 8, 7 * 8 }, "Tone:      Hz", Color::light_grey() },
 		{ { 22 * 8, 15 * 8 + 4 }, "s.", Color::light_grey() },
 		{ { 8 * 8, 20 * 8 }, "Modulation: FM", Color::light_grey() }
 	};
 	
 	ImageOptionsField options_shape {
-		{ 13 * 8, 4, 32, 32 },
+		{ 10 * 8, 4, 32, 32 },
 		Color::white(),
 		Color::black(),
 		{
@@ -82,12 +83,13 @@ private:
 			{ &bitmap_sig_square, 5 },
 			{ &bitmap_sig_noise, 6 },
 			{ &bitmap_sig_noise, 7 },
-			{ &bitmap_sig_noise, 8 }
+			{ &bitmap_sig_noise, 8 },
+			{ &bitmap_sig_noise, 9 }
 		}
 	};
 	
 	Text text_shape {
-		{ 18 * 8, 4 + 10, 8 * 8, 16 },
+		{ 15 * 8, 4 + 10, 8 * 8, 16 },
 		""
 	};
 	
@@ -98,12 +100,12 @@ private:
 	};
 	
 	Button button_update {
-		{ 6 * 8, 10 * 8, 8 * 8, 3 * 8 },
+		{ 5 * 8, 10 * 8, 8 * 8, 3 * 8 },
 		"Update"
 	};
 	
 	Checkbox checkbox_auto {
-		{ 16 * 8, 10 * 8 },
+		{ 15 * 8, 10 * 8 },
 		4,
 		"Auto"
 	};

--- a/firmware/baseband/proc_siggen.hpp
+++ b/firmware/baseband/proc_siggen.hpp
@@ -44,9 +44,12 @@ private:
     bool auto_off { };
 	int32_t phase { 0 }, sphase { 0 }, delta { 0 }; 	// they may have sign .
 	int8_t  sample { 0 }, re { 0 }, im { 0 };			// they may have sign .
-    uint8_t seed_value = {0x56};   						// seed : any nonzero start state will work. 
+    uint8_t seed_value = {0x56};   						// seed 8 bits lfsr  : any nonzero start state will work. 
+	uint16_t seed_value_16 = {0xACE1};					// seed 16 bits lfsr : any nonzero start state will work. 
 	uint8_t lfsr { }, bit { };  						// bit must be 8-bit to allow bit<<7 later in the code */
-	
+	uint16_t lfsr_16 { }, bit_16 { }; 					// bit must be 8-bit to allow bit<<7 later in the code */
+	uint8_t counter {0};
+
 	TXProgressMessage txprogress_message { };
 };
 


### PR DESCRIPTION
We are adding 16 bit LFSR  register to the Noise signal generator and adding more explanations to the GUI 
. (inside utilities , as a refine of previous PR #936)

From the generated 16 bit register , we are only using the lower 8 bits,  but now the generated spectrum looks like almost  continuous . (with freq components < 1 Khz ) , much better than any previous 8 bit LFSR reg options.

FYI  ,  here attach again  the 4  x Noise S.G. options. 
The last one with 16 bits , seems the best if you want to reproduce a WFM White noise . 
 (but the other 3 previous options , using 8 bit LFSR  register , produce more broadband interference discrete harmonics , so depending on the application , user can select about them) 

![image](https://user-images.githubusercontent.com/86470699/235702216-11452dbe-866e-4501-a993-6ffcdaf66828.png)

![image](https://user-images.githubusercontent.com/86470699/235702354-23d071c0-ae60-46f2-9e7c-3e92476a4073.png)

If finally , you want to make a much compact an simple GUI ,  we can just leave that 16 bit NOISE GENERATOR , and delete the other 3 options of 8 bits (8bit - nx20Khz  ,8bit - nx10Khz , 8bit -nx5khz )  .

 Or we can keep the 4 options,  as we have in this PR,  to me no problem at all , any decision is fine to me.  
I just wanted to achieve a much more continuous spectrum , exploring 16 bits / 32 bits LFSR , 
 (and now  with 16 , we already achieved )-  

Just leave your comment below, 

Cheers , 
