### PR TITLE
Add "Auto" mode to FrequencyField

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 /sdcard/FREQMAN/BHT*
 /sdcard/FREQMAN/R.TXT
 /sdcard/FREQMAN/XXX.TXT
+/armbin
 
 # Compiled Object files
 *.slo

--- a/firmware/application/apps/ui_sd_over_usb.hpp
+++ b/firmware/application/apps/ui_sd_over_usb.hpp
@@ -40,7 +40,7 @@ public:
 
 	void focus() override;
 
-	std::string title() const override { return "Flash Utility"; };	
+	std::string title() const override { return "SD over USB"; };	
 
 private:
 	NavigationView& nav_;

--- a/firmware/application/ui/ui_receiver.cpp
+++ b/firmware/application/ui/ui_receiver.cpp
@@ -94,11 +94,11 @@ bool FrequencyField::on_encoder(const EncoderEvent delta) {
 
 		// The goal is to map 'scale' to a range of about 10 to 10M.
 		// The faster the encoder is rotated, the larger the step.
-		// Linear doesn't feel right. Exponential felt better.
+		// Linear doesn't feel right. Hyperbolic felt better.
 		// To get these magic numbers, I graphed the function until the
 		// curve shape seemed about right then tested on device.
 		delta_ms = std::min(145ull, delta_ms) + 5; // Prevent DIV/0
-		int64_t scale = 5'000'000'000 * pow(delta_ms, -4);
+		int64_t scale = 200'000'000 / (0.001'55 * pow(delta_ms, 5.45)) + 8;
 		set_value(value() + (delta * scale));
 	} else {
 		set_value(value() + (delta * step));

--- a/firmware/application/ui/ui_receiver.cpp
+++ b/firmware/application/ui/ui_receiver.cpp
@@ -93,13 +93,13 @@ bool FrequencyField::on_encoder(const EncoderEvent delta) {
 		last_ms_ = ms;
 
 		// The goal is to map 'scale' to a range of about 10 to 10M.
-    // The faster the encoder is rotated, the larger the step.
+		// The faster the encoder is rotated, the larger the step.
 		// Linear doesn't feel right. Exponential felt better.
 		// To get these magic numbers, I graphed the function until the
 		// curve shape seemed about right then tested on device.
 		delta_ms = std::min(145ull, delta_ms) + 5; // Prevent DIV/0
-    int64_t scale = 5'000'000'000 * pow(delta_ms, -4);
-    set_value(value() + (delta * scale));
+		int64_t scale = 5'000'000'000 * pow(delta_ms, -4);
+		set_value(value() + (delta * scale));
 	} else {
 		set_value(value() + (delta * step));
 	}

--- a/firmware/application/ui/ui_receiver.hpp
+++ b/firmware/application/ui/ui_receiver.hpp
@@ -63,6 +63,7 @@ private:
 	const range_t range;
 	rf::Frequency value_ { 0 };
 	rf::Frequency step { 25000 };
+	uint64_t last_ms_ { 0 };
 
 	rf::Frequency clamp_value(rf::Frequency value);
 };
@@ -247,6 +248,7 @@ public:
 			parent_pos,
 			5,
 			{
+				{ " Auto",        0 },  /* Faster == larger step. */
 				{ "   10",       10 },  /* Fine tuning SSB voice pitch,in HF and QO-100 sat #669 */
 				{ "   50",       50 },	/* added 50Hz/10Hz,but we do not increase GUI digit decimal */
 				{ "  100",      100 },


### PR DESCRIPTION
This adds an "Auto" step size to the FrequencyField that is enabled when the step size is set to zero.
The intent of this mode is to make tuning easier by not requiring jumping between the Step size and Frequency fields when tuning. In "auto" turning the encoder faster makes it move with a larger step size and slower makes it move with a slower step size.

It's experimental and a bit finicky, but I like the idea. If anyone has better ideas on how to handle the timing, I would like to hear them.

https://user-images.githubusercontent.com/3761006/236504458-95ee2a66-20cd-4952-a23e-0181c679eb67.mov

