### PR TITLE
Two minor patches - freqman file processing & NumberField "can_loop" option

### DIFF
--- a/firmware/application/freqman.cpp
+++ b/firmware/application/freqman.cpp
@@ -146,17 +146,15 @@ bool load_freqman_file_ex(std::string& file_stem, freqman_db& db, bool load_freq
         // Reset line_start to beginning of buffer
         line_start = file_data;
 
-        if (!strstr(file_data, "f=") && !strstr(file_data, "a=") && !strstr(file_data, "r=") )
-            break;
-
         // Look for complete lines in buffer
         while ((line_end = strstr(line_start, "\x0A"))) {
 
+            *line_end = 0;      // Stop strstr() searches below at EOL
             modulation = -1 ;
             bandwidth = -1 ;
             step = -1 ;
             tone = -1 ;
-            type=SINGLE ;
+            type = ERROR_TYPE;
 
             frequency_a = frequency_b = 0;
             // Read frequency
@@ -164,6 +162,7 @@ bool load_freqman_file_ex(std::string& file_stem, freqman_db& db, bool load_freq
             if(pos) {
                 pos += 2;
                 frequency_a = strtoll(pos, nullptr, 10);
+                type = SINGLE;
             } else {
                 // ...or range
                 pos = strstr(line_start, "a=");

--- a/firmware/common/ui_widget.cpp
+++ b/firmware/common/ui_widget.cpp
@@ -1700,7 +1700,7 @@ int32_t NumberField::value() const {
 
 void NumberField::set_value(int32_t new_value, bool trigger_change) {
 	if (can_loop) {
-		if (new_value >= 0)
+		if (new_value >= range.first)
 			new_value = new_value % (range.second + 1);
 		else
 			new_value = range.second + new_value + 1;


### PR DESCRIPTION
Prior to the freqman change, reading a FREQ.TXT file as follows would incorrectly result in 3 "SIMPLE" entries being added to the frequency list:

  // Unexpected comment
  a=87500000,b=108000000,m=WFM,bw=16k,s=50KHz,d=WFM Standard
  f=88700000,d=FM 88.7

Prior to the widget change, a NumberField with can_loop enabled and range.first!=0 would not allow wrapping in the when encoder is turned in the downward direction (wrapping around to 0 was working in the upward direction).