### PR TITLE
Support frequency files that don't have a C/R at the end of the last line

### DIFF
--- a/firmware/application/freqman.cpp
+++ b/firmware/application/freqman.cpp
@@ -48,7 +48,7 @@ options_t freqman_entry_bandwidths[ 4 ] = {
     { //WFM
         { "200k" , 0 },
         { "180k" , 1 },
-        { "40k"  , 2 },
+        { " 40k" , 2 },
     }
 };
 
@@ -145,6 +145,10 @@ bool load_freqman_file_ex(std::string& file_stem, freqman_db& db, bool load_freq
 
         // Reset line_start to beginning of buffer
         line_start = file_data;
+
+        // If EOF reached, insert 0x0A after, in case the last line doesn't have a C/R
+        if (read_size.value() < 256)
+            *(line_start + read_size.value()) = 0x0A;
 
         // Look for complete lines in buffer
         while ((line_end = strstr(line_start, "\x0A"))) {

--- a/firmware/application/freqman.cpp
+++ b/firmware/application/freqman.cpp
@@ -48,7 +48,7 @@ options_t freqman_entry_bandwidths[ 4 ] = {
     { //WFM
         { "200k" , 0 },
         { "180k" , 1 },
-        { " 40k" , 2 },
+        { "40k"  , 2 },
     }
 };
 


### PR DESCRIPTION
I noticed that the existing load_freqman_file_ex() routine wasn't processing the last line in the file in the case where the last line didn't have a 0x0A character at the end.  (The "while" check on line 150 was failing if it didn't find the 0x0A)

This simple fix pokes a 0x0A character into the read buffer when the EOF is reached, thereby allowing the last line in the file be processed correctly.

No big deal, but it was confusing that a line in the frequency file looked correct yet wasn't being processed.