### PR TITLE
Fix nav.pop order on FileLoadView

### DIFF
--- a/firmware/application/apps/ui_fileman.cpp
+++ b/firmware/application/apps/ui_fileman.cpp
@@ -360,9 +360,9 @@ FileLoadView::FileLoadView(
 		if (get_selected_entry().is_directory) {
 			push_dir(get_selected_entry().path);
 		} else {
+			nav_.pop();
 			if (on_changed)
 				on_changed(get_selected_full_path());
-			nav_.pop();
 		}
 	};
 }


### PR DESCRIPTION
I had made this change in the last PR because it didn't follow the usual pattern of popping the nav stack _after_ the callback.
This breaks any scenarios where the callback tries to use a modal because the modal gets put on the stack first and then gets popped off. (e.g. WAV view trying to open an unsupported file.)

I'm reverting for now to unblock those scenarios. This is not "fixed". Popping should destroy the view object which should invalidate its members -- one of which is the callback. I'll open an issue to track a more holistic fix for the nav stack with modals.