### PR TITLE
Leaving only 1 Noise signal generator GUI option , (the best one , using  LFSR polynomial of 16 bits)

### DIFF
--- a/firmware/application/apps/ui_siggen.hpp
+++ b/firmware/application/apps/ui_siggen.hpp
@@ -55,7 +55,7 @@ private:
 		"Saw up signal  ",
 		"Saw down signal",
 		"Square signal  ",
-		"White Noise    "	// using 16 bits LFSR register, 16 order polynomial feedback.
+		"Noise signal   "	// using 16 bits LFSR register, 16 order polynomial feedback.
 	};
 	
 	bool auto_update { false };

--- a/firmware/application/apps/ui_siggen.hpp
+++ b/firmware/application/apps/ui_siggen.hpp
@@ -49,12 +49,12 @@ private:
 	void on_tx_progress(const uint32_t progress, const bool done);
 	
 	const std::string shape_strings[10] = {
-		"CW-no mod",
-		"Sine     ",
-		"Triangle ",
-		"Saw up   ",
-		"Saw down ",
-		"Square        ",
+		"CW-just carrier",
+		"Sine signal    ",
+		"Triangle signal",
+		"Saw up signal  ",
+		"Saw down signal",
+		"Square signal  ",
 		"Noise 8-nx20Khz",	// using 8 bits LFSR register, 6 order polynomial feedback.
 		"Noise 8-nx10khz",	// using 8 bits LFSR register, 7 order polynomial feedback.
 		"Noise 8 -nx5khz ",	// using 8 bits LFSR register, 8 order polynomial feedback.

--- a/firmware/application/apps/ui_siggen.hpp
+++ b/firmware/application/apps/ui_siggen.hpp
@@ -48,29 +48,30 @@ private:
 	void update_tone();
 	void on_tx_progress(const uint32_t progress, const bool done);
 	
-	const std::string shape_strings[9] = {
-		"CW          ",
-		"Sine        ",
-		"Triangle    ",
-		"Saw up      ",
-		"Saw down    ",
-		"Square      ",
-		"Noise n20Khz",
-		"Noise n10khz",
-		"Noise n5khz "
+	const std::string shape_strings[10] = {
+		"CW-no mod",
+		"Sine     ",
+		"Triangle ",
+		"Saw up   ",
+		"Saw down ",
+		"Square        ",
+		"Noise 8-nx20Khz",	// using 8 bits LFSR register, 6 order polynomial feedback.
+		"Noise 8-nx10khz",	// using 8 bits LFSR register, 7 order polynomial feedback.
+		"Noise 8 -nx5khz ",	// using 8 bits LFSR register, 8 order polynomial feedback.
+		"Noise 16-nx1khz"	// using 16 bits LFSR register, 16 order polynomial feedback.
 	};
 	
 	bool auto_update { false };
 	
 	Labels labels {
-		{ { 6 * 8, 4 + 10 }, "Shape:", Color::light_grey() },
-		{ { 7 * 8, 7 * 8 }, "Tone:      Hz", Color::light_grey() },
+		{ { 3 * 8, 4 + 10 }, "Shape:", Color::light_grey() },
+		{ { 6 * 8, 7 * 8 }, "Tone:      Hz", Color::light_grey() },
 		{ { 22 * 8, 15 * 8 + 4 }, "s.", Color::light_grey() },
 		{ { 8 * 8, 20 * 8 }, "Modulation: FM", Color::light_grey() }
 	};
 	
 	ImageOptionsField options_shape {
-		{ 13 * 8, 4, 32, 32 },
+		{ 10 * 8, 4, 32, 32 },
 		Color::white(),
 		Color::black(),
 		{
@@ -82,12 +83,13 @@ private:
 			{ &bitmap_sig_square, 5 },
 			{ &bitmap_sig_noise, 6 },
 			{ &bitmap_sig_noise, 7 },
-			{ &bitmap_sig_noise, 8 }
+			{ &bitmap_sig_noise, 8 },
+			{ &bitmap_sig_noise, 9 }
 		}
 	};
 	
 	Text text_shape {
-		{ 18 * 8, 4 + 10, 8 * 8, 16 },
+		{ 15 * 8, 4 + 10, 8 * 8, 16 },
 		""
 	};
 	
@@ -98,12 +100,12 @@ private:
 	};
 	
 	Button button_update {
-		{ 6 * 8, 10 * 8, 8 * 8, 3 * 8 },
+		{ 5 * 8, 10 * 8, 8 * 8, 3 * 8 },
 		"Update"
 	};
 	
 	Checkbox checkbox_auto {
-		{ 16 * 8, 10 * 8 },
+		{ 15 * 8, 10 * 8 },
 		4,
 		"Auto"
 	};

--- a/firmware/application/apps/ui_siggen.hpp
+++ b/firmware/application/apps/ui_siggen.hpp
@@ -48,17 +48,14 @@ private:
 	void update_tone();
 	void on_tx_progress(const uint32_t progress, const bool done);
 	
-	const std::string shape_strings[10] = {
+	const std::string shape_strings[7] = {
 		"CW-just carrier",
 		"Sine signal    ",
 		"Triangle signal",
 		"Saw up signal  ",
 		"Saw down signal",
 		"Square signal  ",
-		"Noise 8-nx20Khz",	// using 8 bits LFSR register, 6 order polynomial feedback.
-		"Noise 8-nx10khz",	// using 8 bits LFSR register, 7 order polynomial feedback.
-		"Noise 8 -nx5khz ",	// using 8 bits LFSR register, 8 order polynomial feedback.
-		"Noise 16-nx1khz"	// using 16 bits LFSR register, 16 order polynomial feedback.
+		"White Noise    "	// using 16 bits LFSR register, 16 order polynomial feedback.
 	};
 	
 	bool auto_update { false };
@@ -81,10 +78,7 @@ private:
 			{ &bitmap_sig_saw_up, 3 },
 			{ &bitmap_sig_saw_down, 4 },
 			{ &bitmap_sig_square, 5 },
-			{ &bitmap_sig_noise, 6 },
-			{ &bitmap_sig_noise, 7 },
-			{ &bitmap_sig_noise, 8 },
-			{ &bitmap_sig_noise, 9 }
+			{ &bitmap_sig_noise, 6 }
 		}
 	};
 	

