### PR TITLE
Use receiver/transmitter models everywhere

### DIFF
--- a/firmware/application/apps/ais_app.cpp
+++ b/firmware/application/apps/ais_app.cpp
@@ -395,7 +395,7 @@ AISAppView::AISAppView(NavigationView& nav)
     receiver_model.set_tuning_frequency(tuning_frequency());
     receiver_model.set_sampling_rate(sampling_rate);
     receiver_model.set_baseband_bandwidth(baseband_bandwidth);
-    receiver_model.enable();  // Before using radio::enable(), but not updating Ant.DC-Bias.
+    receiver_model.enable();
 
     options_channel.on_change = [this](size_t, OptionsField::value_t v) {
         this->on_frequency_changed(v);
@@ -420,7 +420,7 @@ AISAppView::~AISAppView() {
     app_settings.rx_frequency = target_frequency_;
     settings.save("rx_ais", &app_settings);
 
-    receiver_model.disable();  // to switch off all, including DC bias.
+    receiver_model.disable();
 
     baseband::shutdown();
 }
@@ -471,7 +471,7 @@ void AISAppView::on_frequency_changed(const uint32_t new_target_frequency) {
 
 void AISAppView::set_target_frequency(const uint32_t new_value) {
     target_frequency_ = new_value;
-    radio::set_tuning_frequency(tuning_frequency());
+    receiver_model.set_tuning_frequency(tuning_frequency());
 }
 
 uint32_t AISAppView::target_frequency() const {

--- a/firmware/application/apps/ert_app.cpp
+++ b/firmware/application/apps/ert_app.cpp
@@ -121,17 +121,7 @@ ERTAppView::ERTAppView(NavigationView&) {
     receiver_model.set_tuning_frequency(initial_target_frequency);
     receiver_model.set_sampling_rate(sampling_rate);
     receiver_model.set_baseband_bandwidth(baseband_bandwidth);
-    receiver_model.enable();  // Before using radio::enable(), but not updating Ant.DC-Bias.
-
-    /*	radio::enable({
-                initial_target_frequency,
-                sampling_rate,
-                baseband_bandwidth,
-                rf::Direction::Receive,
-                receiver_model.rf_amp(),
-                static_cast<int8_t>(receiver_model.lna()),
-                static_cast<int8_t>(receiver_model.vga()),
-        }); */
+    receiver_model.enable();
 
     logger = std::make_unique<ERTLogger>();
     if (logger) {
@@ -143,7 +133,7 @@ ERTAppView::~ERTAppView() {
     // save app settings
     settings.save("rx_ert", &app_settings);
 
-    receiver_model.disable();  // to switch off all, including DC bias and change flag enabled_
+    receiver_model.disable();
 
     baseband::shutdown();
 }

--- a/firmware/application/apps/gps_sim_app.cpp
+++ b/firmware/application/apps/gps_sim_app.cpp
@@ -141,15 +141,9 @@ void GpsSimAppView::start() {
             });
     }
 
-    rf_amp = (transmitter_model.rf_amp());  // recover rf_amp settings applied from ui_transmiter.cpp
-
-    radio::enable({receiver_model.tuning_frequency(),
-                   sample_rate,
-                   baseband_bandwidth,
-                   rf::Direction::Transmit,
-                   rf_amp,  // previous code line : "receiver_model.rf_amp()," was passing the same rf_amp of all Receiver Apps
-                   static_cast<int8_t>(receiver_model.lna()),
-                   static_cast<int8_t>(receiver_model.vga())});
+    transmitter_model.set_sampling_rate(sample_rate * 8);
+    transmitter_model.set_baseband_bandwidth(baseband_bandwidth);
+    transmitter_model.enable();
 }
 
 void GpsSimAppView::stop(const bool do_loop) {
@@ -159,7 +153,7 @@ void GpsSimAppView::stop(const bool do_loop) {
     if (do_loop && check_loop.value()) {
         start();
     } else {
-        radio::disable();
+        transmitter_model.disable();
         button_play.set_bitmap(&bitmap_play);
     }
 
@@ -224,7 +218,7 @@ GpsSimAppView::GpsSimAppView(
 }
 
 GpsSimAppView::~GpsSimAppView() {
-    radio::disable();
+    transmitter_model.disable();
     hackrf::cpld::load_sram_no_verify();  // to leave all RX ok, without ghost signal problem at the exit .
     baseband::shutdown();                 // better this function at the end, not load_sram() that sometimes produces hang up.
 }

--- a/firmware/application/apps/gps_sim_app.cpp
+++ b/firmware/application/apps/gps_sim_app.cpp
@@ -141,7 +141,7 @@ void GpsSimAppView::start() {
             });
     }
 
-    transmitter_model.set_sampling_rate(sample_rate * 8);
+    transmitter_model.set_sampling_rate(sample_rate);
     transmitter_model.set_baseband_bandwidth(baseband_bandwidth);
     transmitter_model.enable();
 }

--- a/firmware/application/apps/replay_app.cpp
+++ b/firmware/application/apps/replay_app.cpp
@@ -141,18 +141,9 @@ void ReplayAppView::start() {
             });
     }
 
