### PR TITLE
ui_spectrum_painter tx gain initialization

### DIFF
--- a/firmware/application/apps/ui_spectrum_painter.cpp
+++ b/firmware/application/apps/ui_spectrum_painter.cpp
@@ -69,7 +69,7 @@ SpectrumPainterView::SpectrumPainterView(
         };
     };
 
-    tx_gain = 10;
+    tx_gain = portapack::transmitter_model.tx_gain();
     field_rfgain.set_value(tx_gain);              // Initial default  value (-12 dB's max ).
     field_rfgain.on_change = [this](int32_t v) {  // allow initial value change just after opened file.
         tx_gain = v;


### PR DESCRIPTION
When starting the app, actual tx gain is 47 while the ui shows 10. "Increasing" gain to 11 takes effect, reducing actual gain as displayed in UI. This change makes the initial UI gain value consistent with actual tx gain.