### PR TITLE
changed the vendor id of sd to usb

### DIFF
--- a/firmware/baseband/sd_over_usb/usb_descriptor.c
+++ b/firmware/baseband/sd_over_usb/usb_descriptor.c
@@ -25,10 +25,10 @@
 #include "usb_type.h"
 #include "usb_descriptor.h"
 
-#define USB_VENDOR_ID (0x1D50)
+#define USB_VENDOR_ID (0x0781) /* SanDisk Corp. */
 
 #ifdef HACKRF_ONE
-#define USB_PRODUCT_ID (0x6089)
+#define USB_PRODUCT_ID (0xa7a8) /* SD card reader */
 #elif JAWBREAKER
 #define USB_PRODUCT_ID (0x604B)
 #elif RAD1O
@@ -37,7 +37,7 @@
 #define USB_PRODUCT_ID (0xFFFF)
 #endif
 
-#define USB_API_VERSION (0x0107)
+#define USB_API_VERSION (0x0127) /* hardware revision */
 
 #define USB_WORD(x) (x & 0xFF), ((x >> 8) & 0xFF)
 


### PR DESCRIPTION
this pull request changes the vendor id of the sd card reader. this should remove the need in windows to change the driver to msd on every mount.