### PR TITLE
1 line change in the CMakeList.txt ,  solving_error_dfu_util_v_011_when_using_integrated_vscode

### DIFF
--- a/firmware/CMakeLists.txt
+++ b/firmware/CMakeLists.txt
@@ -52,7 +52,7 @@ add_custom_target(
 
 add_custom_target(
 	program
-	COMMAND dfu-util --device 1fc9:000c --download ${HACKRF_FIRMWARE_DFU_IMAGE}
+	COMMAND dfu-util --device 1fc9:000c --download ${HACKRF_FIRMWARE_DFU_IMAGE} || (exit 0) # We need to add it for dfu-utils v.011 , (in v.09 it is not necessary)
 	COMMAND sleep 3s
 	COMMAND hackrf_spiflash -w ${FIRMWARE_FILENAME}
 	DEPENDS ${FIRMWARE_FILENAME}


### PR DESCRIPTION
Thanks to @bernd-herzog  ,  we realised that when I was trying to use the program tools (available in firmware/CMakeLists.txt) 
  integrated inside vscode , 
![image](https://github.com/eried/portapack-mayhem/assets/86470699/0f745a44-d7c5-4151-9419-c053e63d23f8)

 My  dfu-util version is  0.11 , (different from his version 0.9)  ,was falling giving  error exit(1) .  (In his version , perfect exit(0) .
In order to avoid that possible problem when you migrate to dfu-util version 0.11, we better apply that change that I am using locally . 

This change is compatible and transparent to the other users using  current  dfu-util v0.9 ,  
and can not break anything. it will only make it continue when dfu-util returns an error (example my case, exit (1)  ) . 

Cheers, 


