### PR TITLE
Fix SD over USB on r9 hackrf

### DIFF
--- a/firmware/baseband/sd_over_usb/hackrf_core.c
+++ b/firmware/baseband/sd_over_usb/hackrf_core.c
@@ -807,10 +807,6 @@ void cpu_clock_init(void) {
     // CCU2_CLK_APLL_CFG = 0;
     // CCU2_CLK_SDIO_CFG = 0;
 #endif
-
-    if (detected_platform() == BOARD_ID_HACKRF1_R9) {
-        clkin_detect_init();
-    }
 }
 
 clock_source_t activate_best_clock_source(void) {


### PR DESCRIPTION
Remove clkin_detect_init() from cpu_clock_init() mirroring upstream change from the hackrf repo