### PR TITLE
Extending Power Colour Warning  in 3 Tx App's (Replay / GPS Simul / Playlist App's) 

### DIFF
--- a/firmware/application/apps/gps_sim_app.cpp
+++ b/firmware/application/apps/gps_sim_app.cpp
@@ -141,18 +141,9 @@ void GpsSimAppView::start() {
 			}
 		);
 	}
-	field_rfgain.on_change = [this](int32_t v) {
-		tx_gain = v;
-	};  
-	field_rfgain.set_value(tx_gain);
-	receiver_model.set_tx_gain(tx_gain); 
-    
 
- 	field_rfamp.on_change = [this](int32_t v) {
-		rf_amp = (bool)v;
-	};
-	field_rfamp.set_value(rf_amp ? 14 : 0);
-	
+	rf_amp =(transmitter_model.rf_amp() );	// recover rf_amp settings applied from ui_transmiter.cpp
+
 	radio::enable({
 		receiver_model.tuning_frequency(),
 		sample_rate ,
@@ -193,21 +184,16 @@ GpsSimAppView::GpsSimAppView(
 	NavigationView& nav
 ) : nav_ (nav)
 {
-	tx_gain = 35;field_rfgain.set_value(tx_gain);  // Initial default  value (-12 dB's max 47dBs ).
-	field_rfamp.set_value(rf_amp ? 14 : 0);  // Initial default value True. (TX RF amp on , +14dB's)
-	
 	baseband::run_image(portapack::spi_flash::image_tag_gps);
 
 	add_children({
-		&labels,
 		&button_open,
 		&text_filename,
 		&text_sample_rate,
 		&text_duration,
 		&progressbar,
 		&field_frequency,
-		&field_rfgain,
-		&field_rfamp,       // let's not use common persistent rf_amp , local rfamp is enough
+		&tx_view,			// now it handles previous rfgain , rfamp.
 		&check_loop,
 		&button_play,
 		&waterfall,

--- a/firmware/application/apps/gps_sim_app.hpp
+++ b/firmware/application/apps/gps_sim_app.hpp
@@ -24,6 +24,9 @@
 #ifndef __GPS_SIM_APP_HPP__
 #define __GPS_SIM_APP_HPP__
 
+#define SHORT_UI	true
+#define NORMAL_UI	false
+
 #include "ui_widget.hpp"
 #include "ui_navigation.hpp"
 #include "ui_receiver.hpp"
@@ -32,6 +35,7 @@
 
 #include <string>
 #include <memory>
+#include "ui_transmitter.hpp"
 
 namespace ui {
 
@@ -77,10 +81,6 @@ private:
 	std::unique_ptr<ReplayThread> replay_thread { };
 	bool ready_signal { false };
 
-	Labels labels {
-		{ { 10 * 8, 2 * 16 }, "GAIN   A:", Color::light_grey() }
-	};
-	
 	Button button_open {
 		{ 0 * 8, 0 * 16, 10 * 8, 2 * 16 },
 		"Open file"
@@ -106,20 +106,12 @@ private:
 	FrequencyField field_frequency {
 		{ 0 * 8, 2 * 16 },
 	};
-	NumberField field_rfgain {
-		{ 14 * 8, 2 * 16 },
-		2,
-		{ 0, 47 },
-		1,
-		' '	
+
+	TransmitterView2 tx_view {				// new handling of NumberField field_rfgain, NumberField field_rfamp
+		74, 1*8, SHORT_UI					// x(columns), y (line) position. (Used in Replay / GPS Simul / Playlist App)
+//		10*8, 2*8, NORMAL_UI				// x(columns), y (line) position. (Used in Mic App)
 	};
-	NumberField field_rfamp {     // previously we were using "RFAmpField field_rf_amp" but that is general Receiver amp setting.
-		{ 19 * 8, 2 * 16 },
-		2,
-		{ 0, 14 },                // this time we will display GUI , 0 or 14 dBs same as Mic and Replay App
-		14,
-		' '
-	};
+
 	Checkbox check_loop {
 		{ 21 * 8, 2 * 16 },
 		4,

--- a/firmware/application/apps/replay_app.cpp
+++ b/firmware/application/apps/replay_app.cpp
@@ -141,21 +141,12 @@ void ReplayAppView::start() {
 			}
 		);
 	}
-    field_rfgain.on_change = [this](int32_t v) {
-		tx_gain = v;
-	};  
-	field_rfgain.set_value(tx_gain);
-	receiver_model.set_tx_gain(tx_gain); 
-    
-
- 	field_rfamp.on_change = [this](int32_t v) {
-		rf_amp = (bool)v;
-	};
-	field_rfamp.set_value(rf_amp ? 14 : 0);
-
+   
 	//Enable Bias Tee if selected
 	radio::set_antenna_bias(portapack::get_antenna_bias());
-		
+
+	rf_amp =(transmitter_model.rf_amp() );	// recover rf_amp settings applied from ui_transmiter.cpp
+
 	radio::enable({
 		receiver_model.tuning_frequency(),
 		sample_rate * 8,
@@ -203,32 +194,16 @@ ReplayAppView::ReplayAppView(
 	NavigationView& nav
 ) : nav_ (nav)
 {
-
-	tx_gain = 35;field_rfgain.set_value(tx_gain);  // Initial default  value (-12 dB's max ).
-	field_rfamp.set_value(rf_amp ? 14 : 0);  // Initial default value True. (TX RF amp on , +14dB's)
-
-	field_rfamp.on_change = [this](int32_t v) {	// allow initial value change just after opened file.	
-		rf_amp = (bool)v;
-	};
-	field_rfamp.set_value(rf_amp ? 14 : 0);
-
-    field_rfgain.on_change = [this](int32_t v) { // allow initial value change just after opened file.
-		tx_gain = v;
-	};  
-	field_rfgain.set_value(tx_gain);
-
 	baseband::run_image(portapack::spi_flash::image_tag_replay);
 
 	add_children({
-		&labels,
 		&button_open,
 		&text_filename,
 		&text_sample_rate,
 		&text_duration,
 		&progressbar,
 		&field_frequency,
-		&field_rfgain, 
-		&field_rfamp,       // let's not use common rf_amp
+		&tx_view,			// now it handles previous rfgain , rfamp.
 		&check_loop,
 		&button_play,
 		&waterfall,

--- a/firmware/application/apps/replay_app.hpp
+++ b/firmware/application/apps/replay_app.hpp
@@ -23,6 +23,9 @@
 #ifndef __REPLAY_APP_HPP__
 #define __REPLAY_APP_HPP__
 
+#define SHORT_UI	true
+#define NORMAL_UI	false
+
 #include "ui_widget.hpp"
 #include "ui_navigation.hpp"
 #include "ui_receiver.hpp"
@@ -31,6 +34,7 @@
 
 #include <string>
 #include <memory>
+#include "ui_transmitter.hpp"
 
 namespace ui {
 
@@ -76,10 +80,6 @@ private:
 	std::unique_ptr<ReplayThread> replay_thread { };
 	bool ready_signal { false };
 
-	Labels labels {
-		{ { 10 * 8, 2 * 16 }, "GAIN   A:", Color::light_grey() }
-	};
-	
 	Button button_open {
 		{ 0 * 8, 0 * 16, 10 * 8, 2 * 16 },
 		"Open file"
@@ -105,21 +105,12 @@ private:
 	FrequencyField field_frequency {
 		{ 0 * 8, 2 * 16 },
 	};
-	
-	NumberField field_rfgain {
-		{ 14 * 8, 2 * 16 },
-		2,
-		{ 0, 47 },
-		1,
-		' '	
+
+	TransmitterView2 tx_view {				// new handling of NumberField field_rfgain, NumberField field_rfamp
+		74, 1*8, SHORT_UI					// x(columns), y (line) position. (Uused in Repay / GPS Simul / Playlist App)
+//		10*8, 2*8, NORMAL_UI				// x(columns), y (line) position. (Used in Mic App)
 	};
-	NumberField field_rfamp {     // previously  I was using "RFAmpField field_rf_amp" but that is general Receiver amp setting.
-		{ 19 * 8, 2 * 16 },
-		2,
-		{ 0, 14 },                // this time we will display GUI , 0 or 14 dBs same as Mic App
-		14,
-		' '
-	};
+
 	Checkbox check_loop {
 		{ 21 * 8, 2 * 16 },
 		4,

--- a/firmware/application/apps/ui_mictx.hpp
+++ b/firmware/application/apps/ui_mictx.hpp
@@ -23,6 +23,9 @@
 #ifndef __UI_MICTX_H__
 #define __UI_MICTX_H__
 
+#define SHORT_UI	true
+#define NORMAL_UI	false
+
 #include "ui.hpp"
 #include "ui_widget.hpp"
 #include "ui_navigation.hpp"
@@ -123,7 +126,7 @@ private:
 		{ {20 * 8, 10 * 8 }, "DEC:", Color::light_grey() },
 		{ { 4 * 8, ( 13 * 8 ) - 2 }, "TONE KEY:", Color::light_grey() },
 		{ { 7 * 8, 23 * 8 }, "VOL:", Color::light_grey() },
-		{ {14 * 8, 23 * 8 }, "RXBW:", Color::light_grey() },		//we remove the label "FM" because we will display all MOD types RX_BW.
+		{ {14 * 8, 23 * 8 }, "RXBW:", Color::light_grey() },				//we remove the label "FM" because we will display all MOD types RX_BW.
 		{ {20 * 8, 25 * 8 }, "SQ:", Color::light_grey() },
 		{ { 5 * 8, 25 * 8 }, "F_RX:", Color::light_grey() }, 			
 		{ { 5 * 8, 27 * 8 }, "LNA:", Color::light_grey()},
@@ -142,7 +145,7 @@ private:
 		{ {20 * 8, 10 * 8 }, "DEC:", Color::light_grey() },
 		{ { 4 * 8, ( 13 * 8 ) - 2 }, "TONE KEY:", Color::light_grey() },
 		{ { (6 * 8)+4, 23 * 8 }, "VOL:", Color::light_grey() },
-		{ {14 * 8, 23 * 8 }, "RXBW:", Color::light_grey() },			//we remove the label "FM" because we will display all MOD types RX_BW.
+		{ {14 * 8, 23 * 8 }, "RXBW:", Color::light_grey() },				//we remove the label "FM" because we will display all MOD types RX_BW.
 		{ {20 * 8, 25 * 8 }, "SQ:", Color::light_grey() },
 		{ { 5 * 8, 25 * 8 }, "F_RX:", Color::light_grey() },
 		{ { 5 * 8, 27 * 8 }, "LNA:", Color::light_grey()},
@@ -210,8 +213,9 @@ OptionsField options_wm8731_boost_mode {
 		' '
 	};
 
-	TransmitterView2 tx_view {					// new handling of NumberField field_rfgain, NumberField field_rfamp
-		2 * 8		// y line position.
+	TransmitterView2 tx_view {				// new handling of NumberField field_rfgain, NumberField field_rfamp
+	//	3*8, 2*8, SHORT_UI					// x(columns), y (line) position. (used in Replay / GPS Simul / Playlist App's) 
+		3*8, 2*8, NORMAL_UI					// x(columns), y (line) position. (used in Mic App)
 	};
 		
 	OptionsField options_mode {

--- a/firmware/application/apps/ui_playlist.cpp
+++ b/firmware/application/apps/ui_playlist.cpp
@@ -149,8 +149,8 @@ void PlaylistView::start() {
 
 		playlist_entry item = playlist_db.front();
 		playlist_db.pop_front();
-	//		playlist_entry item = playlist_db[0];
-//	for (playlist_entry item : playlist_db) {
+	//	playlist_entry item = playlist_db[0];
+	//	for (playlist_entry item : playlist_db) {
 	//	file_path = item.replay_file;
 	//	rf::Frequency replay_frequency = strtoll(item.replay_frequency.c_str(),nullptr,10);
 		on_file_changed(item.replay_file, item.replay_frequency, item.sample_rate);
@@ -181,21 +181,12 @@ void PlaylistView::start() {
 				}
 			);
 		}
-		field_rfgain.on_change = [this](int32_t v) {
-			tx_gain = v;
-		};  
-		field_rfgain.set_value(tx_gain);
-		receiver_model.set_tx_gain(tx_gain); 
-		
-
-		field_rfamp.on_change = [this](int32_t v) {
-			rf_amp = (bool)v;
-		};
-		field_rfamp.set_value(rf_amp ? 14 : 0);
 
 		//Enable Bias Tee if selected
 		radio::set_antenna_bias(portapack::get_antenna_bias());
-			
+
+		rf_amp =(transmitter_model.rf_amp() );	// recover rf_amp settings applied from ui_transmiter.cpp	
+
 		radio::enable({
 			receiver_model.tuning_frequency(),
 			sample_rate * 8,
@@ -244,22 +235,16 @@ PlaylistView::PlaylistView(
 	NavigationView& nav
 ) : nav_ (nav)
 {
-
-	tx_gain = 35;field_rfgain.set_value(tx_gain);  // Initial default  value (-12 dB's max ).
-	field_rfamp.set_value(rf_amp ? 14 : 0);  // Initial default value True. (TX RF amp on , +14dB's)
-
 	baseband::run_image(portapack::spi_flash::image_tag_replay);
 
 	add_children({
-		&labels,
 		&button_open,
 		&text_filename,
 		&text_sample_rate,
 		&text_duration,
 		&progressbar,
 		&field_frequency,
-		&field_rfgain, 
-		&field_rfamp,       // let's not use common rf_amp
+		&tx_view,			// this handles now the previous rfgain, rfamp
 		&check_loop,
 		&button_play,
 		&waterfall,

--- a/firmware/application/apps/ui_playlist.hpp
+++ b/firmware/application/apps/ui_playlist.hpp
@@ -20,7 +20,8 @@
  * Boston, MA 02110-1301, USA.
  */
 
-
+#define SHORT_UI	true
+#define NORMAL_UI	false
 
 #include "ui_widget.hpp"
 #include "ui_navigation.hpp"
@@ -31,6 +32,7 @@
 #include <string>
 #include <memory>
 #include <deque>
+#include "ui_transmitter.hpp"
 
 namespace ui {
 
@@ -85,10 +87,6 @@ private:
 	std::filesystem::path file_path { };
 	std::unique_ptr<ReplayThread> replay_thread { };
 	bool ready_signal { false };
-
-	Labels labels {
-		{ { 10 * 8, 2 * 16 }, "GAIN   A:", Color::light_grey() }
-	};
 	
 	Button button_open {
 		{ 0 * 8, 0 * 16, 10 * 8, 2 * 16 },
@@ -117,20 +115,11 @@ private:
 		{ 0 * 8, 2 * 16 },
 	};
 	
-	NumberField field_rfgain {
-		{ 14 * 8, 2 * 16 },
-		2,
-		{ 0, 47 },
-		1,
-		' '	
+	TransmitterView2 tx_view {				// new handling of NumberField field_rfgain, NumberField field_rfamp
+		74, 1*8, SHORT_UI					// x(columns), y (line) position. (Used in Repay / GPS Simul / Play list App)
+//		10*8, 2*8, NORMAL_UI				// x(columns), y (line) position. (Used in Mic App)
 	};
-	NumberField field_rfamp {     // previously  I was using "RFAmpField field_rf_amp" but that is general Receiver amp setting.
-		{ 19 * 8, 2 * 16 },
-		2,
-		{ 0, 14 },                // this time we will display GUI , 0 or 14 dBs same as Mic App
-		14,
-		' '
-	};
+
 	Checkbox check_loop {
 		{ 21 * 8, 2 * 16 },
 		4,

--- a/firmware/application/ui/ui_transmitter.cpp
+++ b/firmware/application/ui/ui_transmitter.cpp
@@ -190,6 +190,10 @@ TransmitterView::~TransmitterView() {
 }
 
 /* TransmitterView2 *******************************************************/
+// Derivative from TransmitterView (that handles many param. freq, fre_step, start_button, gain, amp, used in the majority of the TX App's.
+// This one ,is a simple version ,  it is only handling 2 x param  (TX GAIN and AMP ) in one line .
+// We use normal character lines , in Mic App,  called (x pos, y pos,  NORMAL_UI)
+// We use short compact char lines , in Replay / GPS Simul / Playlist App , called (x pos , y pos,SHORT_UI )
 
 void TransmitterView2::paint(Painter& painter) {
 //	Not using TransmitterView2, but if we delete it,we got , top line 1 a blanking rect.
@@ -219,36 +223,49 @@ void TransmitterView2::update_gainlevel_styles() {
 	}
 
 	field_gain.set_style(new_style_ptr);
-	text_gain.set_style(new_style_ptr);
+	text_gain_amp.set_style(new_style_ptr);
 	field_amp.set_style(new_style_ptr);
-	text_amp.set_style(new_style_ptr);
+
+	field_gain_short_UI.set_style(new_style_ptr);
+	text_gain_amp_short_UI.set_style(new_style_ptr);
+	field_amp_short_UI.set_style(new_style_ptr);
 }
 
 void TransmitterView2::on_show() {
 	field_gain.set_value(transmitter_model.tx_gain());
 	field_amp.set_value(transmitter_model.rf_amp() ? 14 : 0);
 
+	field_gain_short_UI.set_value(transmitter_model.tx_gain());
+	field_amp_short_UI.set_value(transmitter_model.rf_amp() ? 14 : 0);
+	
 	update_gainlevel_styles();
 }
 
-TransmitterView2::TransmitterView2(	const Coord y)
+TransmitterView2::TransmitterView2(	const Coord x, const Coord y, bool short_UI)
 {
-	set_parent_rect({ 3*8, y, 20 * 8, 1 * 8 });		// set_parent_rect({ 0, y, 30 * 8, 6 * 8 });
-	
+	set_parent_rect({ x , y, 20 * 8, 1 * 8 });		// set_parent_rect({ 0, y, 30 * 8, 6 * 8 });
+
 	add_children({
-		&text_gain,
-		&field_gain,
-		&text_amp,
-		&field_amp,
+		&(short_UI ? text_gain_amp_short_UI : text_gain_amp),
+		&(short_UI ? field_gain_short_UI : field_gain),
+		&(short_UI ? field_amp_short_UI  : field_amp),
 	});
-	
-	field_gain.on_change = [this](uint32_t tx_gain) {
-		on_tx_gain_changed(tx_gain);
-	};
-	
-	field_amp.on_change = [this](uint32_t rf_amp) {
-		on_tx_amp_changed((bool) rf_amp);
-	};
+
+	if (short_UI) {
+		field_gain_short_UI.on_change = [this](uint32_t tx_gain) {
+			on_tx_gain_changed(tx_gain);
+		};
+		field_amp_short_UI.on_change = [this](uint32_t rf_amp) {
+			on_tx_amp_changed((bool) rf_amp);
+		};
+	} else {
+		field_gain.on_change = [this](uint32_t tx_gain) {
+			on_tx_gain_changed(tx_gain);
+		};
+		field_amp.on_change = [this](uint32_t rf_amp) {
+			on_tx_amp_changed((bool) rf_amp);
+		};
+	}			
 }
 
 TransmitterView2::~TransmitterView2() {

--- a/firmware/application/ui/ui_transmitter.hpp
+++ b/firmware/application/ui/ui_transmitter.hpp
@@ -169,7 +169,7 @@ private:
 class TransmitterView2 : public View {
 public:
 	
-	TransmitterView2(const Coord y);
+	TransmitterView2(const Coord x,  const Coord y, bool short_UI);
 
 	~TransmitterView2();
 	
@@ -193,9 +193,9 @@ private:
 		.foreground = Color::red(),
 	};
 
-	Text text_gain {
+	Text text_gain_amp {
 		{ 0, 3 * 8, 5 * 8, 1 * 16 },
-		"Gain:"
+		"Gain:   Amp:"
 	};
 	
 	NumberField field_gain {
@@ -206,11 +206,6 @@ private:
 		' '
 	};
 
-	Text text_amp {
-		{ 8 * 8, 3 * 8, 5 * 8, 1 * 16 },
-		"Amp:"
-	};
-
 	NumberField field_amp {
 		{ 12 * 8, 3 * 8 },
 		2,
@@ -219,6 +214,26 @@ private:
 		' '
 	};
 
+	Text text_gain_amp_short_UI {
+		{ 0, (3 * 8)-1, 5 * 8, 1 * 16 },
+		"Gain   A:"
+	};
+
+	NumberField field_gain_short_UI {
+		{ (4 * 8)+2 , 3 * 8 },
+		2,
+		{ max2837::tx::gain_db_range.minimum, max2837::tx::gain_db_range.maximum },
+		max2837::tx::gain_db_step,
+		' '
+	};
+
+	NumberField field_amp_short_UI {
+		{ (9 * 8)-2, 3 * 8 },
+		2,
+		{ 0, 14 },
+		14,
+		' '
+	};
 
 	void on_tx_gain_changed(int32_t tx_gain);
 	void on_tx_amp_changed(bool rf_amp);


### PR DESCRIPTION
This PR is a minor  extension of yesterday PR #1001 , and refactorization ,.

This is extending and re-using yesterday code introduced in Mic App , about "warning colour indication about selected TX Power"  in the remaining 3 Tx App's : Replay App / GPS Simul App / Playlist App . 

It has been fully tested in Mic App / Replay App / GPS Simul App ,  but I could not check it in Playlist (I got other error when trying to use Playlist.txt , open file error)  , (but it is the same code concept, as it is a derivative of the Replay App , it should work also ok). It is also checked the initial default value and also the stable values in each loop , 

This  change has some additional  benefits compared to the previous code : 
1-) UI colour change. (obvious) 
2-) Now , any user change about TX GAIN / AMP , is applied straight away to the TX antenna "on the fly" , before every change were only applied in next  loop .
3-) the code now  , becomes more compact , and shrink in the main app files (Replay, GPS Simul, Playlist , Mic App) ,

Cheers, 

  