### PR TITLE
Settings directory fix in Level and Recon

### DIFF
--- a/firmware/application/apps/ui_level.cpp
+++ b/firmware/application/apps/ui_level.cpp
@@ -29,10 +29,6 @@ using portapack::memory::map::backup_ram;
 
 namespace ui {
 
-bool LevelView::check_sd_card() {
-    return (sd_card::status() == sd_card::Status::Mounted) ? true : false;
-}
-
 void LevelView::focus() {
     button_frequency.focus();
 }
@@ -74,12 +70,6 @@ LevelView::LevelView(NavigationView& nav)
     field_volume.on_change = [this](int32_t v) { this->on_headphone_volume_changed(v); };
     field_volume.set_value((receiver_model.headphone_volume() - audio::headphone::volume_range().max).decibel() + 99);
 
-    // Level directory
-    if (check_sd_card()) {  // Check to see if SD Card is mounted
-        make_new_directory(u"/LEVEL");
-        sd_card_mounted = true;
-    }
-
     change_mode(NFM_MODULATION);              // Start on AM
     field_mode.set_by_value(NFM_MODULATION);  // Reflect the mode into the manual selector
 
@@ -89,14 +79,12 @@ LevelView::LevelView(NavigationView& nav)
     button_frequency.set_text("<" + to_string_short_freq(freq) + " MHz>");
 
     // load auto common app settings
-    if (sd_card_mounted) {
-        auto rc = settings.load("level", &app_settings);
-        if (rc == SETTINGS_OK) {
-            field_lna.set_value(app_settings.lna);
-            field_vga.set_value(app_settings.vga);
-            field_rf_amp.set_value(app_settings.rx_amp);
-            receiver_model.set_rf_amp(app_settings.rx_amp);
-        }
+    auto rc = settings.load("level", &app_settings);
+    if (rc == SETTINGS_OK) {
+        field_lna.set_value(app_settings.lna);
+        field_vga.set_value(app_settings.vga);
+        field_rf_amp.set_value(app_settings.rx_amp);
+        receiver_model.set_rf_amp(app_settings.rx_amp);
     }
 
     button_frequency.on_select = [this, &nav](ButtonWithEncoder& button) {

--- a/firmware/application/apps/ui_level.hpp
+++ b/firmware/application/apps/ui_level.hpp
@@ -97,11 +97,9 @@ class LevelView : public View {
     size_t change_mode(freqman_index_t mod_type);
     void on_statistics_update(const ChannelStatistics& statistics);
     void set_display_freq(int64_t freq);
-    bool check_sd_card();
 
     int32_t db{0};
     long long int MAX_UFREQ = {7200000000};  // maximum usable freq
-    bool sd_card_mounted = false;
     rf::Frequency freq = {0};
 
     Labels labels{

--- a/firmware/application/apps/ui_recon.hpp
+++ b/firmware/application/apps/ui_recon.hpp
@@ -42,6 +42,8 @@
 
 namespace ui {
 
+#define RECON_CFG_FILE "SETTINGS/recon.cfg"
+
 class ReconView : public View {
    public:
     ReconView(NavigationView& nav);
@@ -113,10 +115,9 @@ class ReconView : public View {
     void recon_redraw();
     void handle_retune();
     void handle_coded_squelch(const uint32_t value);
-    bool ReconSetupLoadStrings(const std::string& source, std::string& input_file, std::string& output_file, uint32_t& recon_lock_duration, uint32_t& recon_lock_nb_match, int32_t& recon_squelch_level, uint32_t& recon_match_mode, int32_t& wait, int32_t& volume);
-    bool ReconSetupSaveStrings(const std::string& dest, const std::string& input_file, const std::string& output_file, uint32_t recon_lock_duration, uint32_t recon_lock_nb_match, int32_t recon_squelch_level, uint32_t recon_match_mode, int32_t wait, int32_t volume);
-    bool ReconSaveFreq(const std::string& freq_file_path, size_t index, bool warn_if_exists);
-
+    bool recon_load_config_from_sd();
+    bool recon_save_config_to_sd();
+    bool recon_save_freq(const std::string& freq_file_path, size_t index, bool warn_if_exists);
     jammer::jammer_range_t frequency_range{false, 0, MAX_UFREQ};  // perfect for manual recon task too...
     int32_t squelch{0};
     int32_t db{0};

--- a/firmware/application/apps/ui_recon_settings.cpp
+++ b/firmware/application/apps/ui_recon_settings.cpp
@@ -92,7 +92,7 @@ ReconSetupViewMain::ReconSetupViewMain(NavigationView& nav, Rect parent_rect, st
     };
 };
 
-void ReconSetupViewMain::Save(std::string& input_file, std::string& output_file) {
+void ReconSetupViewMain::save(std::string& input_file, std::string& output_file) {
     persistent_memory::set_recon_autosave_freqs(checkbox_autosave_freqs.value());
     persistent_memory::set_recon_autostart_recon(checkbox_autostart_recon.value());
     persistent_memory::set_recon_continuous(checkbox_continuous.value());
@@ -100,7 +100,7 @@ void ReconSetupViewMain::Save(std::string& input_file, std::string& output_file)
     input_file = _input_file;
     output_file = _output_file;
 };
-void ReconSetupViewMore::Save(uint32_t& recon_lock_duration, uint32_t& recon_lock_nb_match, uint32_t& recon_match_mode) {
+void ReconSetupViewMore::save(uint32_t& recon_lock_duration, uint32_t& recon_lock_nb_match, uint32_t& recon_match_mode) {
     persistent_memory::set_recon_load_freqs(checkbox_load_freqs.value());
     persistent_memory::set_recon_load_ranges(checkbox_load_ranges.value());
     persistent_memory::set_recon_load_hamradios(checkbox_load_hamradios.value());
@@ -162,8 +162,8 @@ ReconSetupView::ReconSetupView(
                   &button_save});
 
     button_save.on_select = [this, &nav](Button&) {
-        viewMain.Save(input_file, output_file);
-        viewMore.Save(recon_lock_duration, recon_lock_nb_match, recon_match_mode);
+        viewMain.save(input_file, output_file);
+        viewMore.save(recon_lock_duration, recon_lock_nb_match, recon_match_mode);
         std::vector<std::string> messages;
         messages.push_back(input_file);
         messages.push_back(output_file);

--- a/firmware/application/apps/ui_recon_settings.hpp
+++ b/firmware/application/apps/ui_recon_settings.hpp
@@ -66,7 +66,7 @@ namespace ui {
 class ReconSetupViewMain : public View {
    public:
     ReconSetupViewMain(NavigationView& nav, Rect parent_rect, std::string input_file, std::string output_file);
-    void Save(std::string& input_file, std::string& output_file);
+    void save(std::string& input_file, std::string& output_file);
     void focus() override;
 
    private:
@@ -111,7 +111,7 @@ class ReconSetupViewMore : public View {
    public:
     ReconSetupViewMore(NavigationView& nav, Rect parent_rect, uint32_t _recon_lock_duration, uint32_t _recon_lock_nb_match, uint32_t _recon_match_mode);
 
-    void Save(uint32_t& recon_lock_duration, uint32_t& recon_lock_nb_match, uint32_t& recon_match_mode);
+    void save(uint32_t& recon_lock_duration, uint32_t& recon_lock_nb_match, uint32_t& recon_match_mode);
 
     void focus() override;
 


### PR DESCRIPTION
Made a bit of cleanings so two unused directories are not created by my apps.
Renamed a few funcs so they use less uppercase and parameters.