### PR TITLE
Boot sequence

### DIFF
--- a/firmware/application/main.cpp
+++ b/firmware/application/main.cpp
@@ -165,7 +165,8 @@ static void event_loop() {
 int main(void) {
 	first_if.init();    /* To avoid initial short Ant_DC_Bias pulse ,we need quick set up GP01_RFF507X =1 */
 	if( portapack::init() ) {
-		portapack::display.init();
+
+
 
 		// sdcStart(&SDCD1, nullptr); // Commented out as now happens in portapack.cpp
 

--- a/firmware/application/portapack.cpp
+++ b/firmware/application/portapack.cpp
@@ -486,7 +486,7 @@ bool init() {
 	i2c0.start(i2c_config_fast_clock);
 	chThdSleepMilliseconds(10);
 
-    painter.draw_string({ 8, line++ *20 }, style_default, "Initializing persistent");
+    painter.draw_string({ 8, line++ *20 }, style_default, "Init. persistent memory");
 	/* Cache some configuration data from persistent memory. */
 	persistent_memory::cache::init();
 
@@ -516,7 +516,13 @@ bool init() {
 		if (load_config() != 3 && load_config() != 4){
 
 			painter.draw_string({ 8, line++ *20 }, style_default, "Redirecting to HackRf Mode");
-			chThdSleepMilliseconds(1000);
+			painter.draw_string({ 8, line++ *20 }, style_default, "!! Please hold");
+			painter.draw_string({ 8, line++ *20 }, style_default, "!! UP for H1R2, H2, H2+");
+			painter.draw_string({ 8, line++ *20 }, style_default, "!! LEFT for H1R1");
+			painter.draw_string({ 8, line++ *20 }, style_default, "!! CENTER for autodetect");
+			painter.draw_string({ 8, line++ *20 }, style_default, "!! while booting if this");
+			painter.draw_string({ 8, line++ *20 }, style_default, "!! message persists");
+			chThdSleepMilliseconds(2000);
 
 			shutdown_base();
 			return false;


### PR DESCRIPTION
This pull request adds a nice boot sequence on the screen.

I also added a message for the "hold down the correct button to select your pp version" thing.
![grafik](https://user-images.githubusercontent.com/13151053/236260825-6fda379b-c06d-46dd-81b8-39663eb3609a.png)

should only be merged after it is tested on all versions of portapack.