### PR TITLE
Freqman 40k fix

### DIFF
--- a/firmware/application/apps/analog_audio_app.hpp
+++ b/firmware/application/apps/analog_audio_app.hpp
@@ -100,7 +100,7 @@ private:
 	};
 	OptionsField options_config {
 		{ 3 * 8, 0 * 16 },
-		3,
+		4,
 		{		// using  common messages from freqman.cpp
 		}
 	};

--- a/firmware/application/freqman.cpp
+++ b/firmware/application/freqman.cpp
@@ -48,7 +48,7 @@ options_t freqman_entry_bandwidths[ 4 ] = {
     { //WFM
         { "200k" , 0 },
         { "180k" , 1 },
-        { " 40k" , 2 },
+        { "40k"  , 2 },
     }
 };
 


### PR DESCRIPTION
In addition to @NotherNgineer fix for freqman, this is a fix which correct the behavior of the '40k' bandwidth bloc.

The space added at creation and the thing was discussed with @Brumi-2021 . 

This will allow usage of 'bw=40k,' instead of 'bw= 40k,' in freqman files.