### PR TITLE
Fixed Scanner RESUME button when delay timer Wsa==0, issue #1041

### DIFF
--- a/firmware/application/apps/ui_scanner.cpp
+++ b/firmware/application/apps/ui_scanner.cpp
@@ -744,7 +744,7 @@ void ScannerView::scan_resume() {
 }
 
 void ScannerView::user_resume() {
-    browse_timer = browse_wait * STATISTICS_UPDATES_PER_SEC;  // Will trigger a scan_resume() on_statistics_update, also advancing to next freq.
+    browse_timer = browse_wait * STATISTICS_UPDATES_PER_SEC + 1;  // Will trigger a scan_resume() on_statistics_update, also advancing to next freq.
     button_pause.set_text("<PAUSE>");                         // Show button for pause, arrows indicate rotary encoder enabled for freq change
     userpause = false;                                        // Resume scanning
 }

--- a/firmware/application/apps/ui_scanner.cpp
+++ b/firmware/application/apps/ui_scanner.cpp
@@ -745,8 +745,8 @@ void ScannerView::scan_resume() {
 
 void ScannerView::user_resume() {
     browse_timer = browse_wait * STATISTICS_UPDATES_PER_SEC + 1;  // Will trigger a scan_resume() on_statistics_update, also advancing to next freq.
-    button_pause.set_text("<PAUSE>");                         // Show button for pause, arrows indicate rotary encoder enabled for freq change
-    userpause = false;                                        // Resume scanning
+    button_pause.set_text("<PAUSE>");                             // Show button for pause, arrows indicate rotary encoder enabled for freq change
+    userpause = false;                                            // Resume scanning
 }
 
 void ScannerView::on_headphone_volume_changed(int32_t v) {


### PR DESCRIPTION
The user_resume() function needed to set browse_timer to a non-zero value to trigger scan_resume() on the next statistics update.  This wasn't happening when browse_wait (Wsa timer) was 0.