### PR TITLE
fixed crash when BtnGridView has more than one page

### DIFF
--- a/firmware/application/ui/ui_btngrid.cpp
+++ b/firmware/application/ui/ui_btngrid.cpp
@@ -136,14 +136,20 @@ void BtnGridView::update_items() {
 		more = false;
 
 	for (NewButton* item : menu_item_views) {
-		if (i >= menu_items.size()) break;
-
-		// Assign item data to NewButtons according to offset
-		item->set_text(menu_items[i + offset].text);
-		item->set_bitmap(menu_items[i + offset].bitmap);
-		item->set_color(menu_items[i + offset].color);
-		item->on_select = menu_items[i + offset].on_select;
-		item->set_dirty();
+		if ((i + offset) >= menu_items.size()) {
+			item->set_text(" ");
+			item->set_bitmap(nullptr);
+			item->on_select = [](){};
+			item->set_dirty();
+		}
+		else {
+			// Assign item data to NewButtons according to offset
+			item->set_text(menu_items[i + offset].text);
+			item->set_bitmap(menu_items[i + offset].bitmap);
+			item->set_color(menu_items[i + offset].color);
+			item->on_select = menu_items[i + offset].on_select;
+			item->set_dirty();
+		}
 
 		i++;
 	}
@@ -175,9 +181,10 @@ bool BtnGridView::set_highlighted(int32_t new_value) {
 	} else {
 		// Just update highlight
 		highlighted_item = new_value;
-		if (visible())
-		  item_view(highlighted_item - offset)->focus();
 	}
+
+	if (visible())
+		item_view(highlighted_item - offset)->focus();
 
 	return true;
 }

--- a/firmware/application/ui/ui_btngrid.cpp
+++ b/firmware/application/ui/ui_btngrid.cpp
@@ -137,6 +137,7 @@ void BtnGridView::update_items() {
 
 	for (NewButton* item : menu_item_views) {
 		if ((i + offset) >= menu_items.size()) {
+			item->hidden(true);
 			item->set_text(" ");
 			item->set_bitmap(nullptr);
 			item->on_select = [](){};
@@ -144,6 +145,7 @@ void BtnGridView::update_items() {
 		}
 		else {
 			// Assign item data to NewButtons according to offset
+			item->hidden(false);
 			item->set_text(menu_items[i + offset].text);
 			item->set_bitmap(menu_items[i + offset].bitmap);
 			item->set_color(menu_items[i + offset].color);
@@ -173,11 +175,13 @@ bool BtnGridView::set_highlighted(int32_t new_value) {
 		highlighted_item = new_value;
 		offset = new_value - displayed_max + rows_;
 		update_items();
+		set_dirty();
 	} else if ((uint32_t)new_value < offset) {
 		// Shift BtnGridView down
 		highlighted_item = new_value;
 		offset = (new_value / rows_) * rows_;
 		update_items();
+		set_dirty();
 	} else {
 		// Just update highlight
 		highlighted_item = new_value;


### PR DESCRIPTION
The BtnGridView now properly scrolls without crash

![SCR_0006](https://github.com/eried/portapack-mayhem/assets/13151053/719a894e-4a2d-41be-bafc-5ee49b460e97)
