### PR TITLE
fixing freqman limits

### DIFF
--- a/firmware/application/freqman.hpp
+++ b/firmware/application/freqman.hpp
@@ -31,9 +31,10 @@
 #include "string_format.hpp"
 #include "ui_widget.hpp"
 
-#define FREQMAN_DESC_MAX_LEN 30
-#define FREQMAN_MAX_PER_FILE 500        /* MAX PER FILES */
-#define FREQMAN_MAX_PER_FILE_STR "500"  /*STRING OF FREQMAN_MAX_PER_FILE */
+#define FREQMAN_DESC_MAX_LEN 24         // This is the number of characters that can be drawn in front of "R: TEXT..." before taking a full screen line
+#define FREQMAN_MAX_PER_FILE 115        // Maximum of entries we can read. This is a hardware limit
+                                        // It was tested and lowered to leave a bit of space to the caller
+#define FREQMAN_MAX_PER_FILE_STR "115"  // STRING OF FREQMAN_MAX_PER_FILE
 
 using namespace ui;
 using namespace std;


### PR DESCRIPTION
To prevent memory exhaustion due to too much files in freqman lists the memory limit has been set back to something realistic (it was set to 99 in the old 1.4.3, and went up to 500 in 1.6).
