### PR TITLE
Support open in notepad from fileman

### DIFF
--- a/firmware/application/apps/ui_fileman.cpp
+++ b/firmware/application/apps/ui_fileman.cpp
@@ -26,6 +26,7 @@
 
 #include <algorithm>
 #include "ui_fileman.hpp"
+#include "ui_text_editor.hpp"
 #include "string_format.hpp"
 #include "portapack.hpp"
 #include "event_m0.hpp"
@@ -510,16 +511,19 @@ FileManagerView::FileManagerView(
         refresh_widgets(v);
     };
 
-    add_children({&menu_view,
-                  &labels,
-                  &text_date,
-                  &button_rename,
-                  &button_delete,
-                  &button_cut,
-                  &button_copy,
-                  &button_paste,
-                  &button_new_dir,
-                  &button_new_file});
+    add_children({
+        &menu_view,
+        &labels,
+        &text_date,
+        &button_rename,
+        &button_delete,
+        &button_cut,
+        &button_copy,
+        &button_paste,
+        &button_new_dir,
+        &button_new_file,
+        &button_open_notepad,
+    });
 
     menu_view.on_highlight = [this]() {
         if (selected_is_valid())
@@ -577,6 +581,14 @@ FileManagerView::FileManagerView(
 
     button_new_file.on_select = [this]() {
         on_new_file();
+    };
+
+    button_open_notepad.on_select = [this]() {
+        if (selected_is_valid() && !get_selected_entry().is_directory) {
+            auto path = get_selected_full_path();
+            nav_.replace<TextEditorView>(path);
+        } else
+            nav_.display_modal("Open in Notepad", "Can't open that in Notepad.");
     };
 }
 

--- a/firmware/application/apps/ui_fileman.hpp
+++ b/firmware/application/apps/ui_fileman.hpp
@@ -120,7 +120,7 @@ class FileManBaseView : public View {
         ""};
 
     Button button_exit{
-        {21 * 8, 34 * 8, 9 * 8, 32},
+        {22 * 8, 34 * 8, 9 * 8, 32},
         "Exit"};
 };
 

--- a/firmware/application/apps/ui_fileman.hpp
+++ b/firmware/application/apps/ui_fileman.hpp
@@ -263,6 +263,12 @@ class FileManagerView : public FileManBaseView {
         {},
         &bitmap_icon_new_file,
         Color::green()};
+
+    NewButton button_open_notepad{
+        {0 * 8, 34 * 8, 4 * 8, 32},
+        {},
+        &bitmap_icon_notepad,
+        Color::orange()};
 };
 
 } /* namespace ui */

--- a/firmware/application/apps/ui_text_editor.hpp
+++ b/firmware/application/apps/ui_text_editor.hpp
@@ -110,6 +110,9 @@ class FileWrapper {
 class TextEditorView : public View {
    public:
     TextEditorView(NavigationView& nav);
+    TextEditorView(
+        NavigationView& nav,
+        const std::filesystem::path& path);
 
     std::string title() const override {
         return "Notepad";


### PR DESCRIPTION

![IMG_9506](https://github.com/eried/portapack-mayhem/assets/3761006/c7c122ef-a80e-4b26-92ca-d323bc3cc75b)
Adds a button in Filename to open the selected file in Notepad.

- Longer term, I think it would be better to be able to register handlers for extensions in Fileman and use "Select" to "Open", but this will work for now. I'm thinking forward to if/when we can get a PNG viewer.
- Some minor navigation changes in Notepad. This will make it easier to get into and out of the the control for now until I get the menu built.