### PR TITLE
Support for Rotary Encoder Dial sensitivity levels, issue #965

### DIFF
--- a/firmware/application/apps/ui_settings.cpp
+++ b/firmware/application/apps/ui_settings.cpp
@@ -529,9 +529,9 @@ void SetPersistentMemoryView::focus() {
     button_return.focus();
 }
 
-//
-// Audio settings
-//
+// ---------------------------------------------------------
+// Audio Settings
+// ---------------------------------------------------------
 SetAudioView::SetAudioView(NavigationView& nav) {
     add_children({&labels,
                   &field_tone_mix,
@@ -554,6 +554,9 @@ void SetAudioView::focus() {
     button_save.focus();
 }
 
+// ---------------------------------------------------------
+// QR Code Settings
+// ------------------------------------------------------
 SetQRCodeView::SetQRCodeView(NavigationView& nav) {
     add_children({&checkbox_bigger_qr,
                   &button_save,
@@ -576,6 +579,31 @@ void SetQRCodeView::focus() {
 }
 
 // ---------------------------------------------------------
+// Rotary Encoder Dial Settings
+// ---------------------------------------------------------
+SetEncoderDialView::SetEncoderDialView(NavigationView& nav) {
+    add_children({&labels,
+                  &field_encoder_dial_sensitivity,
+                  &button_save,
+                  &button_cancel});
+
+    field_encoder_dial_sensitivity.set_by_value(persistent_memory::config_encoder_dial_sensitivity());
+
+    button_save.on_select = [&nav, this](Button&) {
+        persistent_memory::set_encoder_dial_sensitivity(field_encoder_dial_sensitivity.selected_index_value());
+        nav.pop();
+    };
+
+    button_cancel.on_select = [&nav, this](Button&) {
+        nav.pop();
+    };
+}
+
+void SetEncoderDialView::focus() {
+    button_save.focus();
+}
+
+// ---------------------------------------------------------
 // Settings main menu
 // ---------------------------------------------------------
 SettingsMenuView::SettingsMenuView(NavigationView& nav) {
@@ -593,6 +621,7 @@ SettingsMenuView::SettingsMenuView(NavigationView& nav) {
         {"FreqCorrection", ui::Color::dark_cyan(), &bitmap_icon_options_radio, [&nav]() { nav.push<SetFrequencyCorrectionView>(); }},
         {"QR Code", ui::Color::dark_cyan(), &bitmap_icon_qr_code, [&nav]() { nav.push<SetQRCodeView>(); }},
         {"P.Memory Mgmt", ui::Color::dark_cyan(), &bitmap_icon_memory, [&nav]() { nav.push<SetPersistentMemoryView>(); }},
+        {"Encoder Dial", ui::Color::dark_cyan(), &bitmap_icon_setup, [&nav]() { nav.push<SetEncoderDialView>(); }},
     });
     set_max_rows(2);  // allow wider buttons
 }

--- a/firmware/application/apps/ui_settings.hpp
+++ b/firmware/application/apps/ui_settings.hpp
@@ -432,6 +432,38 @@ class SetQRCodeView : public View {
     };
 };
 
+using portapack::persistent_memory::encoder_dial_sensitivity;
+
+class SetEncoderDialView : public View {
+   public:
+    SetEncoderDialView(NavigationView& nav);
+
+    void focus() override;
+
+    std::string title() const override { return "Encoder Dial"; };
+
+   private:
+    Labels labels{
+        {{2 * 8, 3 * 16}, "Dial sensitivity:", Color::light_grey()},
+    };
+
+    OptionsField field_encoder_dial_sensitivity{
+        {20 * 8, 3 * 16},
+        6,
+        {{"LOW", encoder_dial_sensitivity::DIAL_SENSITIVITY_LOW},
+         {"NORMAL", encoder_dial_sensitivity::DIAL_SENSITIVITY_MEDIUM},
+         {"HIGH", encoder_dial_sensitivity::DIAL_SENSITIVITY_HIGH}}};
+
+    Button button_save{
+        {2 * 8, 16 * 16, 12 * 8, 32},
+        "Save"};
+
+    Button button_cancel{
+        {16 * 8, 16 * 16, 12 * 8, 32},
+        "Cancel",
+    };
+};
+
 class SetPersistentMemoryView : public View {
    public:
     SetPersistentMemoryView(NavigationView& nav);

--- a/firmware/application/hw/encoder.cpp
+++ b/firmware/application/hw/encoder.cpp
@@ -31,7 +31,8 @@
 // between looking at all of them (high sensitivity), half of them (medium/default),
 // or one quarter of them (low sensitivity).
 static const int8_t transition_map[][16] = {
-    {  // low sensitivity
+    // Low Sensitivity
+    {
         0,   // 0000: noop
         0,   // 0001: start
         0,   // 0010: start
@@ -49,7 +50,8 @@ static const int8_t transition_map[][16] = {
         0,   // 1110: start
         0,   // 1111: noop
     },
-    {  // medium sensitivity
+    // Medium Sensitivity (default)
+    {
         0,   // 0000: noop
         0,   // 0001: start
         0,   // 0010: start
@@ -66,24 +68,26 @@ static const int8_t transition_map[][16] = {
         0,   // 1101: start
         0,   // 1110: start
         0,   // 1111: noop
-    },
-// {  // high sensitivity - disabled for now (unnecessary/touchy)
-// 0,   // 0000: noop
-// -1,  // 0001: start
-// 1,   // 0010: start
-// 0,   // 0011: rate
-// 1,   // 0100: end
-// 0,   // 0101: noop
-// 0,   // 0110: rate
-// -1,  // 0111: end
-// -1,  // 1000: end
-// 0,   // 1001: rate
-// 0,   // 1010: noop
-// 1,   // 1011: end
-// 0,   // 1100: rate
-// 1,   // 1101: start
-// -1,  // 1110: start
-// 0,   // 1111: noop
+    }
+//
+// Highest sensitivity - disabled for now (unnecessary/touchy)
+// {
+//      0,   // 0000: noop
+//      -1,  // 0001: start
+//      1,   // 0010: start
+//      0,   // 0011: rate
+//      1,   // 0100: end
+//      0,   // 0101: noop
+//      0,   // 0110: rate
+//      -1,  // 0111: end
+//      -1,  // 1000: end
+//      0,   // 1001: rate
+//      0,   // 1010: noop
+//      1,   // 1011: end
+//      0,   // 1100: rate
+//      1,   // 1101: start
+//      -1,  // 1110: start
+//      0,   // 1111: noop
 // }
 };
 

--- a/firmware/application/hw/encoder.cpp
+++ b/firmware/application/hw/encoder.cpp
@@ -53,10 +53,10 @@ static const int8_t transition_map[][16] = {
     // Medium Sensitivity (default)
     {
         0,   // 0000: noop
-        0,   // 0001: start
-        0,   // 0010: start
+        0,   // 0001: start (use -1 for high-sensitivity)
+        0,   // 0010: start (use 1 for high-sensitivity)
         0,   // 0011: rate
-        1,   // 0100: end
+        1,   // 0100: end (use 1 for high-sensitivity)
         0,   // 0101: noop
         0,   // 0110: rate
         -1,  // 0111: end
@@ -65,30 +65,10 @@ static const int8_t transition_map[][16] = {
         0,   // 1010: noop
         1,   // 1011: end
         0,   // 1100: rate
-        0,   // 1101: start
-        0,   // 1110: start
+        0,   // 1101: start (use 1 for high-sensitivity)
+        0,   // 1110: start (use -1 for high-sensitivity)
         0,   // 1111: noop
     }
-//
-// Highest sensitivity - disabled for now (unnecessary/touchy)
-// {
-//      0,   // 0000: noop
-//      -1,  // 0001: start
-//      1,   // 0010: start
-//      0,   // 0011: rate
-//      1,   // 0100: end
-//      0,   // 0101: noop
-//      0,   // 0110: rate
-//      -1,  // 0111: end
-//      -1,  // 1000: end
-//      0,   // 1001: rate
-//      0,   // 1010: noop
-//      1,   // 1011: end
-//      0,   // 1100: rate
-//      1,   // 1101: start
-//      -1,  // 1110: start
-//      0,   // 1111: noop
-// }
 };
 
 int_fast8_t Encoder::update(

--- a/firmware/application/hw/encoder.cpp
+++ b/firmware/application/hw/encoder.cpp
@@ -31,6 +31,25 @@
 // between looking at all of them (high sensitivity), half of them (medium/default),
 // or one quarter of them (low sensitivity).
 static const int8_t transition_map[][16] = {
+    // Normal (Medium) Sensitivity -- default
+    {
+        0,   // 0000: noop
+        0,   // 0001: start (use -1 for high-sensitivity)
+        0,   // 0010: start (use 1 for high-sensitivity)
+        0,   // 0011: rate
+        1,   // 0100: end (use 1 for high-sensitivity)
+        0,   // 0101: noop
+        0,   // 0110: rate
+        -1,  // 0111: end
+        -1,  // 1000: end
+        0,   // 1001: rate
+        0,   // 1010: noop
+        1,   // 1011: end
+        0,   // 1100: rate
+        0,   // 1101: start (use 1 for high-sensitivity)
+        0,   // 1110: start (use -1 for high-sensitivity)
+        0,   // 1111: noop
+    },
     // Low Sensitivity
     {
         0,   // 0000: noop
@@ -50,25 +69,6 @@ static const int8_t transition_map[][16] = {
         0,   // 1110: start
         0,   // 1111: noop
     },
-    // Medium Sensitivity (default)
-    {
-        0,   // 0000: noop
-        0,   // 0001: start (use -1 for high-sensitivity)
-        0,   // 0010: start (use 1 for high-sensitivity)
-        0,   // 0011: rate
-        1,   // 0100: end (use 1 for high-sensitivity)
-        0,   // 0101: noop
-        0,   // 0110: rate
-        -1,  // 0111: end
-        -1,  // 1000: end
-        0,   // 1001: rate
-        0,   // 1010: noop
-        1,   // 1011: end
-        0,   // 1100: rate
-        0,   // 1101: start (use 1 for high-sensitivity)
-        0,   // 1110: start (use -1 for high-sensitivity)
-        0,   // 1111: noop
-    }
 };
 
 int_fast8_t Encoder::update(

--- a/firmware/application/hw/encoder.cpp
+++ b/firmware/application/hw/encoder.cpp
@@ -57,7 +57,7 @@ static const uint32_t transition_map_[NUM_DIAL_SENSITIVITY] = {
 
 int_fast8_t Encoder::update(
     const uint_fast8_t phase_0,
-    const uint_fast8_t phase_1) {  
+    const uint_fast8_t phase_1) {
     state <<= 1;
     state |= phase_0;
     state <<= 1;

--- a/firmware/application/hw/encoder.cpp
+++ b/firmware/application/hw/encoder.cpp
@@ -20,9 +20,7 @@
  */
 
 #include "encoder.hpp"
-
 #include "utility.hpp"
-
 
 // Now supporting 3 levels of rotary encoder dial sensitivity
 //

--- a/firmware/application/hw/encoder.cpp
+++ b/firmware/application/hw/encoder.cpp
@@ -23,32 +23,54 @@
 
 #include "utility.hpp"
 
-static const int8_t transition_map[] = {
-    0,   // 0000: noop
-    0,   // 0001: start
-    0,   // 0010: start
-    0,   // 0011: rate
-    1,   // 0100: end
-    0,   // 0101: noop
-    0,   // 0110: rate
-    -1,  // 0111: end
-    -1,  // 1000: end
-    0,   // 1001: rate
-    0,   // 1010: noop
-    1,   // 1011: end
-    0,   // 1100: rate
-    0,   // 1101: start
-    0,   // 1110: start
-    0,   // 1111: noop
+
+// Now supporting 3 levels of rotary encoder dial sensitivity
+//
+// Portapack H2 normally has a 30-step encoder, meaning one step (pulse) every
+// 12 degrees of rotation.
+//
+// For each encoder "pulse" there are 4 state transitions, and we can choose
+// between looking at all of them (high sensitivity), half of them (medium/default),
+// or one quarter of them (low sensitivity).
+//
+// Each non-zero nibble in the transition_map represents an encoder state transition
+// that we interpret as either a 1 or -1.
+// Clockwise state transitions are:  00b->10b, 10b->11b, 11b->01b, 01b->00b.
+//                             i.e.  2, B, D, 4
+// Counter-clockwise transitions are: 00b->01b, 01b->11b, 11b->10b, 10b->00b.
+//                             i.e.  1, 7, E, 8
+//  e.g. 0x0B = 1011b means input transition from 10b->11b, which means clockwise +1.
+//       Notice that B is not in transition_map[0] so this transition is ignored when
+//       in "low sensitivity" mode.
+//
+// Four no-op states (no change) are 00b->00b, 01b->01b, 10b->10b, and 11b->11b,
+// (AKA 0, 5, A, and F), which are of course ignored since no rotation occurred.
+// Four additional non-zero values may be seen when the encoder dial is turned
+// rapidly and intermediate states are skipped 00b->11b, 01b->10b, 10b->01b, and 11b->00b
+// (AKA 3, 6, 9, or C); these are also (currently) ignored.
+//
+static const uint32_t transition_map_[NUM_DIAL_SENSITIVITY] = {
+    0x00070004,  // low sensitivity
+    0x008700B4,  // medium sensitivity
+    0xE187D2B4   // high sensitivity
 };
 
 int_fast8_t Encoder::update(
     const uint_fast8_t phase_0,
-    const uint_fast8_t phase_1) {
+    const uint_fast8_t phase_1) {  
     state <<= 1;
     state |= phase_0;
     state <<= 1;
     state |= phase_1;
 
-    return transition_map[state & 0xf];
+    uint32_t tmap = transition_map_[sensitivity_];
+    do {
+        if ((tmap & 0x0F) == (state & 0x0F))
+            return 1;
+        if (((tmap >> 16) & 0x0F) == (state & 0x0F))
+            return -1;
+        tmap >>= 4;
+    } while ((tmap >> 16) != 0);
+
+    return 0;
 }

--- a/firmware/application/hw/encoder.cpp
+++ b/firmware/application/hw/encoder.cpp
@@ -31,7 +31,7 @@
 // between looking at all of them (high sensitivity), half of them (medium/default),
 // or one quarter of them (low sensitivity).
 static const int8_t transition_map[][16] = {
-    { // low sensitivity
+    {  // low sensitivity
         0,   // 0000: noop
         0,   // 0001: start
         0,   // 0010: start
@@ -67,24 +67,24 @@ static const int8_t transition_map[][16] = {
         0,   // 1110: start
         0,   // 1111: noop
     },
-    // {   // high sensitivity - disabled for now (unnecessary/touchy)
-    //     0,   // 0000: noop
-    //     -1,  // 0001: start
-    //     1,   // 0010: start
-    //     0,   // 0011: rate
-    //     1,   // 0100: end
-    //     0,   // 0101: noop
-    //     0,   // 0110: rate
-    //     -1,  // 0111: end
-    //     -1,  // 1000: end
-    //     0,   // 1001: rate
-    //     0,   // 1010: noop
-    //     1,   // 1011: end
-    //     0,   // 1100: rate
-    //     1,   // 1101: start
-    //     -1,  // 1110: start
-    //     0,   // 1111: noop
-    // }
+// {  // high sensitivity - disabled for now (unnecessary/touchy)
+// 0,   // 0000: noop
+// -1,  // 0001: start
+// 1,   // 0010: start
+// 0,   // 0011: rate
+// 1,   // 0100: end
+// 0,   // 0101: noop
+// 0,   // 0110: rate
+// -1,  // 0111: end
+// -1,  // 1000: end
+// 0,   // 1001: rate
+// 0,   // 1010: noop
+// 1,   // 1011: end
+// 0,   // 1100: rate
+// 1,   // 1101: start
+// -1,  // 1110: start
+// 0,   // 1111: noop
+// }
 };
 
 int_fast8_t Encoder::update(

--- a/firmware/application/hw/encoder.cpp
+++ b/firmware/application/hw/encoder.cpp
@@ -102,10 +102,6 @@ int_fast8_t Encoder::update(
     state <<= 1;
     state |= phase_1;
 
-    // get dial sensitivity setting from pmem if valid
-    uint8_t sensitivity = portapack::persistent_memory::config_encoder_dial_sensitivity();
-    if (sensitivity >= portapack::persistent_memory::NUM_DIAL_SENSITIVITY)
-        sensitivity = portapack::persistent_memory::DIAL_SENSITIVITY_MEDIUM;
-
-    return transition_map[sensitivity][state & 0xf];
+    // dial sensitivity setting is stored in pmem
+    return transition_map[portapack::persistent_memory::config_encoder_dial_sensitivity()][state & 0xf];
 }

--- a/firmware/application/hw/encoder.cpp
+++ b/firmware/application/hw/encoder.cpp
@@ -22,7 +22,7 @@
 #include "encoder.hpp"
 #include "utility.hpp"
 
-// Now supporting 3 levels of rotary encoder dial sensitivity
+// Now supporting multiple levels of rotary encoder dial sensitivity
 //
 // Portapack H2 normally has a 30-step encoder, meaning one step (pulse) every
 // 12 degrees of rotation.
@@ -30,27 +30,61 @@
 // For each encoder "pulse" there are 4 state transitions, and we can choose
 // between looking at all of them (high sensitivity), half of them (medium/default),
 // or one quarter of them (low sensitivity).
-//
-// Each non-zero nibble in the transition_map represents an encoder state transition
-// that we interpret as either a 1 or -1.
-// Clockwise state transitions are:  00b->10b, 10b->11b, 11b->01b, 01b->00b.
-//                             i.e.  2, B, D, 4
-// Counter-clockwise transitions are: 00b->01b, 01b->11b, 11b->10b, 10b->00b.
-//                             i.e.  1, 7, E, 8
-//  e.g. 0x0B = 1011b means input transition from 10b->11b, which means clockwise +1.
-//       Notice that B is not in transition_map[0] so this transition is ignored when
-//       in "low sensitivity" mode.
-//
-// Four no-op states (no change) are 00b->00b, 01b->01b, 10b->10b, and 11b->11b,
-// (AKA 0, 5, A, and F), which are of course ignored since no rotation occurred.
-// Four additional non-zero values may be seen when the encoder dial is turned
-// rapidly and intermediate states are skipped 00b->11b, 01b->10b, 10b->01b, and 11b->00b
-// (AKA 3, 6, 9, or C); these are also (currently) ignored.
-//
-static const uint32_t transition_map_[NUM_DIAL_SENSITIVITY] = {
-    0x00070004,  // low sensitivity
-    0x008700B4,  // medium sensitivity
-    0xE187D2B4   // high sensitivity
+static const int8_t transition_map[][16] = {
+    { // low sensitivity
+        0,   // 0000: noop
+        0,   // 0001: start
+        0,   // 0010: start
+        0,   // 0011: rate
+        1,   // 0100: end
+        0,   // 0101: noop
+        0,   // 0110: rate
+        0,   // 0111: end
+        -1,  // 1000: end
+        0,   // 1001: rate
+        0,   // 1010: noop
+        0,   // 1011: end
+        0,   // 1100: rate
+        0,   // 1101: start
+        0,   // 1110: start
+        0,   // 1111: noop
+    },
+    {  // medium sensitivity
+        0,   // 0000: noop
+        0,   // 0001: start
+        0,   // 0010: start
+        0,   // 0011: rate
+        1,   // 0100: end
+        0,   // 0101: noop
+        0,   // 0110: rate
+        -1,  // 0111: end
+        -1,  // 1000: end
+        0,   // 1001: rate
+        0,   // 1010: noop
+        1,   // 1011: end
+        0,   // 1100: rate
+        0,   // 1101: start
+        0,   // 1110: start
+        0,   // 1111: noop
+    },
+    // {   // high sensitivity - disabled for now (unnecessary/touchy)
+    //     0,   // 0000: noop
+    //     -1,  // 0001: start
+    //     1,   // 0010: start
+    //     0,   // 0011: rate
+    //     1,   // 0100: end
+    //     0,   // 0101: noop
+    //     0,   // 0110: rate
+    //     -1,  // 0111: end
+    //     -1,  // 1000: end
+    //     0,   // 1001: rate
+    //     0,   // 1010: noop
+    //     1,   // 1011: end
+    //     0,   // 1100: rate
+    //     1,   // 1101: start
+    //     -1,  // 1110: start
+    //     0,   // 1111: noop
+    // }
 };
 
 int_fast8_t Encoder::update(
@@ -61,14 +95,5 @@ int_fast8_t Encoder::update(
     state <<= 1;
     state |= phase_1;
 
-    uint32_t tmap = transition_map_[sensitivity_];
-    do {
-        if ((tmap & 0x0F) == (state & 0x0F))
-            return 1;
-        if (((tmap >> 16) & 0x0F) == (state & 0x0F))
-            return -1;
-        tmap >>= 4;
-    } while ((tmap >> 16) != 0);
-
-    return 0;
+    return transition_map[sensitivity_][state & 0xf];
 }

--- a/firmware/application/hw/encoder.hpp
+++ b/firmware/application/hw/encoder.hpp
@@ -27,7 +27,7 @@
 enum encoder_sensitivity {
     DIAL_SENSITIVITY_LOW = 0,
     DIAL_SENSITIVITY_MEDIUM,
-//    DIAL_SENSITIVITY_HIGH,  // disabled for now (unnecessary/touchy)
+//  DIAL_SENSITIVITY_HIGH,  // disabled for now (unnecessary/touchy)
     NUM_DIAL_SENSITIVITY
 };
 

--- a/firmware/application/hw/encoder.hpp
+++ b/firmware/application/hw/encoder.hpp
@@ -25,8 +25,8 @@
 #include <cstdint>
 
 enum encoder_sensitivity {
-    DIAL_SENSITIVITY_LOW = 0,
-    DIAL_SENSITIVITY_MEDIUM,
+    DIAL_SENSITIVITY_MEDIUM = 0,
+    DIAL_SENSITIVITY_LOW,
     NUM_DIAL_SENSITIVITY
 };
 

--- a/firmware/application/hw/encoder.hpp
+++ b/firmware/application/hw/encoder.hpp
@@ -27,7 +27,7 @@
 enum encoder_sensitivity {
     DIAL_SENSITIVITY_LOW = 0,
     DIAL_SENSITIVITY_MEDIUM,
-    DIAL_SENSITIVITY_HIGH,
+//    DIAL_SENSITIVITY_HIGH,  // disabled for now (unnecessary/touchy)
     NUM_DIAL_SENSITIVITY
 };
 

--- a/firmware/application/hw/encoder.hpp
+++ b/firmware/application/hw/encoder.hpp
@@ -24,14 +24,27 @@
 
 #include <cstdint>
 
+enum encoder_sensitivity {
+    DIAL_SENSITIVITY_LOW = 0,
+    DIAL_SENSITIVITY_MEDIUM,
+    DIAL_SENSITIVITY_HIGH,
+    NUM_DIAL_SENSITIVITY
+};
+
 class Encoder {
    public:
     int_fast8_t update(
         const uint_fast8_t phase_0,
         const uint_fast8_t phase_1);
 
+    void set_sensitivity(const uint8_t v) {
+        if (v < NUM_DIAL_SENSITIVITY)
+            sensitivity_ = v;
+    };
+
    private:
     uint_fast8_t state{0};
+    uint8_t sensitivity_{DIAL_SENSITIVITY_MEDIUM};
 };
 
 #endif /*__ENCODER_H__*/

--- a/firmware/application/hw/encoder.hpp
+++ b/firmware/application/hw/encoder.hpp
@@ -24,26 +24,14 @@
 
 #include <cstdint>
 
-enum encoder_sensitivity {
-    DIAL_SENSITIVITY_MEDIUM = 0,
-    DIAL_SENSITIVITY_LOW,
-    NUM_DIAL_SENSITIVITY
-};
-
 class Encoder {
    public:
     int_fast8_t update(
         const uint_fast8_t phase_0,
         const uint_fast8_t phase_1);
 
-    void set_sensitivity(const uint8_t v) {
-        if (v < NUM_DIAL_SENSITIVITY)
-            sensitivity_ = v;
-    };
-
    private:
     uint_fast8_t state{0};
-    uint8_t sensitivity_{DIAL_SENSITIVITY_MEDIUM};
 };
 
 #endif /*__ENCODER_H__*/

--- a/firmware/application/hw/encoder.hpp
+++ b/firmware/application/hw/encoder.hpp
@@ -27,7 +27,6 @@
 enum encoder_sensitivity {
     DIAL_SENSITIVITY_LOW = 0,
     DIAL_SENSITIVITY_MEDIUM,
-//  DIAL_SENSITIVITY_HIGH,  // disabled for now (unnecessary/touchy)
     NUM_DIAL_SENSITIVITY
 };
 

--- a/firmware/common/portapack_persistent_memory.cpp
+++ b/firmware/common/portapack_persistent_memory.cpp
@@ -302,6 +302,9 @@ struct data_t {
     uint32_t frequency_tx_correction;
     bool updown_frequency_tx_correction;
 
+    // Rotary encoder dial sensitivity (encoder.cpp/hpp)
+    uint8_t encoder_dial_sensitivity;
+
     constexpr data_t()
         : structure_version(data_structure_version_enum::VERSION_CURRENT),
           tuned_frequency(tuned_frequency_reset_value),
@@ -337,7 +340,8 @@ struct data_t {
           frequency_rx_correction(0),
           updown_frequency_rx_correction(0),
           frequency_tx_correction(0),
-          updown_frequency_tx_correction(0) {
+          updown_frequency_tx_correction(0),
+          encoder_dial_sensitivity(0) {
     }
 };
 
@@ -806,6 +810,14 @@ void set_config_freq_tx_correction(uint32_t v) {
 }
 void set_config_freq_rx_correction(uint32_t v) {
     data->frequency_rx_correction = v;
+}
+
+// rotary encoder dial settings
+uint8_t config_encoder_dial_sensitivity() {
+    return data->encoder_dial_sensitivity;
+}
+void set_encoder_dial_sensitivity(uint8_t v) {
+    data->encoder_dial_sensitivity = v;
 }
 
 // sd persisting settings

--- a/firmware/common/portapack_persistent_memory.hpp
+++ b/firmware/common/portapack_persistent_memory.hpp
@@ -99,6 +99,13 @@ struct backlight_config_t {
     bool _timeout_enabled;
 };
 
+enum encoder_dial_sensitivity {
+    DIAL_SENSITIVITY_MEDIUM = 0,
+    DIAL_SENSITIVITY_LOW = 1,
+    DIAL_SENSITIVITY_HIGH = 2,
+    NUM_DIAL_SENSITIVITY
+};
+
 namespace cache {
 
 /* Set values in cache to sensible defaults. */
@@ -199,6 +206,8 @@ void set_config_login(bool v);
 void set_config_speaker(bool v);
 void set_config_backlight_timer(const backlight_config_t& new_value);
 void set_disable_touchscreen(bool v);
+uint8_t config_encoder_dial_sensitivity();
+void set_encoder_dial_sensitivity(uint8_t v);
 
 // uint8_t ui_config_textentry();
 // void set_config_textentry(uint8_t new_value);


### PR DESCRIPTION
Note that UI will still need a function to allow user to select from these 3 levels and store the setting in pmem.  I've tested all 3 settings on my H2.