### PR TITLE
Looking glass final cut

### DIFF
--- a/firmware/application/apps/ui_looking_glass_app.cpp
+++ b/firmware/application/apps/ui_looking_glass_app.cpp
@@ -24,696 +24,600 @@
 
 using namespace portapack;
 
-namespace ui
-{
-    void GlassView::focus()
-    {
-        button_marker.focus();
-    }
-
-    GlassView::~GlassView()
-    {
-        receiver_model.set_sampling_rate(3072000); // Just a hack to avoid hanging other apps
-        receiver_model.disable();
-        baseband::shutdown();
-    }
-
-    void GlassView::get_max_power( const ChannelSpectrum &spectrum , uint8_t bin , uint8_t &max_power )
-    {
-        if( mode == LOOKING_GLASS_SINGLEPASS )
-        {
-            // analog audio app like view
-            if (bin < 120)
-            {
-                if( spectrum.db[SPEC_NB_BINS - 120 + bin] > max_power)
-                    max_power = spectrum.db[SPEC_NB_BINS - 120 + bin];
-            }
-            else
-            {
-                if (spectrum.db[ bin - 120] > max_power)
-                    max_power = spectrum.db[bin - 120];
-            }
-        }
-        else if( mode == LOOKING_GLASS_FASTSCAN )
-        {
-            // view is made in multiple pass, use original bin picking
-            // Center 12 bins are ignored (DC spike is blanked) Leftmost and rightmost 2 bins are ignored
-            if (bin < 120)
-            {
-                if (spectrum.db[SPEC_NB_BINS - 2 - 120 + bin] > max_power)
-                    max_power = spectrum.db[SPEC_NB_BINS - 2 - 120 + bin];
-            }
-            else
-            {
-                if (spectrum.db[ 2 + bin - 120] > max_power)
-                    max_power = spectrum.db[ 2 + bin - 120];
-            }
-        }
-        else // if( mode == LOOKING_GLASS_SLOWSCAN )
-        {
-            if (bin < 120)
-            {
-                if (spectrum.db[SPEC_NB_BINS - offset - 120 + bin] > max_power)
-                    max_power = spectrum.db[SPEC_NB_BINS - offset - 120 + bin];
-            }
-            else
-            {
-                if (spectrum.db[ offset + bin - 120] > max_power)
-                    max_power = spectrum.db[ offset + bin - 120];
-            }
-        }
-    }
-
-    void GlassView::on_marker_change()
-    {
-        if( mode == LOOKING_GLASS_SINGLEPASS )
-        {
-            marker = f_min + (marker_pixel_index * looking_glass_range) / SCREEN_W ;
-        }
-        else // if( mode == LOOKING_GLASS_SLOWSCAN || mode == LOOKING_GLASS_FASTSCAN )
-        {
-            marker = f_min + (offset * each_bin_size) + (marker_pixel_index * looking_glass_range) / SCREEN_W ;
-        }
-        button_marker.set_text( to_string_short_freq( marker ) );
-        PlotMarker( marker_pixel_index ); // Refresh marker on screen
-    }
-
-
-    // Returns the next multiple of num that is a multiple of multiplier
-    int64_t GlassView::next_mult_of(int64_t num, int64_t multiplier) {
-        return ((num / multiplier) + 1) * multiplier;
-    }
-
-    void GlassView::adjust_range(int64_t* f_min, int64_t* f_max, int64_t width) {
-        int64_t span = *f_max - *f_min;
-        int64_t num_intervals = span / width;
-        if (span % width != 0) {
-            num_intervals++;
-        }
-        int64_t new_span = num_intervals * width;
-        int64_t delta_span = (new_span - span) / 2;
-        *f_min -= delta_span;
-        *f_max += delta_span;
-    }
-
-    void GlassView::retune()
-    {
-        // Start a new sweep
-        radio::set_tuning_frequency(f_center); // tune rx for this new slice directly, faster than using persistent memory saving
-        chThdSleepMilliseconds(5);
-        baseband::spectrum_streaming_start(); // Do the RX
-    }
-
-    void GlassView::on_lna_changed(int32_t v_db)
-    {
-        receiver_model.set_lna(v_db);
-    }
-
-    void GlassView::on_vga_changed(int32_t v_db)
-    {
-        receiver_model.set_vga(v_db);
-    }
-
-    void GlassView::reset_live_view( bool clear_screen )
-    {
-        max_freq_hold = 0 ;
-        max_freq_power = -1000 ;
-        if( clear_screen )
-        {
-            // only clear screen in peak mode
-            if( live_frequency_view == 2 )
-            {
-                display.fill_rectangle( { { 0 , 108 + 16 } , { SCREEN_W , 320 - (108 + 16) } } , { 0 , 0 , 0 } );
-            }
-        }
-    }
-
-    void GlassView::add_spectrum_pixel( uint8_t power )
-    {
-        spectrum_row[pixel_index] = spectrum_rgb3_lut[power] ; // row of colors
-        spectrum_data[pixel_index] = ( live_frequency_integrate * spectrum_data[pixel_index] + power ) / (live_frequency_integrate + 1); // smoothing 
-        pixel_index ++ ;
-
-        if (pixel_index == SCREEN_W ) // got an entire waterfall line
-        {
-            if( live_frequency_view > 0 )
-            {
-                constexpr int rssi_sample_range = SPEC_NB_BINS ;
-                constexpr float rssi_voltage_min = 0.4;
-                constexpr float rssi_voltage_max = 2.2;
-                constexpr float adc_voltage_max = 3.3;
-                constexpr int raw_min = rssi_sample_range * rssi_voltage_min / adc_voltage_max;
-                constexpr int raw_max = rssi_sample_range * rssi_voltage_max / adc_voltage_max;
-                constexpr int raw_delta = raw_max - raw_min;
-                const range_t<int> y_max_range { 0 , 320 - ( 108 + 16 ) };
-
-                //drawing and keeping track of max freq
-                for( uint16_t xpos = 0 ; xpos < SCREEN_W ; xpos ++ )
-                {
-                    // save max powerwull freq 
-                    if( spectrum_data[ xpos ] > max_freq_power )
-                    {
-                        max_freq_power = spectrum_data[ xpos ];
-                        max_freq_hold = f_center + ( (looking_glass_range) * xpos) / SCREEN_W ;
-                    }
-
-                    int16_t point = y_max_range.clip( ( ( spectrum_data[ xpos ] - raw_min ) * ( 320 - ( 108 + 16 ) ) ) / raw_delta );
-                    uint8_t color_gradient = (point * 255) / 212 ;
-                    // clear if not in peak view
-                    if( live_frequency_view != 2 )
-                    {
-                        display.fill_rectangle( { { xpos , 108 + 16 } , { 1 , 320 - point } } , { 0 , 0 , 0 } );
-                    }
-                    display.fill_rectangle( { { xpos , 320 - point } , { 1 , point } } , { color_gradient , 0 , uint8_t( 255 - color_gradient ) } );
-                } 
-                if( last_max_freq != max_freq_hold )
-                {
-                    last_max_freq = max_freq_hold ;
-                    freq_stats.set( "MAX HOLD: "+to_string_short_freq( max_freq_hold ) );
-                }
-                PlotMarker( marker_pixel_index );
-            }
-            else
-            {
-                display.draw_pixels({{0, display.scroll(1)}, {SCREEN_W, 1}}, spectrum_row); // new line at top, one less var, speedier
-            }
-            pixel_index = 0;                                                       // Start New cascade line
-        }
-    }
-
-    // Apparently, the spectrum object returns an array of SPEC_NB_BINS (256) bins
-    // Each having the radio signal power for it's corresponding frequency slot
-    void GlassView::on_channel_spectrum(const ChannelSpectrum &spectrum)
-    {
-        baseband::spectrum_streaming_stop();
-        // Convert bins of this spectrum slice into a representative max_power and when enough, into pixels
-        // we actually need SCREEN_W (240) of those bins
-        for ( bin = offset ; bin < bin_length + offset ; bin++)
-        {   
-            get_max_power( spectrum , bin , max_power );
-            if( ignore_dc && bin == 119 )
-            {
-                uint8_t next_max_power = 0 ;
-                get_max_power( spectrum ,120 , next_max_power );
-                bins_Hz_size += 12 * each_bin_size; // add the ignored DC spike to "pixel fulfilled bag of Hz"
-                max_power = (max_power + next_max_power ) / 2 ;
-            }
-            bins_Hz_size += each_bin_size; // add this bin Hz count into the "pixel fulfilled bag of Hz"
-
-            if (bins_Hz_size >= marker_pixel_step) // new pixel fullfilled
-            {
-                if (min_color_power < max_power)
-                    add_spectrum_pixel(max_power); // Pixel will represent max_power
-                else
-                    add_spectrum_pixel(0); // Filtered out, show black
-
-                max_power = 0;
-
-                if (!pixel_index) // Received indication that a waterfall line has been completed
-                {
-                    bins_Hz_size = 0; // Since this is an entire pixel line, we don't carry "Pixels into next bin"
-                    f_center = f_center_ini ;   
-                    retune();
-                    return ;          // signal a new line
-                }
-                bins_Hz_size -= marker_pixel_step; // reset bins size, but carrying the eventual excess Hz into next pixel
-            }
-        }
-        f_center += looking_glass_step ;
-        retune();
-    }
-
-    void GlassView::on_hide()
-    {
-        baseband::spectrum_streaming_stop();
-        display.scroll_disable();
-    }
-
-    void GlassView::on_show()
-    {
-        display.scroll_set_area(109, 319); // Restart scroll on the correct coordinates
-        baseband::spectrum_streaming_start();
-    }
-
-    void GlassView::on_range_changed()
-    {
-        reset_live_view( false );
-        f_min = field_frequency_min.value();
-        f_max = field_frequency_max.value();
-        f_min = f_min*MHZ_DIV; // Transpose into full frequency realm
-        f_max = f_max*MHZ_DIV;
-        looking_glass_range = f_max - f_min ;
-        if( looking_glass_range < LOOKING_GLASS_SLICE_WIDTH_MAX )
-        {
-            mode = LOOKING_GLASS_SINGLEPASS ;
-        }
-        else
-        {
-            mode = scan_type.selected_index_value();
-        }
-
-        if( mode == LOOKING_GLASS_SINGLEPASS )
-        {
-            // if the view is done in one pass, show it like in analog_audio_app
-            offset = 0 ;
-            bin_length = SCREEN_W ;
-            ignore_dc = 0 ;
-        }
-        else if( mode == LOOKING_GLASS_FASTSCAN )
-        {
-            // view is made in multiple pass, use original bin picking
-            offset = 0 ;
-            bin_length = SCREEN_W ;
-            ignore_dc = 1 ;
-        }
-        else // if( mode == LOOKING_GLASS_SLOWSCAN )
-        { 
-            offset = 16 ;
-            bin_length = 80 ;
-            ignore_dc = 0 ;
-        }
-        each_bin_size = looking_glass_bandwidth / SPEC_NB_BINS ;
-        if( mode != LOOKING_GLASS_SINGLEPASS )
-        {
-            looking_glass_step = ( bin_length + (ignore_dc*12) ) * each_bin_size ;
-        }
-        else
-        {
-            looking_glass_step = SPEC_NB_BINS * each_bin_size ;
-        }
-        adjust_range(&f_min, &f_max, SCREEN_W );
-        looking_glass_range = f_max - f_min ;
-        marker_pixel_step = looking_glass_range / SCREEN_W ; // Each pixel value in Hz
-        search_span = looking_glass_range / MHZ_DIV ;
-        button_range.set_text("      "); // clear up to 6 chars
-        if( locked_range )
-        {
-            button_range.set_text(">"+to_string_dec_uint(search_span)+"<");
-        }
-        else
-        {
-            button_range.set_text(" "+to_string_dec_uint(search_span)+" ");
-        }
-
-        pixel_index = 0;  // reset pixel counter
-        max_power = 0;    // reset save max power level
-        bins_Hz_size = 0; // reset amount of Hz filled up by pixels
-
-        if( mode == LOOKING_GLASS_SINGLEPASS )
-        {
-            looking_glass_bandwidth = looking_glass_range ;
-            looking_glass_sampling_rate = looking_glass_bandwidth/2 ;
-            each_bin_size = looking_glass_bandwidth / SCREEN_W ; 
-        }
-        else // if ( mode == LOOKING_GLASS_SLOWSCAN || mode == LOOKING_GLASS_FASTSCAN )
-        {
-            looking_glass_sampling_rate = LOOKING_GLASS_SLICE_WIDTH_MAX ;
-            looking_glass_bandwidth = LOOKING_GLASS_SLICE_WIDTH_MAX ;
-            each_bin_size = looking_glass_bandwidth / SPEC_NB_BINS ; 
-        }
-
-        on_marker_change();
-
-        // set the sample rate and bandwidth
-        receiver_model.set_sampling_rate( looking_glass_sampling_rate );      
-        receiver_model.set_baseband_bandwidth( looking_glass_bandwidth ); 
-
-        receiver_model.set_squelch_level(0);
-        f_center_ini = f_min + ( looking_glass_bandwidth / 2) ; // Initial center frequency for sweep
-        f_center = f_center_ini ; // Reset sweep into first slice
-        baseband::set_spectrum(looking_glass_sampling_rate, field_trigger.value());
-        receiver_model.set_tuning_frequency(f_center); // tune rx for this slice
-    }
-
-    void GlassView::PlotMarker( uint8_t pos )
-    {
-        uint8_t shift_y = 0 ;
-        if( live_frequency_view > 0 ) // plot one line down when in live view
-        {
-            shift_y = 16 ;
-        }
-        portapack::display.fill_rectangle({0, 100 + shift_y, SCREEN_W, 8}, Color::black());        // Clear old marker and whole marker rectangle btw
-        portapack::display.fill_rectangle({pos - 2, 100 + shift_y, 5, 3}, Color::red()); // Red marker top
-        portapack::display.fill_rectangle({pos - 1, 103 + shift_y, 3, 3}, Color::red()); // Red marker middle
-        portapack::display.fill_rectangle({pos, 106 + shift_y, 1, 2}, Color::red());     // Red marker bottom
-    }
-
-    GlassView::GlassView(
-            NavigationView &nav) : nav_(nav)
-    {
-        baseband::run_image(portapack::spi_flash::image_tag_wideband_spectrum);
-
-        add_children({&labels,
-                &field_frequency_min,
-                &field_frequency_max,
-                &field_lna,
-                &field_vga,
-                &button_range,
-                &steps_config,
-                &scan_type,
-                &view_config,
-                &level_integration,
-                &filter_config,
-                &field_rf_amp,
-                &range_presets,
-                &button_marker,
-                &field_trigger,
-                &button_jump,
-                &button_rst,
-                &freq_stats});
-
-        load_Presets(); // Load available presets from TXT files (or default)
-
-        field_frequency_min.on_change = [this](int32_t v)
-        {
-            reset_live_view( true );
-            int32_t min_size = steps ;
-            if( locked_range )
-                min_size = search_span ;
-            if( min_size < 2 )
-                min_size = 2 ;
-            if( v > 7200 - min_size )
-            {
-                v = 7200 - min_size ;
-                field_frequency_min.set_value( v ); 
-            }
-            if (v > (field_frequency_max.value() - min_size ) )
-                field_frequency_max.set_value( v + min_size );
-            if( locked_range )
-                field_frequency_max.set_value( v + min_size );
-            on_range_changed();
-        };
-        field_frequency_min.set_value(presets_db[0].min); // Defaults to first preset
-        field_frequency_min.set_step( steps );
-
-        field_frequency_min.on_select = [this, &nav](NumberField& field) {
-            auto new_view = nav_.push<FrequencyKeypadView>(field_frequency_min.value()*MHZ_DIV);
-            new_view->on_changed = [this, &field](rf::Frequency f) {
-                int32_t freq = f / MHZ_DIV ;
-                int32_t min_size = steps ;
-                if( locked_range )
-                    min_size = search_span ;
-                if( min_size < 2 )
-                    min_size = 2 ;
-                if( freq > (7200 - min_size ) )
-                    freq = 7200 - min_size  ;
-                field_frequency_min.set_value( freq );
-                if( field_frequency_max.value() < ( freq + min_size ) )
-                    field_frequency_max.set_value( freq + min_size );
-                on_range_changed();
-            };
-        };
-
-        field_frequency_max.on_change = [this](int32_t v)
-        {          
-            reset_live_view( true );
-            int32_t min_size = steps ;
-            if( locked_range )
-                min_size = search_span ;
-            if( min_size < 2 )
-                min_size = 2 ;
-            if( v < min_size )
-            {
-                v = min_size ;
-                field_frequency_max.set_value( v ); 
-            }
-            if (v < (field_frequency_min.value() + min_size) )
-                field_frequency_min.set_value(v - min_size);
-            if( locked_range )
-                field_frequency_min.set_value( v - min_size );
-            on_range_changed();
-        };
-        field_frequency_max.set_value(presets_db[0].max); // Defaults to first preset
-        field_frequency_max.set_step( steps );
-
-        field_frequency_max.on_select = [this, &nav](NumberField& field) {
-            auto new_view = nav_.push<FrequencyKeypadView>(field_frequency_max.value()*MHZ_DIV);
-            new_view->on_changed = [this, &field](rf::Frequency f) {
-                int32_t min_size = steps ;
-                if( locked_range )
-                    min_size = search_span ;
-                if( min_size < 2 )
-                    min_size = 2 ;
-                int32_t freq = f / MHZ_DIV ;
-                if( freq < min_size )
-                    freq = min_size ;
-                field_frequency_max.set_value( freq );
-                if( field_frequency_min.value() > ( freq - min_size) ) 
-                    field_frequency_min.set_value( freq - min_size );
-                on_range_changed();
-            };
-        };
-
-        field_lna.on_change = [this](int32_t v)
-        {
-            reset_live_view( true );
-            this->on_lna_changed(v);
-        };
-        field_lna.set_value(receiver_model.lna());
-
-        field_vga.on_change = [this](int32_t v_db)
-        {
-            reset_live_view( true );
-            this->on_vga_changed(v_db);
-        };
-        field_vga.set_value(receiver_model.vga());
-
-        steps_config.on_change = [this](size_t n, OptionsField::value_t v)
-        {
-            (void)n;
-            field_frequency_min.set_step( v );
-            field_frequency_max.set_step( v );
-            steps = v ;
-        };
-        steps_config.set_selected_index(0); //default of 1 Mhz steps
-
-        scan_type.on_change = [this](size_t n, OptionsField::value_t v)
-        {
-            (void)n;
-            mode = v ;
-            on_range_changed();
-        };
-        scan_type.set_selected_index(0); // default legacy fast scan
-
-        view_config.on_change = [this](size_t n, OptionsField::value_t v)
-        {
-            (void)n;
-            // clear between changes
-            reset_live_view( true );
-            if( v == 0 )
-            {
-                live_frequency_view = 0 ;
-                level_integration.hidden( true );
-                freq_stats.hidden( true );
-                button_jump.hidden( true );
-                button_rst.hidden( true );
-                display.scroll_set_area(109, 319); // Restart scroll on the correct coordinates
-            }
-            else if( v == 1 )
-            {
-                display.fill_rectangle( { { 0 , 108 } , { SCREEN_W , 24 } } , { 0 , 0 , 0 } );
-                live_frequency_view = 1 ;
-                display.scroll_disable();
-                level_integration.hidden( false );
-                freq_stats.hidden( false );
-                button_jump.hidden( false );
-                button_rst.hidden( false );
-            }
-            else if( v == 2 )
-            {
-                display.fill_rectangle( { { 0 , 108 } , { SCREEN_W , 24 } } , { 0 , 0 , 0 } );
-                live_frequency_view = 2 ;
-                display.scroll_disable();
-                level_integration.hidden( false );
-                freq_stats.hidden( false );
-                button_jump.hidden( false );
-                button_rst.hidden( false );
-            }
-            set_dirty();
-        };
-        view_config.set_selected_index(0); //default spectrum
-
-        level_integration.on_change = [this](size_t n, OptionsField::value_t v)
-        {
-            (void)n;
-            reset_live_view( true );
-            live_frequency_integrate = v ;
-        };
-        level_integration.set_selected_index(3); //default integration of ( 3 * old value + new_value ) / 4
-
-        filter_config.on_change = [this](size_t n, OptionsField::value_t v) {
-            (void)n;
-            reset_live_view( true );
-            min_color_power = v;
-        };
-        filter_config.set_selected_index(0);
-
-        range_presets.on_change = [this](size_t n, OptionsField::value_t v)
-        {
-            (void)n;
-            field_frequency_min.set_value(presets_db[v].min, false);
-            field_frequency_max.set_value(presets_db[v].max, false);
-            on_range_changed();
-        };
-
-        button_marker.on_change = [this]()
-        {
-            if( ( (int)marker_pixel_index + button_marker.get_encoder_delta() ) < 0 )
-            {
-                marker_pixel_index = 0 ;
-            }
-            else if( ( (int)marker_pixel_index + button_marker.get_encoder_delta() ) > SCREEN_W )
-            {
-                marker_pixel_index = SCREEN_W ;
-            }
-            else
-            {
-                marker_pixel_index = marker_pixel_index + button_marker.get_encoder_delta() ;
-            }
-            on_marker_change();
-            button_marker.set_encoder_delta( 0 );
-        };
-
-        button_marker.on_select = [this](ButtonWithEncoder &)
-        {
-            receiver_model.set_tuning_frequency(marker); // Center tune rx in marker freq.
-            receiver_model.set_frequency_step(MHZ_DIV);    // Preset a 1 MHz frequency step into RX -> AUDIO
-            nav_.pop();
-            nav_.push<AnalogAudioView>(); // Jump into audio view
-        };
-
-        field_trigger.on_change = [this](int32_t v)
-        {
-            baseband::set_spectrum(looking_glass_sampling_rate, v);
-        };
-        field_trigger.set_value(32); // Defaults to 32, as normal triggering resolution
-
-        button_range.on_select = [this](Button&) {
-            if( locked_range )
-            {
-                locked_range = false ;
-                button_range.set_style(&style_white);
-                button_range.set_text(" "+to_string_dec_uint(search_span)+" ");
-            }
-            else
-            {
-                locked_range = true ;
-                button_range.set_style(&style_red);
-                button_range.set_text(">"+to_string_dec_uint(search_span)+"<");
-            }
-        };
-
-        button_jump.on_select = [this](Button&) {
-            receiver_model.set_tuning_frequency(max_freq_hold); // Center tune rx in marker freq.
-            receiver_model.set_frequency_step(MHZ_DIV);    // Preset a 1 MHz frequency step into RX -> AUDIO
-            nav_.pop();
-            nav_.push<AnalogAudioView>(); // Jump into audio view
-        };
-
-        button_rst.on_select = [this](Button&) {
-            reset_live_view( true );
-        };
-
-        display.scroll_set_area(109, 319);
-        baseband::set_spectrum(looking_glass_sampling_rate, field_trigger.value()); // trigger:
-                                                                                    // Discord User jteich:  WidebandSpectrum::on_message to set the trigger value. In WidebandSpectrum::execute ,
-                                                                                    // it keeps adding the output of the fft to the buffer until "trigger" number of calls are made,
-                                                                                    // at which time it pushes the buffer up with channel_spectrum.feed
-
-        marker_pixel_index = 120 ;
-        on_range_changed();
-
-        receiver_model.set_modulation(ReceiverModel::Mode::SpectrumAnalysis);
-        receiver_model.set_sampling_rate(looking_glass_sampling_rate);      // 20mhz
-        receiver_model.set_baseband_bandwidth(looking_glass_bandwidth); // possible values: 1.75/2.5/3.5/5/5.5/6/7/8/9/10/12/14/15/20/24/28MHz
-        receiver_model.set_squelch_level(0);
-        receiver_model.enable();
-    }
-
-    void GlassView::load_Presets()
-    {
-        File presets_file; // LOAD /WHIPCALC/ANTENNAS.TXT from microSD
-        auto result = presets_file.open("LOOKINGGLASS/PRESETS.TXT");
-        presets_db.clear(); // Start with fresh db
-        if (result.is_valid())
-        {
-            presets_Default(); // There is no txt, store a default range
-        }
-        else
-        {
-            std::string line; // There is a txt file
-            char one_char[1]; // Read it char by char
-            for (size_t pointer = 0; pointer < presets_file.size(); pointer++)
-            {
-                presets_file.seek(pointer);
-                presets_file.read(one_char, 1);
-                if ((int)one_char[0] > 31)
-                {                        // ascii space upwards
-                    line += one_char[0]; // Add it to the textline
-                }
-                else if (one_char[0] == '\n')
-                {                          // New Line
-                    txtline_process(line); // make sense of this textline
-                    line.clear();          // Ready for next textline
-                }
-            }
-            if (line.length() > 0)
-                txtline_process(line); // Last line had no newline at end ?
-            if (!presets_db.size())
-                presets_Default(); // no antenna on txt, use default
-        }
-        populate_Presets();
-    }
-
-    void GlassView::txtline_process(std::string &line)
-    {
-        if (line.find("#") != std::string::npos)
-            return; // Line is just a comment
-
-        size_t comma = line.find(","); // Get first comma position
-        if (comma == std::string::npos)
-            return; // No comma at all
-
-        size_t previous = 0;
-        preset_entry new_preset;
-
-        new_preset.min = std::stoi(line.substr(0, comma));
-        if (!new_preset.min)
-            return; // No frequency!
-
-        previous = comma + 1;
-        comma = line.find(",", previous); // Search for next delimiter
-        if (comma == std::string::npos)
-            return; // No comma at all
-
-        new_preset.max = std::stoi(line.substr(previous, comma - previous));
-        if (!new_preset.max)
-            return; // No frequency!
-
-        new_preset.label = line.substr(comma + 1);
-        if (new_preset.label.size() == 0)
-            return; // No label ?
-
-        presets_db.push_back(new_preset); // Add this preset.
-    }
-
-    void GlassView::populate_Presets()
-    {
-        using option_t = std::pair<std::string, int32_t>;
-        using options_t = std::vector<option_t>;
-        options_t entries;
-
-        for (preset_entry preset : presets_db)
-        { // go thru all available presets
-            entries.emplace_back(preset.label, entries.size());
-        }
-        range_presets.set_options(entries);
-    }
-
-    void GlassView::presets_Default()
-    {
-        presets_db.clear();
-        presets_db.push_back({2320, 2560, "DEFAULT WIFI 2.4GHz"});
-    }
-
+namespace ui {
+void GlassView::focus() {
+    button_marker.focus();
 }
+
+GlassView::~GlassView() {
+    receiver_model.set_sampling_rate(3072000);  // Just a hack to avoid hanging other apps
+    receiver_model.disable();
+    baseband::shutdown();
+}
+
+void GlassView::get_max_power(const ChannelSpectrum& spectrum, uint8_t bin, uint8_t& max_power) {
+    if (mode == LOOKING_GLASS_SINGLEPASS) {
+        // analog audio app like view
+        if (bin < 120) {
+            if (spectrum.db[SPEC_NB_BINS - 120 + bin] > max_power)
+                max_power = spectrum.db[SPEC_NB_BINS - 120 + bin];
+        } else {
+            if (spectrum.db[bin - 120] > max_power)
+                max_power = spectrum.db[bin - 120];
+        }
+    } else if (mode == LOOKING_GLASS_FASTSCAN) {
+        // view is made in multiple pass, use original bin picking
+        // Center 12 bins are ignored (DC spike is blanked) Leftmost and rightmost 2 bins are ignored
+        if (bin < 120) {
+            if (spectrum.db[SPEC_NB_BINS - 2 - 120 + bin] > max_power)
+                max_power = spectrum.db[SPEC_NB_BINS - 2 - 120 + bin];
+        } else {
+            if (spectrum.db[2 + bin - 120] > max_power)
+                max_power = spectrum.db[2 + bin - 120];
+        }
+    } else  // if( mode == LOOKING_GLASS_SLOWSCAN )
+    {
+        if (bin < 120) {
+            if (spectrum.db[SPEC_NB_BINS - offset - 120 + bin] > max_power)
+                max_power = spectrum.db[SPEC_NB_BINS - offset - 120 + bin];
+        } else {
+            if (spectrum.db[offset + bin - 120] > max_power)
+                max_power = spectrum.db[offset + bin - 120];
+        }
+    }
+}
+
+void GlassView::on_marker_change() {
+    if (mode == LOOKING_GLASS_SINGLEPASS) {
+        marker = f_min + (marker_pixel_index * looking_glass_range) / SCREEN_W;
+    } else  // if( mode == LOOKING_GLASS_SLOWSCAN || mode == LOOKING_GLASS_FASTSCAN )
+    {
+        marker = f_min + (offset * each_bin_size) + (marker_pixel_index * looking_glass_range) / SCREEN_W;
+    }
+    button_marker.set_text(to_string_short_freq(marker));
+    PlotMarker(marker_pixel_index);  // Refresh marker on screen
+}
+
+// Returns the next multiple of num that is a multiple of multiplier
+int64_t GlassView::next_mult_of(int64_t num, int64_t multiplier) {
+    return ((num / multiplier) + 1) * multiplier;
+}
+
+void GlassView::adjust_range(int64_t* f_min, int64_t* f_max, int64_t width) {
+    int64_t span = *f_max - *f_min;
+    int64_t num_intervals = span / width;
+    if (span % width != 0) {
+        num_intervals++;
+    }
+    int64_t new_span = num_intervals * width;
+    int64_t delta_span = (new_span - span) / 2;
+    *f_min -= delta_span;
+    *f_max += delta_span;
+}
+
+void GlassView::retune() {
+    // Start a new sweep
+    radio::set_tuning_frequency(f_center);  // tune rx for this new slice directly, faster than using persistent memory saving
+    chThdSleepMilliseconds(5);
+    baseband::spectrum_streaming_start();  // Do the RX
+}
+
+void GlassView::on_lna_changed(int32_t v_db) {
+    receiver_model.set_lna(v_db);
+}
+
+void GlassView::on_vga_changed(int32_t v_db) {
+    receiver_model.set_vga(v_db);
+}
+
+void GlassView::reset_live_view(bool clear_screen) {
+    max_freq_hold = 0;
+    max_freq_power = -1000;
+    if (clear_screen) {
+        // only clear screen in peak mode
+        if (live_frequency_view == 2) {
+            display.fill_rectangle({{0, 108 + 16}, {SCREEN_W, 320 - (108 + 16)}}, {0, 0, 0});
+        }
+    }
+}
+
+void GlassView::add_spectrum_pixel(uint8_t power) {
+    spectrum_row[pixel_index] = spectrum_rgb3_lut[power];                                                                           // row of colors
+    spectrum_data[pixel_index] = (live_frequency_integrate * spectrum_data[pixel_index] + power) / (live_frequency_integrate + 1);  // smoothing
+    pixel_index++;
+
+    if (pixel_index == SCREEN_W)  // got an entire waterfall line
+    {
+        if (live_frequency_view > 0) {
+            constexpr int rssi_sample_range = SPEC_NB_BINS;
+            constexpr float rssi_voltage_min = 0.4;
+            constexpr float rssi_voltage_max = 2.2;
+            constexpr float adc_voltage_max = 3.3;
+            constexpr int raw_min = rssi_sample_range * rssi_voltage_min / adc_voltage_max;
+            constexpr int raw_max = rssi_sample_range * rssi_voltage_max / adc_voltage_max;
+            constexpr int raw_delta = raw_max - raw_min;
+            const range_t<int> y_max_range{0, 320 - (108 + 16)};
+
+            // drawing and keeping track of max freq
+            for (uint16_t xpos = 0; xpos < SCREEN_W; xpos++) {
+                // save max powerwull freq
+                if (spectrum_data[xpos] > max_freq_power) {
+                    max_freq_power = spectrum_data[xpos];
+                    max_freq_hold = f_center + ((looking_glass_range)*xpos) / SCREEN_W;
+                }
+
+                int16_t point = y_max_range.clip(((spectrum_data[xpos] - raw_min) * (320 - (108 + 16))) / raw_delta);
+                uint8_t color_gradient = (point * 255) / 212;
+                // clear if not in peak view
+                if (live_frequency_view != 2) {
+                    display.fill_rectangle({{xpos, 108 + 16}, {1, 320 - point}}, {0, 0, 0});
+                }
+                display.fill_rectangle({{xpos, 320 - point}, {1, point}}, {color_gradient, 0, uint8_t(255 - color_gradient)});
+            }
+            if (last_max_freq != max_freq_hold) {
+                last_max_freq = max_freq_hold;
+                freq_stats.set("MAX HOLD: " + to_string_short_freq(max_freq_hold));
+            }
+            PlotMarker(marker_pixel_index);
+        } else {
+            display.draw_pixels({{0, display.scroll(1)}, {SCREEN_W, 1}}, spectrum_row);  // new line at top, one less var, speedier
+        }
+        pixel_index = 0;  // Start New cascade line
+    }
+}
+
+// Apparently, the spectrum object returns an array of SPEC_NB_BINS (256) bins
+// Each having the radio signal power for it's corresponding frequency slot
+void GlassView::on_channel_spectrum(const ChannelSpectrum& spectrum) {
+    baseband::spectrum_streaming_stop();
+    // Convert bins of this spectrum slice into a representative max_power and when enough, into pixels
+    // we actually need SCREEN_W (240) of those bins
+    for (bin = offset; bin < bin_length + offset; bin++) {
+        get_max_power(spectrum, bin, max_power);
+        if (ignore_dc && bin == 119) {
+            uint8_t next_max_power = 0;
+            get_max_power(spectrum, 120, next_max_power);
+            bins_Hz_size += 12 * each_bin_size;  // add the ignored DC spike to "pixel fulfilled bag of Hz"
+            max_power = (max_power + next_max_power) / 2;
+        }
+        bins_Hz_size += each_bin_size;  // add this bin Hz count into the "pixel fulfilled bag of Hz"
+
+        if (bins_Hz_size >= marker_pixel_step)  // new pixel fullfilled
+        {
+            if (min_color_power < max_power)
+                add_spectrum_pixel(max_power);  // Pixel will represent max_power
+            else
+                add_spectrum_pixel(0);  // Filtered out, show black
+
+            max_power = 0;
+
+            if (!pixel_index)  // Received indication that a waterfall line has been completed
+            {
+                bins_Hz_size = 0;  // Since this is an entire pixel line, we don't carry "Pixels into next bin"
+                f_center = f_center_ini;
+                retune();
+                return;  // signal a new line
+            }
+            bins_Hz_size -= marker_pixel_step;  // reset bins size, but carrying the eventual excess Hz into next pixel
+        }
+    }
+    f_center += looking_glass_step;
+    retune();
+}
+
+void GlassView::on_hide() {
+    baseband::spectrum_streaming_stop();
+    display.scroll_disable();
+}
+
+void GlassView::on_show() {
+    display.scroll_set_area(109, 319);  // Restart scroll on the correct coordinates
+    baseband::spectrum_streaming_start();
+}
+
+void GlassView::on_range_changed() {
+    reset_live_view(false);
+    f_min = field_frequency_min.value();
+    f_max = field_frequency_max.value();
+    f_min = f_min * MHZ_DIV;  // Transpose into full frequency realm
+    f_max = f_max * MHZ_DIV;
+    looking_glass_range = f_max - f_min;
+    if (looking_glass_range < LOOKING_GLASS_SLICE_WIDTH_MAX) {
+        mode = LOOKING_GLASS_SINGLEPASS;
+    } else {
+        mode = scan_type.selected_index_value();
+    }
+
+    if (mode == LOOKING_GLASS_SINGLEPASS) {
+        // if the view is done in one pass, show it like in analog_audio_app
+        offset = 0;
+        bin_length = SCREEN_W;
+        ignore_dc = 0;
+    } else if (mode == LOOKING_GLASS_FASTSCAN) {
+        // view is made in multiple pass, use original bin picking
+        offset = 0;
+        bin_length = SCREEN_W;
+        ignore_dc = 1;
+    } else  // if( mode == LOOKING_GLASS_SLOWSCAN )
+    {
+        offset = 16;
+        bin_length = 80;
+        ignore_dc = 0;
+    }
+    each_bin_size = looking_glass_bandwidth / SPEC_NB_BINS;
+    if (mode != LOOKING_GLASS_SINGLEPASS) {
+        looking_glass_step = (bin_length + (ignore_dc * 12)) * each_bin_size;
+    } else {
+        looking_glass_step = SPEC_NB_BINS * each_bin_size;
+    }
+    adjust_range(&f_min, &f_max, SCREEN_W);
+    looking_glass_range = f_max - f_min;
+    marker_pixel_step = looking_glass_range / SCREEN_W;  // Each pixel value in Hz
+    search_span = looking_glass_range / MHZ_DIV;
+    button_range.set_text("      ");  // clear up to 6 chars
+    if (locked_range) {
+        button_range.set_text(">" + to_string_dec_uint(search_span) + "<");
+    } else {
+        button_range.set_text(" " + to_string_dec_uint(search_span) + " ");
+    }
+
+    pixel_index = 0;   // reset pixel counter
+    max_power = 0;     // reset save max power level
+    bins_Hz_size = 0;  // reset amount of Hz filled up by pixels
+
+    if (mode == LOOKING_GLASS_SINGLEPASS) {
+        looking_glass_bandwidth = looking_glass_range;
+        looking_glass_sampling_rate = looking_glass_bandwidth / 2;
+        each_bin_size = looking_glass_bandwidth / SCREEN_W;
+    } else  // if ( mode == LOOKING_GLASS_SLOWSCAN || mode == LOOKING_GLASS_FASTSCAN )
+    {
+        looking_glass_sampling_rate = LOOKING_GLASS_SLICE_WIDTH_MAX;
+        looking_glass_bandwidth = LOOKING_GLASS_SLICE_WIDTH_MAX;
+        each_bin_size = looking_glass_bandwidth / SPEC_NB_BINS;
+    }
+
+    on_marker_change();
+
+    // set the sample rate and bandwidth
+    receiver_model.set_sampling_rate(looking_glass_sampling_rate);
+    receiver_model.set_baseband_bandwidth(looking_glass_bandwidth);
+
+    receiver_model.set_squelch_level(0);
+    f_center_ini = f_min + (looking_glass_bandwidth / 2);  // Initial center frequency for sweep
+    f_center = f_center_ini;                               // Reset sweep into first slice
+    baseband::set_spectrum(looking_glass_sampling_rate, field_trigger.value());
+    receiver_model.set_tuning_frequency(f_center);  // tune rx for this slice
+}
+
+void GlassView::PlotMarker(uint8_t pos) {
+    uint8_t shift_y = 0;
+    if (live_frequency_view > 0)  // plot one line down when in live view
+    {
+        shift_y = 16;
+    }
+    portapack::display.fill_rectangle({0, 100 + shift_y, SCREEN_W, 8}, Color::black());  // Clear old marker and whole marker rectangle btw
+    portapack::display.fill_rectangle({pos - 2, 100 + shift_y, 5, 3}, Color::red());     // Red marker top
+    portapack::display.fill_rectangle({pos - 1, 103 + shift_y, 3, 3}, Color::red());     // Red marker middle
+    portapack::display.fill_rectangle({pos, 106 + shift_y, 1, 2}, Color::red());         // Red marker bottom
+}
+
+GlassView::GlassView(
+    NavigationView& nav)
+    : nav_(nav) {
+    baseband::run_image(portapack::spi_flash::image_tag_wideband_spectrum);
+
+    add_children({&labels,
+                  &field_frequency_min,
+                  &field_frequency_max,
+                  &field_lna,
+                  &field_vga,
+                  &button_range,
+                  &steps_config,
+                  &scan_type,
+                  &view_config,
+                  &level_integration,
+                  &filter_config,
+                  &field_rf_amp,
+                  &range_presets,
+                  &button_marker,
+                  &field_trigger,
+                  &button_jump,
+                  &button_rst,
+                  &freq_stats});
+
+    load_Presets();  // Load available presets from TXT files (or default)
+
+    field_frequency_min.on_change = [this](int32_t v) {
+        reset_live_view(true);
+        int32_t min_size = steps;
+        if (locked_range)
+            min_size = search_span;
+        if (min_size < 2)
+            min_size = 2;
+        if (v > 7200 - min_size) {
+            v = 7200 - min_size;
+            field_frequency_min.set_value(v);
+        }
+        if (v > (field_frequency_max.value() - min_size))
+            field_frequency_max.set_value(v + min_size);
+        if (locked_range)
+            field_frequency_max.set_value(v + min_size);
+        on_range_changed();
+    };
+    field_frequency_min.set_value(presets_db[0].min);  // Defaults to first preset
+    field_frequency_min.set_step(steps);
+
+    field_frequency_min.on_select = [this, &nav](NumberField& field) {
+        auto new_view = nav_.push<FrequencyKeypadView>(field_frequency_min.value() * MHZ_DIV);
+        new_view->on_changed = [this, &field](rf::Frequency f) {
+            int32_t freq = f / MHZ_DIV;
+            int32_t min_size = steps;
+            if (locked_range)
+                min_size = search_span;
+            if (min_size < 2)
+                min_size = 2;
+            if (freq > (7200 - min_size))
+                freq = 7200 - min_size;
+            field_frequency_min.set_value(freq);
+            if (field_frequency_max.value() < (freq + min_size))
+                field_frequency_max.set_value(freq + min_size);
+            on_range_changed();
+        };
+    };
+
+    field_frequency_max.on_change = [this](int32_t v) {
+        reset_live_view(true);
+        int32_t min_size = steps;
+        if (locked_range)
+            min_size = search_span;
+        if (min_size < 2)
+            min_size = 2;
+        if (v < min_size) {
+            v = min_size;
+            field_frequency_max.set_value(v);
+        }
+        if (v < (field_frequency_min.value() + min_size))
+            field_frequency_min.set_value(v - min_size);
+        if (locked_range)
+            field_frequency_min.set_value(v - min_size);
+        on_range_changed();
+    };
+    field_frequency_max.set_value(presets_db[0].max);  // Defaults to first preset
+    field_frequency_max.set_step(steps);
+
+    field_frequency_max.on_select = [this, &nav](NumberField& field) {
+        auto new_view = nav_.push<FrequencyKeypadView>(field_frequency_max.value() * MHZ_DIV);
+        new_view->on_changed = [this, &field](rf::Frequency f) {
+            int32_t min_size = steps;
+            if (locked_range)
+                min_size = search_span;
+            if (min_size < 2)
+                min_size = 2;
+            int32_t freq = f / MHZ_DIV;
+            if (freq < min_size)
+                freq = min_size;
+            field_frequency_max.set_value(freq);
+            if (field_frequency_min.value() > (freq - min_size))
+                field_frequency_min.set_value(freq - min_size);
+            on_range_changed();
+        };
+    };
+
+    field_lna.on_change = [this](int32_t v) {
+        reset_live_view(true);
+        this->on_lna_changed(v);
+    };
+    field_lna.set_value(receiver_model.lna());
+
+    field_vga.on_change = [this](int32_t v_db) {
+        reset_live_view(true);
+        this->on_vga_changed(v_db);
+    };
+    field_vga.set_value(receiver_model.vga());
+
+    steps_config.on_change = [this](size_t n, OptionsField::value_t v) {
+        (void)n;
+        field_frequency_min.set_step(v);
+        field_frequency_max.set_step(v);
+        steps = v;
+    };
+    steps_config.set_selected_index(0);  // default of 1 Mhz steps
+
+    scan_type.on_change = [this](size_t n, OptionsField::value_t v) {
+        (void)n;
+        mode = v;
+        on_range_changed();
+    };
+    scan_type.set_selected_index(0);  // default legacy fast scan
+
+    view_config.on_change = [this](size_t n, OptionsField::value_t v) {
+        (void)n;
+        // clear between changes
+        reset_live_view(true);
+        if (v == 0) {
+            live_frequency_view = 0;
+            level_integration.hidden(true);
+            freq_stats.hidden(true);
+            button_jump.hidden(true);
+            button_rst.hidden(true);
+            display.scroll_set_area(109, 319);  // Restart scroll on the correct coordinates
+        } else if (v == 1) {
+            display.fill_rectangle({{0, 108}, {SCREEN_W, 24}}, {0, 0, 0});
+            live_frequency_view = 1;
+            display.scroll_disable();
+            level_integration.hidden(false);
+            freq_stats.hidden(false);
+            button_jump.hidden(false);
+            button_rst.hidden(false);
+        } else if (v == 2) {
+            display.fill_rectangle({{0, 108}, {SCREEN_W, 24}}, {0, 0, 0});
+            live_frequency_view = 2;
+            display.scroll_disable();
+            level_integration.hidden(false);
+            freq_stats.hidden(false);
+            button_jump.hidden(false);
+            button_rst.hidden(false);
+        }
+        set_dirty();
+    };
+    view_config.set_selected_index(0);  // default spectrum
+
+    level_integration.on_change = [this](size_t n, OptionsField::value_t v) {
+        (void)n;
+        reset_live_view(true);
+        live_frequency_integrate = v;
+    };
+    level_integration.set_selected_index(3);  // default integration of ( 3 * old value + new_value ) / 4
+
+    filter_config.on_change = [this](size_t n, OptionsField::value_t v) {
+        (void)n;
+        reset_live_view(true);
+        min_color_power = v;
+    };
+    filter_config.set_selected_index(0);
+
+    range_presets.on_change = [this](size_t n, OptionsField::value_t v) {
+        (void)n;
+        field_frequency_min.set_value(presets_db[v].min, false);
+        field_frequency_max.set_value(presets_db[v].max, false);
+        on_range_changed();
+    };
+
+    button_marker.on_change = [this]() {
+        if (((int)marker_pixel_index + button_marker.get_encoder_delta()) < 0) {
+            marker_pixel_index = 0;
+        } else if (((int)marker_pixel_index + button_marker.get_encoder_delta()) > SCREEN_W) {
+            marker_pixel_index = SCREEN_W;
+        } else {
+            marker_pixel_index = marker_pixel_index + button_marker.get_encoder_delta();
+        }
+        on_marker_change();
+        button_marker.set_encoder_delta(0);
+    };
+
+    button_marker.on_select = [this](ButtonWithEncoder&) {
+        receiver_model.set_tuning_frequency(marker);  // Center tune rx in marker freq.
+        receiver_model.set_frequency_step(MHZ_DIV);   // Preset a 1 MHz frequency step into RX -> AUDIO
+        nav_.pop();
+        nav_.push<AnalogAudioView>();  // Jump into audio view
+    };
+
+    field_trigger.on_change = [this](int32_t v) {
+        baseband::set_spectrum(looking_glass_sampling_rate, v);
+    };
+    field_trigger.set_value(32);  // Defaults to 32, as normal triggering resolution
+
+    button_range.on_select = [this](Button&) {
+        if (locked_range) {
+            locked_range = false;
+            button_range.set_style(&style_white);
+            button_range.set_text(" " + to_string_dec_uint(search_span) + " ");
+        } else {
+            locked_range = true;
+            button_range.set_style(&style_red);
+            button_range.set_text(">" + to_string_dec_uint(search_span) + "<");
+        }
+    };
+
+    button_jump.on_select = [this](Button&) {
+        receiver_model.set_tuning_frequency(max_freq_hold);  // Center tune rx in marker freq.
+        receiver_model.set_frequency_step(MHZ_DIV);          // Preset a 1 MHz frequency step into RX -> AUDIO
+        nav_.pop();
+        nav_.push<AnalogAudioView>();  // Jump into audio view
+    };
+
+    button_rst.on_select = [this](Button&) {
+        reset_live_view(true);
+    };
+
+    display.scroll_set_area(109, 319);
+    baseband::set_spectrum(looking_glass_sampling_rate, field_trigger.value());  // trigger:
+                                                                                 // Discord User jteich:  WidebandSpectrum::on_message to set the trigger value. In WidebandSpectrum::execute ,
+                                                                                 // it keeps adding the output of the fft to the buffer until "trigger" number of calls are made,
+                                                                                 // at which time it pushes the buffer up with channel_spectrum.feed
+
+    marker_pixel_index = 120;
+    on_range_changed();
+
+    receiver_model.set_modulation(ReceiverModel::Mode::SpectrumAnalysis);
+    receiver_model.set_sampling_rate(looking_glass_sampling_rate);   // 20mhz
+    receiver_model.set_baseband_bandwidth(looking_glass_bandwidth);  // possible values: 1.75/2.5/3.5/5/5.5/6/7/8/9/10/12/14/15/20/24/28MHz
+    receiver_model.set_squelch_level(0);
+    receiver_model.enable();
+}
+
+void GlassView::load_Presets() {
+    File presets_file;  // LOAD /WHIPCALC/ANTENNAS.TXT from microSD
+    auto result = presets_file.open("LOOKINGGLASS/PRESETS.TXT");
+    presets_db.clear();  // Start with fresh db
+    if (result.is_valid()) {
+        presets_Default();  // There is no txt, store a default range
+    } else {
+        std::string line;  // There is a txt file
+        char one_char[1];  // Read it char by char
+        for (size_t pointer = 0; pointer < presets_file.size(); pointer++) {
+            presets_file.seek(pointer);
+            presets_file.read(one_char, 1);
+            if ((int)one_char[0] > 31) {       // ascii space upwards
+                line += one_char[0];           // Add it to the textline
+            } else if (one_char[0] == '\n') {  // New Line
+                txtline_process(line);         // make sense of this textline
+                line.clear();                  // Ready for next textline
+            }
+        }
+        if (line.length() > 0)
+            txtline_process(line);  // Last line had no newline at end ?
+        if (!presets_db.size())
+            presets_Default();  // no antenna on txt, use default
+    }
+    populate_Presets();
+}
+
+void GlassView::txtline_process(std::string& line) {
+    if (line.find("#") != std::string::npos)
+        return;  // Line is just a comment
+
+    size_t comma = line.find(",");  // Get first comma position
+    if (comma == std::string::npos)
+        return;  // No comma at all
+
+    size_t previous = 0;
+    preset_entry new_preset;
+
+    new_preset.min = std::stoi(line.substr(0, comma));
+    if (!new_preset.min)
+        return;  // No frequency!
+
+    previous = comma + 1;
+    comma = line.find(",", previous);  // Search for next delimiter
+    if (comma == std::string::npos)
+        return;  // No comma at all
+
+    new_preset.max = std::stoi(line.substr(previous, comma - previous));
+    if (!new_preset.max)
+        return;  // No frequency!
+
+    new_preset.label = line.substr(comma + 1);
+    if (new_preset.label.size() == 0)
+        return;  // No label ?
+
+    presets_db.push_back(new_preset);  // Add this preset.
+}
+
+void GlassView::populate_Presets() {
+    using option_t = std::pair<std::string, int32_t>;
+    using options_t = std::vector<option_t>;
+    options_t entries;
+
+    for (preset_entry preset : presets_db) {  // go thru all available presets
+        entries.emplace_back(preset.label, entries.size());
+    }
+    range_presets.set_options(entries);
+}
+
+void GlassView::presets_Default() {
+    presets_db.clear();
+    presets_db.push_back({2320, 2560, "DEFAULT WIFI 2.4GHz"});
+}
+
+}  // namespace ui

--- a/firmware/application/apps/ui_looking_glass_app.cpp
+++ b/firmware/application/apps/ui_looking_glass_app.cpp
@@ -24,590 +24,696 @@
 
 using namespace portapack;
 
-namespace ui {
-void GlassView::focus() {
-    button_marker.focus();
-}
-
-GlassView::~GlassView() {
-    receiver_model.set_sampling_rate(3072000);  // Just a hack to avoid hanging other apps
-    receiver_model.disable();
-    baseband::shutdown();
-}
-
-// Returns the next multiple of num that is a multiple of multiplier
-int64_t GlassView::next_mult_of(int64_t num, int64_t multiplier) {
-    return ((num / multiplier) + 1) * multiplier;
-}
-
-void GlassView::adjust_range(int64_t* f_min, int64_t* f_max, int64_t width) {
-    int64_t span = *f_max - *f_min;
-    int64_t num_intervals = span / width;
-    if (span % width != 0) {
-        num_intervals++;
-    }
-    int64_t new_span = num_intervals * width;
-    int64_t delta_span = (new_span - span) / 2;
-    *f_min -= delta_span;
-    *f_max += delta_span;
-}
-
-void GlassView::on_lna_changed(int32_t v_db) {
-    receiver_model.set_lna(v_db);
-}
-
-void GlassView::on_vga_changed(int32_t v_db) {
-    receiver_model.set_vga(v_db);
-}
-
-void GlassView::reset_live_view(bool clear_screen) {
-    max_freq_hold = 0;
-    max_freq_power = -1000;
-    if (clear_screen) {
-        // only clear screen in peak mode
-        if (live_frequency_view == 2) {
-            display.fill_rectangle({{0, 108 + 16}, {240, 320 - (108 + 16)}}, {0, 0, 0});
-        }
-    }
-}
-
-void GlassView::add_spectrum_pixel(uint8_t power) {
-    static int64_t last_max_freq = 0;
-
-    spectrum_row[pixel_index] = spectrum_rgb3_lut[power];                                                                           // row of colors
-    spectrum_data[pixel_index] = (live_frequency_integrate * spectrum_data[pixel_index] + power) / (live_frequency_integrate + 1);  // smoothing
-    pixel_index++;
-
-    if (pixel_index == 240)  // got an entire waterfall line
+namespace ui
+{
+    void GlassView::focus()
     {
-        if (live_frequency_view > 0) {
-            constexpr int rssi_sample_range = 256;
-            constexpr float rssi_voltage_min = 0.4;
-            constexpr float rssi_voltage_max = 2.2;
-            constexpr float adc_voltage_max = 3.3;
-            constexpr int raw_min = rssi_sample_range * rssi_voltage_min / adc_voltage_max;
-            constexpr int raw_max = rssi_sample_range * rssi_voltage_max / adc_voltage_max;
-            constexpr int raw_delta = raw_max - raw_min;
-            const range_t<int> y_max_range{0, 320 - (108 + 16)};
-
-            // drawing and keeping track of max freq
-            for (uint16_t xpos = 0; xpos < 240; xpos++) {
-                // save max powerwull freq
-                if (spectrum_data[xpos] > max_freq_power) {
-                    max_freq_power = spectrum_data[xpos];
-                    max_freq_hold = f_min + ((f_max - f_min) * xpos) / 240;
-                }
-
-                int16_t point = y_max_range.clip(((spectrum_data[xpos] - raw_min) * (320 - (108 + 16))) / raw_delta);
-                uint8_t color_gradient = (point * 255) / 212;
-                // clear if not in peak view
-                if (live_frequency_view != 2) {
-                    display.fill_rectangle({{xpos, 108 + 16}, {1, 320 - point}}, {0, 0, 0});
-                }
-                display.fill_rectangle({{xpos, 320 - point}, {1, point}}, {color_gradient, 0, uint8_t(255 - color_gradient)});
-            }
-            if (last_max_freq != max_freq_hold) {
-                last_max_freq = max_freq_hold;
-                freq_stats.set("MAX HOLD: " + to_string_short_freq(max_freq_hold));
-            }
-            PlotMarker(marker);
-        } else {
-            display.draw_pixels({{0, display.scroll(1)}, {240, 1}}, spectrum_row);  // new line at top, one less var, speedier
-        }
-        pixel_index = 0;  // Start New cascade line
+        button_marker.focus();
     }
-}
 
-// Apparently, the spectrum object returns an array of 256 bins
-// Each having the radio signal power for it's corresponding frequency slot
-void GlassView::on_channel_spectrum(const ChannelSpectrum& spectrum) {
-    // default fast scan offset
-    uint8_t offset = 2;
-    baseband::spectrum_streaming_stop();
-    if (fast_scan || (LOOKING_GLASS_SLICE_WIDTH < LOOKING_GLASS_SLICE_WIDTH_MAX)) {
+    GlassView::~GlassView()
+    {
+        receiver_model.set_sampling_rate(3072000); // Just a hack to avoid hanging other apps
+        receiver_model.disable();
+        baseband::shutdown();
+    }
+
+    void GlassView::get_max_power( const ChannelSpectrum &spectrum , uint8_t bin , uint8_t &max_power )
+    {
+        if( mode == LOOKING_GLASS_SINGLEPASS )
+        {
+            // analog audio app like view
+            if (bin < 120)
+            {
+                if( spectrum.db[SPEC_NB_BINS - 120 + bin] > max_power)
+                    max_power = spectrum.db[SPEC_NB_BINS - 120 + bin];
+            }
+            else
+            {
+                if (spectrum.db[ bin - 120] > max_power)
+                    max_power = spectrum.db[bin - 120];
+            }
+        }
+        else if( mode == LOOKING_GLASS_FASTSCAN )
+        {
+            // view is made in multiple pass, use original bin picking
+            // Center 12 bins are ignored (DC spike is blanked) Leftmost and rightmost 2 bins are ignored
+            if (bin < 120)
+            {
+                if (spectrum.db[SPEC_NB_BINS - 2 - 120 + bin] > max_power)
+                    max_power = spectrum.db[SPEC_NB_BINS - 2 - 120 + bin];
+            }
+            else
+            {
+                if (spectrum.db[ 2 + bin - 120] > max_power)
+                    max_power = spectrum.db[ 2 + bin - 120];
+            }
+        }
+        else // if( mode == LOOKING_GLASS_SLOWSCAN )
+        {
+            if (bin < 120)
+            {
+                if (spectrum.db[SPEC_NB_BINS - offset - 120 + bin] > max_power)
+                    max_power = spectrum.db[SPEC_NB_BINS - offset - 120 + bin];
+            }
+            else
+            {
+                if (spectrum.db[ offset + bin - 120] > max_power)
+                    max_power = spectrum.db[ offset + bin - 120];
+            }
+        }
+    }
+
+    void GlassView::on_marker_change()
+    {
+        if( mode == LOOKING_GLASS_SINGLEPASS )
+        {
+            marker = f_min + (marker_pixel_index * looking_glass_range) / SCREEN_W ;
+        }
+        else // if( mode == LOOKING_GLASS_SLOWSCAN || mode == LOOKING_GLASS_FASTSCAN )
+        {
+            marker = f_min + (offset * each_bin_size) + (marker_pixel_index * looking_glass_range) / SCREEN_W ;
+        }
+        button_marker.set_text( to_string_short_freq( marker ) );
+        PlotMarker( marker_pixel_index ); // Refresh marker on screen
+    }
+
+
+    // Returns the next multiple of num that is a multiple of multiplier
+    int64_t GlassView::next_mult_of(int64_t num, int64_t multiplier) {
+        return ((num / multiplier) + 1) * multiplier;
+    }
+
+    void GlassView::adjust_range(int64_t* f_min, int64_t* f_max, int64_t width) {
+        int64_t span = *f_max - *f_min;
+        int64_t num_intervals = span / width;
+        if (span % width != 0) {
+            num_intervals++;
+        }
+        int64_t new_span = num_intervals * width;
+        int64_t delta_span = (new_span - span) / 2;
+        *f_min -= delta_span;
+        *f_max += delta_span;
+    }
+
+    void GlassView::retune()
+    {
+        // Start a new sweep
+        radio::set_tuning_frequency(f_center); // tune rx for this new slice directly, faster than using persistent memory saving
+        chThdSleepMilliseconds(5);
+        baseband::spectrum_streaming_start(); // Do the RX
+    }
+
+    void GlassView::on_lna_changed(int32_t v_db)
+    {
+        receiver_model.set_lna(v_db);
+    }
+
+    void GlassView::on_vga_changed(int32_t v_db)
+    {
+        receiver_model.set_vga(v_db);
+    }
+
+    void GlassView::reset_live_view( bool clear_screen )
+    {
+        max_freq_hold = 0 ;
+        max_freq_power = -1000 ;
+        if( clear_screen )
+        {
+            // only clear screen in peak mode
+            if( live_frequency_view == 2 )
+            {
+                display.fill_rectangle( { { 0 , 108 + 16 } , { SCREEN_W , 320 - (108 + 16) } } , { 0 , 0 , 0 } );
+            }
+        }
+    }
+
+    void GlassView::add_spectrum_pixel( uint8_t power )
+    {
+        spectrum_row[pixel_index] = spectrum_rgb3_lut[power] ; // row of colors
+        spectrum_data[pixel_index] = ( live_frequency_integrate * spectrum_data[pixel_index] + power ) / (live_frequency_integrate + 1); // smoothing 
+        pixel_index ++ ;
+
+        if (pixel_index == SCREEN_W ) // got an entire waterfall line
+        {
+            if( live_frequency_view > 0 )
+            {
+                constexpr int rssi_sample_range = SPEC_NB_BINS ;
+                constexpr float rssi_voltage_min = 0.4;
+                constexpr float rssi_voltage_max = 2.2;
+                constexpr float adc_voltage_max = 3.3;
+                constexpr int raw_min = rssi_sample_range * rssi_voltage_min / adc_voltage_max;
+                constexpr int raw_max = rssi_sample_range * rssi_voltage_max / adc_voltage_max;
+                constexpr int raw_delta = raw_max - raw_min;
+                const range_t<int> y_max_range { 0 , 320 - ( 108 + 16 ) };
+
+                //drawing and keeping track of max freq
+                for( uint16_t xpos = 0 ; xpos < SCREEN_W ; xpos ++ )
+                {
+                    // save max powerwull freq 
+                    if( spectrum_data[ xpos ] > max_freq_power )
+                    {
+                        max_freq_power = spectrum_data[ xpos ];
+                        max_freq_hold = f_center + ( (looking_glass_range) * xpos) / SCREEN_W ;
+                    }
+
+                    int16_t point = y_max_range.clip( ( ( spectrum_data[ xpos ] - raw_min ) * ( 320 - ( 108 + 16 ) ) ) / raw_delta );
+                    uint8_t color_gradient = (point * 255) / 212 ;
+                    // clear if not in peak view
+                    if( live_frequency_view != 2 )
+                    {
+                        display.fill_rectangle( { { xpos , 108 + 16 } , { 1 , 320 - point } } , { 0 , 0 , 0 } );
+                    }
+                    display.fill_rectangle( { { xpos , 320 - point } , { 1 , point } } , { color_gradient , 0 , uint8_t( 255 - color_gradient ) } );
+                } 
+                if( last_max_freq != max_freq_hold )
+                {
+                    last_max_freq = max_freq_hold ;
+                    freq_stats.set( "MAX HOLD: "+to_string_short_freq( max_freq_hold ) );
+                }
+                PlotMarker( marker_pixel_index );
+            }
+            else
+            {
+                display.draw_pixels({{0, display.scroll(1)}, {SCREEN_W, 1}}, spectrum_row); // new line at top, one less var, speedier
+            }
+            pixel_index = 0;                                                       // Start New cascade line
+        }
+    }
+
+    // Apparently, the spectrum object returns an array of SPEC_NB_BINS (256) bins
+    // Each having the radio signal power for it's corresponding frequency slot
+    void GlassView::on_channel_spectrum(const ChannelSpectrum &spectrum)
+    {
+        baseband::spectrum_streaming_stop();
         // Convert bins of this spectrum slice into a representative max_power and when enough, into pixels
-        // Spectrum.db has 256 bins.
-        // All things said and done, we actually need 240 of those bins
-        for (uint8_t bin = 0; bin < 240; bin++) {
+        // we actually need SCREEN_W (240) of those bins
+        for ( bin = offset ; bin < bin_length + offset ; bin++)
+        {   
+            get_max_power( spectrum , bin , max_power );
+            if( ignore_dc && bin == 119 )
+            {
+                uint8_t next_max_power = 0 ;
+                get_max_power( spectrum ,120 , next_max_power );
+                bins_Hz_size += 12 * each_bin_size; // add the ignored DC spike to "pixel fulfilled bag of Hz"
+                max_power = (max_power + next_max_power ) / 2 ;
+            }
+            bins_Hz_size += each_bin_size; // add this bin Hz count into the "pixel fulfilled bag of Hz"
+
+            if (bins_Hz_size >= marker_pixel_step) // new pixel fullfilled
+            {
+                if (min_color_power < max_power)
+                    add_spectrum_pixel(max_power); // Pixel will represent max_power
+                else
+                    add_spectrum_pixel(0); // Filtered out, show black
+
+                max_power = 0;
+
+                if (!pixel_index) // Received indication that a waterfall line has been completed
+                {
+                    bins_Hz_size = 0; // Since this is an entire pixel line, we don't carry "Pixels into next bin"
+                    f_center = f_center_ini ;   
+                    retune();
+                    return ;          // signal a new line
+                }
+                bins_Hz_size -= marker_pixel_step; // reset bins size, but carrying the eventual excess Hz into next pixel
+            }
+        }
+        f_center += looking_glass_step ;
+        retune();
+    }
+
+    void GlassView::on_hide()
+    {
+        baseband::spectrum_streaming_stop();
+        display.scroll_disable();
+    }
+
+    void GlassView::on_show()
+    {
+        display.scroll_set_area(109, 319); // Restart scroll on the correct coordinates
+        baseband::spectrum_streaming_start();
+    }
+
+    void GlassView::on_range_changed()
+    {
+        reset_live_view( false );
+        f_min = field_frequency_min.value();
+        f_max = field_frequency_max.value();
+        f_min = f_min*MHZ_DIV; // Transpose into full frequency realm
+        f_max = f_max*MHZ_DIV;
+        looking_glass_range = f_max - f_min ;
+        if( looking_glass_range < LOOKING_GLASS_SLICE_WIDTH_MAX )
+        {
+            mode = LOOKING_GLASS_SINGLEPASS ;
+        }
+        else
+        {
+            mode = scan_type.selected_index_value();
+        }
+
+        if( mode == LOOKING_GLASS_SINGLEPASS )
+        {
             // if the view is done in one pass, show it like in analog_audio_app
-            if ((LOOKING_GLASS_SLICE_WIDTH < LOOKING_GLASS_SLICE_WIDTH_MAX)) {
-                // Center 16 bins are ignored (DC spike is blanked)
-                if (bin < 120) {
-                    if (spectrum.db[256 - 120 + bin] > max_power)  // 134
-                        max_power = spectrum.db[256 - 120 + bin];
-                } else {
-                    if (spectrum.db[bin - 120] > max_power)  // 118
-                        max_power = spectrum.db[bin - 120];
-                }
-            } else  // view is made in multiple pass, use original bin picking
-            {
-                // Center 12 bins are ignored (DC spike is blanked) Leftmost and rightmost 2 bins are ignored
-                if (bin < 120) {
-                    if (spectrum.db[134 + bin] > max_power)  // 134
-                        max_power = spectrum.db[134 + bin];
-                } else {
-                    if (spectrum.db[bin - 118] > max_power)  // 118
-                        max_power = spectrum.db[bin - 118];
-                }
-            }
-
-            if (bin == 120) {
-                bins_Hz_size += 12 * each_bin_size;  // add DC bin Hz count into the "pixel fulfilled bag of Hz"
-            } else {
-                bins_Hz_size += each_bin_size;  // add this bin Hz count into the "pixel fulfilled bag of Hz"
-            }
-
-            if (bins_Hz_size >= marker_pixel_step)  // new pixel fullfilled
-            {
-                if (min_color_power < max_power)
-                    add_spectrum_pixel(max_power);  // Pixel will represent max_power
-                else
-                    add_spectrum_pixel(0);  // Filtered out, show black
-
-                max_power = 0;
-
-                if (!pixel_index)  // Received indication that a waterfall line has been completed
-                {
-                    bins_Hz_size = 0;                                  // Since this is an entire pixel line, we don't carry "Pixels into next bin"
-                    f_center = f_center_ini - offset * each_bin_size;  // Start a new sweep
-                    radio::set_tuning_frequency(f_center);             // tune rx for this new slice directly, faster than using persistent memory saving
-                    chThdSleepMilliseconds(10);
-                    baseband::spectrum_streaming_start();  // Do the RX
-                    return;
-                }
-                bins_Hz_size -= marker_pixel_step;  // reset bins size, but carrying the eventual excess Hz into next pixel
-            }
+            offset = 0 ;
+            bin_length = SCREEN_W ;
+            ignore_dc = 0 ;
         }
-        f_center += (256 - (2 * offset)) * each_bin_size;  // Move into the next bandwidth slice NOTE: spectrum.sampling_rate = LOOKING_GLASS_SLICE_WIDTH
-                                                           // lost bins are taken in account so next slice first ignored bins overlap previous kept ones
-    } else                                                 // slow scan
+        else if( mode == LOOKING_GLASS_FASTSCAN )
+        {
+            // view is made in multiple pass, use original bin picking
+            offset = 0 ;
+            bin_length = SCREEN_W ;
+            ignore_dc = 1 ;
+        }
+        else // if( mode == LOOKING_GLASS_SLOWSCAN )
+        { 
+            offset = 16 ;
+            bin_length = 80 ;
+            ignore_dc = 0 ;
+        }
+        each_bin_size = looking_glass_bandwidth / SPEC_NB_BINS ;
+        if( mode != LOOKING_GLASS_SINGLEPASS )
+        {
+            looking_glass_step = ( bin_length + (ignore_dc*12) ) * each_bin_size ;
+        }
+        else
+        {
+            looking_glass_step = SPEC_NB_BINS * each_bin_size ;
+        }
+        adjust_range(&f_min, &f_max, SCREEN_W );
+        looking_glass_range = f_max - f_min ;
+        marker_pixel_step = looking_glass_range / SCREEN_W ; // Each pixel value in Hz
+        search_span = looking_glass_range / MHZ_DIV ;
+        button_range.set_text("      "); // clear up to 6 chars
+        if( locked_range )
+        {
+            button_range.set_text(">"+to_string_dec_uint(search_span)+"<");
+        }
+        else
+        {
+            button_range.set_text(" "+to_string_dec_uint(search_span)+" ");
+        }
+
+        pixel_index = 0;  // reset pixel counter
+        max_power = 0;    // reset save max power level
+        bins_Hz_size = 0; // reset amount of Hz filled up by pixels
+
+        if( mode == LOOKING_GLASS_SINGLEPASS )
+        {
+            looking_glass_bandwidth = looking_glass_range ;
+            looking_glass_sampling_rate = looking_glass_bandwidth/2 ;
+            each_bin_size = looking_glass_bandwidth / SCREEN_W ; 
+        }
+        else // if ( mode == LOOKING_GLASS_SLOWSCAN || mode == LOOKING_GLASS_FASTSCAN )
+        {
+            looking_glass_sampling_rate = LOOKING_GLASS_SLICE_WIDTH_MAX ;
+            looking_glass_bandwidth = LOOKING_GLASS_SLICE_WIDTH_MAX ;
+            each_bin_size = looking_glass_bandwidth / SPEC_NB_BINS ; 
+        }
+
+        on_marker_change();
+
+        // set the sample rate and bandwidth
+        receiver_model.set_sampling_rate( looking_glass_sampling_rate );      
+        receiver_model.set_baseband_bandwidth( looking_glass_bandwidth ); 
+
+        receiver_model.set_squelch_level(0);
+        f_center_ini = f_min + ( looking_glass_bandwidth / 2) ; // Initial center frequency for sweep
+        f_center = f_center_ini ; // Reset sweep into first slice
+        baseband::set_spectrum(looking_glass_sampling_rate, field_trigger.value());
+        receiver_model.set_tuning_frequency(f_center); // tune rx for this slice
+    }
+
+    void GlassView::PlotMarker( uint8_t pos )
     {
-        offset = 32;
-        uint8_t bin_length = 80;
-        for (uint8_t bin = offset; bin < bin_length + offset; bin++) {
-            if (bin < 120) {
-                if (spectrum.db[134 + bin] > max_power)  // 134
-                    max_power = spectrum.db[134 + bin];
-            } else {
-                if (spectrum.db[bin - 118] > max_power)  // 118
-                    max_power = spectrum.db[bin - 118];
-            }
-
-            bins_Hz_size += each_bin_size;  // add this bin Hz count into the "pixel fulfilled bag of Hz"
-
-            if (bins_Hz_size >= marker_pixel_step)  // new pixel fullfilled
-            {
-                if (min_color_power < max_power)
-                    add_spectrum_pixel(max_power);  // Pixel will represent max_power
-                else
-                    add_spectrum_pixel(0);  // Filtered out, show black
-
-                max_power = 0;
-
-                if (!pixel_index)  // Received indication that a waterfall line has been completed
-                {
-                    bins_Hz_size = 0;                                  // Since this is an entire pixel line, we don't carry "Pixels into next bin"
-                    f_center = f_center_ini - offset * each_bin_size;  // Start a new sweep
-                    radio::set_tuning_frequency(f_center);             // tune rx for this new slice directly, faster than using persistent memory saving
-                    chThdSleepMilliseconds(10);
-                    baseband::spectrum_streaming_start();  // Do the RX
-                    return;
-                }
-                bins_Hz_size -= marker_pixel_step;  // reset bins size, but carrying the eventual excess Hz into next pixel
-            }
+        uint8_t shift_y = 0 ;
+        if( live_frequency_view > 0 ) // plot one line down when in live view
+        {
+            shift_y = 16 ;
         }
-        f_center += bin_length * each_bin_size;
-    }
-    radio::set_tuning_frequency(f_center);  // tune rx for this new slice directly, faster than using persistent memory saving
-    chThdSleepMilliseconds(5);
-    baseband::spectrum_streaming_start();  // Do the RX
-}
-
-void GlassView::on_hide() {
-    baseband::spectrum_streaming_stop();
-    display.scroll_disable();
-}
-
-void GlassView::on_show() {
-    display.scroll_set_area(109, 319);  // Restart scroll on the correct coordinates
-    baseband::spectrum_streaming_start();
-}
-
-void GlassView::on_range_changed() {
-    reset_live_view(false);
-    f_min = field_frequency_min.value();
-    f_max = field_frequency_max.value();
-    search_span = f_max - f_min;
-
-    if (locked_range) {
-        button_range.set_text(">" + to_string_dec_uint(search_span) + "<");
-    } else {
-        button_range.set_text(" " + to_string_dec_uint(search_span) + " ");
+        portapack::display.fill_rectangle({0, 100 + shift_y, SCREEN_W, 8}, Color::black());        // Clear old marker and whole marker rectangle btw
+        portapack::display.fill_rectangle({pos - 2, 100 + shift_y, 5, 3}, Color::red()); // Red marker top
+        portapack::display.fill_rectangle({pos - 1, 103 + shift_y, 3, 3}, Color::red()); // Red marker middle
+        portapack::display.fill_rectangle({pos, 106 + shift_y, 1, 2}, Color::red());     // Red marker bottom
     }
 
-    f_min = (f_min)*MHZ_DIV;  // Transpose into full frequency realm
-    f_max = (f_max)*MHZ_DIV;
-    adjust_range(&f_min, &f_max, 240);
-
-    marker_pixel_step = (f_max - f_min) / 240;  // Each pixel value in Hz
-    marker = f_min + (f_max - f_min) / 2;
-    button_marker.set_text(to_string_short_freq(marker));
-    PlotMarker(marker);  // Refresh marker on screen
-
-    pixel_index = 0;  // reset pixel counter
-    max_power = 0;
-    bins_Hz_size = 0;  // reset amount of Hz filled up by pixels
-    if ((f_max - f_min) <= LOOKING_GLASS_SLICE_WIDTH_MAX) {
-        LOOKING_GLASS_SLICE_WIDTH = (f_max - f_min);
-        receiver_model.set_sampling_rate(LOOKING_GLASS_SLICE_WIDTH);
-        receiver_model.set_baseband_bandwidth(LOOKING_GLASS_SLICE_WIDTH / 2);
-    } else if (LOOKING_GLASS_SLICE_WIDTH != LOOKING_GLASS_SLICE_WIDTH_MAX) {
-        LOOKING_GLASS_SLICE_WIDTH = LOOKING_GLASS_SLICE_WIDTH_MAX;
-        receiver_model.set_sampling_rate(LOOKING_GLASS_SLICE_WIDTH);
-        receiver_model.set_baseband_bandwidth(LOOKING_GLASS_SLICE_WIDTH);
-    }
-    if (next_mult_of(LOOKING_GLASS_SLICE_WIDTH, 256) > LOOKING_GLASS_SLICE_WIDTH_MAX)
-        LOOKING_GLASS_SLICE_WIDTH = LOOKING_GLASS_SLICE_WIDTH_MAX;
-    else
-        LOOKING_GLASS_SLICE_WIDTH = next_mult_of(LOOKING_GLASS_SLICE_WIDTH, 256);
-
-    receiver_model.set_squelch_level(0);
-    each_bin_size = LOOKING_GLASS_SLICE_WIDTH / 256;
-    f_center_ini = f_min + (LOOKING_GLASS_SLICE_WIDTH / 2);  // Initial center frequency for sweep
-    f_center = f_center_ini;                                 // Reset sweep into first slice
-    baseband::set_spectrum(LOOKING_GLASS_SLICE_WIDTH, field_trigger.value());
-    receiver_model.set_tuning_frequency(f_center_ini);  // tune rx for this slice
-}
-
-void GlassView::PlotMarker(rf::Frequency pos) {
-    pos -= f_min;
-    pos = pos / marker_pixel_step;  // Real pixel
-
-    uint8_t shift_y = 0;
-    if (live_frequency_view > 0)  // plot one line down when in live view
+    GlassView::GlassView(
+            NavigationView &nav) : nav_(nav)
     {
-        shift_y = 16;
-    }
-    portapack::display.fill_rectangle({0, 100 + shift_y, 240, 8}, Color::black());         // Clear old marker and whole marker rectangle btw
-    portapack::display.fill_rectangle({(int)pos - 2, 100 + shift_y, 5, 3}, Color::red());  // Red marker top
-    portapack::display.fill_rectangle({(int)pos - 1, 103 + shift_y, 3, 3}, Color::red());  // Red marker middle
-    portapack::display.fill_rectangle({(int)pos, 106 + shift_y, 1, 2}, Color::red());      // Red marker bottom
-}
+        baseband::run_image(portapack::spi_flash::image_tag_wideband_spectrum);
 
-GlassView::GlassView(
-    NavigationView& nav)
-    : nav_(nav) {
-    baseband::run_image(portapack::spi_flash::image_tag_wideband_spectrum);
+        add_children({&labels,
+                &field_frequency_min,
+                &field_frequency_max,
+                &field_lna,
+                &field_vga,
+                &button_range,
+                &steps_config,
+                &scan_type,
+                &view_config,
+                &level_integration,
+                &filter_config,
+                &field_rf_amp,
+                &range_presets,
+                &button_marker,
+                &field_trigger,
+                &button_jump,
+                &button_rst,
+                &freq_stats});
 
-    add_children({&labels,
-                  &field_frequency_min,
-                  &field_frequency_max,
-                  &field_lna,
-                  &field_vga,
-                  &button_range,
-                  &steps_config,
-                  &scan_type,
-                  &view_config,
-                  &level_integration,
-                  &filter_config,
-                  &field_rf_amp,
-                  &range_presets,
-                  &button_marker,
-                  &field_trigger,
-                  &button_jump,
-                  &button_rst,
-                  &freq_stats});
+        load_Presets(); // Load available presets from TXT files (or default)
 
-    load_Presets();  // Load available presets from TXT files (or default)
-
-    field_frequency_min.on_change = [this](int32_t v) {
-        reset_live_view(true);
-        int32_t min_size = steps;
-        if (locked_range)
-            min_size = search_span;
-        if (min_size < 2)
-            min_size = 2;
-        if (v > 7200 - min_size) {
-            v = 7200 - min_size;
-            field_frequency_min.set_value(v);
-        }
-        if (v > (field_frequency_max.value() - min_size))
-            field_frequency_max.set_value(v + min_size);
-        if (locked_range)
-            field_frequency_max.set_value(v + min_size);
-        this->on_range_changed();
-    };
-    field_frequency_min.set_value(presets_db[0].min);  // Defaults to first preset
-    field_frequency_min.set_step(steps);
-
-    field_frequency_min.on_select = [this, &nav](NumberField& field) {
-        auto new_view = nav_.push<FrequencyKeypadView>(field_frequency_min.value() * 1000000);
-        new_view->on_changed = [this, &field](rf::Frequency f) {
-            int32_t freq = f / 1000000;
-            int32_t min_size = steps;
-            if (locked_range)
-                min_size = search_span;
-            if (min_size < 2)
-                min_size = 2;
-            if (freq > (7200 - min_size))
-                freq = 7200 - min_size;
-            field_frequency_min.set_value(freq);
-            if (field_frequency_max.value() < (freq + min_size))
-                field_frequency_max.set_value(freq + min_size);
-            this->on_range_changed();
-        };
-    };
-
-    field_frequency_max.on_change = [this](int32_t v) {
-        reset_live_view(true);
-        int32_t min_size = steps;
-        if (locked_range)
-            min_size = search_span;
-        if (min_size < 2)
-            min_size = 2;
-        if (v < min_size) {
-            v = min_size;
-            field_frequency_max.set_value(v);
-        }
-        if (v < (field_frequency_min.value() + min_size))
-            field_frequency_min.set_value(v - min_size);
-        if (locked_range)
-            field_frequency_min.set_value(v - min_size);
-        this->on_range_changed();
-    };
-    field_frequency_max.set_value(presets_db[0].max);  // Defaults to first preset
-    field_frequency_max.set_step(steps);
-
-    field_frequency_max.on_select = [this, &nav](NumberField& field) {
-        auto new_view = nav_.push<FrequencyKeypadView>(field_frequency_max.value() * 1000000);
-        new_view->on_changed = [this, &field](rf::Frequency f) {
-            int32_t min_size = steps;
-            if (locked_range)
-                min_size = search_span;
-            if (min_size < 2)
-                min_size = 2;
-            int32_t freq = f / 1000000;
-            if (freq < min_size)
-                freq = min_size;
-            field_frequency_max.set_value(freq);
-            if (field_frequency_min.value() > (freq - min_size))
-                field_frequency_min.set_value(freq - min_size);
-            this->on_range_changed();
-        };
-    };
-
-    field_lna.on_change = [this](int32_t v) {
-        reset_live_view(true);
-        this->on_lna_changed(v);
-    };
-    field_lna.set_value(receiver_model.lna());
-
-    field_vga.on_change = [this](int32_t v_db) {
-        reset_live_view(true);
-        this->on_vga_changed(v_db);
-    };
-    field_vga.set_value(receiver_model.vga());
-
-    steps_config.on_change = [this](size_t n, OptionsField::value_t v) {
-        (void)n;
-        field_frequency_min.set_step(v);
-        field_frequency_max.set_step(v);
-        steps = v;
-    };
-    steps_config.set_selected_index(0);  // default of 1 Mhz steps
-
-    scan_type.on_change = [this](size_t n, OptionsField::value_t v) {
-        (void)n;
-        fast_scan = v;
-    };
-    scan_type.set_selected_index(0);  // default legacy fast scan
-
-    view_config.on_change = [this](size_t n, OptionsField::value_t v) {
-        (void)n;
-        // clear between changes
-        reset_live_view(true);
-        if (v == 0) {
-            live_frequency_view = 0;
-            level_integration.hidden(true);
-            freq_stats.hidden(true);
-            button_jump.hidden(true);
-            button_rst.hidden(true);
-            display.scroll_set_area(109, 319);  // Restart scroll on the correct coordinates
-        } else if (v == 1) {
-            display.fill_rectangle({{0, 108}, {240, 24}}, {0, 0, 0});
-            live_frequency_view = 1;
-            display.scroll_disable();
-            level_integration.hidden(false);
-            freq_stats.hidden(false);
-            button_jump.hidden(false);
-            button_rst.hidden(false);
-        } else if (v == 2) {
-            display.fill_rectangle({{0, 108}, {240, 24}}, {0, 0, 0});
-            live_frequency_view = 2;
-            display.scroll_disable();
-            level_integration.hidden(false);
-            freq_stats.hidden(false);
-            button_jump.hidden(false);
-            button_rst.hidden(false);
-        }
-        set_dirty();
-    };
-    view_config.set_selected_index(0);  // default spectrum
-
-    level_integration.on_change = [this](size_t n, OptionsField::value_t v) {
-        (void)n;
-        reset_live_view(true);
-        live_frequency_integrate = v;
-    };
-    level_integration.set_selected_index(3);  // default integration of ( 3 * old value + new_value ) / 4
-
-    filter_config.on_change = [this](size_t n, OptionsField::value_t v) {
-        (void)n;
-        reset_live_view(true);
-        min_color_power = v;
-    };
-    filter_config.set_selected_index(0);
-
-    range_presets.on_change = [this](size_t n, OptionsField::value_t v) {
-        (void)n;
-        field_frequency_min.set_value(presets_db[v].min, false);
-        field_frequency_max.set_value(presets_db[v].max, false);
-        this->on_range_changed();
-    };
-
-    button_marker.on_change = [this]() {
-        marker = marker + button_marker.get_encoder_delta() * marker_pixel_step;
-        if (marker < f_min)
-            marker = f_min;
-        if (marker > f_max)
-            marker = f_max;
-        button_marker.set_text(to_string_short_freq(marker));
-        button_marker.set_encoder_delta(0);
-        PlotMarker(marker);  // Refresh marker on screen
-    };
-
-    button_marker.on_select = [this](ButtonWithEncoder&) {
-        receiver_model.set_tuning_frequency(marker);  // Center tune rx in marker freq.
-        receiver_model.set_frequency_step(MHZ_DIV);   // Preset a 1 MHz frequency step into RX -> AUDIO
-        nav_.pop();
-        nav_.push<AnalogAudioView>();  // Jump into audio view
-    };
-
-    field_trigger.on_change = [this](int32_t v) {
-        baseband::set_spectrum(LOOKING_GLASS_SLICE_WIDTH, v);
-    };
-    field_trigger.set_value(32);  // Defaults to 32, as normal triggering resolution
-
-    button_range.on_select = [this](Button&) {
-        if (locked_range) {
-            locked_range = false;
-            button_range.set_style(&style_white);
-            button_range.set_text(" " + to_string_dec_uint(search_span) + " ");
-        } else {
-            locked_range = true;
-            button_range.set_style(&style_red);
-            button_range.set_text(">" + to_string_dec_uint(search_span) + "<");
-        }
-    };
-
-    button_jump.on_select = [this](Button&) {
-        receiver_model.set_tuning_frequency(max_freq_hold);  // Center tune rx in marker freq.
-        receiver_model.set_frequency_step(MHZ_DIV);          // Preset a 1 MHz frequency step into RX -> AUDIO
-        nav_.pop();
-        nav_.push<AnalogAudioView>();  // Jump into audio view
-    };
-
-    button_rst.on_select = [this](Button&) {
-        reset_live_view(true);
-    };
-
-    display.scroll_set_area(109, 319);
-    baseband::set_spectrum(LOOKING_GLASS_SLICE_WIDTH, field_trigger.value());  // trigger:
-    // Discord User jteich:  WidebandSpectrum::on_message to set the trigger value. In WidebandSpectrum::execute ,
-    // it keeps adding the output of the fft to the buffer until "trigger" number of calls are made,
-    // at which time it pushes the buffer up with channel_spectrum.feed
-
-    on_range_changed();
-
-    receiver_model.set_modulation(ReceiverModel::Mode::SpectrumAnalysis);
-    receiver_model.set_sampling_rate(LOOKING_GLASS_SLICE_WIDTH);       // 20mhz
-    receiver_model.set_baseband_bandwidth(LOOKING_GLASS_SLICE_WIDTH);  // possible values: 1.75/2.5/3.5/5/5.5/6/7/8/9/10/12/14/15/20/24/28MHz
-    receiver_model.set_squelch_level(0);
-    receiver_model.enable();
-}
-
-void GlassView::load_Presets() {
-    File presets_file;  // LOAD /WHIPCALC/ANTENNAS.TXT from microSD
-    auto result = presets_file.open("LOOKINGGLASS/PRESETS.TXT");
-    presets_db.clear();  // Start with fresh db
-    if (result.is_valid()) {
-        presets_Default();  // There is no txt, store a default range
-    } else {
-        std::string line;  // There is a txt file
-        char one_char[1];  // Read it char by char
-        for (size_t pointer = 0; pointer < presets_file.size(); pointer++) {
-            presets_file.seek(pointer);
-            presets_file.read(one_char, 1);
-            if ((int)one_char[0] > 31) {       // ascii space upwards
-                line += one_char[0];           // Add it to the textline
-            } else if (one_char[0] == '\n') {  // New Line
-                txtline_process(line);         // make sense of this textline
-                line.clear();                  // Ready for next textline
+        field_frequency_min.on_change = [this](int32_t v)
+        {
+            reset_live_view( true );
+            int32_t min_size = steps ;
+            if( locked_range )
+                min_size = search_span ;
+            if( min_size < 2 )
+                min_size = 2 ;
+            if( v > 7200 - min_size )
+            {
+                v = 7200 - min_size ;
+                field_frequency_min.set_value( v ); 
             }
+            if (v > (field_frequency_max.value() - min_size ) )
+                field_frequency_max.set_value( v + min_size );
+            if( locked_range )
+                field_frequency_max.set_value( v + min_size );
+            on_range_changed();
+        };
+        field_frequency_min.set_value(presets_db[0].min); // Defaults to first preset
+        field_frequency_min.set_step( steps );
+
+        field_frequency_min.on_select = [this, &nav](NumberField& field) {
+            auto new_view = nav_.push<FrequencyKeypadView>(field_frequency_min.value()*MHZ_DIV);
+            new_view->on_changed = [this, &field](rf::Frequency f) {
+                int32_t freq = f / MHZ_DIV ;
+                int32_t min_size = steps ;
+                if( locked_range )
+                    min_size = search_span ;
+                if( min_size < 2 )
+                    min_size = 2 ;
+                if( freq > (7200 - min_size ) )
+                    freq = 7200 - min_size  ;
+                field_frequency_min.set_value( freq );
+                if( field_frequency_max.value() < ( freq + min_size ) )
+                    field_frequency_max.set_value( freq + min_size );
+                on_range_changed();
+            };
+        };
+
+        field_frequency_max.on_change = [this](int32_t v)
+        {          
+            reset_live_view( true );
+            int32_t min_size = steps ;
+            if( locked_range )
+                min_size = search_span ;
+            if( min_size < 2 )
+                min_size = 2 ;
+            if( v < min_size )
+            {
+                v = min_size ;
+                field_frequency_max.set_value( v ); 
+            }
+            if (v < (field_frequency_min.value() + min_size) )
+                field_frequency_min.set_value(v - min_size);
+            if( locked_range )
+                field_frequency_min.set_value( v - min_size );
+            on_range_changed();
+        };
+        field_frequency_max.set_value(presets_db[0].max); // Defaults to first preset
+        field_frequency_max.set_step( steps );
+
+        field_frequency_max.on_select = [this, &nav](NumberField& field) {
+            auto new_view = nav_.push<FrequencyKeypadView>(field_frequency_max.value()*MHZ_DIV);
+            new_view->on_changed = [this, &field](rf::Frequency f) {
+                int32_t min_size = steps ;
+                if( locked_range )
+                    min_size = search_span ;
+                if( min_size < 2 )
+                    min_size = 2 ;
+                int32_t freq = f / MHZ_DIV ;
+                if( freq < min_size )
+                    freq = min_size ;
+                field_frequency_max.set_value( freq );
+                if( field_frequency_min.value() > ( freq - min_size) ) 
+                    field_frequency_min.set_value( freq - min_size );
+                on_range_changed();
+            };
+        };
+
+        field_lna.on_change = [this](int32_t v)
+        {
+            reset_live_view( true );
+            this->on_lna_changed(v);
+        };
+        field_lna.set_value(receiver_model.lna());
+
+        field_vga.on_change = [this](int32_t v_db)
+        {
+            reset_live_view( true );
+            this->on_vga_changed(v_db);
+        };
+        field_vga.set_value(receiver_model.vga());
+
+        steps_config.on_change = [this](size_t n, OptionsField::value_t v)
+        {
+            (void)n;
+            field_frequency_min.set_step( v );
+            field_frequency_max.set_step( v );
+            steps = v ;
+        };
+        steps_config.set_selected_index(0); //default of 1 Mhz steps
+
+        scan_type.on_change = [this](size_t n, OptionsField::value_t v)
+        {
+            (void)n;
+            mode = v ;
+            on_range_changed();
+        };
+        scan_type.set_selected_index(0); // default legacy fast scan
+
+        view_config.on_change = [this](size_t n, OptionsField::value_t v)
+        {
+            (void)n;
+            // clear between changes
+            reset_live_view( true );
+            if( v == 0 )
+            {
+                live_frequency_view = 0 ;
+                level_integration.hidden( true );
+                freq_stats.hidden( true );
+                button_jump.hidden( true );
+                button_rst.hidden( true );
+                display.scroll_set_area(109, 319); // Restart scroll on the correct coordinates
+            }
+            else if( v == 1 )
+            {
+                display.fill_rectangle( { { 0 , 108 } , { SCREEN_W , 24 } } , { 0 , 0 , 0 } );
+                live_frequency_view = 1 ;
+                display.scroll_disable();
+                level_integration.hidden( false );
+                freq_stats.hidden( false );
+                button_jump.hidden( false );
+                button_rst.hidden( false );
+            }
+            else if( v == 2 )
+            {
+                display.fill_rectangle( { { 0 , 108 } , { SCREEN_W , 24 } } , { 0 , 0 , 0 } );
+                live_frequency_view = 2 ;
+                display.scroll_disable();
+                level_integration.hidden( false );
+                freq_stats.hidden( false );
+                button_jump.hidden( false );
+                button_rst.hidden( false );
+            }
+            set_dirty();
+        };
+        view_config.set_selected_index(0); //default spectrum
+
+        level_integration.on_change = [this](size_t n, OptionsField::value_t v)
+        {
+            (void)n;
+            reset_live_view( true );
+            live_frequency_integrate = v ;
+        };
+        level_integration.set_selected_index(3); //default integration of ( 3 * old value + new_value ) / 4
+
+        filter_config.on_change = [this](size_t n, OptionsField::value_t v) {
+            (void)n;
+            reset_live_view( true );
+            min_color_power = v;
+        };
+        filter_config.set_selected_index(0);
+
+        range_presets.on_change = [this](size_t n, OptionsField::value_t v)
+        {
+            (void)n;
+            field_frequency_min.set_value(presets_db[v].min, false);
+            field_frequency_max.set_value(presets_db[v].max, false);
+            on_range_changed();
+        };
+
+        button_marker.on_change = [this]()
+        {
+            if( ( (int)marker_pixel_index + button_marker.get_encoder_delta() ) < 0 )
+            {
+                marker_pixel_index = 0 ;
+            }
+            else if( ( (int)marker_pixel_index + button_marker.get_encoder_delta() ) > SCREEN_W )
+            {
+                marker_pixel_index = SCREEN_W ;
+            }
+            else
+            {
+                marker_pixel_index = marker_pixel_index + button_marker.get_encoder_delta() ;
+            }
+            on_marker_change();
+            button_marker.set_encoder_delta( 0 );
+        };
+
+        button_marker.on_select = [this](ButtonWithEncoder &)
+        {
+            receiver_model.set_tuning_frequency(marker); // Center tune rx in marker freq.
+            receiver_model.set_frequency_step(MHZ_DIV);    // Preset a 1 MHz frequency step into RX -> AUDIO
+            nav_.pop();
+            nav_.push<AnalogAudioView>(); // Jump into audio view
+        };
+
+        field_trigger.on_change = [this](int32_t v)
+        {
+            baseband::set_spectrum(looking_glass_sampling_rate, v);
+        };
+        field_trigger.set_value(32); // Defaults to 32, as normal triggering resolution
+
+        button_range.on_select = [this](Button&) {
+            if( locked_range )
+            {
+                locked_range = false ;
+                button_range.set_style(&style_white);
+                button_range.set_text(" "+to_string_dec_uint(search_span)+" ");
+            }
+            else
+            {
+                locked_range = true ;
+                button_range.set_style(&style_red);
+                button_range.set_text(">"+to_string_dec_uint(search_span)+"<");
+            }
+        };
+
+        button_jump.on_select = [this](Button&) {
+            receiver_model.set_tuning_frequency(max_freq_hold); // Center tune rx in marker freq.
+            receiver_model.set_frequency_step(MHZ_DIV);    // Preset a 1 MHz frequency step into RX -> AUDIO
+            nav_.pop();
+            nav_.push<AnalogAudioView>(); // Jump into audio view
+        };
+
+        button_rst.on_select = [this](Button&) {
+            reset_live_view( true );
+        };
+
+        display.scroll_set_area(109, 319);
+        baseband::set_spectrum(looking_glass_sampling_rate, field_trigger.value()); // trigger:
+                                                                                    // Discord User jteich:  WidebandSpectrum::on_message to set the trigger value. In WidebandSpectrum::execute ,
+                                                                                    // it keeps adding the output of the fft to the buffer until "trigger" number of calls are made,
+                                                                                    // at which time it pushes the buffer up with channel_spectrum.feed
+
+        marker_pixel_index = 120 ;
+        on_range_changed();
+
+        receiver_model.set_modulation(ReceiverModel::Mode::SpectrumAnalysis);
+        receiver_model.set_sampling_rate(looking_glass_sampling_rate);      // 20mhz
+        receiver_model.set_baseband_bandwidth(looking_glass_bandwidth); // possible values: 1.75/2.5/3.5/5/5.5/6/7/8/9/10/12/14/15/20/24/28MHz
+        receiver_model.set_squelch_level(0);
+        receiver_model.enable();
+    }
+
+    void GlassView::load_Presets()
+    {
+        File presets_file; // LOAD /WHIPCALC/ANTENNAS.TXT from microSD
+        auto result = presets_file.open("LOOKINGGLASS/PRESETS.TXT");
+        presets_db.clear(); // Start with fresh db
+        if (result.is_valid())
+        {
+            presets_Default(); // There is no txt, store a default range
         }
-        if (line.length() > 0)
-            txtline_process(line);  // Last line had no newline at end ?
-        if (!presets_db.size())
-            presets_Default();  // no antenna on txt, use default
+        else
+        {
+            std::string line; // There is a txt file
+            char one_char[1]; // Read it char by char
+            for (size_t pointer = 0; pointer < presets_file.size(); pointer++)
+            {
+                presets_file.seek(pointer);
+                presets_file.read(one_char, 1);
+                if ((int)one_char[0] > 31)
+                {                        // ascii space upwards
+                    line += one_char[0]; // Add it to the textline
+                }
+                else if (one_char[0] == '\n')
+                {                          // New Line
+                    txtline_process(line); // make sense of this textline
+                    line.clear();          // Ready for next textline
+                }
+            }
+            if (line.length() > 0)
+                txtline_process(line); // Last line had no newline at end ?
+            if (!presets_db.size())
+                presets_Default(); // no antenna on txt, use default
+        }
+        populate_Presets();
     }
-    populate_Presets();
-}
 
-void GlassView::txtline_process(std::string& line) {
-    if (line.find("#") != std::string::npos)
-        return;  // Line is just a comment
+    void GlassView::txtline_process(std::string &line)
+    {
+        if (line.find("#") != std::string::npos)
+            return; // Line is just a comment
 
-    size_t comma = line.find(",");  // Get first comma position
-    if (comma == std::string::npos)
-        return;  // No comma at all
+        size_t comma = line.find(","); // Get first comma position
+        if (comma == std::string::npos)
+            return; // No comma at all
 
-    size_t previous = 0;
-    preset_entry new_preset;
+        size_t previous = 0;
+        preset_entry new_preset;
 
-    new_preset.min = std::stoi(line.substr(0, comma));
-    if (!new_preset.min)
-        return;  // No frequency!
+        new_preset.min = std::stoi(line.substr(0, comma));
+        if (!new_preset.min)
+            return; // No frequency!
 
-    previous = comma + 1;
-    comma = line.find(",", previous);  // Search for next delimiter
-    if (comma == std::string::npos)
-        return;  // No comma at all
+        previous = comma + 1;
+        comma = line.find(",", previous); // Search for next delimiter
+        if (comma == std::string::npos)
+            return; // No comma at all
 
-    new_preset.max = std::stoi(line.substr(previous, comma - previous));
-    if (!new_preset.max)
-        return;  // No frequency!
+        new_preset.max = std::stoi(line.substr(previous, comma - previous));
+        if (!new_preset.max)
+            return; // No frequency!
 
-    new_preset.label = line.substr(comma + 1);
-    if (new_preset.label.size() == 0)
-        return;  // No label ?
+        new_preset.label = line.substr(comma + 1);
+        if (new_preset.label.size() == 0)
+            return; // No label ?
 
-    presets_db.push_back(new_preset);  // Add this preset.
-}
-
-void GlassView::populate_Presets() {
-    using option_t = std::pair<std::string, int32_t>;
-    using options_t = std::vector<option_t>;
-    options_t entries;
-
-    for (preset_entry preset : presets_db) {  // go thru all available presets
-        entries.emplace_back(preset.label, entries.size());
+        presets_db.push_back(new_preset); // Add this preset.
     }
-    range_presets.set_options(entries);
-}
 
-void GlassView::presets_Default() {
-    presets_db.clear();
-    presets_db.push_back({2320, 2560, "DEFAULT WIFI 2.4GHz"});
-}
+    void GlassView::populate_Presets()
+    {
+        using option_t = std::pair<std::string, int32_t>;
+        using options_t = std::vector<option_t>;
+        options_t entries;
 
-}  // namespace ui
+        for (preset_entry preset : presets_db)
+        { // go thru all available presets
+            entries.emplace_back(preset.label, entries.size());
+        }
+        range_presets.set_options(entries);
+    }
+
+    void GlassView::presets_Default()
+    {
+        presets_db.clear();
+        presets_db.push_back({2320, 2560, "DEFAULT WIFI 2.4GHz"});
+    }
+
+}

--- a/firmware/application/apps/ui_looking_glass_app.hpp
+++ b/firmware/application/apps/ui_looking_glass_app.hpp
@@ -35,228 +35,267 @@
 #include "analog_audio_app.hpp"
 #include "spectrum_color_lut.hpp"
 
-namespace ui {
+namespace ui
+{
 #define LOOKING_GLASS_SLICE_WIDTH_MAX 20000000
-#define MHZ_DIV 1000000
-#define X2_MHZ_DIV 2000000
+#define MHZ_DIV                       1000000
 
-class GlassView : public View {
-   public:
-    GlassView(NavigationView& nav);
+    // blanked DC (16 centered bins ignored ) and top left and right (2 bins ignored on each side )
+#define LOOKING_GLASS_FASTSCAN   0
+    // only first half used (so DC spike is not ignored, it's stopped before the DC spike) minus the 2 first bins
+#define LOOKING_GLASS_SLOWSCAN   1
+    // analog audio view like 
+#define LOOKING_GLASS_SINGLEPASS 2
+    // one spectrum line number of bins
+#define SPEC_NB_BINS 256
+    // screen dimensions 
+#define SCREEN_W 240
+#define SCREEN_H 320
 
-    GlassView(const GlassView&);
-    GlassView& operator=(const GlassView& nav);
+    class GlassView : public View
+    {
+        public:
 
-    ~GlassView();
-    std::string title() const override { return "LookingGlass"; };
+            GlassView(NavigationView &nav);
 
-    void on_show() override;
-    void on_hide() override;
-    void focus() override;
+            GlassView( const GlassView &);
+            GlassView& operator=(const GlassView &nav);
 
-   private:
-    NavigationView& nav_;
+            ~GlassView();
+            std::string title() const override { return "LookingGlass"; };
 
-    struct preset_entry {
-        rf::Frequency min{};
-        rf::Frequency max{};
-        std::string label{};
+            void on_show() override;
+            void on_hide() override;
+            void focus() override;
+
+        private:
+            NavigationView& nav_;
+
+            struct preset_entry
+            {
+                rf::Frequency min{};
+                rf::Frequency max{};
+                std::string label{};
+            };
+
+            const Style style_white { // free range
+                .font = font::fixed_8x16,
+                    .background = Color::black(),
+                    .foreground = Color::white(),
+            };
+
+            const Style style_red { // locked range
+                .font = font::fixed_8x16,
+                    .background = Color::black(),
+                    .foreground = Color::red(),
+            };
+
+            std::vector<preset_entry> presets_db{};
+            void get_max_power( const ChannelSpectrum &spectrum, uint8_t bin , uint8_t &max_power );
+            void on_marker_change();
+            int64_t next_mult_of(int64_t num, int64_t multiplier);
+            void adjust_range(int64_t* f_min, int64_t* f_max, int64_t width); 
+            void retune();
+            bool move_to_next_position();
+            void on_channel_spectrum(const ChannelSpectrum& spectrum);
+            void do_timers();
+            void on_range_changed();
+            void on_lna_changed(int32_t v_db);
+            void on_vga_changed(int32_t v_db);
+            void reset_live_view( bool clear_screen );
+            void add_spectrum_pixel(uint8_t power);
+            void PlotMarker( uint8_t pos);
+            void load_Presets();
+            void txtline_process(std::string& line);
+            void populate_Presets();
+            void presets_Default();
+
+            rf::Frequency f_min { 0 }, f_max { 0 };
+            rf::Frequency search_span { 0 };
+            rf::Frequency f_center { 0 };
+            rf::Frequency f_center_ini { 0 };
+            rf::Frequency marker { 0 };
+            uint8_t marker_pixel_index { 0 };
+            rf::Frequency marker_pixel_step { 0 };
+            // size of one spectrum bin in Hz
+            rf::Frequency each_bin_size { 0 };
+            // consumed number of Hz, used to know if we have filled a 'bag' , a corresponding pixel length on screen
+            rf::Frequency bins_Hz_size { 0 };
+            rf::Frequency looking_glass_sampling_rate { 0 };
+            rf::Frequency looking_glass_bandwidth { 0 };
+            rf::Frequency looking_glass_range { 0 };
+            rf::Frequency looking_glass_step { 0 };
+            uint8_t min_color_power { 0 };
+            uint32_t pixel_index { 0 };
+            std::array<Color, SCREEN_W> spectrum_row = { 0 };
+            std::array<uint8_t, SCREEN_W> spectrum_data = { 0 };
+            ChannelSpectrumFIFO* fifo { nullptr }; 
+            uint8_t max_power = 0;
+            int32_t steps = 0 ;
+            uint8_t live_frequency_view = 0 ;
+            int16_t live_frequency_integrate = 3 ;
+            int64_t max_freq_hold = 0 ;
+            int16_t max_freq_power = -1000 ;
+            bool locked_range = false ; 
+            uint8_t bin_length = SCREEN_W ; 	
+            uint8_t real_bin_length = SCREEN_W ; 	
+            uint8_t offset = 0 ; 
+            uint8_t tune_offset = 0 ;
+            uint8_t bin = 0 ;
+            int64_t last_max_freq = 0 ;
+            uint8_t mode = LOOKING_GLASS_FASTSCAN ;
+            uint8_t ignore_dc = 0 ;
+
+
+            Labels labels{
+                {{0, 0}, "MIN:     MAX:     LNA   VGA  ", Color::light_grey()},
+                    {{0, 1 * 16}, "RANGE:       FILTER:      AMP:", Color::light_grey()},
+                    {{0, 2 * 16}, "PRESET:", Color::light_grey()},
+                    {{0, 3 * 16}, "MARKER:            MHz", Color::light_grey()},
+                    {{0, 4 * 16}, "RES:    STEP:", Color::light_grey()}
+            };
+
+            NumberField field_frequency_min {
+                { 4 * 8, 0 * 16 },
+                    4,
+                    { 0, 7199 },
+                    1, // number of steps by encoder delta
+                    ' '
+            };
+
+            NumberField field_frequency_max {
+                { 13 * 8, 0 * 16 },
+                    4,
+                    { 1, 7200 },
+                    1, // number of steps by encoder delta
+                    ' '
+            };
+
+            LNAGainField field_lna {
+                { 21 * 8, 0 * 16 }
+            };
+
+            VGAGainField field_vga {
+                { 27 * 8, 0 * 16 }
+            };
+
+            Button  button_range{
+                {7 * 8, 1 * 16, 4 * 8, 16},
+                    ""
+            };
+
+            OptionsField filter_config{
+                {20 * 8, 1 * 16},
+                    4,
+                    {
+                        {"OFF ", 0},
+                        {"MID ", 118}, //85 +25 (110) + a bit more to kill all blue
+                        {"HIGH", 202}, //168 + 25 (193)
+                    }};
+
+            RFAmpField field_rf_amp{
+                {29 * 8, 1 * 16}};
+
+            OptionsField range_presets{
+                {7 * 8, 2 * 16},
+                    20,
+                    {
+                        {" NONE (WIFI 2.4GHz)", 0},
+                    }};
+
+            ButtonWithEncoder button_marker{
+                {7 * 8, 3 * 16 , 10 * 8 , 16},
+                    " "
+            };
+
+            NumberField field_trigger{
+                {4 * 8, 4 * 16},
+                    3,
+                    {2, 128},
+                    2,
+                    ' '};
+
+            OptionsField steps_config{
+                { 13 * 8, 4 * 16},
+                    3,
+                    {
+                        {"1",    1},
+                        {"25",   25},
+                        {"50",   50},
+                        {"100",  100},
+                        {"250",  250}, 
+                        {"500",  500},
+                    }
+            };
+
+            OptionsField scan_type{
+                { 17 * 8, 4 * 16},
+                    2,
+                    {
+                        {"F-", LOOKING_GLASS_FASTSCAN },
+                        {"S-", LOOKING_GLASS_SLOWSCAN },
+                    }
+            };
+
+            OptionsField view_config{
+                { 19 * 8, 4 * 16},
+                    7,
+                    {
+                        {"SPCTR-V", 0 },
+                        {"LEVEL-V", 1 },
+                        {"PEAK-V" , 2 },
+                    }
+            };
+
+            OptionsField level_integration{
+                { 27 * 8, 4 * 16},
+                    2,
+                    {
+                        {"x0", 0 },
+                        {"x1", 1 },
+                        {"x2", 2 },
+                        {"x3", 3 },
+                        {"x4", 4 },
+                        {"x5", 5 },
+                        {"x6", 6 },
+                        {"x7", 7 },
+                        {"x8", 8 },
+                        {"x9", 9 },
+                    }};
+
+            Button button_jump {
+                { SCREEN_W - 4 * 8 , 5 * 16 , 4 * 8, 16 },
+                    "JMP"
+            };
+
+            Button button_rst {
+                { SCREEN_W - 9 * 8 , 5 * 16 , 4 * 8, 16 },
+                    "RST"
+            };
+
+            Text freq_stats{
+                {0 * 8, 5 * 16 , SCREEN_W - 10 * 8 , 8 },
+                    ""
+            };
+
+            MessageHandlerRegistration message_handler_spectrum_config {
+                Message::ID::ChannelSpectrumConfig,
+                    [this](const Message* const p) {
+                        const auto message = *reinterpret_cast<const ChannelSpectrumConfigMessage*>(p);
+                        this->fifo = message.fifo;
+                    }
+            };
+            MessageHandlerRegistration message_handler_frame_sync {
+                Message::ID::DisplayFrameSync,
+                    [this](const Message* const) {
+                        if( this->fifo ) {
+                            ChannelSpectrum channel_spectrum;
+                            while( fifo->out(channel_spectrum) ) {
+                                this->on_channel_spectrum(channel_spectrum);
+                            }
+                        }
+                    }
+            };
     };
-
-    const Style style_white{
-        // free range
-        .font = font::fixed_8x16,
-        .background = Color::black(),
-        .foreground = Color::white(),
-    };
-
-    const Style style_red{
-        // locked range
-        .font = font::fixed_8x16,
-        .background = Color::black(),
-        .foreground = Color::red(),
-    };
-
-    std::vector<preset_entry> presets_db{};
-
-    // Each slice bandwidth 20 MHz and a multiple of 256
-    // since we are using LOOKING_GLASS_SLICE_WIDTH/256 as the each_bin_size
-    // it should also be a multiple of 2 since we are using LOOKING_GLASS_SLICE_WIDTH / 2 as centering freq
-    int64_t LOOKING_GLASS_SLICE_WIDTH = 20000000;
-
-    // frequency rounding helpers
-    int64_t next_mult_of(int64_t num, int64_t multiplier);
-    void adjust_range(int64_t* f_min, int64_t* f_max, int64_t width);
-
-    void on_channel_spectrum(const ChannelSpectrum& spectrum);
-    void do_timers();
-    void on_range_changed();
-    void on_lna_changed(int32_t v_db);
-    void on_vga_changed(int32_t v_db);
-    void reset_live_view(bool clear_screen);
-    void add_spectrum_pixel(uint8_t power);
-    void PlotMarker(rf::Frequency pos);
-    void load_Presets();
-    void txtline_process(std::string& line);
-    void populate_Presets();
-    void presets_Default();
-
-    rf::Frequency f_min{0}, f_max{0};
-    rf::Frequency search_span{0};
-    rf::Frequency f_center{0};
-    rf::Frequency f_center_ini{0};
-    rf::Frequency marker{0};
-    rf::Frequency marker_pixel_step{0};
-    rf::Frequency each_bin_size{LOOKING_GLASS_SLICE_WIDTH / 256};
-    rf::Frequency bins_Hz_size{0};
-    uint8_t min_color_power{0};
-    uint32_t pixel_index{0};
-    std::array<Color, 240> spectrum_row = {0};
-    std::array<uint8_t, 240> spectrum_data = {0};
-    ChannelSpectrumFIFO* fifo{nullptr};
-    uint8_t max_power = 0;
-    int32_t steps = 0;
-    uint8_t live_frequency_view = 0;
-    int16_t live_frequency_integrate = 3;
-    int64_t max_freq_hold = 0;
-    int16_t max_freq_power = -1000;
-    bool fast_scan = true;  // default to legacy fast scan
-    bool locked_range = false;
-
-    Labels labels{
-        {{0, 0}, "MIN:     MAX:     LNA   VGA  ", Color::light_grey()},
-        {{0, 1 * 16}, "RANGE:       FILTER:      AMP:", Color::light_grey()},
-        {{0, 2 * 16}, "PRESET:", Color::light_grey()},
-        {{0, 3 * 16}, "MARKER:            MHz", Color::light_grey()},
-        {{0, 4 * 16}, "RES:    STEP:", Color::light_grey()}};
-
-    NumberField field_frequency_min{
-        {4 * 8, 0 * 16},
-        4,
-        {0, 7199},
-        1,  // number of steps by encoder delta
-        ' '};
-
-    NumberField field_frequency_max{
-        {13 * 8, 0 * 16},
-        4,
-        {1, 7200},
-        1,  // number of steps by encoder delta
-        ' '};
-
-    LNAGainField field_lna{
-        {21 * 8, 0 * 16}};
-
-    VGAGainField field_vga{
-        {27 * 8, 0 * 16}};
-
-    Button button_range{
-        {7 * 8, 1 * 16, 4 * 8, 16},
-        ""};
-
-    OptionsField filter_config{
-        {20 * 8, 1 * 16},
-        4,
-        {
-            {"OFF ", 0},
-            {"MID ", 118},  // 85 +25 (110) + a bit more to kill all blue
-            {"HIGH", 202},  // 168 + 25 (193)
-        }};
-
-    RFAmpField field_rf_amp{
-        {29 * 8, 1 * 16}};
-
-    OptionsField range_presets{
-        {7 * 8, 2 * 16},
-        20,
-        {
-            {" NONE (WIFI 2.4GHz)", 0},
-        }};
-
-    ButtonWithEncoder button_marker{
-        {7 * 8, 3 * 16, 10 * 8, 16},
-        " "};
-
-    NumberField field_trigger{
-        {4 * 8, 4 * 16},
-        3,
-        {2, 128},
-        2,
-        ' '};
-
-    OptionsField steps_config{
-        {13 * 8, 4 * 16},
-        3,
-        {
-            {"1", 1},
-            {"25", 25},
-            {"50", 50},
-            {"100", 100},
-            {"250", 250},
-            {"500", 500},
-        }};
-
-    OptionsField scan_type{
-        {17 * 8, 4 * 16},
-        2,
-        {
-            {"F-", true},
-            {"S-", false},
-        }};
-
-    OptionsField view_config{
-        {19 * 8, 4 * 16},
-        7,
-        {
-            {"SPCTR-V", 0},
-            {"LEVEL-V", 1},
-            {"PEAK-V", 2},
-        }};
-
-    OptionsField level_integration{
-        {27 * 8, 4 * 16},
-        2,
-        {
-            {"x0", 0},
-            {"x1", 1},
-            {"x2", 2},
-            {"x3", 3},
-            {"x4", 4},
-            {"x5", 5},
-            {"x6", 6},
-            {"x7", 7},
-            {"x8", 8},
-            {"x9", 9},
-        }};
-
-    Button button_jump{
-        {240 - 4 * 8, 5 * 16, 4 * 8, 16},
-        "JMP"};
-
-    Button button_rst{
-        {240 - 9 * 8, 5 * 16, 4 * 8, 16},
-        "RST"};
-
-    Text freq_stats{
-        {0 * 8, 5 * 16, 240 - 10 * 8, 8},
-        ""};
-
-    MessageHandlerRegistration message_handler_spectrum_config{
-        Message::ID::ChannelSpectrumConfig,
-        [this](const Message* const p) {
-            const auto message = *reinterpret_cast<const ChannelSpectrumConfigMessage*>(p);
-            this->fifo = message.fifo;
-        }};
-    MessageHandlerRegistration message_handler_frame_sync{
-        Message::ID::DisplayFrameSync,
-        [this](const Message* const) {
-            if (this->fifo) {
-                ChannelSpectrum channel_spectrum;
-                while (fifo->out(channel_spectrum)) {
-                    this->on_channel_spectrum(channel_spectrum);
-                }
-            }
-        }};
-};
-}  // namespace ui
+} 
 #endif

--- a/firmware/application/apps/ui_looking_glass_app.hpp
+++ b/firmware/application/apps/ui_looking_glass_app.hpp
@@ -35,267 +35,249 @@
 #include "analog_audio_app.hpp"
 #include "spectrum_color_lut.hpp"
 
-namespace ui
-{
+namespace ui {
 #define LOOKING_GLASS_SLICE_WIDTH_MAX 20000000
-#define MHZ_DIV                       1000000
+#define MHZ_DIV 1000000
 
-    // blanked DC (16 centered bins ignored ) and top left and right (2 bins ignored on each side )
-#define LOOKING_GLASS_FASTSCAN   0
-    // only first half used (so DC spike is not ignored, it's stopped before the DC spike) minus the 2 first bins
-#define LOOKING_GLASS_SLOWSCAN   1
-    // analog audio view like 
+// blanked DC (16 centered bins ignored ) and top left and right (2 bins ignored on each side )
+#define LOOKING_GLASS_FASTSCAN 0
+// only first half used (so DC spike is not ignored, it's stopped before the DC spike) minus the 2 first bins
+#define LOOKING_GLASS_SLOWSCAN 1
+// analog audio view like
 #define LOOKING_GLASS_SINGLEPASS 2
-    // one spectrum line number of bins
+// one spectrum line number of bins
 #define SPEC_NB_BINS 256
-    // screen dimensions 
+// screen dimensions
 #define SCREEN_W 240
 #define SCREEN_H 320
 
-    class GlassView : public View
-    {
-        public:
+class GlassView : public View {
+   public:
+    GlassView(NavigationView& nav);
 
-            GlassView(NavigationView &nav);
+    GlassView(const GlassView&);
+    GlassView& operator=(const GlassView& nav);
 
-            GlassView( const GlassView &);
-            GlassView& operator=(const GlassView &nav);
+    ~GlassView();
+    std::string title() const override { return "LookingGlass"; };
 
-            ~GlassView();
-            std::string title() const override { return "LookingGlass"; };
+    void on_show() override;
+    void on_hide() override;
+    void focus() override;
 
-            void on_show() override;
-            void on_hide() override;
-            void focus() override;
+   private:
+    NavigationView& nav_;
 
-        private:
-            NavigationView& nav_;
-
-            struct preset_entry
-            {
-                rf::Frequency min{};
-                rf::Frequency max{};
-                std::string label{};
-            };
-
-            const Style style_white { // free range
-                .font = font::fixed_8x16,
-                    .background = Color::black(),
-                    .foreground = Color::white(),
-            };
-
-            const Style style_red { // locked range
-                .font = font::fixed_8x16,
-                    .background = Color::black(),
-                    .foreground = Color::red(),
-            };
-
-            std::vector<preset_entry> presets_db{};
-            void get_max_power( const ChannelSpectrum &spectrum, uint8_t bin , uint8_t &max_power );
-            void on_marker_change();
-            int64_t next_mult_of(int64_t num, int64_t multiplier);
-            void adjust_range(int64_t* f_min, int64_t* f_max, int64_t width); 
-            void retune();
-            bool move_to_next_position();
-            void on_channel_spectrum(const ChannelSpectrum& spectrum);
-            void do_timers();
-            void on_range_changed();
-            void on_lna_changed(int32_t v_db);
-            void on_vga_changed(int32_t v_db);
-            void reset_live_view( bool clear_screen );
-            void add_spectrum_pixel(uint8_t power);
-            void PlotMarker( uint8_t pos);
-            void load_Presets();
-            void txtline_process(std::string& line);
-            void populate_Presets();
-            void presets_Default();
-
-            rf::Frequency f_min { 0 }, f_max { 0 };
-            rf::Frequency search_span { 0 };
-            rf::Frequency f_center { 0 };
-            rf::Frequency f_center_ini { 0 };
-            rf::Frequency marker { 0 };
-            uint8_t marker_pixel_index { 0 };
-            rf::Frequency marker_pixel_step { 0 };
-            // size of one spectrum bin in Hz
-            rf::Frequency each_bin_size { 0 };
-            // consumed number of Hz, used to know if we have filled a 'bag' , a corresponding pixel length on screen
-            rf::Frequency bins_Hz_size { 0 };
-            rf::Frequency looking_glass_sampling_rate { 0 };
-            rf::Frequency looking_glass_bandwidth { 0 };
-            rf::Frequency looking_glass_range { 0 };
-            rf::Frequency looking_glass_step { 0 };
-            uint8_t min_color_power { 0 };
-            uint32_t pixel_index { 0 };
-            std::array<Color, SCREEN_W> spectrum_row = { 0 };
-            std::array<uint8_t, SCREEN_W> spectrum_data = { 0 };
-            ChannelSpectrumFIFO* fifo { nullptr }; 
-            uint8_t max_power = 0;
-            int32_t steps = 0 ;
-            uint8_t live_frequency_view = 0 ;
-            int16_t live_frequency_integrate = 3 ;
-            int64_t max_freq_hold = 0 ;
-            int16_t max_freq_power = -1000 ;
-            bool locked_range = false ; 
-            uint8_t bin_length = SCREEN_W ; 	
-            uint8_t real_bin_length = SCREEN_W ; 	
-            uint8_t offset = 0 ; 
-            uint8_t tune_offset = 0 ;
-            uint8_t bin = 0 ;
-            int64_t last_max_freq = 0 ;
-            uint8_t mode = LOOKING_GLASS_FASTSCAN ;
-            uint8_t ignore_dc = 0 ;
-
-
-            Labels labels{
-                {{0, 0}, "MIN:     MAX:     LNA   VGA  ", Color::light_grey()},
-                    {{0, 1 * 16}, "RANGE:       FILTER:      AMP:", Color::light_grey()},
-                    {{0, 2 * 16}, "PRESET:", Color::light_grey()},
-                    {{0, 3 * 16}, "MARKER:            MHz", Color::light_grey()},
-                    {{0, 4 * 16}, "RES:    STEP:", Color::light_grey()}
-            };
-
-            NumberField field_frequency_min {
-                { 4 * 8, 0 * 16 },
-                    4,
-                    { 0, 7199 },
-                    1, // number of steps by encoder delta
-                    ' '
-            };
-
-            NumberField field_frequency_max {
-                { 13 * 8, 0 * 16 },
-                    4,
-                    { 1, 7200 },
-                    1, // number of steps by encoder delta
-                    ' '
-            };
-
-            LNAGainField field_lna {
-                { 21 * 8, 0 * 16 }
-            };
-
-            VGAGainField field_vga {
-                { 27 * 8, 0 * 16 }
-            };
-
-            Button  button_range{
-                {7 * 8, 1 * 16, 4 * 8, 16},
-                    ""
-            };
-
-            OptionsField filter_config{
-                {20 * 8, 1 * 16},
-                    4,
-                    {
-                        {"OFF ", 0},
-                        {"MID ", 118}, //85 +25 (110) + a bit more to kill all blue
-                        {"HIGH", 202}, //168 + 25 (193)
-                    }};
-
-            RFAmpField field_rf_amp{
-                {29 * 8, 1 * 16}};
-
-            OptionsField range_presets{
-                {7 * 8, 2 * 16},
-                    20,
-                    {
-                        {" NONE (WIFI 2.4GHz)", 0},
-                    }};
-
-            ButtonWithEncoder button_marker{
-                {7 * 8, 3 * 16 , 10 * 8 , 16},
-                    " "
-            };
-
-            NumberField field_trigger{
-                {4 * 8, 4 * 16},
-                    3,
-                    {2, 128},
-                    2,
-                    ' '};
-
-            OptionsField steps_config{
-                { 13 * 8, 4 * 16},
-                    3,
-                    {
-                        {"1",    1},
-                        {"25",   25},
-                        {"50",   50},
-                        {"100",  100},
-                        {"250",  250}, 
-                        {"500",  500},
-                    }
-            };
-
-            OptionsField scan_type{
-                { 17 * 8, 4 * 16},
-                    2,
-                    {
-                        {"F-", LOOKING_GLASS_FASTSCAN },
-                        {"S-", LOOKING_GLASS_SLOWSCAN },
-                    }
-            };
-
-            OptionsField view_config{
-                { 19 * 8, 4 * 16},
-                    7,
-                    {
-                        {"SPCTR-V", 0 },
-                        {"LEVEL-V", 1 },
-                        {"PEAK-V" , 2 },
-                    }
-            };
-
-            OptionsField level_integration{
-                { 27 * 8, 4 * 16},
-                    2,
-                    {
-                        {"x0", 0 },
-                        {"x1", 1 },
-                        {"x2", 2 },
-                        {"x3", 3 },
-                        {"x4", 4 },
-                        {"x5", 5 },
-                        {"x6", 6 },
-                        {"x7", 7 },
-                        {"x8", 8 },
-                        {"x9", 9 },
-                    }};
-
-            Button button_jump {
-                { SCREEN_W - 4 * 8 , 5 * 16 , 4 * 8, 16 },
-                    "JMP"
-            };
-
-            Button button_rst {
-                { SCREEN_W - 9 * 8 , 5 * 16 , 4 * 8, 16 },
-                    "RST"
-            };
-
-            Text freq_stats{
-                {0 * 8, 5 * 16 , SCREEN_W - 10 * 8 , 8 },
-                    ""
-            };
-
-            MessageHandlerRegistration message_handler_spectrum_config {
-                Message::ID::ChannelSpectrumConfig,
-                    [this](const Message* const p) {
-                        const auto message = *reinterpret_cast<const ChannelSpectrumConfigMessage*>(p);
-                        this->fifo = message.fifo;
-                    }
-            };
-            MessageHandlerRegistration message_handler_frame_sync {
-                Message::ID::DisplayFrameSync,
-                    [this](const Message* const) {
-                        if( this->fifo ) {
-                            ChannelSpectrum channel_spectrum;
-                            while( fifo->out(channel_spectrum) ) {
-                                this->on_channel_spectrum(channel_spectrum);
-                            }
-                        }
-                    }
-            };
+    struct preset_entry {
+        rf::Frequency min{};
+        rf::Frequency max{};
+        std::string label{};
     };
-} 
+
+    const Style style_white{
+        // free range
+        .font = font::fixed_8x16,
+        .background = Color::black(),
+        .foreground = Color::white(),
+    };
+
+    const Style style_red{
+        // locked range
+        .font = font::fixed_8x16,
+        .background = Color::black(),
+        .foreground = Color::red(),
+    };
+
+    std::vector<preset_entry> presets_db{};
+    void get_max_power(const ChannelSpectrum& spectrum, uint8_t bin, uint8_t& max_power);
+    void on_marker_change();
+    int64_t next_mult_of(int64_t num, int64_t multiplier);
+    void adjust_range(int64_t* f_min, int64_t* f_max, int64_t width);
+    void retune();
+    bool move_to_next_position();
+    void on_channel_spectrum(const ChannelSpectrum& spectrum);
+    void do_timers();
+    void on_range_changed();
+    void on_lna_changed(int32_t v_db);
+    void on_vga_changed(int32_t v_db);
+    void reset_live_view(bool clear_screen);
+    void add_spectrum_pixel(uint8_t power);
+    void PlotMarker(uint8_t pos);
+    void load_Presets();
+    void txtline_process(std::string& line);
+    void populate_Presets();
+    void presets_Default();
+
+    rf::Frequency f_min{0}, f_max{0};
+    rf::Frequency search_span{0};
+    rf::Frequency f_center{0};
+    rf::Frequency f_center_ini{0};
+    rf::Frequency marker{0};
+    uint8_t marker_pixel_index{0};
+    rf::Frequency marker_pixel_step{0};
+    // size of one spectrum bin in Hz
+    rf::Frequency each_bin_size{0};
+    // consumed number of Hz, used to know if we have filled a 'bag' , a corresponding pixel length on screen
+    rf::Frequency bins_Hz_size{0};
+    rf::Frequency looking_glass_sampling_rate{0};
+    rf::Frequency looking_glass_bandwidth{0};
+    rf::Frequency looking_glass_range{0};
+    rf::Frequency looking_glass_step{0};
+    uint8_t min_color_power{0};
+    uint32_t pixel_index{0};
+    std::array<Color, SCREEN_W> spectrum_row = {0};
+    std::array<uint8_t, SCREEN_W> spectrum_data = {0};
+    ChannelSpectrumFIFO* fifo{nullptr};
+    uint8_t max_power = 0;
+    int32_t steps = 0;
+    uint8_t live_frequency_view = 0;
+    int16_t live_frequency_integrate = 3;
+    int64_t max_freq_hold = 0;
+    int16_t max_freq_power = -1000;
+    bool locked_range = false;
+    uint8_t bin_length = SCREEN_W;
+    uint8_t real_bin_length = SCREEN_W;
+    uint8_t offset = 0;
+    uint8_t tune_offset = 0;
+    uint8_t bin = 0;
+    int64_t last_max_freq = 0;
+    uint8_t mode = LOOKING_GLASS_FASTSCAN;
+    uint8_t ignore_dc = 0;
+
+    Labels labels{
+        {{0, 0}, "MIN:     MAX:     LNA   VGA  ", Color::light_grey()},
+        {{0, 1 * 16}, "RANGE:       FILTER:      AMP:", Color::light_grey()},
+        {{0, 2 * 16}, "PRESET:", Color::light_grey()},
+        {{0, 3 * 16}, "MARKER:            MHz", Color::light_grey()},
+        {{0, 4 * 16}, "RES:    STEP:", Color::light_grey()}};
+
+    NumberField field_frequency_min{
+        {4 * 8, 0 * 16},
+        4,
+        {0, 7199},
+        1,  // number of steps by encoder delta
+        ' '};
+
+    NumberField field_frequency_max{
+        {13 * 8, 0 * 16},
+        4,
+        {1, 7200},
+        1,  // number of steps by encoder delta
+        ' '};
+
+    LNAGainField field_lna{
+        {21 * 8, 0 * 16}};
+
+    VGAGainField field_vga{
+        {27 * 8, 0 * 16}};
+
+    Button button_range{
+        {7 * 8, 1 * 16, 4 * 8, 16},
+        ""};
+
+    OptionsField filter_config{
+        {20 * 8, 1 * 16},
+        4,
+        {
+            {"OFF ", 0},
+            {"MID ", 118},  // 85 +25 (110) + a bit more to kill all blue
+            {"HIGH", 202},  // 168 + 25 (193)
+        }};
+
+    RFAmpField field_rf_amp{
+        {29 * 8, 1 * 16}};
+
+    OptionsField range_presets{
+        {7 * 8, 2 * 16},
+        20,
+        {
+            {" NONE (WIFI 2.4GHz)", 0},
+        }};
+
+    ButtonWithEncoder button_marker{
+        {7 * 8, 3 * 16, 10 * 8, 16},
+        " "};
+
+    NumberField field_trigger{
+        {4 * 8, 4 * 16},
+        3,
+        {2, 128},
+        2,
+        ' '};
+
+    OptionsField steps_config{
+        {13 * 8, 4 * 16},
+        3,
+        {
+            {"1", 1},
+            {"25", 25},
+            {"50", 50},
+            {"100", 100},
+            {"250", 250},
+            {"500", 500},
+        }};
+
+    OptionsField scan_type{
+        {17 * 8, 4 * 16},
+        2,
+        {
+            {"F-", LOOKING_GLASS_FASTSCAN},
+            {"S-", LOOKING_GLASS_SLOWSCAN},
+        }};
+
+    OptionsField view_config{
+        {19 * 8, 4 * 16},
+        7,
+        {
+            {"SPCTR-V", 0},
+            {"LEVEL-V", 1},
+            {"PEAK-V", 2},
+        }};
+
+    OptionsField level_integration{
+        {27 * 8, 4 * 16},
+        2,
+        {
+            {"x0", 0},
+            {"x1", 1},
+            {"x2", 2},
+            {"x3", 3},
+            {"x4", 4},
+            {"x5", 5},
+            {"x6", 6},
+            {"x7", 7},
+            {"x8", 8},
+            {"x9", 9},
+        }};
+
+    Button button_jump{
+        {SCREEN_W - 4 * 8, 5 * 16, 4 * 8, 16},
+        "JMP"};
+
+    Button button_rst{
+        {SCREEN_W - 9 * 8, 5 * 16, 4 * 8, 16},
+        "RST"};
+
+    Text freq_stats{
+        {0 * 8, 5 * 16, SCREEN_W - 10 * 8, 8},
+        ""};
+
+    MessageHandlerRegistration message_handler_spectrum_config{
+        Message::ID::ChannelSpectrumConfig,
+        [this](const Message* const p) {
+            const auto message = *reinterpret_cast<const ChannelSpectrumConfigMessage*>(p);
+            this->fifo = message.fifo;
+        }};
+    MessageHandlerRegistration message_handler_frame_sync{
+        Message::ID::DisplayFrameSync,
+        [this](const Message* const) {
+            if (this->fifo) {
+                ChannelSpectrum channel_spectrum;
+                while (fifo->out(channel_spectrum)) {
+                    this->on_channel_spectrum(channel_spectrum);
+                }
+            }
+        }};
+};
+}  // namespace ui
 #endif


### PR DESCRIPTION
Perfect painting in Single Pass (range< 20MHz), and in Fast/Slow multiple pass (range >= 20MHz)
-marker scale is adjusted between modes (see informations 1 below)
-revamped the code to avoid repetitions and hard coded numbers as much as possible (poke @kallanreed I had you in mind when putting the finishing touches), so in the end we have less lines than before
-as good as possible range auto adjustment (see information 2)
Informations (technical, hold onto your papers !):
1 => The various modes does not use the same step, and thus end up having ranges rounded differently. The Fast and Slow scan are not ignoring the same number of bins in the spectrum band , so there is a shift between modes. 
2=> Ranges are rounded to the nearest multiple of the screen size, since it's used everywhere else
Bonus: ignored but still shifted DC bins are now counted in the bin_Hz_size in fast scan mode and a med value is used to fill it if ever 