### PR TITLE
Minor change to the Mic App UI ,  (adding colour warning indication, based on RF settings GAIN , AMP) 

### DIFF
--- a/firmware/application/apps/ui_mictx.cpp
+++ b/firmware/application/apps/ui_mictx.cpp
@@ -90,9 +90,7 @@ void MicTXView::set_tx(bool enable) {
 			rxaudio(false); //Then turn off audio RX
 		transmitting = true;
 		configure_baseband();
-		transmitter_model.set_tuning_frequency(tx_frequency);
-		transmitter_model.set_tx_gain(tx_gain);
-		transmitter_model.set_rf_amp(rf_amp);
+		transmitter_model.set_tuning_frequency(tx_frequency);		// Now,no need: transmitter_model.set_tx_gain(tx_gain), nor (rf_amp);
 		transmitter_model.enable();
 		portapack::pin_i2s0_rx_sda.mode(3);		// This is already done in audio::init but gets changed by the CPLD overlay reprogramming
 	} else {
@@ -234,8 +232,7 @@ MicTXView::MicTXView(
 		&field_va_attack,
 		&field_va_decay,
 		&field_bw,
-		&field_rfgain,
-		&field_rfamp,
+		&tx_view,					// it already integrates previous rfgain, rfamp.
 		&options_mode,
 		&field_frequency,
 		&options_tone_key,
@@ -264,8 +261,7 @@ MicTXView::MicTXView(
 		&field_va_attack,
 		&field_va_decay,
 		&field_bw,
-		&field_rfgain,
-		&field_rfamp,
+		&tx_view,					// it already integrates previous rfgain, rfamp.
 		&options_mode,
 		&field_frequency,
 		&options_tone_key,
@@ -366,20 +362,8 @@ MicTXView::MicTXView(
 	};
 	field_bw.set_value(10);	// pre-default first time, TX  deviation FM for NFM / FM
 	
-	
-	tx_gain = transmitter_model.tx_gain();
-	field_rfgain.on_change = [this](int32_t v) {
-		tx_gain = v;
-		
-	};
-	field_rfgain.set_value(tx_gain);
+	// now , no need direct update , field_rfgain , field_rfamp (it is done in ui_transmitter.cpp)
 
-	rf_amp = transmitter_model.rf_amp();
-	field_rfamp.on_change = [this](int32_t v) {
-		rf_amp = (bool)v;
-	};
-	field_rfamp.set_value(rf_amp ? 14 : 0);
-	
 	options_mode.on_change = [this](size_t, int32_t v) {   //{ "NFM/FM", 0 }, { " WFM  ", 1 },{ "AM", 2 },{ "USB", 3 },{ "LSB", 4 },{ "DSB", 5 }
 		enable_am  = false;
 		enable_usb = false;

--- a/firmware/application/apps/ui_mictx.hpp
+++ b/firmware/application/apps/ui_mictx.hpp
@@ -31,6 +31,7 @@
 #include "tone_key.hpp"
 #include "message.hpp"
 #include "receiver_model.hpp"
+#include "ui_transmitter.hpp"
 
 namespace ui {
 
@@ -115,11 +116,9 @@ private:
 		{ { 17 * 8, 1 * 8 }, "Boost", Color::light_grey() },
 		{ { 3 * 8, 3 * 8 }, "F:", Color::light_grey() },
 		{ { 15 * 8, 3 * 8 }, "FM TXBW:    kHz", Color::light_grey() },		// to be more symetric and consistent to the below FM RXBW
-		{ { 3 * 8, 5 * 8 }, "GAIN:", Color::light_grey() },
-		{ {11 * 8, 5 * 8 }, "Amp:", Color::light_grey() },
-		{ { 18 * 8, (5 * 8) }, "Mode:", Color::light_grey() },
-		{ { 3 * 8, 8 * 8 }, "TX Activation:", Color::light_grey() },
-		{ { 4 * 8, 10 * 8 }, "LVL:", Color::light_grey() },
+		{ { 18 * 8, (5 * 8) }, "Mode:", Color::light_grey() },				// now , no need to handle GAIN , Amp here It is handled by ui_transmitter.cpp
+		{ { 3 * 8, 8 * 8 }, "TX Activation:", Color::light_grey() },		// we delete  { { 3 * 8, 5 * 8 }, "GAIN:", Color::light_grey() },
+		{ { 4 * 8, 10 * 8 }, "LVL:", Color::light_grey() },					// we delete  { {11 * 8, 5 * 8 }, "Amp:", Color::light_grey() },
 		{ {12 * 8, 10 * 8 }, "ATT:", Color::light_grey() },
 		{ {20 * 8, 10 * 8 }, "DEC:", Color::light_grey() },
 		{ { 4 * 8, ( 13 * 8 ) - 2 }, "TONE KEY:", Color::light_grey() },
@@ -136,11 +135,9 @@ private:
 		{ { 17 * 8, 1 * 8 }, "ALC", Color::light_grey() },
 		{ { 3 * 8, 3 * 8 }, "F:", Color::light_grey() },
 		{ { 15 * 8, 3 * 8 }, "FM TXBW:    kHz", Color::light_grey() },
-		{ { 3 * 8, 5 * 8 }, "GAIN:", Color::light_grey() },
-		{ {11 * 8, 5 * 8 }, "Amp:", Color::light_grey() },
-		{ { 18 * 8, (5 * 8) }, "Mode:", Color::light_grey() },
-		{ { 3 * 8, 8 * 8 }, "TX Activation:", Color::light_grey() },
-		{ { 4 * 8, 10 * 8 }, "LVL:", Color::light_grey() },
+		{ { 18 * 8, (5 * 8) }, "Mode:", Color::light_grey() },				// now , no need to handle GAIN , Amp here It is handled by ui_transmitter.cpp
+		{ { 3 * 8, 8 * 8 }, "TX Activation:", Color::light_grey() },		// we delete  { { 3 * 8, 5 * 8 }, "GAIN:", Color::light_grey() },
+		{ { 4 * 8, 10 * 8 }, "LVL:", Color::light_grey() },					// we delete  { {11 * 8, 5 * 8 }, "Amp:", Color::light_grey() },
 		{ {12 * 8, 10 * 8 }, "ATT:", Color::light_grey() },
 		{ {20 * 8, 10 * 8 }, "DEC:", Color::light_grey() },
 		{ { 4 * 8, ( 13 * 8 ) - 2 }, "TONE KEY:", Color::light_grey() },
@@ -212,22 +209,11 @@ OptionsField options_wm8731_boost_mode {
 		1,
 		' '
 	};
-	
-	NumberField field_rfgain {
-		{ 8 * 8, 5 * 8 },
-		2,
-		{ 0, 47 },
-		1,
-		' '
+
+	TransmitterView2 tx_view {					// new handling of NumberField field_rfgain, NumberField field_rfamp
+		2 * 8		// y line position.
 	};
-	NumberField field_rfamp {
-		{ 15 * 8, 5 * 8 },
-		2,
-		{ 0, 14 },
-		14,
-		' '
-	};
-	
+		
 	OptionsField options_mode {
 		{ 24 * 8, 5 * 8 },
 		4,

--- a/firmware/application/ui/ui_transmitter.cpp
+++ b/firmware/application/ui/ui_transmitter.cpp
@@ -192,8 +192,8 @@ TransmitterView::~TransmitterView() {
 /* TransmitterView2 *******************************************************/
 
 void TransmitterView2::paint(Painter& painter) {
-	size_t c;
-	Point pos = { 3*8, screen_pos().y() };
+//	Not using TransmitterView2, but if we delete it,we got , top line 1 a blanking rect.
+	(void) painter;	// Avoid  warning: unused parameter .
 }
 
 void TransmitterView2::on_tx_gain_changed(int32_t tx_gain) {

--- a/firmware/application/ui/ui_transmitter.cpp
+++ b/firmware/application/ui/ui_transmitter.cpp
@@ -189,4 +189,72 @@ TransmitterView::~TransmitterView() {
 	baseband::shutdown();
 }
 
+/* TransmitterView2 *******************************************************/
+
+void TransmitterView2::paint(Painter& painter) {
+	size_t c;
+	Point pos = { 3*8, screen_pos().y() };
+}
+
+void TransmitterView2::on_tx_gain_changed(int32_t tx_gain) {
+	transmitter_model.set_tx_gain(tx_gain);
+	update_gainlevel_styles();
+}
+
+void TransmitterView2::on_tx_amp_changed(bool rf_amp) {
+	transmitter_model.set_rf_amp(rf_amp);
+	update_gainlevel_styles();
+}
+
+void TransmitterView2::update_gainlevel_styles() {
+	const Style *new_style_ptr = NULL;
+	int8_t tot_gain = transmitter_model.tx_gain() + (transmitter_model.rf_amp() ? 14 : 0);
+	
+	if(tot_gain > POWER_THRESHOLD_HIGH) {
+		new_style_ptr = &style_power_high;
+	} else if(tot_gain > POWER_THRESHOLD_MED) {
+		new_style_ptr = &style_power_med;
+	} else if(tot_gain > POWER_THRESHOLD_LOW) {
+		new_style_ptr = &style_power_low;
+	}
+
+	field_gain.set_style(new_style_ptr);
+	text_gain.set_style(new_style_ptr);
+	field_amp.set_style(new_style_ptr);
+	text_amp.set_style(new_style_ptr);
+}
+
+void TransmitterView2::on_show() {
+	field_gain.set_value(transmitter_model.tx_gain());
+	field_amp.set_value(transmitter_model.rf_amp() ? 14 : 0);
+
+	update_gainlevel_styles();
+}
+
+TransmitterView2::TransmitterView2(	const Coord y)
+{
+	set_parent_rect({ 3*8, y, 20 * 8, 1 * 8 });		// set_parent_rect({ 0, y, 30 * 8, 6 * 8 });
+	
+	add_children({
+		&text_gain,
+		&field_gain,
+		&text_amp,
+		&field_amp,
+	});
+	
+	field_gain.on_change = [this](uint32_t tx_gain) {
+		on_tx_gain_changed(tx_gain);
+	};
+	
+	field_amp.on_change = [this](uint32_t rf_amp) {
+		on_tx_amp_changed((bool) rf_amp);
+	};
+}
+
+TransmitterView2::~TransmitterView2() {
+	audio::output::stop();
+	transmitter_model.disable();
+	baseband::shutdown();
+}
+
 } /* namespace ui */

--- a/firmware/application/ui/ui_transmitter.hpp
+++ b/firmware/application/ui/ui_transmitter.hpp
@@ -165,6 +165,69 @@ private:
 	void update_gainlevel_styles(void);
 };
 
+
+class TransmitterView2 : public View {
+public:
+	
+	TransmitterView2(const Coord y);
+
+	~TransmitterView2();
+	
+	void on_show() override;
+	void paint(Painter& painter) override;
+	
+private:
+	const Style style_power_low {
+		.font = font::fixed_8x16,
+		.background = Color::black(),
+		.foreground = Color::yellow(),
+	};
+	const Style style_power_med {
+		.font = font::fixed_8x16,
+		.background = Color::black(),
+		.foreground = Color::orange(),
+	};
+	const Style style_power_high {
+		.font = font::fixed_8x16,
+		.background = Color::black(),
+		.foreground = Color::red(),
+	};
+
+	Text text_gain {
+		{ 0, 3 * 8, 5 * 8, 1 * 16 },
+		"Gain:"
+	};
+	
+	NumberField field_gain {
+		{ 5 * 8, 3 * 8 },
+		2,
+		{ max2837::tx::gain_db_range.minimum, max2837::tx::gain_db_range.maximum },
+		max2837::tx::gain_db_step,
+		' '
+	};
+
+	Text text_amp {
+		{ 8 * 8, 3 * 8, 5 * 8, 1 * 16 },
+		"Amp:"
+	};
+
+	NumberField field_amp {
+		{ 12 * 8, 3 * 8 },
+		2,
+		{ 0, 14 },
+		14,
+		' '
+	};
+
+
+	void on_tx_gain_changed(int32_t tx_gain);
+	void on_tx_amp_changed(bool rf_amp);
+
+	void update_gainlevel_styles(void);
+};
+
+
+
 } /* namespace ui */
 
 #endif/*__UI_TRANSMITTER_H__*/


### PR DESCRIPTION
Following the same concept and code about existing   Colour -UI warning about the RF power settings (Gain , Amp) of the majority of the Transmitter Applications, 
![image](https://github.com/eried/portapack-mayhem/assets/86470699/f68af34c-5ea5-401c-bc48-a819ab1474a2)

let me re-use the same idea to the Mic App
I already validated in H1R2 and H2R4 , without any problems. 

![image](https://github.com/eried/portapack-mayhem/assets/86470699/b125cc4b-e13e-430b-b011-795dd261c619)


I tried to expand and re-use also the same concept to the others ,
Replay App, GPS Simul App  , Playlist App but I got some reset failing about the  Amp settings in every re-start of the  "loop" ,  then , it  will need further detailed checking , it is not straight forward.

Cheers, 



