### PR TITLE
Fixed debounce code to handle noisy switch transitions #989

### DIFF
--- a/firmware/application/hw/debounce.cpp
+++ b/firmware/application/hw/debounce.cpp
@@ -23,17 +23,24 @@
 
 #include "utility.hpp"
 
+/ Returns TRUE if button state changed (after debouncing)
 bool Debounce::feed(const uint8_t bit) {
-    history_ = (history_ << 1) | (bit & 1);
+    history_ = (history_ << 1) | (bit & 1);     // bitmap of last 8 readings
 
-    if (history_ == 0b00001111) {
-        state_ = 1;
-        return true;
+    if (state_ == 0) {
+        // Previous button state was 0 (released);
+        // Has button been held for DEBOUNCE_COUNT ticks?
+        if ((history_ & DEBOUNCE_MASK) == DEBOUNCE_MASK) {
+            state_ = 1;
+            return true;
+        }
+    } else {
+        // Previous button state was 1 (pressed);
+        // Has button been released for DEBOUNCE_COUNT ticks?
+        if ((history_ & DEBOUNCE_MASK) == 0) {
+            state_ = 0;
+            return true;
+        }
     }
-    if (history_ == 0b11110000) {
-        state_ = 0;
-        return true;
-    }
-
     return false;
 }

--- a/firmware/application/hw/debounce.cpp
+++ b/firmware/application/hw/debounce.cpp
@@ -23,7 +23,7 @@
 
 #include "utility.hpp"
 
-/ Returns TRUE if button state changed (after debouncing)
+// Returns TRUE if button state changed (after debouncing)
 bool Debounce::feed(const uint8_t bit) {
     history_ = (history_ << 1) | (bit & 1);     // bitmap of last 8 readings
 

--- a/firmware/application/hw/debounce.cpp
+++ b/firmware/application/hw/debounce.cpp
@@ -25,7 +25,7 @@
 
 // Returns TRUE if button state changed (after debouncing)
 bool Debounce::feed(const uint8_t bit) {
-    history_ = (history_ << 1) | (bit & 1);     // bitmap of last 8 readings
+    history_ = (history_ << 1) | (bit & 1);
 
     if (state_ == 0) {
         // Previous button state was 0 (released);

--- a/firmware/application/hw/debounce.hpp
+++ b/firmware/application/hw/debounce.hpp
@@ -24,6 +24,10 @@
 
 #include <cstdint>
 
+// consecutive # of times button input must be same (<=8)
+#define DEBOUNCE_COUNT   4
+#define DEBOUNCE_MASK    ((1 << DEBOUNCE_COUNT) - 1)
+
 class Debounce {
    public:
     bool feed(const uint8_t bit);

--- a/firmware/application/hw/debounce.hpp
+++ b/firmware/application/hw/debounce.hpp
@@ -25,8 +25,8 @@
 #include <cstdint>
 
 // consecutive # of times button input must be same (<=8)
-#define DEBOUNCE_COUNT   4
-#define DEBOUNCE_MASK    ((1 << DEBOUNCE_COUNT) - 1)
+#define DEBOUNCE_COUNT 4
+#define DEBOUNCE_MASK ((1 << DEBOUNCE_COUNT) - 1)
 
 class Debounce {
    public:


### PR DESCRIPTION
The pre-existing debounce code seemed to assume that mechanical switch transitions occurred cleanly without electrical glitches; a switch transition from 0->1 (button pressed) was only recorded as a state change if 8 consecutive read operations returned EXACTLY 0,0,0,0,1,1,1,1, and a transition from 1->0 was only recorded if 8 consecutive read operations returned exactly 1,1,1,1,0,0,0,0.  However, consecutive read operations from a noisy mechanical switch might return something like 0,0,1,0,1,1,1,1 when the switch is pressed, or something like 1,1,1,1,0,1,0,0 when the switch is released, in which case existing code would not see these state changes, causing a switch to appear "stuck".  In the switches event handler, note that any "stuck" switch results in subsequent presses of other switches being ignored.

Instead of looking for a specific sequence of 8 bits (this isn't OOK :-), the modified code simply looks for a sequence of 4 consecutive bits of the opposite value to the current state.  i.e. If state_ (the previous result of debouncing) was 0, an incoming sequence of 1,1,1,1 will be interpreted as the switch being pressed and the new state_ will be set to 1.  Similarly, if the previous result of debouncing was 1, an incoming sequence of 0,0,0,0 will be interpreted as the switch being released.  With this change, even if a glitchy switch returns a sequence like 1,0,1,0,1,0,1,0,0,0,0 when released, the bounced-state will be updated when the read operations eventually return consecutive 0's.

I don't know if this will completely fix "Unresponsive buttons issue #989", but it was an issue IMO.  (I'm having trouble reproducing #989 right now, so not sure; maybe I've cleaned the oxidation off my switch contacts with too many button presses)