--- a/firmware/baseband/proc_siggen.cpp
+++ b/firmware/baseband/proc_siggen.cpp
@@ -61,21 +61,9 @@ void SigGenProcessor::execute(const buffer_c8_t& buffer) {
 			} else if (tone_shape == 5) {
 				// Square
 				sample = (((tone_phase & 0xFF000000) >> 24) & 0x80) ? 127 : -128;
-			} else if (tone_shape == 6) { // taps: 6 5; feedback polynomial: x^6 + x^5 + 1 , Periode  63 = 2^n-1,it generates armonincs n x 20Khz
-				// White Noise generator, pseudo random noise generator, 8 bits linear-feedback shift register (LFSR) algorithm, variant Fibonacci.
+			} else if (tone_shape == 6) { 	// White Noise generator, pseudo random noise generator, 8 bits linear-feedback shift register (LFSR) algorithm, variant Fibonacci.
 				// https://en.wikipedia.org/wiki/Linear-feedback_shift_register 
-        		bit = ((lfsr >> 2) ^ (lfsr >> 3)) & 1;	
-		   		lfsr = (lfsr >> 1) | (bit << 7);
-           		sample = lfsr;
-			} else if (tone_shape == 7) { // taps: 7 6; feedback polynomial:  x^7 + x^6 + 1 , Periode 127 = 2^n-1,it generates armonincs n x 10Khz 
-				bit = ((lfsr >> 1) ^ (lfsr >> 2)) & 1;	
-				lfsr = (lfsr >> 1) | (bit << 7);
-           		sample = lfsr;
-			} else if (tone_shape == 8) { //taps:8,6,5,4;feedback polynomial: x^8 + x^6 + x^5 + x^4 + 1,Periode 255= 2^n-1, armonics  n x 5khz
-				bit = ((lfsr >> 0) ^ (lfsr >> 2) ^ (lfsr >> 3) ^ (lfsr >> 4))  & 1;	
-        		lfsr = (lfsr >> 1) | (bit << 7);
-           		sample = lfsr;
-			} else if (tone_shape == 9) { // 16 bits LFSR .taps: 16, 15, 13, 4 ;feedback polynomial: x^16 + x^15 + x^13 + x^4 + 1
+				// 16 bits LFSR .taps: 16, 15, 13, 4 ;feedback polynomial: x^16 + x^15 + x^13 + x^4 + 1
 				// Periode 65535= 2^n-1, harmonics every < 1Khz  , quite continuous .  
 				if (counter == 0) {
 					bit_16 = ((lfsr_16 >> 0) ^ (lfsr_16 >> 1) ^ (lfsr_16 >> 3) ^ (lfsr_16 >> 4) ^ (lfsr_16 >> 12) & 1);
@@ -87,6 +75,20 @@ void SigGenProcessor::execute(const buffer_c8_t& buffer) {
 					counter = 0;	
 				}
 			} 
+			
+			/* else if (tone_shape == 7) { 	// 8 bit options,  finally not used-
+        		bit = ((lfsr >> 2) ^ (lfsr >> 3)) & 1;	// taps: 6 5; feedback polynomial: x^6 + x^5 + 1 , Periode  63 = 2^n-1,it generates armonincs n x 20Khz
+		   		lfsr = (lfsr >> 1) | (bit << 7);
+           		sample = lfsr;
+			} else if (tone_shape == 8) { // taps: 7 6; feedback polynomial:  x^7 + x^6 + 1 , Periode 127 = 2^n-1,it generates armonincs n x 10Khz 
+				bit = ((lfsr >> 1) ^ (lfsr >> 2)) & 1;	
+				lfsr = (lfsr >> 1) | (bit << 7);
+           		sample = lfsr;
+			} else if (tone_shape == 9) { //taps:8,6,5,4;feedback polynomial: x^8 + x^6 + x^5 + x^4 + 1,Periode 255= 2^n-1, armonics  n x 5khz
+				bit = ((lfsr >> 0) ^ (lfsr >> 2) ^ (lfsr >> 3) ^ (lfsr >> 4))  & 1;	
+        		lfsr = (lfsr >> 1) | (bit << 7);
+           		sample = lfsr; 		} */ 
+
 
 			if (tone_shape < 6) 	{
 				tone_phase += tone_delta;
@@ -125,7 +127,7 @@ void SigGenProcessor::on_message(const Message* const msg) {
 			fm_delta = message.bw * (0xFFFFFFULL / 1536000);
 			tone_shape = message.shape;
 			
-			 lfsr = seed_value ;  		// init lfsr 8 bits.
+			// lfsr = seed_value ;  		// Finally not used , init lfsr 8 bits.
 			 lfsr_16 = seed_value_16;	// init lfsr 16 bits.
 
 			configured = true;

--- a/firmware/baseband/proc_siggen.hpp
+++ b/firmware/baseband/proc_siggen.hpp
@@ -44,9 +44,12 @@ private:
     bool auto_off { };
 	int32_t phase { 0 }, sphase { 0 }, delta { 0 }; 	// they may have sign .
 	int8_t  sample { 0 }, re { 0 }, im { 0 };			// they may have sign .
-    uint8_t seed_value = {0x56};   						// seed : any nonzero start state will work. 
+    uint8_t seed_value = {0x56};   						// seed 8 bits lfsr  : any nonzero start state will work. 
+	uint16_t seed_value_16 = {0xACE1};					// seed 16 bits lfsr : any nonzero start state will work. 
 	uint8_t lfsr { }, bit { };  						// bit must be 8-bit to allow bit<<7 later in the code */
-	
+	uint16_t lfsr_16 { }, bit_16 { }; 					// bit must be 8-bit to allow bit<<7 later in the code */
+	uint8_t counter {0};
+
 	TXProgressMessage txprogress_message { };
 };
 

--- a/firmware/baseband/proc_siggen.hpp
+++ b/firmware/baseband/proc_siggen.hpp
@@ -42,13 +42,13 @@ private:
 	uint8_t tone_shape { };
     uint32_t sample_count { 0 };
     bool auto_off { };
-	int32_t phase { 0 }, sphase { 0 }, delta { 0 }; 	// they may have sign .
-	int8_t  sample { 0 }, re { 0 }, im { 0 };			// they may have sign .
-    uint8_t seed_value = {0x56};   						// seed 8 bits lfsr  : any nonzero start state will work. 
-	uint16_t seed_value_16 = {0xACE1};					// seed 16 bits lfsr : any nonzero start state will work. 
-	uint8_t lfsr { }, bit { };  						// bit must be 8-bit to allow bit<<7 later in the code */
-	uint16_t lfsr_16 { }, bit_16 { }; 					// bit must be 8-bit to allow bit<<7 later in the code */
+	int32_t phase { 0 }, sphase { 0 }, delta { 0 }; 	// they may have sign in the pseudo random sample generation.
+	int8_t  sample { 0 }, re { 0 }, im { 0 };			// they have sign + and -.
+   	uint16_t seed_value_16 = {0xACE1};					// seed 16 bits lfsr : any nonzero start state will work. 
+	uint16_t lfsr_16 { }, bit_16 { }; 					// bit must be 16-bit to allow bit<<15 later in the code */
 	uint8_t counter {0};
+	// uint8_t seed_value = {0x56}; 					// Finally not used lfsr of 8 bits , seed 8blfsr : any nonzero start state will work. 
+	// uint8_t lfsr { }, bit { };  						// Finally not used lfsr of 8 bits , bit must be 8-bit to allow bit<<7 later in the code */
 
 	TXProgressMessage txprogress_message { };
 };


### PR DESCRIPTION
Hello , in this PR , we are just leaving the best option to the Noise generator . 

The previous 3 options were using three different  8 bits LFSR  polynomial and had the following problems , 
i-) they had small  pseudo random sequence period , (63, 127, 255)
==> and therefore producing spectrum component harmonics, not so contiunuos spectrum .
ii-) probably too high bit stream to the modulator
==> and therefore in the demodulated baseband , we can not recognise any signal ,
and  the spectrum radiated energy was > 40 o 50 dB's down compared to the other signals (triangle , saw, ..) 
and only useful in very short distance transmitting .

Now we are introducing only one user option, about Noise generator ,  using the best LFSR that we tested : 16 bit polynomial  feedback LFSR , that has longer random sequence period and produces more continuous spectrum ,
We also added the repetition of 5 x times the same random sample , to reduce the too much high freq. contents delivered to the FM modulator. And now, thanks to that ,  we can hear in any FM receiver the random noise (and we can also see the random demodulated signal, as it is attached below ) and the peak radiated spectrum power is now  just -10 dB's compared to the triangle or saw signal , that is fine (acceptable)  . (not -40 or -50 dB's as it was before, really too small) .

![image](https://user-images.githubusercontent.com/86470699/235900353-09879379-3b3c-4115-9d96-45ca2ede5372.png)


And if we check the FM demodulated signal,  right top corner , now we can see it .
![image](https://user-images.githubusercontent.com/86470699/235902039-688f73f4-0ee3-4dfb-abc0-48c72cd2b151.png)



(before PR condition,  the demodulated sound was too small)

![image](https://user-images.githubusercontent.com/86470699/235901545-dcbe5aa9-d911-49ca-84fc-bdc824cc0cb8.png)

 