### PR TITLE
Recon skip fix

### DIFF
--- a/firmware/application/apps/ui_recon.cpp
+++ b/firmware/application/apps/ui_recon.cpp
@@ -735,13 +735,13 @@ namespace ui {
 		//HELPER: Pre-setting a manual range, based on stored frequency
 		rf::Frequency stored_freq = persistent_memory::tuned_frequency();
 		receiver_model.set_tuning_frequency( stored_freq );
-		if( stored_freq - 1000000 > 0 )
-			frequency_range.min = stored_freq - 1000000;
+		if( stored_freq - OneMHz > 0 )
+			frequency_range.min = stored_freq - OneMHz ;
 		else
 			frequency_range.min = 0 ;
 		button_manual_start.set_text(to_string_short_freq(frequency_range.min));
-		if( stored_freq + 1000000 < MAX_UFREQ )
-			frequency_range.max = stored_freq + 1000000;
+		if( stored_freq + OneMHz < MAX_UFREQ )
+			frequency_range.max = stored_freq + OneMHz ;
 		else
 			frequency_range.max = MAX_UFREQ ;
 		button_manual_end.set_text(to_string_short_freq(frequency_range.max));
@@ -791,7 +791,7 @@ namespace ui {
 			{
 				auto new_view = nav_.push<FrequencyKeypadView>(current_index);
 				new_view->on_changed = [this, &button](rf::Frequency f) {
-					f = f / 1000000 ;
+					f = f / OneMHz ;
 					if( f >= 1 && f <= frequency_list.size() )
 					{
 						recon_thread-> set_index_stepper( f - 1 - current_index );

--- a/firmware/application/apps/ui_recon.cpp
+++ b/firmware/application/apps/ui_recon.cpp
@@ -432,7 +432,7 @@ namespace ui {
                         // needed to stabilize consecutive match without skipping 
                         // the little the rest, the more reactive and more CPU hog
                         // the bigger the rest, less CPU and more delay when switching
-				        while( _freq_lock != -1 && _freq_lock < (int32_t)_lock_nb_match && !chThdShouldTerminate() )
+                        while( _freq_lock != -1 && _freq_lock < (int32_t)_lock_nb_match && !chThdShouldTerminate() )
                         {
                             chThdSleepMilliseconds( 10 );
 				            if( remaining_sleep >= 10 )
@@ -662,8 +662,8 @@ namespace ui {
 		if( recon_thread )
 		{
 			int32_t nb_match = recon_thread->is_freq_lock();
-            if( nb_match == -1 )
-                nb_match = 0 ;
+ 			if( nb_match == -1 )
+ 			nb_match = 0 ;
 			if( last_db != db )
 			{
 				last_db = db ;

--- a/firmware/application/apps/ui_recon.cpp
+++ b/firmware/application/apps/ui_recon.cpp
@@ -735,9 +735,15 @@ namespace ui {
 		//HELPER: Pre-setting a manual range, based on stored frequency
 		rf::Frequency stored_freq = persistent_memory::tuned_frequency();
 		receiver_model.set_tuning_frequency( stored_freq );
-		frequency_range.min = stored_freq - 1000000;
+		if( stored_freq - 1000000 > 0 )
+			frequency_range.min = stored_freq - 1000000;
+		else
+			frequency_range.min = 0 ;
 		button_manual_start.set_text(to_string_short_freq(frequency_range.min));
-		frequency_range.max = stored_freq + 1000000;
+		if( stored_freq + 1000000 < MAX_UFREQ )
+			frequency_range.max = stored_freq + 1000000;
+		else
+			frequency_range.max = MAX_UFREQ ;
 		button_manual_end.set_text(to_string_short_freq(frequency_range.max));
 		// Loading settings
 		autostart = persistent_memory::recon_autostart_recon();
@@ -797,9 +803,9 @@ namespace ui {
 
 		button_manual_start.on_change = [this]() {
 			frequency_range.min = frequency_range.min + button_manual_start.get_encoder_delta() * freqman_entry_get_step_value( def_step );
-			if( frequency_range.min < 1 )
+			if( frequency_range.min < 0 )
 			{
-				frequency_range.min = 1 ;
+				frequency_range.min = 0 ;
 			}
 			if( frequency_range.min > ( MAX_UFREQ - freqman_entry_get_step_value( def_step ) ) )
 			{

--- a/firmware/application/apps/ui_recon.cpp
+++ b/firmware/application/apps/ui_recon.cpp
@@ -1452,10 +1452,13 @@ namespace ui {
 				}
 				else
 				{
-					RetuneMessage message { };
-					message.freq = recon_thread->get_current_freq();
-					message.range = current_index ;
-					EventDispatcher::send_message(message);
+ 					if( recon_thread && frequency_list.size() != 0 )
+ 					{
+ 						RetuneMessage message { };
+ 						message.freq = recon_thread->get_current_freq();
+ 						message.range = current_index ;
+ 						EventDispatcher::send_message(message);
+ 					}
 				}
 			};
 		};

--- a/firmware/application/apps/ui_recon.hpp
+++ b/firmware/application/apps/ui_recon.hpp
@@ -59,8 +59,8 @@ namespace ui {
 			void set_match_mode( const uint32_t v );
 			uint32_t get_lock_nb_match();
 
-			void set_freq_lock(const uint32_t v);
-			uint32_t is_freq_lock();
+			void set_freq_lock(const int32_t v);
+			int32_t is_freq_lock();
 			int64_t get_current_freq();
 
 			void set_stepper(const int64_t v);

--- a/firmware/application/apps/ui_recon.hpp
+++ b/firmware/application/apps/ui_recon.hpp
@@ -42,6 +42,12 @@
 // maximum usable freq
 #define MAX_UFREQ 7200000000
 
+// 1Mhz helper
+#ifdef OneMHz
+    #undef OneMHz
+#endif
+#define OneMHz 1000000
+
 namespace ui {
 
 	class ReconThread {


### PR DESCRIPTION
The Recon app have inherited a history defect of the scanner app that I had hard time to solve.
The problem was present both in frequencies or ranges, when an entry locked and matched, it skipped the next one.
This is due to the way the timers are managed in the applications and how the app is obtaining the statistics.
For the records:
-the statistics are coming each 50 ms, the timer is modified in the statistic handler to timer-=50;
-the thread was waiting a minimum of 50 ms, but not all the time
-it was designed so the thread 'wait' the changes made by statistics update, but not waiting more than his delay before looping
When both are set at this rate, the mechanism of locking is not quick enough for the thread.
You can test on 1.7.0 or below, load a range, set a very low squelch like -90, a wait 300 and lock 1000, and run. You'll see the skip being of 2 or 3 instead of 1 after each match.
On 1.7.0 or below, the simple fix is to get into recon settings, and set a lock_duration of at least 100 msec and there is nearly no bad skip, but you loose speed and the locking is bad because we tried to mitigate the effect in previous commit.
That PR is fixing the problem by forcing the thread to loop on a shorter 'wait' until the statistics are up to date.
With that PR if you make the same test, you'll clearly see that you're not skipping matches, even each 0.1 kHz.