### PR TITLE
Fix button_exit width

### DIFF
--- a/firmware/application/apps/ui_fileman.hpp
+++ b/firmware/application/apps/ui_fileman.hpp
@@ -121,7 +121,7 @@ class FileManBaseView : public View {
         ""};
 
     Button button_exit{
-        {22 * 8, 34 * 8, 9 * 8, 32},
+        {22 * 8, 34 * 8, 8 * 8, 32},
         "Exit"};
 };
 


### PR DESCRIPTION
I moved the exit button without making it narrower in the last change. This shrinks the width, so it fits on the screen.