### PR TITLE
removed need for cpld mode setup for QFP100

### DIFF
--- a/firmware/application/portapack.cpp
+++ b/firmware/application/portapack.cpp
@@ -489,8 +489,9 @@ bool init() {
 	
 	chThdSleepMilliseconds(10);
 
-	uint32_t result = portapack::cpld::update_if_necessary(portapack_cpld_config());
-	if ( result == 3 /* program failed */ ) {
+	portapack::cpld::CpldUpdateStatus result = portapack::cpld::update_if_necessary(portapack_cpld_config());
+	if ( result == portapack::cpld::CpldUpdateStatus::Program_failed ) {
+
 		chThdSleepMilliseconds(10);
 		// Mode left (R1) and right (R2,H2,H2+) bypass going into hackrf mode after failing CPLD update
 		// Mode center (autodetect), up (R1) and down (R2,H2,H2) will go into hackrf mode after failing CPLD update

--- a/firmware/application/portapack.cpp
+++ b/firmware/application/portapack.cpp
@@ -494,7 +494,7 @@ bool init() {
 
 		chThdSleepMilliseconds(10);
 		// Mode left (R1) and right (R2,H2,H2+) bypass going into hackrf mode after failing CPLD update
-		// Mode center (autodetect), up (R1) and down (R2,H2,H2) will go into hackrf mode after failing CPLD update
+		// Mode center (autodetect), up (R1) and down (R2,H2,H2+) will go into hackrf mode after failing CPLD update
 		if (load_config() != 3 /* left */ && load_config() != 4 /* right */){
 			shutdown_base();
 			return false;

--- a/firmware/application/portapack.cpp
+++ b/firmware/application/portapack.cpp
@@ -489,12 +489,20 @@ bool init() {
 	
 	chThdSleepMilliseconds(10);
 
-	if( !portapack::cpld::update_if_necessary(portapack_cpld_config()) ) {
-		chThdSleepMilliseconds(10);
-		// If using a "2021/12 QFP100", press and hold the left button while booting. Should only need to do once.
-		if (load_config() != 3 && load_config() != 4){
-			shutdown_base();
-			return false;
+	auto pp_config = portapack_cpld_config();
+	auto cpld_update_possible = portapack::cpld::update_possible(); //QFP100 CPLD fails this check. skip CPLD update
+	auto cpld_update_necessary = cpld_update_possible && portapack::cpld::update_necessary(pp_config);
+	if ( cpld_update_necessary ) {
+		auto ok = portapack::cpld::update(pp_config);
+
+		if( !ok ) {
+			chThdSleepMilliseconds(10);
+			// Mode left (R1) and right (R2,H2,H2+) bypass going into hackrf mode after failing CPLD update
+			// Mode center (autodetect), up (R1) and down (R2,H2,H2) will go into hackrf mode after failing CPLD update
+			if (load_config() != 3 /* left */ && load_config() != 4 /* right */){
+				shutdown_base();
+				return false;
+			}
 		}
 	}
 

--- a/firmware/common/cpld_update.cpp
+++ b/firmware/common/cpld_update.cpp
@@ -33,7 +33,7 @@
 namespace portapack {
 namespace cpld {
 
-uint32_t update_if_necessary(
+CpldUpdateStatus update_if_necessary(
 	const Config config
 ) {
 	jtag::GPIOTarget target {
@@ -51,7 +51,7 @@ uint32_t update_if_necessary(
 
 	/* Run-Test/Idle */
 	if( !cpld.idcode_ok() ) {
-		return 1;
+		return CpldUpdateStatus::Idcode_check_failed;
 	}
 
 	cpld.sample();
@@ -62,7 +62,7 @@ uint32_t update_if_necessary(
 	 * in passive state.
 	 */
 	if( !cpld.silicon_id_ok() ) {
-		return 2;
+		return CpldUpdateStatus::Silicon_id_check_failed;
 	}
 
 	/* Verify CPLD contents against current bitstream. */
@@ -86,7 +86,7 @@ uint32_t update_if_necessary(
 		cpld.disable();
 	}
 
-	return ok ? 0 : 3;
+	return ok ? CpldUpdateStatus::Success : CpldUpdateStatus::Program_failed;
 }
 
 } /* namespace cpld */

--- a/firmware/common/cpld_update.hpp
+++ b/firmware/common/cpld_update.hpp
@@ -27,13 +27,8 @@
 namespace portapack {
 namespace cpld {
 
-bool update_possible();
 
-bool update_necessary(
-	const Config config
-);
-
-bool update(
+uint32_t update_if_necessary(
 	const Config config
 );
 

--- a/firmware/common/cpld_update.hpp
+++ b/firmware/common/cpld_update.hpp
@@ -27,7 +27,13 @@
 namespace portapack {
 namespace cpld {
 
-bool update_if_necessary(
+bool update_possible();
+
+bool update_necessary(
+	const Config config
+);
+
+bool update(
 	const Config config
 );
 

--- a/firmware/common/cpld_update.hpp
+++ b/firmware/common/cpld_update.hpp
@@ -27,8 +27,14 @@
 namespace portapack {
 namespace cpld {
 
+enum class CpldUpdateStatus {
+	Success = 0,
+	Idcode_check_failed = 1,
+	Silicon_id_check_failed = 2,
+	Program_failed = 3
+};
 
-uint32_t update_if_necessary(
+CpldUpdateStatus update_if_necessary(
 	const Config config
 );
 


### PR DESCRIPTION
This pull request skips the CPLD update procedure for QFP100 models of Portapack. This removes the need of pressing left or top button in first startup to get the portapack running. Other versions are unaffected.

should only be merged after it is tested on all versions of portapack.