### PR TITLE
Adds firmware to cd card files

### DIFF
--- a/.github/workflows/create_nightly_release.yml
+++ b/.github/workflows/create_nightly_release.yml
@@ -52,7 +52,7 @@ jobs:
           zip -j firmware.zip build/firmware/portapack-h1_h2-mayhem.bin && cd flashing && zip -r ../firmware.zip *
       - name: Create SD Card ZIP
         run: |
-          zip -r sdcard.zip sdcard
+          cp build/firmware/portapack-h1_h2-mayhem.bin sdcard/FIRMWARE/portapack-h1_h2-mayhem_${{ steps.version_date.outputs.date }}.bin && zip -r sdcard.zip sdcard
       - name: Create changelog
         run: |
           CHANGELOG=$(python3 .github/workflows/changelog.py)

--- a/.github/workflows/create_nightly_release.yml
+++ b/.github/workflows/create_nightly_release.yml
@@ -52,7 +52,7 @@ jobs:
           zip -j firmware.zip build/firmware/portapack-h1_h2-mayhem.bin && cd flashing && zip -r ../firmware.zip *
       - name: Create SD Card ZIP
         run: |
-          mkdir -p sdcard/FIRMWARE && cp build/firmware/portapack-h1_h2-mayhem.bin sdcard/FIRMWARE/portapack-h1_h2-mayhem_${{ steps.version_date.outputs.date }}.bin && zip -r sdcard.zip sdcard
+          mkdir -p sdcard/FIRMWARE && cp build/firmware/portapack-h1_h2-mayhem.bin sdcard/FIRMWARE/portapack-mayhem_${{ steps.version_date.outputs.date }}.bin && zip -r sdcard.zip sdcard
       - name: Create changelog
         run: |
           CHANGELOG=$(python3 .github/workflows/changelog.py)

--- a/.github/workflows/create_nightly_release.yml
+++ b/.github/workflows/create_nightly_release.yml
@@ -52,7 +52,7 @@ jobs:
           zip -j firmware.zip build/firmware/portapack-h1_h2-mayhem.bin && cd flashing && zip -r ../firmware.zip *
       - name: Create SD Card ZIP
         run: |
-          cp build/firmware/portapack-h1_h2-mayhem.bin sdcard/FIRMWARE/portapack-h1_h2-mayhem_${{ steps.version_date.outputs.date }}.bin && zip -r sdcard.zip sdcard
+          mkdir -p sdcard/FIRMWARE && cp build/firmware/portapack-h1_h2-mayhem.bin sdcard/FIRMWARE/portapack-h1_h2-mayhem_${{ steps.version_date.outputs.date }}.bin && zip -r sdcard.zip sdcard
       - name: Create changelog
         run: |
           CHANGELOG=$(python3 .github/workflows/changelog.py)

--- a/.github/workflows/create_stable_release.yml
+++ b/.github/workflows/create_stable_release.yml
@@ -36,7 +36,7 @@ jobs:
           zip -j firmware.zip build/firmware/portapack-h1_h2-mayhem.bin && cd flashing && zip -r ../firmware.zip *
       - name: Create SD Card ZIP
         run: |
-          zip -r sdcard.zip sdcard
+          cp build/firmware/portapack-h1_h2-mayhem.bin sdcard/FIRMWARE/portapack-h1_h2-mayhem_${{ steps.version.outputs.version }}.bin && zip -r sdcard.zip sdcard
       - name: Create changelog
         run: |
           CHANGELOG=$(python3 .github/workflows/stable_changelog.py ${{ steps.past_version.outputs.past_version }})

--- a/.github/workflows/create_stable_release.yml
+++ b/.github/workflows/create_stable_release.yml
@@ -36,7 +36,7 @@ jobs:
           zip -j firmware.zip build/firmware/portapack-h1_h2-mayhem.bin && cd flashing && zip -r ../firmware.zip *
       - name: Create SD Card ZIP
         run: |
-          cp build/firmware/portapack-h1_h2-mayhem.bin sdcard/FIRMWARE/portapack-h1_h2-mayhem_${{ steps.version.outputs.version }}.bin && zip -r sdcard.zip sdcard
+          mkdir -p sdcard/FIRMWARE && cp build/firmware/portapack-h1_h2-mayhem.bin sdcard/FIRMWARE/portapack-h1_h2-mayhem_${{ steps.version.outputs.version }}.bin && zip -r sdcard.zip sdcard
       - name: Create changelog
         run: |
           CHANGELOG=$(python3 .github/workflows/stable_changelog.py ${{ steps.past_version.outputs.past_version }})

--- a/.github/workflows/create_stable_release.yml
+++ b/.github/workflows/create_stable_release.yml
@@ -36,7 +36,7 @@ jobs:
           zip -j firmware.zip build/firmware/portapack-h1_h2-mayhem.bin && cd flashing && zip -r ../firmware.zip *
       - name: Create SD Card ZIP
         run: |
-          mkdir -p sdcard/FIRMWARE && cp build/firmware/portapack-h1_h2-mayhem.bin sdcard/FIRMWARE/portapack-h1_h2-mayhem_${{ steps.version.outputs.version }}.bin && zip -r sdcard.zip sdcard
+          mkdir -p sdcard/FIRMWARE && cp build/firmware/portapack-h1_h2-mayhem.bin sdcard/FIRMWARE/portapack-mayhem_${{ steps.version.outputs.version }}.bin && zip -r sdcard.zip sdcard
       - name: Create changelog
         run: |
           CHANGELOG=$(python3 .github/workflows/stable_changelog.py ${{ steps.past_version.outputs.past_version }})


### PR DESCRIPTION
When creating nightly and sable release, we will now automatically include the firmware in the SD card contents so users can flash using the flash app on the portapack