-    // Enable Bias Tee if selected
-    radio::set_antenna_bias(portapack::get_antenna_bias());
-
-    rf_amp = (transmitter_model.rf_amp());  // recover rf_amp settings applied from ui_transmiter.cpp
-
-    radio::enable({receiver_model.tuning_frequency(),
-                   sample_rate * 8,
-                   baseband_bandwidth,
-                   rf::Direction::Transmit,
-                   rf_amp,  // previous code line : "receiver_model.rf_amp()," was passing the same rf_amp of all Receiver Apps
-                   static_cast<int8_t>(receiver_model.lna()),
-                   static_cast<int8_t>(receiver_model.vga())});
+    transmitter_model.set_sampling_rate(sample_rate * 8);
+    transmitter_model.set_baseband_bandwidth(baseband_bandwidth);
+    transmitter_model.enable();
 
     if (portapack::persistent_memory::stealth_mode()) {
         DisplaySleepMessage message;
@@ -167,8 +158,7 @@ void ReplayAppView::stop(const bool do_loop) {
     if (do_loop && check_loop.value()) {
         start();
     } else {
-        radio::set_antenna_bias(false);  // Turn off Bias Tee
-        radio::disable();
+        transmitter_model.disable();
         button_play.set_bitmap(&bitmap_play);
     }
 
@@ -233,7 +223,7 @@ ReplayAppView::ReplayAppView(
 }
 
 ReplayAppView::~ReplayAppView() {
-    radio::disable();
+    transmitter_model.disable();
 
     display.fill_rectangle({0, 0, 240, 320}, Color::black());  // Solving sometimes visible bottom waterfall artifacts, clearing all LCD  pixels.
     chThdSleepMilliseconds(40);                                // (that happened sometimes if we interrupt the waterfall play at the beggining of the play  around 25% and exit )

--- a/firmware/application/apps/tpms_app.cpp
+++ b/firmware/application/apps/tpms_app.cpp
@@ -170,17 +170,7 @@ TPMSAppView::TPMSAppView(NavigationView&) {
     receiver_model.set_tuning_frequency(tuning_frequency());
     receiver_model.set_sampling_rate(sampling_rate);
     receiver_model.set_baseband_bandwidth(baseband_bandwidth);
-    receiver_model.enable();  // Before using radio::enable(), but not updating Ant.DC-Bias.
-
-    /*	radio::enable({
-                tuning_frequency(),
-                sampling_rate,
-                baseband_bandwidth,
-                rf::Direction::Receive,
-                receiver_model.rf_amp(),
-                static_cast<int8_t>(receiver_model.lna()),
-                static_cast<int8_t>(receiver_model.vga()),
-        }); */
+    receiver_model.enable();
 
     options_band.on_change = [this](size_t, OptionsField::value_t v) {
         this->on_band_changed(v);
@@ -212,8 +202,7 @@ TPMSAppView::~TPMSAppView() {
     app_settings.rx_frequency = target_frequency_;
     settings.save("rx_tpms", &app_settings);
 
-    receiver_model.disable();  // to switch off all, including DC bias and change flag enabled_
-
+    receiver_model.disable();
     baseband::shutdown();
 }
 
@@ -258,7 +247,7 @@ void TPMSAppView::on_band_changed(const uint32_t new_band_frequency) {
 
 void TPMSAppView::set_target_frequency(const uint32_t new_value) {
     target_frequency_ = new_value;
-    radio::set_tuning_frequency(tuning_frequency());
+    receiver_model.set_tuning_frequency(tuning_frequency());
 }
 
 uint32_t TPMSAppView::target_frequency() const {

--- a/firmware/application/apps/ui_jammer.cpp
+++ b/firmware/application/apps/ui_jammer.cpp
@@ -286,7 +286,6 @@ void JammerView::stop_tx() {
     button_transmit.set_style(&style_val);
     button_transmit.set_text("START");
     transmitter_model.disable();
-    radio::disable();
     baseband::set_jammer(false, JammerType::TYPE_FSK, 0);
     jamming = false;
     cooling = false;

--- a/firmware/application/apps/ui_looking_glass_app.cpp
+++ b/firmware/application/apps/ui_looking_glass_app.cpp
@@ -97,8 +97,10 @@ void GlassView::adjust_range(int64_t* f_min, int64_t* f_max, int64_t width) {
 }
 
 void GlassView::retune() {
-    // Start a new sweep
-    radio::set_tuning_frequency(f_center);  // tune rx for this new slice directly, faster than using persistent memory saving
+    // Start a new sweep.
+    // Tune rx for this new slice directly because the model
+    // saves to persistent memory which is slower.
+    radio::set_tuning_frequency(f_center);
     chThdSleepMilliseconds(5);
     baseband::spectrum_streaming_start();  // Do the RX
 }

--- a/firmware/application/apps/ui_playlist.cpp
+++ b/firmware/application/apps/ui_playlist.cpp
@@ -193,20 +193,9 @@ void PlaylistView::start() {
             });
     }
 
-    // Enable Bias Tee if selected
-    radio::set_antenna_bias(portapack::get_antenna_bias());
-
-    rf_amp = (transmitter_model.rf_amp());  // recover rf_amp settings applied from ui_transmiter.cpp
-
-    radio::enable({receiver_model.tuning_frequency(),
-                   sample_rate * 8,
-                   baseband_bandwidth,
-                   rf::Direction::Transmit,
-                   rf_amp,  // previous code line : "receiver_model.rf_amp()," was passing the same rf_amp of all Receiver Apps
-                   static_cast<int8_t>(receiver_model.lna()),
-                   static_cast<int8_t>(receiver_model.vga())});
-
-    //	}
+    transmitter_model.set_sampling_rate(sample_rate * 8);
+    transmitter_model.set_baseband_bandwidth(baseband_bandwidth);
+    transmitter_model.enable();
 }
 
 void PlaylistView::stop(const bool do_loop) {
@@ -231,8 +220,7 @@ void PlaylistView::stop(const bool do_loop) {
                 start();
             }
         } else {
-            radio::set_antenna_bias(false);  // Turn off Bias Tee
-            radio::disable();
+            transmitter_model.disable();
             button_play.set_bitmap(&bitmap_play);
         }
     } else if (!check_loop.value()) {
@@ -244,8 +232,7 @@ void PlaylistView::stop(const bool do_loop) {
                 start();
             }
         } else {
-            radio::set_antenna_bias(false);  // Turn off Bias Tee
-            radio::disable();
+            transmitter_model.disable();
             button_play.set_bitmap(&bitmap_play);
         }
     }
@@ -314,7 +301,7 @@ PlaylistView::PlaylistView(
 }
 
 PlaylistView::~PlaylistView() {
-    radio::disable();
+    transmitter_model.disable();
     baseband::shutdown();
 }
 

--- a/firmware/application/apps/ui_settings.cpp
+++ b/firmware/application/apps/ui_settings.cpp
@@ -196,6 +196,15 @@ SetRadioView::SetRadioView(
     check_bias.set_value(portapack::get_antenna_bias());
     check_bias.on_select = [this](Checkbox&, bool v) {
         portapack::set_antenna_bias(v);
+
+        // Update the radio.
+        receiver_model.set_antenna_bias();
+        transmitter_model.set_antenna_bias();
+        // The models won't actually disable this if they are not 'enabled_'.
+        // Be extra sure this is turned off.
+        if (!v)
+            radio::set_antenna_bias(false);
+
         StatusRefreshMessage message{};
         EventDispatcher::send_message(message);
     };

--- a/firmware/application/apps/ui_sonde.cpp
+++ b/firmware/application/apps/ui_sonde.cpp
@@ -107,7 +107,7 @@ SondeView::SondeView(NavigationView& nav) {
     receiver_model.set_tuning_frequency(tuning_frequency());
     receiver_model.set_sampling_rate(sampling_rate);
     receiver_model.set_baseband_bandwidth(baseband_bandwidth);
-    receiver_model.enable();  // Before using radio::enable(), but not updating Ant.DC-Bias.
+    receiver_model.enable();
 
     // QR code with geo URI
     button_see_qr.on_select = [this, &nav](Button&) {
@@ -155,7 +155,7 @@ SondeView::~SondeView() {
 
     baseband::set_pitch_rssi(0, false);
 
-    receiver_model.disable();  // to switch off all, including DC bias.
+    receiver_model.disable();
     baseband::shutdown();
     audio::output::stop();
 }
@@ -258,8 +258,6 @@ void SondeView::on_headphone_volume_changed(int32_t v) {
 
 void SondeView::set_target_frequency(const uint32_t new_value) {
     target_frequency_ = new_value;
-    // radio::set_tuning_frequency(tuning_frequency());
-    //  we better remember the tuned frequency, by using this function instead:
     receiver_model.set_tuning_frequency(target_frequency_);
 }
 

--- a/firmware/application/apps/ui_spectrum_painter.cpp
+++ b/firmware/application/apps/ui_spectrum_painter.cpp
@@ -93,16 +93,9 @@ SpectrumPainterView::SpectrumPainterView(
             if (tx_mode == 0 && image_input_avaliable == false)
                 return;
 
-            // Enable Bias Tee if selected
-            radio::set_antenna_bias(portapack::get_antenna_bias());
-
-            radio::enable({portapack::receiver_model.tuning_frequency(),
-                           3072000U,
-                           1750000,
-                           rf::Direction::Transmit,
-                           rf_amp,
-                           static_cast<int8_t>(portapack::receiver_model.lna()),
-                           static_cast<int8_t>(portapack::receiver_model.vga())});
+            portapack::transmitter_model.set_sampling_rate(3072000U);
+            portapack::transmitter_model.set_baseband_bandwidth(1750000);
+            portapack::transmitter_model.enable();
 
             if (portapack::persistent_memory::stealth_mode()) {
                 DisplaySleepMessage message;

--- a/firmware/application/apps/ui_test.cpp
+++ b/firmware/application/apps/ui_test.cpp
@@ -81,19 +81,14 @@ TestView::TestView(NavigationView& nav) {
     if (logger)
         logger->append("saucepan.txt");
 
-    radio::enable({
-        tuning_frequency(),
-        sampling_rate,
-        baseband_bandwidth,
-        rf::Direction::Receive,
-        receiver_model.rf_amp(),
-        static_cast<int8_t>(receiver_model.lna()),
-        static_cast<int8_t>(receiver_model.vga()),
-    });
+    receiver_model.set_tuning_frequency(tuning_frequency());
+    receiver_model.set_sampling_rate(sampling_rate);
+    receiver_model.set_baseband_bandwidth(baseband_bandwidth);
+    receiver_model.enable();
 }
 
 TestView::~TestView() {
-    radio::disable();
+    receiver_model.disable();
     baseband::shutdown();
 }
 
@@ -127,8 +122,6 @@ void TestView::on_packet(const testapp::Packet& packet) {
     if (logger && logging)
         logger->log_raw_data(packet, raw_alt - cal_value);
 
-    // radio::disable();
-
     /*text_serial.set(packet.serial_number());
         text_voltage.set(unit_auto_scale(packet.battery_voltage(), 2, 3) + "V");
 
@@ -139,7 +132,7 @@ void TestView::on_packet(const testapp::Packet& packet) {
 
 void TestView::set_target_frequency(const uint32_t new_value) {
     target_frequency_ = new_value;
-    radio::set_tuning_frequency(tuning_frequency());
+    receiver_model.set_tuning_frequency(tuning_frequency());
 }
 
 uint32_t TestView::tuning_frequency() const {

--- a/firmware/application/portapack.cpp
+++ b/firmware/application/portapack.cpp
@@ -521,7 +521,8 @@ void shutdown(const bool leave_screen_on) {
         display.shutdown();
     }
 
-    radio::disable();
+    receiver_model.disable();
+    transmitter_model.disable();
     audio::shutdown();
 
     hackrf::cpld::init_from_eeprom();

--- a/firmware/application/portapack.hpp
+++ b/firmware/application/portapack.hpp
@@ -36,6 +36,8 @@
 #include "clock_manager.hpp"
 #include "temperature_logger.hpp"
 
+/* TODO: This would be better as a class to add
+ * guardrails on setting properties. */
 namespace portapack {
 
 extern portapack::IO io;
@@ -59,6 +61,8 @@ extern bool antenna_bias;
 
 extern TemperatureLogger temperature_logger;
 
+/* Get or set the antenna_bias flag.
+ * NB: Does not actually update the radio state. */
 void set_antenna_bias(const bool v);
 bool get_antenna_bias();
 

--- a/firmware/application/radio.cpp
+++ b/firmware/application/radio.cpp
@@ -42,6 +42,9 @@ using namespace hackrf::one;
 #include "portapack.hpp"
 #include "portapack_persistent_memory.hpp"
 
+/* Direct access to the radio. Setting values incorrectly can damage
+ * the device. Applications should use ReceiverModel or TransmitterModel
+ * instead of calling these functions directly. */
 namespace radio {
 
 static constexpr uint32_t ssp1_cpsr = 2;
@@ -245,18 +248,7 @@ void set_antenna_bias(const bool on) {
     }
 }
 
-void disable() {
-    set_antenna_bias(false);
-    baseband_codec.set_mode(max5864::Mode::Shutdown);
-    second_if->set_mode(max2837::Mode::Standby);
-    first_if.disable();
-    set_rf_amp(false);
-
-    led_rx.off();
-    led_tx.off();
-}
-
-void enable(Configuration configuration) {
+/*void enable(Configuration configuration) {
     configure(configuration);
 }
 
@@ -268,6 +260,17 @@ void configure(Configuration configuration) {
     set_baseband_rate(configuration.baseband_rate);
     set_baseband_filter_bandwidth(configuration.baseband_filter_bandwidth);
     set_direction(configuration.direction);
+}*/
+
+void disable() {
+    set_antenna_bias(false);
+    baseband_codec.set_mode(max5864::Mode::Shutdown);
+    second_if->set_mode(max2837::Mode::Standby);
+    first_if.disable();
+    set_rf_amp(false);
+
+    led_rx.off();
+    led_tx.off();
 }
 
 namespace debug {

--- a/firmware/application/radio.hpp
+++ b/firmware/application/radio.hpp
@@ -27,6 +27,9 @@
 #include <cstdint>
 #include <cstddef>
 
+/* Direct access to the radio. Setting values incorrectly can damage
+ * the device. Applications should use ReceiverModel or TransmitterModel
+ * instead of calling these functions directly. */
 namespace radio {
 
 struct Configuration {
@@ -51,8 +54,9 @@ void set_baseband_filter_bandwidth(const uint32_t bandwidth_minimum);
 void set_baseband_rate(const uint32_t rate);
 void set_antenna_bias(const bool on);
 
-void enable(Configuration configuration);
-void configure(Configuration configuration);
+/* Use ReceiverModel or TransmitterModel instead. */
+//void enable(Configuration configuration);
+//void configure(Configuration configuration);
 void disable();
 
 namespace debug {

--- a/firmware/application/radio.hpp
+++ b/firmware/application/radio.hpp
@@ -55,8 +55,8 @@ void set_baseband_rate(const uint32_t rate);
 void set_antenna_bias(const bool on);
 
 /* Use ReceiverModel or TransmitterModel instead. */
-//void enable(Configuration configuration);
-//void configure(Configuration configuration);
+// void enable(Configuration configuration);
+// void configure(Configuration configuration);
 void disable();
 
 namespace debug {

--- a/firmware/application/receiver_model.cpp
+++ b/firmware/application/receiver_model.cpp
@@ -185,7 +185,6 @@ void ReceiverModel::enable() {
 
 void ReceiverModel::disable() {
     enabled_ = false;
-    radio::set_antenna_bias(false);
 
     // TODO: Responsibility for enabling/disabling the radio is muddy.
     // Some happens in ReceiverModel, some inside radio namespace.

--- a/firmware/application/receiver_model.cpp
+++ b/firmware/application/receiver_model.cpp
@@ -118,14 +118,14 @@ void ReceiverModel::set_vga(int32_t v_db) {
     update_vga();
 }
 
-int32_t ReceiverModel::tx_gain() const {
+/*int32_t ReceiverModel::tx_gain() const {
     return tx_gain_db_;
 }
 
 void ReceiverModel::set_tx_gain(int32_t v_db) {
     tx_gain_db_ = v_db;
     update_tx_gain();
-}
+}*/
 
 uint32_t ReceiverModel::sampling_rate() const {
     return sampling_rate_;
@@ -171,7 +171,7 @@ void ReceiverModel::enable() {
     update_rf_amp();
     update_lna();
     update_vga();
-    update_tx_gain();
+    // update_tx_gain();
     update_baseband_bandwidth();
     update_sampling_rate();
     update_modulation();
@@ -229,9 +229,9 @@ void ReceiverModel::update_vga() {
     radio::set_vga_gain(vga_gain_db_);
 }
 
-void ReceiverModel::update_tx_gain() {
+/*void ReceiverModel::update_tx_gain() {
     radio::set_tx_gain(tx_gain_db_);
-}
+}*/
 
 void ReceiverModel::set_am_configuration(const size_t n) {
     if (n < am_configs.size()) {

--- a/firmware/application/receiver_model.hpp
+++ b/firmware/application/receiver_model.hpp
@@ -30,6 +30,7 @@
 #include "max283x.hpp"
 #include "volume.hpp"
 
+// TODO: consider a base class for ReceiverModel & TransmitterModel.
 class ReceiverModel {
    public:
     enum class Mode {
@@ -60,8 +61,9 @@ class ReceiverModel {
     int32_t vga() const;
     void set_vga(int32_t v_db);
 
-    int32_t tx_gain() const;
-    void set_tx_gain(int32_t v_db);
+    // TODO: Why does receiver need tx_gain?
+    // int32_t tx_gain() const;
+    // void set_tx_gain(int32_t v_db);
 
     uint32_t sampling_rate() const;
     void set_sampling_rate(uint32_t v);
@@ -87,7 +89,13 @@ class ReceiverModel {
     size_t wfm_configuration() const;
     void set_wfm_configuration(const size_t n);
 
-    void set_configuration_without_init(const Mode new_mode, const rf::Frequency new_frequency_step, const size_t new_am_config_index, const size_t new_nbfm_config_index, const size_t new_wfm_config_index, uint8_t new_squelch_level);
+    void set_configuration_without_init(
+        const Mode new_mode,
+        const rf::Frequency new_frequency_step,
+        const size_t new_am_config_index,
+        const size_t new_nbfm_config_index,
+        const size_t new_wfm_config_index,
+        uint8_t new_squelch_level);
 
    private:
     rf::Frequency frequency_step_{25000};
@@ -96,7 +104,7 @@ class ReceiverModel {
     int32_t lna_gain_db_{32};
     uint32_t baseband_bandwidth_{max283x::filter::bandwidth_minimum};
     int32_t vga_gain_db_{32};
-    int32_t tx_gain_db_{47};
+    // int32_t tx_gain_db_{47};
     Mode mode_{Mode::NarrowbandFMAudio};
     uint32_t sampling_rate_{3072000};
     size_t am_config_index = 0;
@@ -113,7 +121,7 @@ class ReceiverModel {
     void update_lna();
     void update_baseband_bandwidth();
     void update_vga();
-    void update_tx_gain();
+    // void update_tx_gain();
     void update_sampling_rate();
     void update_headphone_volume();
 

--- a/firmware/application/transmitter_model.cpp
+++ b/firmware/application/transmitter_model.cpp
@@ -125,6 +125,7 @@ void TransmitterModel::enable() {
     update_vga();
     update_baseband_bandwidth();
     update_sampling_rate();
+    update_tx_gain();
 
     led_tx.on();
     signal_token_tick_second = rtc_time::signal_tick_second += [this]() {

--- a/firmware/application/transmitter_model.cpp
+++ b/firmware/application/transmitter_model.cpp
@@ -138,7 +138,6 @@ void TransmitterModel::enable() {
 
 void TransmitterModel::disable() {
     enabled_ = false;
-    radio::set_antenna_bias(false);
 
     // TODO: Responsibility for enabling/disabling the radio is muddy.
     // Some happens in ReceiverModel, some inside radio namespace.

--- a/firmware/application/ui_navigation.cpp
+++ b/firmware/application/ui_navigation.cpp
@@ -307,11 +307,10 @@ void SystemStatusView::on_stealth() {
 }
 
 void SystemStatusView::on_bias_tee() {
-    if (!portapack::antenna_bias) {
+    if (!portapack::get_antenna_bias()) {
         nav_.display_modal("Bias voltage", "Enable DC voltage on\nantenna connector?", YESNO, [this](bool v) {
             if (v) {
                 portapack::set_antenna_bias(true);
-                // radio::set_antenna_bias(true);
                 receiver_model.set_antenna_bias();
                 transmitter_model.set_antenna_bias();
                 refresh();
@@ -319,9 +318,12 @@ void SystemStatusView::on_bias_tee() {
         });
     } else {
         portapack::set_antenna_bias(false);
-        // radio::set_antenna_bias(false);
         receiver_model.set_antenna_bias();
         transmitter_model.set_antenna_bias();
+
+        // Ensure this is disabled. The models don't actually
+        // update the radio unless they are 'enabled_'.
+        radio::set_antenna_bias(false);
         refresh();
     }
 }


### PR DESCRIPTION
The use of `set_antenna_bias` all over the place was concerning because getting that wrong can damage the device.

This change updates all calls to `radio::*` and instead uses the receiver and transmitter models.
This will hopefully stop the less safe patterns from being spread by copy-paste in new apps.

This attempts to consolidate all of the real set_antenna_bias to a very narrow set of places.
Probably want to have folks test their apps with this change as a sanity check.