### PR TITLE
simple 1 pixel error correction

### DIFF
--- a/firmware/application/ui/ui_transmitter.hpp
+++ b/firmware/application/ui/ui_transmitter.hpp
@@ -203,7 +203,7 @@ class TransmitterView2 : public View {
         ' '};
 
     Text text_gain_amp_short_UI{
-        {0, (3 * 8) - 1, 5 * 8, 1 * 16},
+        {0, (3 * 8), 5 * 8, 1 * 16},
         "Gain   A:"};
 
     NumberField field_gain_short_UI{


### PR DESCRIPTION
Just 1 pixel error correction , to the PR #1005 

Thanks to Sommermorgentraum for finding the problem and also , the solution.  (excellent support !!!) 
It was a minor error , when I was adjusting the blanking rectangle to not overwrite the Loop check box, and I confused X adj, by wrong Y adj. 

Before that PR , you can see that in the top of the progress rectangle, close to the "A:" ,  is missing the corner pixel 
![image](https://github.com/eried/portapack-mayhem/assets/86470699/ece32dd0-519e-4fcd-bba1-5b8b23ad14df)

After removing that -1 pixel in vertical , becomes ok , as it should be . 
![20230519_211920](https://github.com/eried/portapack-mayhem/assets/86470699/f9879941-f667-4014-b4c0-8650fea32627)


Cheers


