### PR TITLE
Recon event nothread

### DIFF
--- a/firmware/application/apps/ui_recon.cpp
+++ b/firmware/application/apps/ui_recon.cpp
@@ -990,9 +990,22 @@ namespace ui {
             }
         };
 
-        field_lock_wait.on_change = [this](int32_t v)
+        field_lock_wait.on_change = [this](uint32_t v)
         {
             recon_lock_duration = v ;
+
+            if( (v / 50) > recon_lock_nb_match )
+            {
+                field_lock_wait.set_style( &style_white );
+            }
+            else if( (v / 50) == recon_lock_nb_match )
+            {
+                field_lock_wait.set_style( &style_yellow);
+            }
+            else
+            {
+                field_lock_wait.set_style(&style_red);
+            }
         };
 
         field_squelch.on_change = [this](int32_t v) {

--- a/firmware/application/apps/ui_recon.cpp
+++ b/firmware/application/apps/ui_recon.cpp
@@ -38,213 +38,213 @@ using portapack::memory::map::backup_ram;
 
 namespace ui {
 
-	bool ReconView::check_sd_card()
-	{
-		return (sd_card::status() == sd_card::Status::Mounted) ? true : false;
-	}
+    bool ReconView::check_sd_card()
+    {
+        return (sd_card::status() == sd_card::Status::Mounted) ? true : false;
+    }
 
-	void ReconView::set_display_freq( int64_t freq )
-	{
-		big_display.set( "FREQ: "+to_string_short_freq( freq )+" MHz" );
-	}
+    void ReconView::set_display_freq( int64_t freq )
+    {
+        big_display.set( "FREQ: "+to_string_short_freq( freq )+" MHz" );
+    }
 
-	void ReconView::handle_retune( int64_t freq , uint32_t index ) {
+    void ReconView::handle_retune( int64_t freq , uint32_t index ) {
 
-		static int64_t last_freq = 0 ;
-		static uint32_t last_index = 999999 ;
+        static int64_t last_freq = 0 ;
+        static uint32_t last_index = 999999 ;
 
-		switch( index ) {
-			case MSG_RECON_PAUSE:
-				user_pause();
-				if( update_ranges && index < (uint32_t)frequency_list.size() )
-				{
-					button_manual_start.set_text( to_string_short_freq( frequency_list[ index ] . frequency_a ) );
-					frequency_range.min = frequency_list[ index ] . frequency_a ;
-					if( frequency_list[ index ] . frequency_b != 0 )
-					{
-						button_manual_end.set_text( to_string_short_freq( frequency_list[ index ] . frequency_b ) );
-						frequency_range.max = frequency_list[ index ] . frequency_b ;
-					}
-					else
-					{
-						button_manual_end.set_text( to_string_short_freq( frequency_list[ index ] . frequency_a ) );
-						frequency_range.max = frequency_list[ index ] . frequency_a ;
-					}
-				}
-				return ;
-				break ;
-			case MSG_RECON_SET_MODULATION :
-				receiver_model.disable();
-				baseband::shutdown();
-				change_mode( freq );
-				if( recon ) // for some motive, audio output gets stopped.
-					audio::output::start();      // so if recon was stopped we resume audio
-				receiver_model.enable();
-				field_mode.set_selected_index( freq );
-				return ;
-				break ;
-			case MSG_RECON_SET_BANDWIDTH:
-				switch( last_entry . modulation ) 
-				{
-					case AM_MODULATION:
-						receiver_model.set_am_configuration( freq );
-						break ;
-					case NFM_MODULATION:
-						receiver_model.set_nbfm_configuration( freq );
-						break ;
-					case WFM_MODULATION:
-						receiver_model.set_wfm_configuration( freq );
-					default:
-						break ;
-				}
-				field_bw.set_selected_index( freq );
-				return ;
-				break ;
-			case MSG_RECON_SET_STEP:
-				step_mode.set_selected_index( freq );
-				return ;
-				break ;
-		}
+        switch( index ) {
+            case MSG_RECON_PAUSE:
+                user_pause();
+                if( update_ranges && index < (uint32_t)frequency_list.size() )
+                {
+                    button_manual_start.set_text( to_string_short_freq( frequency_list[ index ] . frequency_a ) );
+                    frequency_range.min = frequency_list[ index ] . frequency_a ;
+                    if( frequency_list[ index ] . frequency_b != 0 )
+                    {
+                        button_manual_end.set_text( to_string_short_freq( frequency_list[ index ] . frequency_b ) );
+                        frequency_range.max = frequency_list[ index ] . frequency_b ;
+                    }
+                    else
+                    {
+                        button_manual_end.set_text( to_string_short_freq( frequency_list[ index ] . frequency_a ) );
+                        frequency_range.max = frequency_list[ index ] . frequency_a ;
+                    }
+                }
+                return ;
+                break ;
+            case MSG_RECON_SET_MODULATION :
+                receiver_model.disable();
+                baseband::shutdown();
+                change_mode( freq );
+                if( recon ) // for some motive, audio output gets stopped.
+                    audio::output::start();      // so if recon was stopped we resume audio
+                receiver_model.enable();
+                field_mode.set_selected_index( freq );
+                return ;
+                break ;
+            case MSG_RECON_SET_BANDWIDTH:
+                switch( last_entry . modulation ) 
+                {
+                    case AM_MODULATION:
+                        receiver_model.set_am_configuration( freq );
+                        break ;
+                    case NFM_MODULATION:
+                        receiver_model.set_nbfm_configuration( freq );
+                        break ;
+                    case WFM_MODULATION:
+                        receiver_model.set_wfm_configuration( freq );
+                    default:
+                        break ;
+                }
+                field_bw.set_selected_index( freq );
+                return ;
+                break ;
+            case MSG_RECON_SET_STEP:
+                step_mode.set_selected_index( freq );
+                return ;
+                break ;
+        }
 
-		if( last_index != index )
-		{
-			last_index = index ;
-			if(  frequency_list.size() && index <  frequency_list.size() && frequency_list[ index ] . type == RANGE )
-			{
-				if( update_ranges )
-				{
-					button_manual_start.set_text( to_string_short_freq( frequency_list[ index ] . frequency_a ) );
-					frequency_range.min = frequency_list[ index ] . frequency_a ;
-					if( frequency_list[ index ] . frequency_b != 0 )
-					{
-						button_manual_end.set_text( to_string_short_freq( frequency_list[ index ] . frequency_b ) );
-						frequency_range.max = frequency_list[ index ] . frequency_b ;
-					}
-					else
-					{
-						button_manual_end.set_text( to_string_short_freq( frequency_list[ index ] . frequency_a ) );
-						frequency_range.max = frequency_list[ index ] . frequency_a ;
-					}
-				}
-			}
-			text_cycle.set_text( to_string_dec_uint( index + 1 , 3 ) );
-			if(frequency_list[index].description.size() > 0) 
-			{
-				switch( frequency_list[index].type )
-				{
-					case RANGE:
-						desc_cycle.set( "R: " + frequency_list[index].description ); //Show new description
-						break ;
-					case HAMRADIO:
-						desc_cycle.set( "H: " + frequency_list[index].description ); //Show new description
-						break ;
-					default:
-					case SINGLE:
-						desc_cycle.set( "S: " + frequency_list[index].description ); //Show new description
-						break ;
-				}
-			}
-			else
-			{
-				desc_cycle.set( "...no description..." ); //Show new description
-			}
-		}
-	
-		if( freq_lock == 0 ) {
-			//NO FREQ LOCK, ONGOING STANDARD SCANNING
-			big_display.set_style(&style_white);
-			if( !userpause )
-				button_pause.set_text("<PAUSE>");	
-			else
-				button_pause.set_text("<RESUME>");	
-		}
-		else if( freq_lock == 1 && recon_lock_nb_match != 1 )
-		{
-			//STARTING LOCK FREQ
-			big_display.set_style(&style_yellow);
-			button_pause.set_text("<SKPLCK>");	
-		}
-		else if( index < 1000 && freq_lock >= recon_lock_nb_match )
-		{
-			big_display.set_style( &style_green);
-			button_pause.set_text("<UNLOCK>");	
+        if( last_index != index )
+        {
+            last_index = index ;
+            if(  frequency_list.size() && index <  frequency_list.size() && frequency_list[ index ] . type == RANGE )
+            {
+                if( update_ranges )
+                {
+                    button_manual_start.set_text( to_string_short_freq( frequency_list[ index ] . frequency_a ) );
+                    frequency_range.min = frequency_list[ index ] . frequency_a ;
+                    if( frequency_list[ index ] . frequency_b != 0 )
+                    {
+                        button_manual_end.set_text( to_string_short_freq( frequency_list[ index ] . frequency_b ) );
+                        frequency_range.max = frequency_list[ index ] . frequency_b ;
+                    }
+                    else
+                    {
+                        button_manual_end.set_text( to_string_short_freq( frequency_list[ index ] . frequency_a ) );
+                        frequency_range.max = frequency_list[ index ] . frequency_a ;
+                    }
+                }
+            }
+            text_cycle.set_text( to_string_dec_uint( index + 1 , 3 ) );
+            if(frequency_list[index].description.size() > 0) 
+            {
+                switch( frequency_list[index].type )
+                {
+                    case RANGE:
+                        desc_cycle.set( "R: " + frequency_list[index].description ); //Show new description
+                        break ;
+                    case HAMRADIO:
+                        desc_cycle.set( "H: " + frequency_list[index].description ); //Show new description
+                        break ;
+                    default:
+                    case SINGLE:
+                        desc_cycle.set( "S: " + frequency_list[index].description ); //Show new description
+                        break ;
+                }
+            }
+            else
+            {
+                desc_cycle.set( "...no description..." ); //Show new description
+            }
+        }
 
-			//FREQ IS STRONG: GREEN and recon will pause when on_statistics_update()
-			if( (!scanner_mode) && autosave && last_freq != freq ) {
-				File recon_file;
-				std::string freq_file_path = "/FREQMAN/"+output_file+".TXT" ;
-				std::string frequency_to_add ;
+        if( freq_lock == 0 ) {
+            //NO FREQ LOCK, ONGOING STANDARD SCANNING
+            big_display.set_style(&style_white);
+            if( !userpause )
+                button_pause.set_text("<PAUSE>");	
+            else
+                button_pause.set_text("<RESUME>");	
+        }
+        else if( freq_lock == 1 && recon_lock_nb_match != 1 )
+        {
+            //STARTING LOCK FREQ
+            big_display.set_style(&style_yellow);
+            button_pause.set_text("<SKPLCK>");	
+        }
+        else if( index < 1000 && freq_lock >= recon_lock_nb_match )
+        {
+            big_display.set_style( &style_green);
+            button_pause.set_text("<UNLOCK>");	
 
-				freqman_entry entry = frequency_list[ index ] ;
-				entry . frequency_a =  freq ;
-				entry . frequency_b =  0 ;
-				entry . modulation =  last_entry.modulation ;
-				entry . bandwidth =  last_entry.bandwidth ;
-				entry . type = SINGLE ;
+            //FREQ IS STRONG: GREEN and recon will pause when on_statistics_update()
+            if( (!scanner_mode) && autosave && last_freq != freq ) {
+                File recon_file;
+                std::string freq_file_path = "/FREQMAN/"+output_file+".TXT" ;
+                std::string frequency_to_add ;
 
-				get_freq_string( entry , frequency_to_add );
+                freqman_entry entry = frequency_list[ index ] ;
+                entry . frequency_a =  freq ;
+                entry . frequency_b =  0 ;
+                entry . modulation =  last_entry.modulation ;
+                entry . bandwidth =  last_entry.bandwidth ;
+                entry . type = SINGLE ;
 
-				auto result = recon_file.open(freq_file_path);	//First recon if freq is already in txt
-				if (!result.is_valid()) {
-					char one_char[1];		//Read it char by char
-					std::string line;		//and put read line in here
-					bool found=false;
-					for (size_t pointer=0; pointer < recon_file.size();pointer++) {
-						recon_file.seek(pointer);
-						recon_file.read(one_char, 1);
-						if ((int)one_char[0] > 31) {			//ascii space upwards
-							line += one_char[0];				//Add it to the textline
-						}
-						else if (one_char[0] == '\n') {			//New Line
-							if (line.compare(0, frequency_to_add.size(),frequency_to_add) == 0) {
-								found=true;
-								break;
-							}
-							line.clear();						//Ready for next textline
-						}
-					}
-					if( !found) {
-						result = recon_file.append(freq_file_path); //Second: append if it is not there
-						if( !result.is_valid() )
-						{
-							recon_file.write_line( frequency_to_add );
-						}
-					}
-				}
-				else {
-					result = recon_file.create( freq_file_path );	//First freq if no output file
-					if( !result.is_valid() )
-					{
-						recon_file.write_line( frequency_to_add );
-					}
-				}
-			}
-			last_freq = freq ;
-		}
-		set_display_freq( freq );	//UPDATE the big Freq after 0, 1 or recon_lock_nb_match (at least, for color synching)
-	}
+                get_freq_string( entry , frequency_to_add );
+
+                auto result = recon_file.open(freq_file_path);	//First recon if freq is already in txt
+                if (!result.is_valid()) {
+                    char one_char[1];		//Read it char by char
+                    std::string line;		//and put read line in here
+                    bool found=false;
+                    for (size_t pointer=0; pointer < recon_file.size();pointer++) {
+                        recon_file.seek(pointer);
+                        recon_file.read(one_char, 1);
+                        if ((int)one_char[0] > 31) {			//ascii space upwards
+                            line += one_char[0];				//Add it to the textline
+                        }
+                        else if (one_char[0] == '\n') {			//New Line
+                            if (line.compare(0, frequency_to_add.size(),frequency_to_add) == 0) {
+                                found=true;
+                                break;
+                            }
+                            line.clear();						//Ready for next textline
+                        }
+                    }
+                    if( !found) {
+                        result = recon_file.append(freq_file_path); //Second: append if it is not there
+                        if( !result.is_valid() )
+                        {
+                            recon_file.write_line( frequency_to_add );
+                        }
+                    }
+                }
+                else {
+                    result = recon_file.create( freq_file_path );	//First freq if no output file
+                    if( !result.is_valid() )
+                    {
+                        recon_file.write_line( frequency_to_add );
+                    }
+                }
+            }
+            last_freq = freq ;
+        }
+        set_display_freq( freq );	//UPDATE the big Freq after 0, 1 or recon_lock_nb_match (at least, for color synching)
+    }
 
 
-	void ReconView::focus() {
-		button_pause.focus();
-	}
+    void ReconView::focus() {
+        button_pause.focus();
+    }
 
-	ReconView::~ReconView() {
+    ReconView::~ReconView() {
 
-		ReconSetupSaveStrings( "RECON/RECON.CFG" , input_file , output_file , recon_lock_duration , recon_lock_nb_match , squelch , recon_match_mode , wait , lock_wait , field_volume.value() );
+        ReconSetupSaveStrings( "RECON/RECON.CFG" , input_file , output_file , recon_lock_duration , recon_lock_nb_match , squelch , recon_match_mode , wait , recon_lock_duration , field_volume.value() );
 
-		// save app settings
-		settings.save("recon", &app_settings);
+        // save app settings
+        settings.save("recon", &app_settings);
 
-		audio::output::stop();
-		receiver_model.disable();
-		baseband::shutdown();
-	}
+        audio::output::stop();
+        receiver_model.disable();
+        baseband::shutdown();
+    }
 
-	void ReconView::show_max( bool refresh_display ) {		//show total number of freqs to recon
-		static int32_t last_db = 999999 ;
-		static int32_t last_nb_match = 999999 ;
-		static int32_t last_timer = -1 ;
+    void ReconView::show_max( bool refresh_display ) {		//show total number of freqs to recon
+        static int32_t last_db = 999999 ;
+        static int32_t last_nb_match = 999999 ;
+        static int32_t last_timer = -1 ;
         if( last_db != db )
         {
             last_db = db ;
@@ -266,670 +266,668 @@ namespace ui {
             freq_stats.set( "RSSI: "+to_string_dec_int( rssi.get_min() )+"/"+to_string_dec_int( rssi.get_avg() )+"/"+to_string_dec_int( rssi.get_max() )+" db" );
             text_timer.set( "TIMER: " + to_string_dec_int( timer ) );
         }
-	}
+    }
 
-	ReconView::ReconView( NavigationView& nav) : nav_ { nav } {
+    ReconView::ReconView( NavigationView& nav) : nav_ { nav } {
 
-		add_children( {
-				&labels,
-				&field_lna,
-				&field_vga,
-				&field_rf_amp,
-				&field_volume,
-				&field_bw,
-				&field_squelch,
-				&field_wait,
-				&field_lock_wait,
-				&button_recon_setup,
-				&button_scanner_mode,
-				&button_looking_glass,
-				&file_name,
-				&rssi,
-				&text_cycle,
-				&text_max,
-				&desc_cycle,
-				&big_display,
-				&freq_stats,
-				&text_timer,
-				&text_ctcss,
-				&button_manual_start,
-				&button_manual_end,
-				&button_manual_recon,
-				&field_mode,
-				&step_mode,
-				&button_pause,
-				&button_audio_app,
-				&button_add,
-				&button_dir,
-				&button_restart,
-				&button_mic_app,
-				&button_remove
-		} );
+        add_children( {
+                &labels,
+                &field_lna,
+                &field_vga,
+                &field_rf_amp,
+                &field_volume,
+                &field_bw,
+                &field_squelch,
+                &field_wait,
+                &field_lock_wait,
+                &button_recon_setup,
+                &button_scanner_mode,
+                &button_looking_glass,
+                &file_name,
+                &rssi,
+                &text_cycle,
+                &text_max,
+                &desc_cycle,
+                &big_display,
+                &freq_stats,
+                &text_timer,
+                &text_ctcss,
+                &button_manual_start,
+                &button_manual_end,
+                &button_manual_recon,
+                &field_mode,
+                &step_mode,
+                &button_pause,
+                &button_audio_app,
+                &button_add,
+                &button_dir,
+                &button_restart,
+                &button_mic_app,
+                &button_remove
+        } );
 
-		// Recon directory
-		if( check_sd_card() ) {					 // Check to see if SD Card is mounted
-			make_new_directory( u"/RECON" );
-			sd_card_mounted = true ;
-		}
-		def_step = 0 ;
-		//HELPER: Pre-setting a manual range, based on stored frequency
-		rf::Frequency stored_freq = persistent_memory::tuned_frequency();
-		receiver_model.set_tuning_frequency( stored_freq );
-		if( stored_freq - OneMHz > 0 )
-			frequency_range.min = stored_freq - OneMHz ;
-		else
-			frequency_range.min = 0 ;
-		button_manual_start.set_text(to_string_short_freq(frequency_range.min));
-		if( stored_freq + OneMHz < MAX_UFREQ )
-			frequency_range.max = stored_freq + OneMHz ;
-		else
-			frequency_range.max = MAX_UFREQ ;
-		button_manual_end.set_text(to_string_short_freq(frequency_range.max));
-		// Loading settings
-		autostart = persistent_memory::recon_autostart_recon();
-		autosave = persistent_memory::recon_autosave_freqs();
-		continuous = persistent_memory::recon_continuous();
-		filedelete = persistent_memory::recon_clear_output();
-		load_freqs = persistent_memory::recon_load_freqs();
-		load_ranges = persistent_memory::recon_load_ranges();
-		load_hamradios = persistent_memory::recon_load_hamradios();
-		update_ranges = persistent_memory::recon_update_ranges_when_recon();
+        // Recon directory
+        if( check_sd_card() ) {					 // Check to see if SD Card is mounted
+            make_new_directory( u"/RECON" );
+            sd_card_mounted = true ;
+        }
+        def_step = 0 ;
+        //HELPER: Pre-setting a manual range, based on stored frequency
+        rf::Frequency stored_freq = persistent_memory::tuned_frequency();
+        receiver_model.set_tuning_frequency( stored_freq );
+        if( stored_freq - OneMHz > 0 )
+            frequency_range.min = stored_freq - OneMHz ;
+        else
+            frequency_range.min = 0 ;
+        button_manual_start.set_text(to_string_short_freq(frequency_range.min));
+        if( stored_freq + OneMHz < MAX_UFREQ )
+            frequency_range.max = stored_freq + OneMHz ;
+        else
+            frequency_range.max = MAX_UFREQ ;
+        button_manual_end.set_text(to_string_short_freq(frequency_range.max));
+        // Loading settings
+        autostart = persistent_memory::recon_autostart_recon();
+        autosave = persistent_memory::recon_autosave_freqs();
+        continuous = persistent_memory::recon_continuous();
+        filedelete = persistent_memory::recon_clear_output();
+        load_freqs = persistent_memory::recon_load_freqs();
+        load_ranges = persistent_memory::recon_load_ranges();
+        load_hamradios = persistent_memory::recon_load_hamradios();
+        update_ranges = persistent_memory::recon_update_ranges_when_recon();
 
-		field_volume.set_value( volume );
-		if( sd_card_mounted )
-		{
-			// load auto common app settings
-			auto rc = settings.load("recon", &app_settings);
-			if(rc == SETTINGS_OK) {
-				field_lna.set_value(app_settings.lna);
-				field_vga.set_value(app_settings.vga);
-				field_rf_amp.set_value(app_settings.rx_amp);
-				receiver_model.set_rf_amp(app_settings.rx_amp);
-			}
-		}
-	
-		button_manual_start.on_select = [this, &nav](ButtonWithEncoder& button) {
-			auto new_view = nav_.push<FrequencyKeypadView>(frequency_range.min);
-			new_view->on_changed = [this, &button](rf::Frequency f) {
-				frequency_range.min = f;
-				button_manual_start.set_text(to_string_short_freq(f));
-			};
-		};
+        field_volume.set_value( volume );
+        if( sd_card_mounted )
+        {
+            // load auto common app settings
+            auto rc = settings.load("recon", &app_settings);
+            if(rc == SETTINGS_OK) {
+                field_lna.set_value(app_settings.lna);
+                field_vga.set_value(app_settings.vga);
+                field_rf_amp.set_value(app_settings.rx_amp);
+                receiver_model.set_rf_amp(app_settings.rx_amp);
+            }
+        }
 
-		button_manual_end.on_select = [this, &nav](ButtonWithEncoder& button) {
-			auto new_view = nav.push<FrequencyKeypadView>(frequency_range.max);
-			new_view->on_changed = [this, &button](rf::Frequency f) {
-				frequency_range.max = f;
-				button_manual_end.set_text(to_string_short_freq(f));
-			};
-		};
+        button_manual_start.on_select = [this, &nav](ButtonWithEncoder& button) {
+            auto new_view = nav_.push<FrequencyKeypadView>(frequency_range.min);
+            new_view->on_changed = [this, &button](rf::Frequency f) {
+                frequency_range.min = f;
+                button_manual_start.set_text(to_string_short_freq(f));
+            };
+        };
 
-		text_cycle.on_select = [this, &nav](ButtonWithEncoder& button) {
-			if( frequency_list.size() > 0 )
-			{
-				auto new_view = nav_.push<FrequencyKeypadView>(current_index);
-				new_view->on_changed = [this, &button](rf::Frequency f) {
-					f = f / OneMHz ;
-					if( f >= 1 && f <= frequency_list.size() )
-					{
-						index_stepper = f - 1 - current_index ;
-						freq_lock = 0 ;
-					}
-				};
-			}
-		};
+        button_manual_end.on_select = [this, &nav](ButtonWithEncoder& button) {
+            auto new_view = nav.push<FrequencyKeypadView>(frequency_range.max);
+            new_view->on_changed = [this, &button](rf::Frequency f) {
+                frequency_range.max = f;
+                button_manual_end.set_text(to_string_short_freq(f));
+            };
+        };
 
-		button_manual_start.on_change = [this]() {
-			frequency_range.min = frequency_range.min + button_manual_start.get_encoder_delta() * freqman_entry_get_step_value( def_step );
-			if( frequency_range.min < 0 )
-			{
-				frequency_range.min = 0 ;
-			}
-			if( frequency_range.min > ( MAX_UFREQ - freqman_entry_get_step_value( def_step ) ) )
-			{
-				frequency_range.min = MAX_UFREQ - freqman_entry_get_step_value( def_step );
-			}
-			if( frequency_range.min > (frequency_range.max - freqman_entry_get_step_value( def_step ) ) )
-			{
-				frequency_range.max = frequency_range.min + freqman_entry_get_step_value( def_step );
-				if( frequency_range.max > MAX_UFREQ )
-				{
-					frequency_range.min = MAX_UFREQ - freqman_entry_get_step_value( def_step );
-					frequency_range.max = MAX_UFREQ ;
-				}
-			}
-			button_manual_start.set_text( to_string_short_freq(frequency_range.min) );
-			button_manual_end.set_text( to_string_short_freq(frequency_range.max) );
-			button_manual_start.set_encoder_delta( 0 );
-		};
+        text_cycle.on_select = [this, &nav](ButtonWithEncoder& button) {
+            if( frequency_list.size() > 0 )
+            {
+                auto new_view = nav_.push<FrequencyKeypadView>(current_index);
+                new_view->on_changed = [this, &button](rf::Frequency f) {
+                    f = f / OneMHz ;
+                    if( f >= 1 && f <= frequency_list.size() )
+                    {
+                        index_stepper = f - 1 - current_index ;
+                        freq_lock = 0 ;
+                    }
+                };
+            }
+        };
 
-		button_manual_end.on_change = [this]() {
-			frequency_range.max = frequency_range.max + button_manual_end.get_encoder_delta() * freqman_entry_get_step_value( def_step );
-			if( frequency_range.max < ( freqman_entry_get_step_value( def_step ) + 1 ) )
-			{
-				frequency_range.max = ( freqman_entry_get_step_value( def_step ) + 1 );
-			}
-			if( frequency_range.max > MAX_UFREQ )
-			{
-				frequency_range.max = MAX_UFREQ ;
-			}
-			if( frequency_range.max < (frequency_range.min + freqman_entry_get_step_value( def_step ) ) )
-			{
-				frequency_range.min = frequency_range.max - freqman_entry_get_step_value( def_step );
-				if( frequency_range.max < ( freqman_entry_get_step_value( def_step ) + 1 ) )
-				{
-					frequency_range.min = 1 ;
-					frequency_range.max = ( freqman_entry_get_step_value( def_step ) + 1 ) ;
-				}
-			}
-			button_manual_start.set_text( to_string_short_freq(frequency_range.min) );
-			button_manual_end.set_text( to_string_short_freq(frequency_range.max) );
-			button_manual_end.set_encoder_delta( 0 );
-		};
+        button_manual_start.on_change = [this]() {
+            frequency_range.min = frequency_range.min + button_manual_start.get_encoder_delta() * freqman_entry_get_step_value( def_step );
+            if( frequency_range.min < 0 )
+            {
+                frequency_range.min = 0 ;
+            }
+            if( frequency_range.min > ( MAX_UFREQ - freqman_entry_get_step_value( def_step ) ) )
+            {
+                frequency_range.min = MAX_UFREQ - freqman_entry_get_step_value( def_step );
+            }
+            if( frequency_range.min > (frequency_range.max - freqman_entry_get_step_value( def_step ) ) )
+            {
+                frequency_range.max = frequency_range.min + freqman_entry_get_step_value( def_step );
+                if( frequency_range.max > MAX_UFREQ )
+                {
+                    frequency_range.min = MAX_UFREQ - freqman_entry_get_step_value( def_step );
+                    frequency_range.max = MAX_UFREQ ;
+                }
+            }
+            button_manual_start.set_text( to_string_short_freq(frequency_range.min) );
+            button_manual_end.set_text( to_string_short_freq(frequency_range.max) );
+            button_manual_start.set_encoder_delta( 0 );
+        };
 
-		text_cycle.on_change = [this]() {
-			if( frequency_list.size() > 0 )
-			{
-				if( text_cycle.get_encoder_delta() > 0 )
-				{
-					fwd = true ;
-					button_dir.set_text( "FW>" );
-					index_stepper = 1 ;
+        button_manual_end.on_change = [this]() {
+            frequency_range.max = frequency_range.max + button_manual_end.get_encoder_delta() * freqman_entry_get_step_value( def_step );
+            if( frequency_range.max < ( freqman_entry_get_step_value( def_step ) + 1 ) )
+            {
+                frequency_range.max = ( freqman_entry_get_step_value( def_step ) + 1 );
+            }
+            if( frequency_range.max > MAX_UFREQ )
+            {
+                frequency_range.max = MAX_UFREQ ;
+            }
+            if( frequency_range.max < (frequency_range.min + freqman_entry_get_step_value( def_step ) ) )
+            {
+                frequency_range.min = frequency_range.max - freqman_entry_get_step_value( def_step );
+                if( frequency_range.max < ( freqman_entry_get_step_value( def_step ) + 1 ) )
+                {
+                    frequency_range.min = 1 ;
+                    frequency_range.max = ( freqman_entry_get_step_value( def_step ) + 1 ) ;
+                }
+            }
+            button_manual_start.set_text( to_string_short_freq(frequency_range.min) );
+            button_manual_end.set_text( to_string_short_freq(frequency_range.max) );
+            button_manual_end.set_encoder_delta( 0 );
+        };
+
+        text_cycle.on_change = [this]() {
+            if( frequency_list.size() > 0 )
+            {
+                if( text_cycle.get_encoder_delta() > 0 )
+                {
+                    fwd = true ;
+                    button_dir.set_text( "FW>" );
+                    index_stepper = 1 ;
                     freq_lock = 0 ;
-				}
-				else if( text_cycle.get_encoder_delta() < 0 )
-				{
-					fwd = false ;
-					button_dir.set_text( "<RW" );
-					index_stepper = -1 ;
+                }
+                else if( text_cycle.get_encoder_delta() < 0 )
+                {
+                    fwd = false ;
+                    button_dir.set_text( "<RW" );
+                    index_stepper = -1 ;
                     freq_lock = 0 ;
-				}
-			}
-			text_cycle.set_encoder_delta( 0 );
-		};
+                }
+            }
+            text_cycle.set_encoder_delta( 0 );
+        };
 
-		button_pause.on_select = [this](ButtonWithEncoder&) {
-			if( frequency_list.size() > 0 )
-			{
-				if( continuous_lock )
-				{
-					if( fwd )
-					{
-						stepper = 1 ;
-					}
-					else
-					{
-						stepper = -1 ;
-					}
-					timer = 0 ;
-					recon_resume();
-					button_pause.set_text("<PAUSE>");		//Show button for non continuous stop
-					continuous_lock = false ;
-				}
-				else
-				{
-					if( userpause )
-					{
-						user_resume();
-					}
-					else
-					{
-						user_pause();
+        button_pause.on_select = [this](ButtonWithEncoder&) {
+            if( frequency_list.size() > 0 )
+            {
+                if( continuous_lock )
+                {
+                    if( fwd )
+                    {
+                        stepper = 1 ;
+                    }
+                    else
+                    {
+                        stepper = -1 ;
+                    }
+                    timer = 0 ;
+                    recon_resume();
+                    button_pause.set_text("<PAUSE>");		//Show button for non continuous stop
+                    continuous_lock = false ;
+                }
+                else
+                {
+                    if( userpause )
+                    {
+                        user_resume();
+                    }
+                    else
+                    {
+                        user_pause();
 
-						if( update_ranges )
-						{
-							button_manual_start.set_text( to_string_short_freq( frequency_list[ current_index ] . frequency_a ) );
-							frequency_range.min = frequency_list[ current_index ] . frequency_a ;
-							if( frequency_list[ current_index ] . frequency_b != 0 )
-							{
-								button_manual_end.set_text( to_string_short_freq( frequency_list[ current_index ] . frequency_b ) );
-								frequency_range.max = frequency_list[ current_index ] . frequency_b ;
-							}
-							else
-							{
-								button_manual_end.set_text( to_string_short_freq( frequency_list[ current_index ] . frequency_a ) );
-								frequency_range.max = frequency_list[ current_index ] . frequency_a ;
-							}
-						}
-					}
-				}
-			}
-		};
+                        if( update_ranges )
+                        {
+                            button_manual_start.set_text( to_string_short_freq( frequency_list[ current_index ] . frequency_a ) );
+                            frequency_range.min = frequency_list[ current_index ] . frequency_a ;
+                            if( frequency_list[ current_index ] . frequency_b != 0 )
+                            {
+                                button_manual_end.set_text( to_string_short_freq( frequency_list[ current_index ] . frequency_b ) );
+                                frequency_range.max = frequency_list[ current_index ] . frequency_b ;
+                            }
+                            else
+                            {
+                                button_manual_end.set_text( to_string_short_freq( frequency_list[ current_index ] . frequency_a ) );
+                                frequency_range.max = frequency_list[ current_index ] . frequency_a ;
+                            }
+                        }
+                    }
+                }
+            }
+        };
 
-		button_pause.on_change = [this]() {
-			if( frequency_list.size() > 0 )
-			{
-				if( button_pause.get_encoder_delta() > 0 )
-				{
-					fwd = true ;
-					button_dir.set_text( "FW>" );
-					stepper = 1 ;
-					freq_lock = 0 ;
-				}
-				else if( button_pause.get_encoder_delta() < 0 )
-				{
-					fwd = false ;
-					button_dir.set_text( "<RW" );
-					stepper = -1 ;
-					freq_lock = 0 ;
-				}
-			}
-			button_pause.set_encoder_delta( 0 );
-		};
-
-		button_audio_app.on_select = [this](Button&) {
-			nav_.pop();
-			nav_.push<AnalogAudioView>();
-		};
-
-		button_looking_glass.on_select = [this](Button&) {
-			nav_.pop();
-			nav_.push<GlassView>();
-		};
-
-
-		rssi.set_focusable(true);
-		rssi.set_peak( true , 500 );
-		rssi.on_select = [this](RSSI&) {
-			nav_.pop();
-			nav_.push<LevelView>();
-		};
-
-		button_mic_app.on_select = [this](Button&) {
-			nav_.pop();
-			nav_.push<MicTXView>();
-		};
-
-		button_remove.on_select = [this](ButtonWithEncoder&) {
-			if( scanner_mode )
-			{
-				if(frequency_list.size() > 0 )
-				{
-					if( current_index >= (int32_t)frequency_list.size() )
-					{
-						current_index = frequency_list.size() - 1 ;
-					}
-					frequency_list.erase( frequency_list.begin()+ current_index );
-					if( current_index >= (int32_t)frequency_list.size() )
-					{
-						current_index = frequency_list.size() - 1 ;
-					}
-					if( frequency_list.size() > 0 )
-					{
-						if(frequency_list[current_index].description.size() > 0)
-						{
-							switch( frequency_list[current_index].type )
-							{
-								case RANGE:
-									desc_cycle.set( "R: " + frequency_list[current_index].description );
-									break ;
-								case HAMRADIO:
-									desc_cycle.set( "H: " + frequency_list[current_index].description );
-									break ;
-								default:
-								case SINGLE:
-									desc_cycle.set( "S: " + frequency_list[current_index].description );
-									break ;
-							}
-						}
-						else
-						{
-							desc_cycle.set( "...no description..." );
-							show_max( true );
-						}
-						text_cycle.set_text( to_string_dec_uint( current_index + 1 , 3 ) );
-
-						File freqman_file;
-
-						std::string freq_file_path = "FREQMAN/" + output_file + ".TXT";
-
-						delete_file( freq_file_path );
-
-						auto result = freqman_file.create( freq_file_path );
-						if ( !result.is_valid() )
-						{
-							for (size_t n = 0; n < frequency_list.size(); n++)
-							{
-								std::string line ;
-								get_freq_string( frequency_list[ n ] , line );
-								freqman_file.write_line( line );
-							}
-						}
-					}
-				}
-			}
-			else // RECON MODE / MANUAL, only remove matching from output
-			{
-				File recon_file;
-				File tmp_recon_file;
-				std::string freq_file_path = "/FREQMAN/"+output_file+".TXT" ;
-				std::string tmp_freq_file_path = "/FREQMAN/"+output_file+"TMP.TXT" ;
-				std::string frequency_to_add ;
-
-				freqman_entry entry = frequency_list[ current_index ] ;
-				entry . frequency_a =  freq ;
-				entry . frequency_b =  0 ;
-				entry . modulation =  last_entry.modulation ;
-				entry . bandwidth =  last_entry.bandwidth ;
-				entry . type = SINGLE ;
-
-				get_freq_string( entry , frequency_to_add );
-
-				delete_file( tmp_freq_file_path );
-				auto result = tmp_recon_file.create(tmp_freq_file_path);	//First recon if freq is already in txt
-																			//
-				if (!result.is_valid()) {
-					bool found=false;
-					result = recon_file.open(freq_file_path);	//First recon if freq is already in txt
-					if (!result.is_valid()) {
-						char one_char[1];		//Read it char by char
-						std::string line;		//and put read line in here
-						for (size_t pointer=0; pointer < recon_file.size();pointer++) {
-							recon_file.seek(pointer);
-							recon_file.read(one_char, 1);
-							if ((int)one_char[0] > 31) {			//ascii space upwards
-								line += one_char[0];				//Add it to the textline
-							}
-							else if (one_char[0] == '\n') {			//New Line
-								if (line.compare(0, frequency_to_add.size(),frequency_to_add) == 0) {
-									found=true;
-								}
-								else
-								{
-									tmp_recon_file.write_line( frequency_to_add );
-								}
-								line.clear();						//Ready for next textline
-							}
-						}
-						if( found)
-						{
-							delete_file( freq_file_path );
-							rename_file( tmp_freq_file_path , freq_file_path );
-						}
-						else
-						{
-							delete_file( tmp_freq_file_path );
-						}
-					}
-				}
-			}
-			if( frequency_list.size() == 0 )
-			{
-				text_cycle.set_text( " " );
-				desc_cycle.set( "no entries in list" ); //Show new description
-				show_max( true );								//UPDATE new list size on screen
-				delete_file( "FREQMAN/"+output_file+".TXT" );
-			}
-			timer = 0 ;
-			receiver_model.set_tuning_frequency( frequency_list[ current_index ] . frequency_a );	// Retune
-			message.freq = frequency_list[ current_index ] . frequency_a ;
-			message.range = current_index ;
-			EventDispatcher::send_message(message);
-		};
-
-		button_remove.on_change = [this]() {
-			if( frequency_list.size() > 0 )
-			{
-				timer = 0 ;
-				if( button_remove.get_encoder_delta() > 0 )
-				{
-					fwd = true ;
-					button_dir.set_text( "FW>" );
-					stepper = 1 ;
+        button_pause.on_change = [this]() {
+            if( frequency_list.size() > 0 )
+            {
+                if( button_pause.get_encoder_delta() > 0 )
+                {
+                    fwd = true ;
+                    button_dir.set_text( "FW>" );
+                    stepper = 1 ;
                     freq_lock = 0 ;
-				}
-				else if( button_remove.get_encoder_delta() < 0 )
-				{
-					fwd = false ;
-					button_dir.set_text( "<RW" );
-					stepper = -1 ;
+                }
+                else if( button_pause.get_encoder_delta() < 0 )
+                {
+                    fwd = false ;
+                    button_dir.set_text( "<RW" );
+                    stepper = -1 ;
                     freq_lock = 0 ;
-				}
-			}
-			button_remove.set_encoder_delta( 0 );
-		};
+                }
+            }
+            button_pause.set_encoder_delta( 0 );
+        };
 
-		button_manual_recon.on_select = [this](Button&) {
-			scanner_mode = false ;
-			manual_mode = true ;
-			if (!frequency_range.min || !frequency_range.max) {
-				nav_.display_modal("Error", "Both START and END freqs\nneed a value");
-			} else if (frequency_range.min > frequency_range.max) {
-				nav_.display_modal("Error", "END freq\nis lower than START");
-			} else {
-				audio::output::stop();
+        button_audio_app.on_select = [this](Button&) {
+            nav_.pop();
+            nav_.push<AnalogAudioView>();
+        };
 
-				frequency_list.clear();
-				freqman_entry manual_freq_entry ;
+        button_looking_glass.on_select = [this](Button&) {
+            nav_.pop();
+            nav_.push<GlassView>();
+        };
 
-				def_step = step_mode.selected_index(); // max range val
 
-				manual_freq_entry . type = RANGE ;
-				manual_freq_entry . description =
-					"R " + to_string_short_freq(frequency_range.min) + ">"
-					+ to_string_short_freq(frequency_range.max) + " S" 	// current Manual range
-					+ to_string_short_freq(freqman_entry_get_step_value(def_step)).erase(0,1) ; //euquiq: lame kludge to reduce spacing in step freq
-				manual_freq_entry . frequency_a = frequency_range.min ; // min range val
-				manual_freq_entry . frequency_b = frequency_range.max ; // max range val
-				manual_freq_entry . modulation = -1 ;
-				manual_freq_entry . bandwidth = -1 ;
-				manual_freq_entry . step = def_step ;
+        rssi.set_focusable(true);
+        rssi.set_peak( true , 500 );
+        rssi.on_select = [this](RSSI&) {
+            nav_.pop();
+            nav_.push<LevelView>();
+        };
 
-				frequency_list . push_back( manual_freq_entry );
+        button_mic_app.on_select = [this](Button&) {
+            nav_.pop();
+            nav_.push<MicTXView>();
+        };
 
-				big_display.set_style(&style_white); //Back to white color
-				set_display_freq( frequency_range.min );
+        button_remove.on_select = [this](ButtonWithEncoder&) {
+            if( scanner_mode )
+            {
+                if(frequency_list.size() > 0 )
+                {
+                    if( current_index >= (int32_t)frequency_list.size() )
+                    {
+                        current_index = frequency_list.size() - 1 ;
+                    }
+                    frequency_list.erase( frequency_list.begin()+ current_index );
+                    if( current_index >= (int32_t)frequency_list.size() )
+                    {
+                        current_index = frequency_list.size() - 1 ;
+                    }
+                    if( frequency_list.size() > 0 )
+                    {
+                        if(frequency_list[current_index].description.size() > 0)
+                        {
+                            switch( frequency_list[current_index].type )
+                            {
+                                case RANGE:
+                                    desc_cycle.set( "R: " + frequency_list[current_index].description );
+                                    break ;
+                                case HAMRADIO:
+                                    desc_cycle.set( "H: " + frequency_list[current_index].description );
+                                    break ;
+                                default:
+                                case SINGLE:
+                                    desc_cycle.set( "S: " + frequency_list[current_index].description );
+                                    break ;
+                            }
+                        }
+                        else
+                        {
+                            desc_cycle.set( "...no description..." );
+                            show_max( true );
+                        }
+                        text_cycle.set_text( to_string_dec_uint( current_index + 1 , 3 ) );
 
-				freq_stats.set_style(&style_white);
-				freq_stats.set( "0/0/0" );
+                        File freqman_file;
 
-				show_max(); /* display step information */
-				text_cycle.set_text( "1" );
-				text_max.set( "/1" );
-				button_scanner_mode.set_style( &style_white );
-				button_scanner_mode.set_text( "MSEARCH" );
-				file_name.set_style( &style_white );
-				file_name.set( "MANUAL RANGE RECON" );
-				desc_cycle.set_style( &style_white );
-				desc_cycle.set( "MANUAL RANGE RECON" );
+                        std::string freq_file_path = "FREQMAN/" + output_file + ".TXT";
 
-				user_resume();
-			}
-		};
+                        delete_file( freq_file_path );
 
-		field_mode.on_change = [this](size_t, OptionsField::value_t v) {
-			if( v != -1 )
-			{
-				receiver_model.disable();
-				baseband::shutdown();
-				change_mode(v);
-				if( recon  ) 						//for some motive, audio output gets stopped.
-					audio::output::start();								//So if recon was stopped we resume audio
-				receiver_model.enable();
-			}
-		};
+                        auto result = freqman_file.create( freq_file_path );
+                        if ( !result.is_valid() )
+                        {
+                            for (size_t n = 0; n < frequency_list.size(); n++)
+                            {
+                                std::string line ;
+                                get_freq_string( frequency_list[ n ] , line );
+                                freqman_file.write_line( line );
+                            }
+                        }
+                    }
+                }
+            }
+            else // RECON MODE / MANUAL, only remove matching from output
+            {
+                File recon_file;
+                File tmp_recon_file;
+                std::string freq_file_path = "/FREQMAN/"+output_file+".TXT" ;
+                std::string tmp_freq_file_path = "/FREQMAN/"+output_file+"TMP.TXT" ;
+                std::string frequency_to_add ;
 
-		button_dir.on_select = [this](Button&) {
+                freqman_entry entry = frequency_list[ current_index ] ;
+                entry . frequency_a =  freq ;
+                entry . frequency_b =  0 ;
+                entry . modulation =  last_entry.modulation ;
+                entry . bandwidth =  last_entry.bandwidth ;
+                entry . type = SINGLE ;
+
+                get_freq_string( entry , frequency_to_add );
+
+                delete_file( tmp_freq_file_path );
+                auto result = tmp_recon_file.create(tmp_freq_file_path);	//First recon if freq is already in txt
+                                                                            //
+                if (!result.is_valid()) {
+                    bool found=false;
+                    result = recon_file.open(freq_file_path);	//First recon if freq is already in txt
+                    if (!result.is_valid()) {
+                        char one_char[1];		//Read it char by char
+                        std::string line;		//and put read line in here
+                        for (size_t pointer=0; pointer < recon_file.size();pointer++) {
+                            recon_file.seek(pointer);
+                            recon_file.read(one_char, 1);
+                            if ((int)one_char[0] > 31) {			//ascii space upwards
+                                line += one_char[0];				//Add it to the textline
+                            }
+                            else if (one_char[0] == '\n') {			//New Line
+                                if (line.compare(0, frequency_to_add.size(),frequency_to_add) == 0) {
+                                    found=true;
+                                }
+                                else
+                                {
+                                    tmp_recon_file.write_line( frequency_to_add );
+                                }
+                                line.clear();						//Ready for next textline
+                            }
+                        }
+                        if( found)
+                        {
+                            delete_file( freq_file_path );
+                            rename_file( tmp_freq_file_path , freq_file_path );
+                        }
+                        else
+                        {
+                            delete_file( tmp_freq_file_path );
+                        }
+                    }
+                }
+            }
+            if( frequency_list.size() == 0 )
+            {
+                text_cycle.set_text( " " );
+                desc_cycle.set( "no entries in list" ); //Show new description
+                show_max( true );								//UPDATE new list size on screen
+                delete_file( "FREQMAN/"+output_file+".TXT" );
+            }
+            timer = 0 ;
+            receiver_model.set_tuning_frequency( frequency_list[ current_index ] . frequency_a );	// Retune
+            handle_retune( frequency_list[ current_index ] . frequency_a , current_index );
+        };
+
+        button_remove.on_change = [this]() {
+            if( frequency_list.size() > 0 )
+            {
+                timer = 0 ;
+                if( button_remove.get_encoder_delta() > 0 )
+                {
+                    fwd = true ;
+                    button_dir.set_text( "FW>" );
+                    stepper = 1 ;
+                    freq_lock = 0 ;
+                }
+                else if( button_remove.get_encoder_delta() < 0 )
+                {
+                    fwd = false ;
+                    button_dir.set_text( "<RW" );
+                    stepper = -1 ;
+                    freq_lock = 0 ;
+                }
+            }
+            button_remove.set_encoder_delta( 0 );
+        };
+
+        button_manual_recon.on_select = [this](Button&) {
+            scanner_mode = false ;
+            manual_mode = true ;
+            if (!frequency_range.min || !frequency_range.max) {
+                nav_.display_modal("Error", "Both START and END freqs\nneed a value");
+            } else if (frequency_range.min > frequency_range.max) {
+                nav_.display_modal("Error", "END freq\nis lower than START");
+            } else {
+                audio::output::stop();
+
+                frequency_list.clear();
+                freqman_entry manual_freq_entry ;
+
+                def_step = step_mode.selected_index(); // max range val
+
+                manual_freq_entry . type = RANGE ;
+                manual_freq_entry . description =
+                    "R " + to_string_short_freq(frequency_range.min) + ">"
+                    + to_string_short_freq(frequency_range.max) + " S" 	// current Manual range
+                    + to_string_short_freq(freqman_entry_get_step_value(def_step)).erase(0,1) ; //euquiq: lame kludge to reduce spacing in step freq
+                manual_freq_entry . frequency_a = frequency_range.min ; // min range val
+                manual_freq_entry . frequency_b = frequency_range.max ; // max range val
+                manual_freq_entry . modulation = -1 ;
+                manual_freq_entry . bandwidth = -1 ;
+                manual_freq_entry . step = def_step ;
+
+                frequency_list . push_back( manual_freq_entry );
+
+                big_display.set_style(&style_white); //Back to white color
+                set_display_freq( frequency_range.min );
+
+                freq_stats.set_style(&style_white);
+                freq_stats.set( "0/0/0" );
+
+                show_max(); /* display step information */
+                text_cycle.set_text( "1" );
+                text_max.set( "/1" );
+                button_scanner_mode.set_style( &style_white );
+                button_scanner_mode.set_text( "MSEARCH" );
+                file_name.set_style( &style_white );
+                file_name.set( "MANUAL RANGE RECON" );
+                desc_cycle.set_style( &style_white );
+                desc_cycle.set( "MANUAL RANGE RECON" );
+
+                user_resume();
+            }
+        };
+
+        field_mode.on_change = [this](size_t, OptionsField::value_t v) {
+            if( v != -1 )
+            {
+                receiver_model.disable();
+                baseband::shutdown();
+                change_mode(v);
+                if( recon  ) 						//for some motive, audio output gets stopped.
+                    audio::output::start();								//So if recon was stopped we resume audio
+                receiver_model.enable();
+            }
+        };
+
+        button_dir.on_select = [this](Button&) {
             if( fwd )
             {
                 fwd = false ;
-				button_dir.set_text( "<RW" );
+                button_dir.set_text( "<RW" );
             }
             else
             {
                 fwd = true ;
-				button_dir.set_text( "FW>" );
-			}
-			timer = 0 ;
-			if ( userpause )				//If user-paused, resume
-				user_resume();
-		};
+                button_dir.set_text( "FW>" );
+            }
+            timer = 0 ;
+            if ( userpause )				//If user-paused, resume
+                user_resume();
+        };
 
-		button_restart.on_select = [this](Button&) {
-			if( frequency_list.size() > 0 )
-			{
-				def_step = step_mode.selected_index();	 //Use def_step from manual selector
-				frequency_file_load( true );
-				if( fwd )
-				{
-					button_dir.set_text( "FW>" );
-				}
-				else
-				{
-					button_dir.set_text( "<RW" );
-				}
-				timer = 0 ; 	 		//Will trigger a recon_resume() on_statistics_update, also advancing to next freq.
-				show_max();
-				user_resume();
-			}
-			if( scanner_mode )
-			{
-				file_name.set_style( &style_red );
-				button_scanner_mode.set_style( &style_red );
-				button_scanner_mode.set_text( "SCANNER" );
-			}
-			else
-			{
-				file_name.set_style( &style_blue );
-				button_scanner_mode.set_style( &style_blue );
-				button_scanner_mode.set_text( "RECON" );
-			}
-		};
+        button_restart.on_select = [this](Button&) {
+            if( frequency_list.size() > 0 )
+            {
+                def_step = step_mode.selected_index();	 //Use def_step from manual selector
+                frequency_file_load( true );
+                if( fwd )
+                {
+                    button_dir.set_text( "FW>" );
+                }
+                else
+                {
+                    button_dir.set_text( "<RW" );
+                }
+                timer = 0 ; 	 		//Will trigger a recon_resume() on_statistics_update, also advancing to next freq.
+                show_max();
+                user_resume();
+            }
+            if( scanner_mode )
+            {
+                file_name.set_style( &style_red );
+                button_scanner_mode.set_style( &style_red );
+                button_scanner_mode.set_text( "SCANNER" );
+            }
+            else
+            {
+                file_name.set_style( &style_blue );
+                button_scanner_mode.set_style( &style_blue );
+                button_scanner_mode.set_text( "RECON" );
+            }
+        };
 
-		button_add.on_select = [this](ButtonWithEncoder&) {  //frequency_list[current_index]
-			if( !scanner_mode)
-			{
-				if( frequency_list.size() && frequency_list.size() && current_index < (int32_t)frequency_list.size() )
-				{
-					bool found=false;
-					File recon_file;
-					std::string freq_file_path = "/FREQMAN/"+output_file+".TXT" ;
-					std::string frequency_to_add ;
+        button_add.on_select = [this](ButtonWithEncoder&) {  //frequency_list[current_index]
+            if( !scanner_mode)
+            {
+                if( frequency_list.size() && frequency_list.size() && current_index < (int32_t)frequency_list.size() )
+                {
+                    bool found=false;
+                    File recon_file;
+                    std::string freq_file_path = "/FREQMAN/"+output_file+".TXT" ;
+                    std::string frequency_to_add ;
 
-					freqman_entry entry = frequency_list[ current_index ] ;
-					entry . frequency_a =  freq ;
-					entry . frequency_b =  0 ;
-					entry . modulation =  last_entry.modulation ;
-					entry . bandwidth =  last_entry.bandwidth;
-					entry . type = SINGLE ;
+                    freqman_entry entry = frequency_list[ current_index ] ;
+                    entry . frequency_a =  freq ;
+                    entry . frequency_b =  0 ;
+                    entry . modulation =  last_entry.modulation ;
+                    entry . bandwidth =  last_entry.bandwidth;
+                    entry . type = SINGLE ;
 
-					get_freq_string( entry , frequency_to_add );
+                    get_freq_string( entry , frequency_to_add );
 
-					auto result = recon_file.open(freq_file_path);	//First recon if freq is already in txt
-					if (!result.is_valid()) {
-						char one_char[1];		//Read it char by char
-						std::string line;		//and put read line in here
-						for (size_t pointer=0; pointer < recon_file.size();pointer++) {
-							recon_file.seek(pointer);
-							recon_file.read(one_char, 1);
-							if ((int)one_char[0] > 31) {			//ascii space upwards
-								line += one_char[0];				//Add it to the textline
-							}
-							else if (one_char[0] == '\n') {			//New Line
-								if (line.compare(0, frequency_to_add.size(),frequency_to_add) == 0) {
-									found=true;
-									break;
-								}
-								line.clear();						//Ready for next textline
-							}
-						}
-						if( !found) {
-							result = recon_file.append(freq_file_path); //Second: append if it is not there
-							if( !result.is_valid() )
-							{
-								recon_file.write_line( frequency_to_add );
-							}
-						}
-						if (found) {
-							nav_.display_modal("Error", "Frequency already exists");
-							set_display_freq( freq );
-						}
-					}
-					else
-					{
-						auto result = recon_file.create(freq_file_path); //third: create if it is not there
-						if( !result.is_valid() )
-						{
-							recon_file.write_line( frequency_to_add );
-						}
-					}
-				}
-			}
-		};
+                    auto result = recon_file.open(freq_file_path);	//First recon if freq is already in txt
+                    if (!result.is_valid()) {
+                        char one_char[1];		//Read it char by char
+                        std::string line;		//and put read line in here
+                        for (size_t pointer=0; pointer < recon_file.size();pointer++) {
+                            recon_file.seek(pointer);
+                            recon_file.read(one_char, 1);
+                            if ((int)one_char[0] > 31) {			//ascii space upwards
+                                line += one_char[0];				//Add it to the textline
+                            }
+                            else if (one_char[0] == '\n') {			//New Line
+                                if (line.compare(0, frequency_to_add.size(),frequency_to_add) == 0) {
+                                    found=true;
+                                    break;
+                                }
+                                line.clear();						//Ready for next textline
+                            }
+                        }
+                        if( !found) {
+                            result = recon_file.append(freq_file_path); //Second: append if it is not there
+                            if( !result.is_valid() )
+                            {
+                                recon_file.write_line( frequency_to_add );
+                            }
+                        }
+                        if (found) {
+                            nav_.display_modal("Error", "Frequency already exists");
+                            set_display_freq( freq );
+                        }
+                    }
+                    else
+                    {
+                        auto result = recon_file.create(freq_file_path); //third: create if it is not there
+                        if( !result.is_valid() )
+                        {
+                            recon_file.write_line( frequency_to_add );
+                        }
+                    }
+                }
+            }
+        };
 
-		button_add.on_change = [this]() {
-			if( frequency_list.size() > 0 )
-			{
-				timer = 0 ;
-				if( button_add.get_encoder_delta() > 0 )
-				{
-					fwd = true ;
-					button_dir.set_text( "FW>" );
-					stepper = 1 ;
+        button_add.on_change = [this]() {
+            if( frequency_list.size() > 0 )
+            {
+                timer = 0 ;
+                if( button_add.get_encoder_delta() > 0 )
+                {
+                    fwd = true ;
+                    button_dir.set_text( "FW>" );
+                    stepper = 1 ;
                     freq_lock = 0 ;
-				}
-				else if( button_add.get_encoder_delta() < 0 )
-				{
-					fwd = false ;
-					button_dir.set_text( "<RW" );
-					stepper = -1 ;
+                }
+                else if( button_add.get_encoder_delta() < 0 )
+                {
+                    fwd = false ;
+                    button_dir.set_text( "<RW" );
+                    stepper = -1 ;
                     freq_lock = 0 ;
-				}
-			}
-			button_add.set_encoder_delta( 0 );
-		};
+                }
+            }
+            button_add.set_encoder_delta( 0 );
+        };
 
 
-		button_scanner_mode.on_select = [this,&nav](Button&) {
-			manual_mode = false ;
-			if( scanner_mode )
-			{
-				scanner_mode = false ;
-				button_scanner_mode.set_style( &style_blue );
-				button_scanner_mode.set_text( "RECON" );
-			}
-			else
-			{
-				scanner_mode = true ;
-				button_scanner_mode.set_style( &style_red );
-				button_scanner_mode.set_text( "SCANNER" );
-			}
-			frequency_file_load( true );
-			if( autostart )
-			{
-				user_resume();
-			}
-			else
-			{
-				user_pause();
-			}
-		};
+        button_scanner_mode.on_select = [this,&nav](Button&) {
+            manual_mode = false ;
+            if( scanner_mode )
+            {
+                scanner_mode = false ;
+                button_scanner_mode.set_style( &style_blue );
+                button_scanner_mode.set_text( "RECON" );
+            }
+            else
+            {
+                scanner_mode = true ;
+                button_scanner_mode.set_style( &style_red );
+                button_scanner_mode.set_text( "SCANNER" );
+            }
+            frequency_file_load( true );
+            if( autostart )
+            {
+                user_resume();
+            }
+            else
+            {
+                user_pause();
+            }
+        };
 
-		button_recon_setup.on_select = [this,&nav](Button&) {
+        button_recon_setup.on_select = [this,&nav](Button&) {
 
-			audio::output::stop();
-			frequency_list.clear();
+            audio::output::stop();
+            frequency_list.clear();
 
-			auto open_view = nav.push<ReconSetupView>(input_file,output_file,recon_lock_duration,recon_lock_nb_match,recon_match_mode);
-			open_view -> on_changed = [this](std::vector<std::string> result) {
-				input_file = result[0];
-				output_file = result[1];
-				recon_lock_duration = strtol( result[2].c_str() , nullptr , 10 );
-				recon_lock_nb_match = strtol( result[3].c_str() , nullptr , 10 );
-				recon_match_mode	= strtol( result[4].c_str() , nullptr , 10 );
+            auto open_view = nav.push<ReconSetupView>(input_file,output_file,recon_lock_duration,recon_lock_nb_match,recon_match_mode);
+            open_view -> on_changed = [this](std::vector<std::string> result) {
+                input_file = result[0];
+                output_file = result[1];
+                recon_lock_duration = strtol( result[2].c_str() , nullptr , 10 );
+                recon_lock_nb_match = strtol( result[3].c_str() , nullptr , 10 );
+                recon_match_mode	= strtol( result[4].c_str() , nullptr , 10 );
 
-				ReconSetupSaveStrings( "RECON/RECON.CFG" , input_file , output_file , recon_lock_duration , recon_lock_nb_match , squelch , recon_match_mode , wait , lock_wait , field_volume.value() );
+                ReconSetupSaveStrings( "RECON/RECON.CFG" , input_file , output_file , recon_lock_duration , recon_lock_nb_match , squelch , recon_match_mode , wait , recon_lock_duration , field_volume.value() );
 
-				autosave = persistent_memory::recon_autosave_freqs();
-				autostart = persistent_memory::recon_autostart_recon();
-				continuous = persistent_memory::recon_continuous();
-				filedelete = persistent_memory::recon_clear_output();
-				load_freqs = persistent_memory::recon_load_freqs();
-				load_ranges = persistent_memory::recon_load_ranges();
-				load_hamradios = persistent_memory::recon_load_hamradios();
+                autosave = persistent_memory::recon_autosave_freqs();
+                autostart = persistent_memory::recon_autostart_recon();
+                continuous = persistent_memory::recon_continuous();
+                filedelete = persistent_memory::recon_clear_output();
+                load_freqs = persistent_memory::recon_load_freqs();
+                load_ranges = persistent_memory::recon_load_ranges();
+                load_hamradios = persistent_memory::recon_load_hamradios();
 
-				update_ranges = persistent_memory::recon_update_ranges_when_recon();
-				frequency_file_load( false );
+                update_ranges = persistent_memory::recon_update_ranges_when_recon();
+                frequency_file_load( false );
                 if( autostart )
                 {
                     user_resume();
@@ -954,107 +952,85 @@ namespace ui {
                         frequency_range.max = frequency_list[ current_index ] . frequency_a ;
                     }
                 }
-				field_lock_wait.set_value( lock_wait );
-				show_max();
-				if( userpause != true )
-				{
-					timer = 0 ;
-					user_resume();
-				}
-				else
-				{
- 					if( frequency_list.size() != 0 )
- 					{
- 						message.freq = freq ;
- 						message.range = current_index ;
- 						EventDispatcher::send_message(message);
- 					}
-				}
-			};
-		};
+                field_lock_wait.set_value( recon_lock_duration );
+                show_max();
+                if( userpause != true )
+                {
+                    timer = 0 ;
+                    user_resume();
+                }
+                else
+                {
+                    if( frequency_list.size() != 0 )
+                    {
+                        handle_retune( frequency_list[ current_index ] . frequency_a , current_index );
+                    }
+                }
+            };
+        };
 
-		field_wait.on_change = [this](int32_t v)
-		{
-			wait = v ;
-			if( wait == 0 )
-			{
-				field_wait.set_style( &style_blue );
-			}
-			else if( wait >= 500 )
-			{
-				field_wait.set_style(&style_white);
-			}
-			else if( wait > -500 && wait < 500 )
-			{
-				field_wait.set_style( &style_red );
-			}
-			else if( wait <= -500 )
-			{
-				field_wait.set_style( &style_green );
-			}
-		};
+        field_wait.on_change = [this](int32_t v)
+        {
+            wait = v ;
+            if( wait == 0 )
+            {
+                field_wait.set_style( &style_blue );
+            }
+            else if( wait >= 500 )
+            {
+                field_wait.set_style(&style_white);
+            }
+            else if( wait > -500 && wait < 500 )
+            {
+                field_wait.set_style( &style_red );
+            }
+            else if( wait <= -500 )
+            {
+                field_wait.set_style( &style_green );
+            }
+        };
 
-		field_lock_wait.on_change = [this](int32_t v)
-		{
-			lock_wait = v ;
+        field_lock_wait.on_change = [this](int32_t v)
+        {
+            recon_lock_duration = v ;
+        };
 
-			uint32_t lock_white = ( 4 * ( recon_lock_duration * recon_lock_nb_match ) ) / 100 ;
-			lock_white = lock_white * 100 ;
-			if( lock_white < 400 )
-				lock_white = 400 ;
+        field_squelch.on_change = [this](int32_t v) {
+            squelch = v ;
+        };
 
-			uint32_t lock_yellow = 300 ;
+        field_volume.on_change = [this](int32_t v) { 
+            this->on_headphone_volume_changed(v);	
+        };
 
-			if( lock_wait >= lock_white )
-			{
-				field_lock_wait.set_style( &style_white );
-			}
-			else if( lock_wait >= lock_yellow )
-			{
-				field_lock_wait.set_style( &style_yellow);
-			}
-			else
-			{
-				field_lock_wait.set_style(&style_red);
-			}
-		};
-		
-		field_squelch.on_change = [this](int32_t v) {
-			squelch = v ;
-		};
+        //PRE-CONFIGURATION:
+        change_mode(AM_MODULATION);	//Start on AM
+        field_mode.set_by_value(AM_MODULATION);	//Reflect the mode into the manual selector
+        button_scanner_mode.set_style( &style_blue );
+        button_scanner_mode.set_text( "RECON" );
+        file_name.set( "=>" );
 
-		field_volume.on_change = [this](int32_t v) { 
-			this->on_headphone_volume_changed(v);	
-		};
+        //Loading input and output file from settings
+        ReconSetupLoadStrings( "RECON/RECON.CFG" , input_file , output_file , recon_lock_duration , recon_lock_nb_match , squelch , recon_match_mode , wait , recon_lock_duration , volume );
 
-		//PRE-CONFIGURATION:
-		change_mode(AM_MODULATION);	//Start on AM
-		field_mode.set_by_value(AM_MODULATION);	//Reflect the mode into the manual selector
-		button_scanner_mode.set_style( &style_blue );
-		button_scanner_mode.set_text( "RECON" );
-		file_name.set( "=>" );
+        field_squelch.set_value( squelch );
+        field_wait.set_value(wait);
+        field_lock_wait.set_value(recon_lock_duration);
+        field_volume.set_value((receiver_model.headphone_volume() - audio::headphone::volume_range().max).decibel() + 99);
 
-		//Loading input and output file from settings
-		ReconSetupLoadStrings( "RECON/RECON.CFG" , input_file , output_file , recon_lock_duration , recon_lock_nb_match , squelch , recon_match_mode , wait , lock_wait , volume );
+        //FILL STEP OPTIONS
+        freqman_set_modulation_option( field_mode );
+        freqman_set_step_option( step_mode );
 
-		field_squelch.set_value( squelch );
-		field_wait.set_value(wait);
-		field_lock_wait.set_value(lock_wait);
-		field_volume.set_value((receiver_model.headphone_volume() - audio::headphone::volume_range().max).decibel() + 99);
+        receiver_model.set_tuning_frequency( portapack::persistent_memory::tuned_frequency() );	// Retune
 
-		//FILL STEP OPTIONS
-		freqman_set_modulation_option( field_mode );
-		freqman_set_step_option( step_mode );
-		
-		receiver_model.set_tuning_frequency( portapack::persistent_memory::tuned_frequency() );	// Retune
+        if( filedelete )
+        {
+            delete_file( "FREQMAN/"+output_file+".TXT" );
+        }
 
-		if( filedelete )
-		{
-			delete_file( "FREQMAN/"+output_file+".TXT" );
-		}
-
-		frequency_file_load( false ); /* do not stop all at start */
-    if( update_ranges && frequency_list.size() > 0 )
+        frequency_file_load( false ); /* do not stop all at start */
+        if( update_ranges && frequency_list.size() > 0 )
         {
             button_manual_start.set_text( to_string_short_freq( frequency_list[ current_index ] . frequency_a ) );
             frequency_range.min = frequency_list[ current_index ] . frequency_a ;
@@ -1081,55 +1057,55 @@ namespace ui {
         show_max();
     }
 
-	void ReconView::frequency_file_load( bool stop_all_before) {
+    void ReconView::frequency_file_load( bool stop_all_before) {
 
-		(void)(stop_all_before);
-		audio::output::stop();
+        (void)(stop_all_before);
+        audio::output::stop();
 
-		def_step = step_mode.selected_index();		// use def_step from manual selector
-		frequency_list.clear();					 // clear the existing frequency list (expected behavior)
-		std::string file_input = input_file ;	   // default recon mode
-		if( scanner_mode )
-		{
-			file_input = output_file ;
-			file_name.set_style( &style_red );
-			button_scanner_mode.set_style( &style_red );
-			button_scanner_mode.set_text( "SCANNER" );
-		}
-		else
-		{
-			file_name.set_style( &style_blue );
-			button_scanner_mode.set_style( &style_blue );
-			button_scanner_mode.set_text( "RECON" );
-		}
-		file_name.set_style( &style_white );
-		desc_cycle.set_style( &style_white );
-		if( !load_freqman_file_ex( file_input , frequency_list, load_freqs, load_ranges, load_hamradios ) )
-		{	
-			file_name.set_style( &style_red );
-			desc_cycle.set_style( &style_red );
-			desc_cycle.set(" NO " + file_input + ".TXT FILE ..." );
-			file_name.set( "=> NO DATA" );
-		}
-		else
-		{
-			file_name.set( "=> "+file_input );
-			if( frequency_list.size() == 0 )
-			{
-				file_name.set_style( &style_red );
-				desc_cycle.set_style( &style_red );
-				desc_cycle.set("/0 no entries in list" );
-				file_name.set( "BadOrEmpty "+file_input );
-			}
-			else
-			{
-				if( frequency_list.size() > FREQMAN_MAX_PER_FILE )
-				{
-					file_name.set_style( &style_yellow );
-					desc_cycle.set_style( &style_yellow );
-				}
-			}
-		}
+        def_step = step_mode.selected_index();		// use def_step from manual selector
+        frequency_list.clear();					 // clear the existing frequency list (expected behavior)
+        std::string file_input = input_file ;	   // default recon mode
+        if( scanner_mode )
+        {
+            file_input = output_file ;
+            file_name.set_style( &style_red );
+            button_scanner_mode.set_style( &style_red );
+            button_scanner_mode.set_text( "SCANNER" );
+        }
+        else
+        {
+            file_name.set_style( &style_blue );
+            button_scanner_mode.set_style( &style_blue );
+            button_scanner_mode.set_text( "RECON" );
+        }
+        file_name.set_style( &style_white );
+        desc_cycle.set_style( &style_white );
+        if( !load_freqman_file_ex( file_input , frequency_list, load_freqs, load_ranges, load_hamradios ) )
+        {	
+            file_name.set_style( &style_red );
+            desc_cycle.set_style( &style_red );
+            desc_cycle.set(" NO " + file_input + ".TXT FILE ..." );
+            file_name.set( "=> NO DATA" );
+        }
+        else
+        {
+            file_name.set( "=> "+file_input );
+            if( frequency_list.size() == 0 )
+            {
+                file_name.set_style( &style_red );
+                desc_cycle.set_style( &style_red );
+                desc_cycle.set("/0 no entries in list" );
+                file_name.set( "BadOrEmpty "+file_input );
+            }
+            else
+            {
+                if( frequency_list.size() > FREQMAN_MAX_PER_FILE )
+                {
+                    file_name.set_style( &style_yellow );
+                    desc_cycle.set_style( &style_yellow );
+                }
+            }
+        }
 
         if( frequency_list[ 0 ] . step >= 0 )
             step = freqman_entry_get_step_value( frequency_list[ 0 ] . step );
@@ -1173,207 +1149,188 @@ namespace ui {
         last_entry . bandwidth = -1 ;
         last_entry . step = -1 ;
 
-		step_mode.set_selected_index(def_step); //Impose the default step into the manual step selector
-		receiver_model.enable();
-		receiver_model.set_squelch_level(0);
-		std::string description = "...no description..." ;
-		if( frequency_list.size() != 0 )
-		{
-			current_index = 0 ;
-			switch( frequency_list[current_index].type )
-			{
-				case RANGE:
-					description = "R: " + frequency_list[current_index].description ;
-					break ;
-				case HAMRADIO:
-					description = "H: " + frequency_list[current_index].description ; 
-					break ;
-				default:
-				case SINGLE:
-					description = "S: " + frequency_list[current_index].description ;
-					break ;
-			}
-			text_cycle.set_text( to_string_dec_uint( current_index + 1 , 3 ) );
-		}
-		else
-		{
-			text_cycle.set_text( " " );
-		}
-		desc_cycle.set( description );
+        step_mode.set_selected_index(def_step); //Impose the default step into the manual step selector
+        receiver_model.enable();
+        receiver_model.set_squelch_level(0);
+        std::string description = "...no description..." ;
+        if( frequency_list.size() != 0 )
+        {
+            current_index = 0 ;
+            switch( frequency_list[current_index].type )
+            {
+                case RANGE:
+                    description = "R: " + frequency_list[current_index].description ;
+                    break ;
+                case HAMRADIO:
+                    description = "H: " + frequency_list[current_index].description ; 
+                    break ;
+                default:
+                case SINGLE:
+                    description = "S: " + frequency_list[current_index].description ;
+                    break ;
+            }
+            text_cycle.set_text( to_string_dec_uint( current_index + 1 , 3 ) );
+        }
+        else
+        {
+            text_cycle.set_text( " " );
+        }
+        desc_cycle.set( description );
         chThdSleepMilliseconds( 50 ); // give time for first tuning
-	}
+    }
 
-	void ReconView::on_statistics_update(const ChannelStatistics& statistics) {
+    void ReconView::on_statistics_update(const ChannelStatistics& statistics) {
 
-		int32_t actual_db = statistics.max_db ;
-		bool update_stats = false ;
+        int32_t actual_db = statistics.max_db ;
+        bool update_stats = false ;
 
-		// 0 recon , 1 locking , 2 locked
-		static int32_t status = -1 ;
+        // 0 recon , 1 locking , 2 locked
+        static int32_t status = -1 ;
 
-		if( actual_db != 0 && db != actual_db )
-		{
-			db = actual_db ;
-			update_stats = true ;
-		}
+        if( actual_db != 0 && db != actual_db )
+        {
+            db = actual_db ;
+            update_stats = true ;
+        }
 
-		if( !userpause )
-		{
-			if( !timer )
-			{
-				if( status != 0 )
-				{
-					status = 0 ;
-					update_stats = true ;
-					continuous_lock = false ;
-					freq_lock = 0 ; //in lock period, still analyzing the signal
-					recon_resume();  // RESUME!
-					big_display.set_style(&style_white);
-				}
-			}
-			if( freq_lock >= recon_lock_nb_match ) // LOCKED
-			{
-				if( status != 2 )
-				{
-					status = 2 ;
-					update_stats = true ;
-
-					if( wait != 0 )
-					{
-						audio::output::start();
-						this->on_headphone_volume_changed( (receiver_model.headphone_volume() - audio::headphone::volume_range().max).decibel() + 99 );
-					}
-					if( wait >= 0 )
-					{
-						timer = wait ;
-					}
-					//Inform freq (for coloring purposes also!)
-					message.freq = freq ;
-					message.range = current_index ;
-					EventDispatcher::send_message(message);
-				}
-				if( wait < 0 )
-				{
-					if( actual_db > squelch ) //MATCHING LEVEL IN STAY X AFTER LAST ACTIVITY
-					{
-						timer = abs( wait );
-					}
-				}
-			}
-			else // freq_lock < recon_lock_nb_match , LOCKING
-			{
-				if( actual_db > squelch ) //MATCHING LEVEL
-				{
-					if( status != 1 )
-					{
-						status = 1 ;
-						continuous_lock = true ;
-						if( wait != 0 )
-						{
-							audio::output::stop();
-						}
-						timer = lock_wait ;
-						//Inform freq (for coloring purposes also!)
-						message.freq = freq ;
-						message.range = current_index ;
-						EventDispatcher::send_message(message);
-					}
-					freq_lock ++ ;
-					update_stats = true ;
-				}
-				else
-				{
-					// continuous, direct cut it if not consecutive match
-					if( recon_match_mode == 0 )
-					{
-						timer = 0 ;
-						update_stats = true ;
-						freq_lock = 0 ;
-					}
-				}
-			}
-		}
-		else
-		{
-			if( actual_db > squelch )
-			{
-				if( status != 2 ) //MATCHING LEVEL
-				{
-					status = 2 ;
-					big_display.set_style(&style_yellow);
-					set_display_freq( freq );
-				}
-			}
-			else
-			{
-				if( status != 0 )
-				{
-					status = 0 ;
-					big_display.set_style(&style_white);
-					set_display_freq( freq );
-				}
-
-			}
-		}
-		if( update_stats )
-		{
-			show_max();
-		}
-
-		if( timer > 0 )
-			show_max();
-
-		timer -= 50 ;
-		if( timer < 0 )
-		{
-			timer = 0 ;
-			show_max();
-		}
-
-		//IF THERE IS A FREQUENCY LIST ...
-		if (frequency_list.size() > 0 )
-		{
-            has_looped = false ;
-            if( last_entry . frequency_a != freq || entry_has_changed )
+        if( !userpause )
+        {
+            if( !timer )
             {
-                last_entry . frequency_a = freq ;
-                receiver_model.set_tuning_frequency( freq );	// Retune
-                message.freq = freq ;
-                message.range = current_index ;
-                EventDispatcher::send_message(message);
-            }
-            entry_has_changed = false ;
-
-            // Set modulation if any
-            if( last_entry . modulation != frequency_list[ current_index ] . modulation && frequency_list[ current_index ] . modulation >= 0 )
-            {
-                last_entry . modulation = frequency_list[ current_index ]. modulation;
-                message.freq  = last_entry . modulation  ;
-                message.range = MSG_RECON_SET_MODULATION ;
-                EventDispatcher::send_message(message);
-            }
-            // Set bandwidth if any
-            if( last_entry . bandwidth != frequency_list[ current_index ] . bandwidth && frequency_list[ current_index ] . bandwidth >= 0 )
-            {
-                last_entry . bandwidth = frequency_list[ current_index ]. bandwidth;
-                message.freq  = last_entry . bandwidth  ;
-                message.range = MSG_RECON_SET_BANDWIDTH ;
-                EventDispatcher::send_message(message);
-            }
-            if( last_entry . step != frequency_list[ current_index ] . step && frequency_list[ current_index ] . step >= 0 )
-            {
-                last_entry . step = frequency_list[ current_index ]. step ;
-                message.freq  = last_entry . step ;
-                message.range = MSG_RECON_SET_STEP ;
-                EventDispatcher::send_message(message);
-                step = freqman_entry_get_step_value( last_entry . step );
-            }
-
-            if( recon || stepper != 0 || index_stepper != 0 )
-            {
-                if( freq_lock == 0 || stepper != 0 || index_stepper != 0 )  //normal recon (not performing freq_lock)
+                if( status != 0 )
                 {
-                    if( stepper != 0 || index_stepper != 0 || remaining_time <= recon_lock_duration )
+                    status = 0 ;
+                    update_stats = true ;
+                    continuous_lock = false ;
+                    freq_lock = 0 ; //in lock period, still analyzing the signal
+                    recon_resume();  // RESUME!
+                    big_display.set_style(&style_white);
+                }
+            }
+            if( freq_lock >= recon_lock_nb_match ) // LOCKED
+            {
+                if( status != 2 )
+                {
+                    status = 2 ;
+                    update_stats = true ;
+
+                    if( wait != 0 )
+                    {
+                        audio::output::start();
+                        this->on_headphone_volume_changed( (receiver_model.headphone_volume() - audio::headphone::volume_range().max).decibel() + 99 );
+                    }
+                    if( wait >= 0 )
+                    {
+                        timer = wait ;
+                    }
+                    //Inform freq (for coloring purposes also!)
+                    handle_retune( frequency_list[ current_index ] . frequency_a , current_index );
+                }
+                if( wait < 0 )
+                {
+                    if( actual_db > squelch ) //MATCHING LEVEL IN STAY X AFTER LAST ACTIVITY
+                    {
+                        timer = abs( wait );
+                    }
+                }
+            }
+            else // freq_lock < recon_lock_nb_match , LOCKING
+            {
+                if( actual_db > squelch ) //MATCHING LEVEL
+                {
+                    if( status != 1 )
+                    {
+                        status = 1 ;
+                        continuous_lock = true ;
+                        if( wait != 0 )
+                        {
+                            audio::output::stop();
+                        }
+                        timer = recon_lock_duration ;
+                        //Inform freq (for coloring purposes also!)
+                        handle_retune( frequency_list[ current_index ] . frequency_a , current_index );
+                    }
+                    freq_lock ++ ;
+                    update_stats = true ;
+                }
+                else
+                {
+                    // continuous, direct cut it if not consecutive match
+                    if( recon_match_mode == 0 )
+                    {
+                        timer = 0 ;
+                        update_stats = true ;
+                    }
+                }
+            }
+        }
+        else
+        {
+            if( actual_db > squelch )
+            {
+                if( status != 2 ) //MATCHING LEVEL
+                {
+                    status = 2 ;
+                    big_display.set_style(&style_yellow);
+                    set_display_freq( freq );
+                }
+            }
+            else
+            {
+                if( status != 0 )
+                {
+                    status = 0 ;
+                    big_display.set_style(&style_white);
+                    set_display_freq( freq );
+                }
+
+            }
+        }
+        if( update_stats )
+        {
+            show_max();
+        }
+
+        if( timer > 0 )
+            show_max();
+
+        timer -= 50 ;
+        if( timer <= 0 || stepper != 0 || index_stepper != 0 )
+        {
+            timer = 0 ;
+
+            //IF THERE IS A FREQUENCY LIST ...
+            if (frequency_list.size() > 0 )
+            {
+                has_looped = false ;
+                if( last_entry . frequency_a != freq || entry_has_changed )
+                {
+                    last_entry . frequency_a = freq ;
+                    receiver_model.set_tuning_frequency( freq );	// Retune
+                    handle_retune( frequency_list[ current_index ] . frequency_a , current_index );
+                }
+                entry_has_changed = false ;
+
+                // Set modulation if any
+                if( last_entry . modulation != frequency_list[ current_index ] . modulation && frequency_list[ current_index ] . modulation >= 0 )
+                {
+                    last_entry . modulation = frequency_list[ current_index ]. modulation;
+                    handle_retune( last_entry . modulation , MSG_RECON_SET_MODULATION );
+                }
+                // Set bandwidth if any
+                if( last_entry . bandwidth != frequency_list[ current_index ] . bandwidth && frequency_list[ current_index ] . bandwidth >= 0 )
+                {
+                    last_entry . bandwidth = frequency_list[ current_index ]. bandwidth;
+                    handle_retune( last_entry . bandwidth , MSG_RECON_SET_BANDWIDTH );
+                }
+                if( last_entry . step != frequency_list[ current_index ] . step && frequency_list[ current_index ] . step >= 0 )
+                {
+                    last_entry . step = frequency_list[ current_index ]. step ;
+                    handle_retune( last_entry . step , MSG_RECON_SET_STEP );
+                    step = freqman_entry_get_step_value( last_entry . step );
+                }
+
+                if( recon || stepper != 0 || index_stepper != 0 )
                     {
                         if( index_stepper == 0 )
                         {
@@ -1500,7 +1457,6 @@ namespace ui {
                                 current_index = 0 ;
                             entry_has_changed = true ;
                         }
-
                         // reload entry if changed
                         if( entry_has_changed ){
                             switch( frequency_list[ current_index ] . type ){
@@ -1539,138 +1495,129 @@ namespace ui {
                         if( has_looped && !continuous )
                         {
                             // signal pause to handle_retune
-                            message.freq = freq ;
-                            message.range = MSG_RECON_PAUSE ;
-                            EventDispatcher::send_message(message);
+                            handle_retune( freq , MSG_RECON_PAUSE );
                             receiver_model.set_tuning_frequency( freq );	// Retune to actual freq
                         }
                         if( stepper < 0 ) stepper ++ ;
                         if( stepper > 0 ) stepper -- ;
                         if( index_stepper < 0 ) index_stepper ++ ;
                         if( index_stepper > 0 ) index_stepper -- ;
-                    } // if( stepper != 0 || index_stepper != 0 )
-                } // if( freq_lock == 0 || stepper != 0 || index_stepper != 0 ) 
-            } // if( recon || stepper != 0 || index_stepper != 0 )
-        }//if (frequency_list.size() > 0 )		
-        if( remaining_time >= 50 )
-            remaining_time -= 50 ;
-        else
-            remaining_time = 0 ;
-        if( remaining_time == 0 )
+                    } // if( recon || stepper != 0 || index_stepper != 0 )
+            }//if (frequency_list.size() > 0 )		
+        } /* on_statistic_updates */
+    }
+
+    void ReconView::recon_pause() {
+        if(recon) 
+        {
+            audio::output::start();
+            this->on_headphone_volume_changed( (receiver_model.headphone_volume() - audio::headphone::volume_range().max).decibel() + 99 );
             freq_lock = 0 ;
-	} /* on_statistic_updates */
-
-	void ReconView::recon_pause() {
-		if(recon) 
-		{
-			audio::output::start();
-			this->on_headphone_volume_changed( (receiver_model.headphone_volume() - audio::headphone::volume_range().max).decibel() + 99 );
-			freq_lock = 0 ;
             recon = false ; 
-		}
-	}
+        }
+    }
 
 
-	void ReconView::recon_resume() {
-		audio::output::stop();
-		recon = true ;	   // RESUME!
-		big_display.set_style(&style_white); //Back to grey color
-	}
+    void ReconView::recon_resume() {
+        audio::output::stop();
+        recon = true ;	   // RESUME!
+        big_display.set_style(&style_white); //Back to grey color
+    }
 
-	void ReconView::user_pause() {
-		timer = 0 ; 	 				    // Will trigger a recon_resume() on_statistics_update, also advancing to next freq.
-		button_pause.set_text("<RESUME>");	//PAUSED, show resume
-		userpause=true;
-		continuous_lock=false;
-		recon_pause();
-	}
+    void ReconView::user_pause() {
+        timer = 0 ; 	 				    // Will trigger a recon_resume() on_statistics_update, also advancing to next freq.
+        button_pause.set_text("<RESUME>");	//PAUSED, show resume
+        userpause=true;
+        continuous_lock=false;
+        recon_pause();
+    }
 
-	void ReconView::user_resume() {
-		timer = 0 ;                       // Will trigger a recon_resume() on_statistics_update, also advancing to next freq.
-		button_pause.set_text("<PAUSE>"); //Show button for pause
-		userpause=false;                  // Resume recon
-		continuous_lock=false;
-		recon_resume();
-	}
+    void ReconView::user_resume() {
+        timer = 0 ;                       // Will trigger a recon_resume() on_statistics_update, also advancing to next freq.
+        button_pause.set_text("<PAUSE>"); //Show button for pause
+        userpause=false;                  // Resume recon
+        continuous_lock=false;
+        recon_resume();
+    }
 
-	void ReconView::on_headphone_volume_changed(int32_t v) {
-		const auto new_volume = volume_t::decibel(v - 99) + audio::headphone::volume_range().max;
-		receiver_model.set_headphone_volume(new_volume);
-	}
+    void ReconView::on_headphone_volume_changed(int32_t v) {
+        const auto new_volume = volume_t::decibel(v - 99) + audio::headphone::volume_range().max;
+        receiver_model.set_headphone_volume(new_volume);
+    }
 
-	size_t ReconView::change_mode( freqman_index_t new_mod ) { 
+    size_t ReconView::change_mode( freqman_index_t new_mod ) { 
 
-		field_bw.on_change = [this](size_t n, OptionsField::value_t) { (void)n;	};
+        field_bw.on_change = [this](size_t n, OptionsField::value_t) { (void)n;	};
 
-		switch( new_mod ) {
-			case AM_MODULATION:
-				freqman_set_bandwidth_option( new_mod , field_bw );
-				//bw DSB (0) default
-				field_bw.set_selected_index(0);
-				baseband::run_image(portapack::spi_flash::image_tag_am_audio);
-				receiver_model.set_modulation(ReceiverModel::Mode::AMAudio);
-				receiver_model.set_am_configuration(field_bw.selected_index());
-				field_bw.on_change = [this](size_t n, OptionsField::value_t) { receiver_model.set_am_configuration(n);	};
-				receiver_model.set_sampling_rate(3072000);	receiver_model.set_baseband_bandwidth(1750000);
-				text_ctcss.set("             ");
-				break;
-			case NFM_MODULATION:
-				freqman_set_bandwidth_option( new_mod , field_bw );
-				//bw 16k (2) default
-				field_bw.set_selected_index(2);
-				baseband::run_image(portapack::spi_flash::image_tag_nfm_audio);
-				receiver_model.set_modulation(ReceiverModel::Mode::NarrowbandFMAudio);
-				receiver_model.set_nbfm_configuration(field_bw.selected_index());
-				field_bw.on_change = [this](size_t n, OptionsField::value_t) { 	receiver_model.set_nbfm_configuration(n); };
-				receiver_model.set_sampling_rate(3072000);	receiver_model.set_baseband_bandwidth(1750000);
-				break;
-			case WFM_MODULATION:
-				freqman_set_bandwidth_option( new_mod , field_bw );
-				//bw 200k (0) only/default
-				field_bw.set_selected_index(0);
-				baseband::run_image(portapack::spi_flash::image_tag_wfm_audio);
-				receiver_model.set_modulation(ReceiverModel::Mode::WidebandFMAudio);
-				receiver_model.set_wfm_configuration(field_bw.selected_index());
-				field_bw.on_change = [this](size_t n, OptionsField::value_t) {	receiver_model.set_wfm_configuration(n); };
-				receiver_model.set_sampling_rate(3072000);	receiver_model.set_baseband_bandwidth(1750000);
-				text_ctcss.set("             ");
-				break;
-			default:
-				break;
-		}
-		return freqman_entry_get_step_value( def_step );
-	}
+        switch( new_mod ) {
+            case AM_MODULATION:
+                freqman_set_bandwidth_option( new_mod , field_bw );
+                //bw DSB (0) default
+                field_bw.set_selected_index(0);
+                baseband::run_image(portapack::spi_flash::image_tag_am_audio);
+                receiver_model.set_modulation(ReceiverModel::Mode::AMAudio);
+                receiver_model.set_am_configuration(field_bw.selected_index());
+                field_bw.on_change = [this](size_t n, OptionsField::value_t) { receiver_model.set_am_configuration(n);	};
+                receiver_model.set_sampling_rate(3072000);	receiver_model.set_baseband_bandwidth(1750000);
+                text_ctcss.set("             ");
+                break;
+            case NFM_MODULATION:
+                freqman_set_bandwidth_option( new_mod , field_bw );
+                //bw 16k (2) default
+                field_bw.set_selected_index(2);
+                baseband::run_image(portapack::spi_flash::image_tag_nfm_audio);
+                receiver_model.set_modulation(ReceiverModel::Mode::NarrowbandFMAudio);
+                receiver_model.set_nbfm_configuration(field_bw.selected_index());
+                field_bw.on_change = [this](size_t n, OptionsField::value_t) { 	receiver_model.set_nbfm_configuration(n); };
+                receiver_model.set_sampling_rate(3072000);	receiver_model.set_baseband_bandwidth(1750000);
+                break;
+            case WFM_MODULATION:
+                freqman_set_bandwidth_option( new_mod , field_bw );
+                //bw 200k (0) only/default
+                field_bw.set_selected_index(0);
+                baseband::run_image(portapack::spi_flash::image_tag_wfm_audio);
+                receiver_model.set_modulation(ReceiverModel::Mode::WidebandFMAudio);
+                receiver_model.set_wfm_configuration(field_bw.selected_index());
+                field_bw.on_change = [this](size_t n, OptionsField::value_t) {	receiver_model.set_wfm_configuration(n); };
+                receiver_model.set_sampling_rate(3072000);	receiver_model.set_baseband_bandwidth(1750000);
+                text_ctcss.set("             ");
+                break;
+            default:
+                break;
+        }
+        return freqman_entry_get_step_value( def_step );
+    }
 
-	void ReconView::handle_coded_squelch(const uint32_t value) {
-		static int32_t last_idx = -1 ;
+    void ReconView::handle_coded_squelch(const uint32_t value) {
+        static int32_t last_idx = -1 ;
 
-		float diff, min_diff = value;
-		size_t min_idx { 0 };
-		size_t c;
+        float diff, min_diff = value;
+        size_t min_idx { 0 };
+        size_t c;
 
-		if( field_mode.selected_index() != NFM_MODULATION )
-		{
-			text_ctcss.set("             ");
-			return ;
-		}
+        if( field_mode.selected_index() != NFM_MODULATION )
+        {
+            text_ctcss.set("             ");
+            return ;
+        }
 
-		// Find nearest match
-		for (c = 0; c < tone_keys.size(); c++) {
-			diff = abs(((float)value / 100.0) - tone_keys[c].second);
-			if (diff < min_diff) {
-				min_idx = c;
-				min_diff = diff;
-			}
-		}
+        // Find nearest match
+        for (c = 0; c < tone_keys.size(); c++) {
+            diff = abs(((float)value / 100.0) - tone_keys[c].second);
+            if (diff < min_diff) {
+                min_idx = c;
+                min_diff = diff;
+            }
+        }
 
-		// Arbitrary confidence threshold
-		if( last_idx < 0 || (unsigned)last_idx != min_idx )
-		{
-			last_idx = min_idx ;
-			if (min_diff < 40)
-				text_ctcss.set("T: "+tone_keys[min_idx].first);
-			else
-				text_ctcss.set("             ");
-		}
-	}
+        // Arbitrary confidence threshold
+        if( last_idx < 0 || (unsigned)last_idx != min_idx )
+        {
+            last_idx = min_idx ;
+            if (min_diff < 40)
+                text_ctcss.set("T: "+tone_keys[min_idx].first);
+            else
+                text_ctcss.set("             ");
+        }
+    }
 } /* namespace ui */

--- a/firmware/application/apps/ui_recon.cpp
+++ b/firmware/application/apps/ui_recon.cpp
@@ -598,7 +598,8 @@ namespace ui {
         button_manual_recon.on_select = [this](Button&) {
             scanner_mode = false ;
             manual_mode = true ;
-            current_index = 0 ;
+            recon_pause();
+
             if (!frequency_range.min || !frequency_range.max) {
                 nav_.display_modal("Error", "Both START and END freqs\nneed a value");
             } else if (frequency_range.min > frequency_range.max) {
@@ -638,6 +639,10 @@ namespace ui {
                 desc_cycle.set_style( &style_white );
                 desc_cycle.set( "MANUAL RANGE RECON" );
 
+                current_index = 0 ;
+                freq = manual_freq_entry . frequency_a ;
+                handle_retune();
+                recon_redraw();
                 recon_resume();
             }
         };

--- a/firmware/application/apps/ui_recon.hpp
+++ b/firmware/application/apps/ui_recon.hpp
@@ -104,13 +104,10 @@ namespace ui {
 			void show_max( bool refresh_display = false );
 			void recon_pause();
 			void recon_resume();
-			void user_pause();
-			void user_resume();
 			void frequency_file_load( bool stop_all_before = false);
 			void on_statistics_update(const ChannelStatistics& statistics);
 			void on_headphone_volume_changed(int32_t v);
-			void set_display_freq( int64_t freq );
-			void handle_retune( int64_t freq , uint32_t index );
+			void handle_retune();
 			bool check_sd_card();
 			void handle_coded_squelch(const uint32_t value);
 

--- a/firmware/application/apps/ui_recon.hpp
+++ b/firmware/application/apps/ui_recon.hpp
@@ -107,6 +107,9 @@ namespace ui {
 			void frequency_file_load( bool stop_all_before = false);
 			void on_statistics_update(const ChannelStatistics& statistics);
 			void on_headphone_volume_changed(int32_t v);
+			void on_index_delta(int32_t v);
+			void on_stepper_delta(int32_t v);
+			void recon_redraw();
 			void handle_retune();
 			bool check_sd_card();
 			void handle_coded_squelch(const uint32_t value);
@@ -133,7 +136,7 @@ namespace ui {
 			bool fwd = { true };
             bool recon = true ;
 			uint32_t recon_lock_nb_match = { 3 };
-			uint32_t recon_lock_duration = { 50 };
+			uint32_t recon_lock_duration = { 100 };
 			uint32_t recon_match_mode = { 0 };
 			bool scanner_mode { false };
 			bool manual_mode { false };
@@ -208,8 +211,8 @@ namespace ui {
 			NumberField field_lock_wait {
 				{ 26 * 8, 1 * 16 },
 					4,
-					{ 50 , 9950 },
-					50,
+					{ 100 , 9900 },
+					100,
 					' ',
 			};
 

--- a/firmware/application/apps/ui_recon.hpp
+++ b/firmware/application/apps/ui_recon.hpp
@@ -92,6 +92,8 @@ namespace ui {
 		private:
 			NavigationView& nav_;
 
+            void audio_output_start();
+			bool check_sd_card();
 			size_t change_mode( freqman_index_t mod_type);
 			void show_max( bool refresh_display = false );
 			void recon_pause();
@@ -103,7 +105,6 @@ namespace ui {
 			void on_stepper_delta(int32_t v);
 			void recon_redraw();
 			void handle_retune();
-			bool check_sd_card();
 			void handle_coded_squelch(const uint32_t value);
 
 			jammer::jammer_range_t frequency_range { false, 0, MAX_UFREQ };  //perfect for manual recon task too...

--- a/firmware/application/apps/ui_recon.hpp
+++ b/firmware/application/apps/ui_recon.hpp
@@ -195,8 +195,8 @@ namespace ui {
 			NumberField field_wait {
 				{ 20 * 8, 1 * 16 },
 					5,
-					{ -(10000-RECON_DEF_WAIT_DURATION) , (10000-RECON_DEF_WAIT_DURATION) },
-					RECON_DEF_WAIT_DURATION,
+					{ -(10000-STATS_UPDATE_INTERVAL) , (10000-STATS_UPDATE_INTERVAL) },
+					STATS_UPDATE_INTERVAL,
 					' ',
 			};
 

--- a/firmware/application/apps/ui_recon.hpp
+++ b/firmware/application/apps/ui_recon.hpp
@@ -38,15 +38,7 @@
 #include "string_format.hpp"
 #include "file.hpp"
 #include "app_settings.hpp"
-
-// maximum usable freq
-#define MAX_UFREQ 7200000000
-
-// 1Mhz helper
-#ifdef OneMHz
-    #undef OneMHz
-#endif
-#define OneMHz 1000000
+#include "ui_recon_settings.hpp"
 
 namespace ui {
 
@@ -118,7 +110,7 @@ namespace ui {
 			int32_t squelch { 0 };
 			int32_t db { 0 };
 			int32_t timer { 0 };
-			int32_t wait { 1000 };   // in msec. if > 0 wait duration after a lock, if < 0 duration is set to 'wait' unless there is no more activity
+			int32_t wait { RECON_DEF_WAIT_DURATION };   // in msec. if > 0 wait duration after a lock, if < 0 duration is set to 'wait' unless there is no more activity
 			freqman_db frequency_list  = { };
 			int32_t current_index { 0 };
 			bool userpause { false };
@@ -136,8 +128,8 @@ namespace ui {
 			bool fwd = { true };
             bool recon = true ;
 			uint32_t recon_lock_nb_match = { 3 };
-			uint32_t recon_lock_duration = { 100 };
-			uint32_t recon_match_mode = { 0 };
+			uint32_t recon_lock_duration = { RECON_DEF_LOCK_DURATION };
+			uint32_t recon_match_mode = { RECON_MATCH_CONTINUOUS };
 			bool scanner_mode { false };
 			bool manual_mode { false };
 			bool sd_card_mounted = false ;
@@ -203,16 +195,16 @@ namespace ui {
 			NumberField field_wait {
 				{ 20 * 8, 1 * 16 },
 					5,
-					{ -9000, 9000 },
-					100,
+					{ -(10000-RECON_DEF_WAIT_DURATION) , (10000-RECON_DEF_WAIT_DURATION) },
+					RECON_DEF_WAIT_DURATION,
 					' ',
 			};
 
 			NumberField field_lock_wait {
 				{ 26 * 8, 1 * 16 },
 					4,
-					{ 100 , 9900 },
-					100,
+					{ RECON_DEF_LOCK_DURATION , (10000-RECON_DEF_LOCK_DURATION) },
+					RECON_DEF_LOCK_DURATION,
 					' ',
 			};
 

--- a/firmware/application/apps/ui_recon.hpp
+++ b/firmware/application/apps/ui_recon.hpp
@@ -119,7 +119,6 @@ namespace ui {
 			int32_t db { 0 };
 			int32_t timer { 0 };
 			int32_t wait { 1000 };   // in msec. if > 0 wait duration after a lock, if < 0 duration is set to 'wait' unless there is no more activity
-			uint32_t lock_wait { 1000 }; // in msec. Represent the maximum amount of time we will wait for a lock to complete before switching to next
 			freqman_db frequency_list  = { };
 			int32_t current_index { 0 };
 			bool userpause { false };
@@ -157,8 +156,6 @@ namespace ui {
             int64_t minfreq = 0 ;
 			int64_t maxfreq = 0 ;
 			bool has_looped = false ;
-			RetuneMessage message { };
-            uint32_t remaining_time = 0 ;
 
 			Labels labels 
 			{ 
@@ -214,8 +211,8 @@ namespace ui {
 			NumberField field_lock_wait {
 				{ 26 * 8, 1 * 16 },
 					4,
-					{ 100 , 9000 },
-					100,
+					{ 50 , 9950 },
+					50,
 					' ',
 			};
 
@@ -351,14 +348,6 @@ namespace ui {
 					[this](const Message* const p) {
 						const auto message = *reinterpret_cast<const CodedSquelchMessage*>(p);
 						this->handle_coded_squelch(message.value);
-					}
-			};
-
-			MessageHandlerRegistration message_handler_retune {
-				Message::ID::Retune,
-					[this](const Message* const p) {
-						const auto message = *reinterpret_cast<const RetuneMessage*>(p);
-						this->handle_retune(message.freq,message.range);
 					}
 			};
 

--- a/firmware/application/apps/ui_recon.hpp
+++ b/firmware/application/apps/ui_recon.hpp
@@ -210,7 +210,7 @@ namespace ui {
 			};
 
 			RSSI rssi {
-				{ 0 * 16, 2 * 16, 240 - 8 * 8 + 4 , 16 },
+				{ 0 * 16, 2 * 16, SCREEN_W - 8 * 8 + 4 , 16 },
 			}; 
 
 			ButtonWithEncoder text_cycle {
@@ -219,11 +219,11 @@ namespace ui {
 			};
 
 			Text text_max {
-				{ 4 * 8, 3 * 16, 240 - 7 * 8 - 4 * 8 , 16 },  
+				{ 4 * 8, 3 * 16, SCREEN_W - 7 * 8 - 4 * 8 , 16 },  
 			};
 
 			Text desc_cycle {
-				{0, 4 * 16, 240 , 16 },	   
+				{0, 4 * 16, SCREEN_W , 16 },	   
 			};
 
 			/* BigFrequency big_display {		//Show frequency in glamour
@@ -251,23 +251,23 @@ namespace ui {
 			};
 
 			Button button_recon_setup {
-				{ 240 - 7 * 8 , 2 * 16 , 7 * 8, 28 },
+				{ SCREEN_W - 7 * 8 , 2 * 16 , 7 * 8, 28 },
 					"CONFIG"
 			};
 
 			Button button_looking_glass {
-				{ 240 - 7 * 8 , 5 * 16 , 7 * 8, 28 },
+				{ SCREEN_W - 7 * 8 , 5 * 16 , 7 * 8, 28 },
 					"GLASS"
 			};
 
 			// Button can be RECON or SCANNER
 			Button button_scanner_mode {
-				{ 240 - 7 * 8 , 8 * 16 , 7 * 8, 28 },
+				{ SCREEN_W - 7 * 8 , 8 * 16 , 7 * 8, 28 },
 					"RECON"
 			};
 
 			Text file_name {		//Show file used
-				{ 0 , 8 * 16 + 6 , 240 - 7 * 8, 16 },
+				{ 0 , 8 * 16 + 6 , SCREEN_W - 7 * 8, 16 },
 			};
 
 			ButtonWithEncoder button_manual_start {

--- a/firmware/application/apps/ui_recon_settings.cpp
+++ b/firmware/application/apps/ui_recon_settings.cpp
@@ -34,7 +34,7 @@ using namespace portapack;
 
 namespace ui {
 
-	bool ReconSetupLoadStrings( std::string source, std::string &input_file , std::string &output_file , uint32_t &recon_lock_duration , uint32_t &recon_lock_nb_match , int32_t &recon_squelch_level , uint32_t &recon_match_mode , int32_t &wait , uint32_t &lock_wait , int32_t &volume )
+	bool ReconSetupLoadStrings( std::string source, std::string &input_file , std::string &output_file , uint32_t &recon_lock_duration , uint32_t &recon_lock_nb_match , int32_t &recon_squelch_level , uint32_t &recon_match_mode , int32_t &wait , int32_t &volume )
 	{
 		File settings_file;
 		size_t length, file_position = 0;
@@ -91,12 +91,11 @@ namespace ui {
 			/* bad number of params, signal defaults */
 			input_file  = "RECON" ;
 			output_file = "RECON_RESULTS" ;
-			recon_lock_duration = 100 ;
-			recon_lock_nb_match = 3 ;
+			recon_lock_duration = RECON_DEF_LOCK_DURATION ;
+			recon_lock_nb_match = RECON_DEF_NB_MATCH ;
 			recon_squelch_level = -14 ;
-			recon_match_mode = 0 ;
-			wait = 1000 ;
-			lock_wait = 1000 ;
+			recon_match_mode = RECON_MATCH_CONTINUOUS ;
+			wait = RECON_DEF_WAIT_DURATION ;
 			volume = 40 ;
 			return false ;
 		}
@@ -114,12 +113,12 @@ namespace ui {
 		if( it > 2 )
 			recon_lock_duration = strtoll( params[ 2 ].c_str() , nullptr , 10 );
 		else
-			recon_lock_duration = 100 ;
+			recon_lock_duration = RECON_DEF_LOCK_DURATION ;
 
 		if( it > 3 )
 			recon_lock_nb_match = strtoll( params[ 3 ].c_str() , nullptr , 10 );
 		else
-			recon_lock_nb_match = 3 ;
+			recon_lock_nb_match = RECON_DEF_NB_MATCH ;
 
 		if( it > 4 )
 			recon_squelch_level = strtoll( params[ 4 ].c_str() , nullptr , 10 );
@@ -129,17 +128,12 @@ namespace ui {
 		if( it > 5 )
 			recon_match_mode    = strtoll( params[ 5 ].c_str() , nullptr , 10 );
 		else
-			recon_match_mode = 0 ;
+			recon_match_mode = RECON_MATCH_CONTINUOUS ;
 
 		if( it > 6 )
 			wait = strtoll( params[ 6 ].c_str() , nullptr , 10 );
 		else
-			wait = 1000 ;
-
-		if( it > 7 )
-			lock_wait = strtoll( params[ 7 ].c_str() , nullptr , 10 );
-		else
-			lock_wait = 1000 ;
+			wait = RECON_DEF_WAIT_DURATION ;
 
 		if( it > 8 )
 			volume = strtoll( params[ 8 ].c_str() , nullptr , 10 );
@@ -149,7 +143,7 @@ namespace ui {
 		return true ;
 	}
 
-	bool ReconSetupSaveStrings( std::string dest, std::string input_file , std::string output_file , uint32_t recon_lock_duration , uint32_t recon_lock_nb_match , int32_t recon_squelch_level , uint32_t recon_match_mode , int32_t wait , uint32_t lock_wait , int32_t volume )
+	bool ReconSetupSaveStrings( std::string dest, std::string input_file , std::string output_file , uint32_t recon_lock_duration , uint32_t recon_lock_nb_match , int32_t recon_squelch_level , uint32_t recon_match_mode , int32_t wait , int32_t volume )
 	{
 		File settings_file;
 
@@ -163,7 +157,6 @@ namespace ui {
 		settings_file.write_line( to_string_dec_int( recon_squelch_level ) );
 		settings_file.write_line( to_string_dec_uint( recon_match_mode ) );
 		settings_file.write_line( to_string_dec_int( wait ) );
-		settings_file.write_line( to_string_dec_uint( lock_wait ) );
 		settings_file.write_line( to_string_dec_int( volume ) );
 		return true ;
 	}

--- a/firmware/application/apps/ui_recon_settings.cpp
+++ b/firmware/application/apps/ui_recon_settings.cpp
@@ -91,7 +91,7 @@ namespace ui {
 			/* bad number of params, signal defaults */
 			input_file  = "RECON" ;
 			output_file = "RECON_RESULTS" ;
-			recon_lock_duration = 50 ;
+			recon_lock_duration = 100 ;
 			recon_lock_nb_match = 3 ;
 			recon_squelch_level = -14 ;
 			recon_match_mode = 0 ;
@@ -114,7 +114,7 @@ namespace ui {
 		if( it > 2 )
 			recon_lock_duration = strtoll( params[ 2 ].c_str() , nullptr , 10 );
 		else
-			recon_lock_duration = 50 ;
+			recon_lock_duration = 100 ;
 
 		if( it > 3 )
 			recon_lock_nb_match = strtoll( params[ 3 ].c_str() , nullptr , 10 );

--- a/firmware/application/apps/ui_recon_settings.hpp
+++ b/firmware/application/apps/ui_recon_settings.hpp
@@ -53,7 +53,7 @@
 
 // screen size helper
 #define SCREEN_W 240
-#define SCREEN_H 320
+//#define SCREEN_H 320
 
 namespace ui {
 

--- a/firmware/application/apps/ui_recon_settings.hpp
+++ b/firmware/application/apps/ui_recon_settings.hpp
@@ -128,8 +128,8 @@ namespace ui {
 			NumberField field_recon_lock_duration {
 				{ 1 * 8, 132 },             // position X , Y
 					4,                      // number of displayed digits (even empty)
-					{ 50 , 990 },           // range of number
-					10,                     // rotary encoder increment
+					{ 50 , 9950 },           // range of number
+					50,                     // rotary encoder increment
 					' ',                    // filling character 
 					false                   // can loop
 			};

--- a/firmware/application/apps/ui_recon_settings.hpp
+++ b/firmware/application/apps/ui_recon_settings.hpp
@@ -20,6 +20,9 @@
  * Boston, MA 02110-1301, USA.
  */
 
+#ifndef _UI_RECON_SETTINGS
+#define _UI_RECON_SETTINGS
+
 #include "serializer.hpp"
 #include "ui.hpp"
 #include "ui_widget.hpp"
@@ -27,10 +30,35 @@
 #include "ui_navigation.hpp"
 #include "string_format.hpp"
 
+// maximum usable freq
+#define MAX_UFREQ 7200000000
+
+// 1Mhz helper
+#ifdef OneMHz
+    #undef OneMHz
+#endif
+#define OneMHz 1000000
+
+// modes
+#define RECON_MATCH_CONTINUOUS 0
+#define RECON_MATCH_SPARSE 1
+
+// statistics update interval (change here if it's evolving) in ms
+#define STATS_UPDATE_INTERVAL 100
+
+// default number of match to have a lock
+#define RECON_DEF_NB_MATCH 3
+#define RECON_DEF_LOCK_DURATION 100  // have to be >= and a multiple of STATS_UPDATE_INTERVAL
+#define RECON_DEF_WAIT_DURATION 1000 // will be incremented/decremented by STATS_UPDATE_INTERVAL steps
+
+// screen size helper
+#define SCREEN_W 240
+#define SCREEN_H 320
+
 namespace ui {
 
-	bool ReconSetupLoadStrings( std::string source, std::string &input_file , std::string &output_file , uint32_t &recon_lock_duration , uint32_t &recon_lock_nb_match , int32_t &recon_squelch_level , uint32_t &recon_match_mode , int32_t &wait , uint32_t &lock_wait , int32_t &volume );
-	bool ReconSetupSaveStrings( std::string dest, const std::string input_file , const std::string output_file , const uint32_t recon_lock_duration , const uint32_t recon_lock_nb_match , int32_t recon_squelch_level , uint32_t recon_match_mode , int32_t wait , uint32_t lock_wait , int32_t volume );
+	bool ReconSetupLoadStrings( std::string source, std::string &input_file , std::string &output_file , uint32_t &recon_lock_duration , uint32_t &recon_lock_nb_match , int32_t &recon_squelch_level , uint32_t &recon_match_mode , int32_t &wait , int32_t &volume );
+	bool ReconSetupSaveStrings( std::string dest, const std::string input_file , const std::string output_file , const uint32_t recon_lock_duration , const uint32_t recon_lock_nb_match , int32_t recon_squelch_level , uint32_t recon_match_mode , int32_t wait , int32_t volume );
 
 	class ReconSetupViewMain : public View {
 		public:
@@ -94,8 +122,8 @@ namespace ui {
 
 		private:
 
-			const uint32_t _recon_lock_duration = 100 ;
-			const uint32_t _recon_lock_nb_match = 10 ;
+			const uint32_t _recon_lock_duration = STATS_UPDATE_INTERVAL ;
+			const uint32_t _recon_lock_nb_match = RECON_DEF_NB_MATCH ;
 			const uint32_t _recon_match_mode = 0 ;
 
 			Checkbox checkbox_load_freqs {
@@ -128,8 +156,8 @@ namespace ui {
 			NumberField field_recon_lock_duration {
 				{ 1 * 8, 132 },             // position X , Y
 					4,                      // number of displayed digits (even empty)
-					{ 100 , 9900 },           // range of number
-					100,                     // rotary encoder increment
+					{ STATS_UPDATE_INTERVAL , 10000-STATS_UPDATE_INTERVAL },           // range of number
+					STATS_UPDATE_INTERVAL,                     // rotary encoder increment
 					' ',                    // filling character 
 					false                   // can loop
 			};
@@ -172,11 +200,11 @@ namespace ui {
 
 			std::string input_file  = { "RECON" };
 			std::string output_file = { "RECON_RESULTS" };
-			uint32_t recon_lock_duration = 100 ;
-			uint32_t recon_lock_nb_match = 10 ;
-			uint32_t recon_match_mode = 0 ;
+			uint32_t recon_lock_duration = STATS_UPDATE_INTERVAL ;
+			uint32_t recon_lock_nb_match = RECON_DEF_NB_MATCH ;
+			uint32_t recon_match_mode = RECON_MATCH_CONTINUOUS ;
 
-			Rect view_rect = { 0, 3 * 8, 240, 230 };
+			Rect view_rect = { 0, 3 * 8, SCREEN_W, 230 };
 
 			ReconSetupViewMain viewMain{ nav_ , view_rect , input_file , output_file };
 			ReconSetupViewMore viewMore{ nav_ , view_rect , recon_lock_duration , recon_lock_nb_match , recon_match_mode };
@@ -192,3 +220,5 @@ namespace ui {
 	};
 
 } /* namespace ui */
+
+#endif

--- a/firmware/application/apps/ui_recon_settings.hpp
+++ b/firmware/application/apps/ui_recon_settings.hpp
@@ -94,7 +94,7 @@ namespace ui {
 
 		private:
 
-			const uint32_t _recon_lock_duration = 50 ;
+			const uint32_t _recon_lock_duration = 100 ;
 			const uint32_t _recon_lock_nb_match = 10 ;
 			const uint32_t _recon_match_mode = 0 ;
 
@@ -128,8 +128,8 @@ namespace ui {
 			NumberField field_recon_lock_duration {
 				{ 1 * 8, 132 },             // position X , Y
 					4,                      // number of displayed digits (even empty)
-					{ 50 , 9950 },           // range of number
-					50,                     // rotary encoder increment
+					{ 100 , 9900 },           // range of number
+					100,                     // rotary encoder increment
 					' ',                    // filling character 
 					false                   // can loop
 			};
@@ -172,7 +172,7 @@ namespace ui {
 
 			std::string input_file  = { "RECON" };
 			std::string output_file = { "RECON_RESULTS" };
-			uint32_t recon_lock_duration = 50 ;
+			uint32_t recon_lock_duration = 100 ;
 			uint32_t recon_lock_nb_match = 10 ;
 			uint32_t recon_match_mode = 0 ;
 


### PR DESCRIPTION
Long story, why I made a full revamp: 
-The Scanner app and the Recon app are using the statistics messages from the receiver API to get the level of db of the actual signal.
-These stats are updated not each 50 ms as I was thinking first, but each 100ms (hence the low limit to cap is 100ms).
-The Scanner app, as well as the actual Recon code in next since it's still WIP, are using a method with a thread cadenced to 50ms, and which switch frequencies each 50ms. But voilà, the statistic are only updated each 100ms. So you may loose signal. I tried some synchronisation but ended up having... around 100ms waits.

So I tried a new approach, only based on the statistic updates and the API/GUI events (on_change/on_message/etc)

This allowed me to remove all thread and sleep things, all app generated messages (only receive the stats)
I largely agree this is still WIP and may need adjustements.

Basically I traded fast approximated results to close to each packet of data slower resuls.

I also took the occasion to rewrite and factorize parts of the code, and adding a few comments.

Tested and working better than the one in latest stable (overall notation).
