### PR TITLE
Recon: reducing memory imprint, live list removal function in Recon

### DIFF
--- a/firmware/application/apps/ui_recon.cpp
+++ b/firmware/application/apps/ui_recon.cpp
@@ -907,7 +907,6 @@ void ReconView::frequency_file_load(bool stop_all_before) {
         button_scanner_mode.set_style(&style_blue);
         button_scanner_mode.set_text("RECON");
     }
-    file_name.set_style(&style_white);
     desc_cycle.set_style(&style_white);
     if (!load_freqman_file_ex(file_input, frequency_list, load_freqs, load_ranges, load_hamradios)) {
         file_name.set_style(&style_red);

--- a/firmware/application/apps/ui_recon.hpp
+++ b/firmware/application/apps/ui_recon.hpp
@@ -128,6 +128,7 @@ class ReconView : public View {
     freqman_db frequency_list = {};
     int32_t current_index{0};
     bool continuous_lock{false};
+    bool config_cleared_freqlist{false};
     std::string input_file = {"RECON"};
     std::string output_file = {"RECON_RESULTS"};
     std::string description = {"...no description..."};

--- a/firmware/application/apps/ui_recon.hpp
+++ b/firmware/application/apps/ui_recon.hpp
@@ -101,6 +101,7 @@ class ReconView : public View {
    private:
     NavigationView& nav_;
 
+    void reset_indexes();
     void audio_output_start();
     bool check_sd_card();
     size_t change_mode(freqman_index_t mod_type);
@@ -129,6 +130,7 @@ class ReconView : public View {
     bool continuous_lock{false};
     std::string input_file = {"RECON"};
     std::string output_file = {"RECON_RESULTS"};
+    std::string description = {"...no description..."};
     bool autosave = {true};
     bool autostart = {true};
     bool continuous = {true};
@@ -271,7 +273,7 @@ class ReconView : public View {
         {12 * 8 + 4, 7 * 16, 14 * 8, 1 * 8},
         ""};
 
-    Button button_recon_setup{
+    Button button_config{
         {SCREEN_W - 7 * 8, 2 * 16, 7 * 8, 28},
         "CONFIG"};
 

--- a/firmware/application/apps/ui_recon.hpp
+++ b/firmware/application/apps/ui_recon.hpp
@@ -101,6 +101,7 @@ class ReconView : public View {
    private:
     NavigationView& nav_;
 
+    void clear_freqlist_for_ui_action();
     void reset_indexes();
     void audio_output_start();
     bool check_sd_card();
@@ -128,7 +129,7 @@ class ReconView : public View {
     freqman_db frequency_list = {};
     int32_t current_index{0};
     bool continuous_lock{false};
-    bool config_cleared_freqlist{false};
+    bool freqlist_cleared_for_ui_action{false};  // flag positioned by ui widgets to manage freqlist unload/load
     std::string input_file = {"RECON"};
     std::string output_file = {"RECON_RESULTS"};
     std::string description = {"...no description..."};


### PR DESCRIPTION
In an attempt to reduce the memory imprint and try to reduce the possible numbers of guru memory error when launching a sub process, I added a mechanism to unload the frequency_list from memory before launching a navigation, and restoring it after, except for Manual mode which stays in memory.

I also added back a mechanism that has disappeared which consist of allowing user to temporary remove elements  from loaded frequency list from input in Recon mode, and from both loaded frequency list from output and output file itself in Scanner mode. This allow a temporary disable of some searched frequencies / ranges / hamradio without the cost of a flag on each entry.

Renamed CONFIG button in source to match the name.
