### PR TITLE
Minor  GUI change to the Mic App 

### DIFF
--- a/firmware/application/apps/ui_mictx.hpp
+++ b/firmware/application/apps/ui_mictx.hpp
@@ -123,14 +123,15 @@ class MicTXView : public View {
         {{4 * 8, 10 * 8}, "LVL:", Color::light_grey()},             // we delete  { {11 * 8, 5 * 8 }, "Amp:", Color::light_grey() },
         {{12 * 8, 10 * 8}, "ATT:", Color::light_grey()},
         {{20 * 8, 10 * 8}, "DEC:", Color::light_grey()},
-        {{4 * 8, (13 * 8) - 2}, "TONE KEY:", Color::light_grey()},
-        {{7 * 8, 23 * 8}, "VOL:", Color::light_grey()},
-        {{14 * 8, 23 * 8}, "RXBW:", Color::light_grey()},  // we remove the label "FM" because we will display all MOD types RX_BW.
-        {{20 * 8, 25 * 8}, "SQ:", Color::light_grey()},
-        {{5 * 8, 25 * 8}, "F_RX:", Color::light_grey()},
-        {{5 * 8, 27 * 8}, "LNA:", Color::light_grey()},
-        {{12 * 8, 27 * 8}, "VGA:", Color::light_grey()},
-        {{19 * 8, 27 * 8}, "AMP:", Color::light_grey()}};
+        {{3 * 8, (13 * 8) - 5}, "TONE KEY:", Color::light_grey()},
+        {{3 * 8, (18 * 8) -1}, "======== Receiver ========", Color::green()},
+        {{5 * 8, (23 * 8)+2}, "VOL:", Color::light_grey()},
+        {{14 * 8,(23 * 8)+2}, "RXBW:", Color::light_grey()},  // we remove the label "FM" because we will display all MOD types RX_BW.
+        {{20 * 8, (25 * 8)+2}, "SQ:", Color::light_grey()},
+        {{5 * 8, (25 * 8)+2}, "F_RX:", Color::light_grey()},
+        {{5 * 8, (27 * 8)+2}, "LNA:", Color::light_grey()},
+        {{12 * 8, (27 * 8)+2}, "VGA:", Color::light_grey()},
+        {{19 * 8, (27 * 8)+2}, "AMP:", Color::light_grey()}};
     Labels labels_AK4951{
         {{3 * 8, 1 * 8}, "MIC-GAIN:", Color::light_grey()},
         {{17 * 8, 1 * 8}, "ALC", Color::light_grey()},
@@ -141,14 +142,15 @@ class MicTXView : public View {
         {{4 * 8, 10 * 8}, "LVL:", Color::light_grey()},           // we delete  { {11 * 8, 5 * 8 }, "Amp:", Color::light_grey() },
         {{12 * 8, 10 * 8}, "ATT:", Color::light_grey()},
         {{20 * 8, 10 * 8}, "DEC:", Color::light_grey()},
-        {{4 * 8, (13 * 8) - 2}, "TONE KEY:", Color::light_grey()},
-        {{(6 * 8) + 4, 23 * 8}, "VOL:", Color::light_grey()},
-        {{14 * 8, 23 * 8}, "RXBW:", Color::light_grey()},  // we remove the label "FM" because we will display all MOD types RX_BW.
-        {{20 * 8, 25 * 8}, "SQ:", Color::light_grey()},
-        {{5 * 8, 25 * 8}, "F_RX:", Color::light_grey()},
-        {{5 * 8, 27 * 8}, "LNA:", Color::light_grey()},
-        {{12 * 8, 27 * 8}, "VGA:", Color::light_grey()},
-        {{19 * 8, 27 * 8}, "AMP:", Color::light_grey()}};
+        {{3 * 8, (13 * 8) - 5}, "TONE KEY:", Color::light_grey()},
+        {{3 * 8, (18 * 8) -1}, "======== Receiver ========", Color::green()},
+        {{(5 * 8) , (23 * 8)+2}, "VOL:", Color::light_grey()},
+        {{14 * 8, (23 * 8)+2}, "RXBW:", Color::light_grey()},  // we remove the label "FM" because we will display all MOD types RX_BW.
+        {{20 * 8, (25 * 8)+2}, "SQ:", Color::light_grey()},
+        {{5 * 8, (25 * 8)+2}, "F_RX:", Color::light_grey()},
+        {{5 * 8, (27 * 8)+2}, "LNA:", Color::light_grey()},
+        {{12 * 8, (27 * 8)+2}, "VGA:", Color::light_grey()},
+        {{19 * 8, (27 * 8)+2}, "AMP:", Color::light_grey()}};
 
     VuMeter vumeter{
         {0 * 8, 1 * 8, 2 * 8, 33 * 8},
@@ -210,7 +212,7 @@ class MicTXView : public View {
 
     OptionsField options_mode{
         {24 * 8, 5 * 8},
-        4,
+        6,
         {
             {"NFM/FM", 0},
             {" WFM  ", 1},
@@ -230,7 +232,7 @@ class MicTXView : public View {
 
     OptionsField field_va{
         {17 * 8, 8 * 8},
-        3,
+        4,
         {{" OFF", 0},
          {" PTT", 1},
          {"AUTO", 2}}};
@@ -255,30 +257,30 @@ class MicTXView : public View {
         ' '};
 
     OptionsField options_tone_key{
-        {10 * 8, (15 * 8) - 2},
+        {12 * 8, (13 * 8) - 5},
         23,
         {}};
 
     Checkbox check_rogerbeep{
-        {3 * 8, (16 * 8) + 7},
+        {3 * 8, (14 * 8) + 4},
         10,
         "Roger beep",
         false};
 
     Checkbox check_rxactive{
-        {3 * 8, (21 * 8) - 4},
-        18,  // it was 8, but if it is string size should be 18
-        "RX audio listening",
+        {3 * 8, (21 * 8) - 7},
+        8,  // it was 18, but if it is string size should be 8
+        "RX audio",
         false};
 
     Checkbox check_common_freq_tx_rx{
-        {18 * 8, (16 * 8) + 7},
+        {18 * 8, (21 * 8) - 7},
         8,
-        "F = F_RX",
+        "F  TX=RX",
         false};
 
     NumberField field_volume{
-        {11 * 8, 23 * 8},
+        {9 * 8, (23 * 8)+2},
         2,
         {0, 99},
         1,
@@ -286,7 +288,7 @@ class MicTXView : public View {
     };
 
     OptionsField field_rxbw{
-        {19 * 8, 23 * 8},
+        {19 * 8, (23 * 8)+2},
         3,
         {
             {" NFM1:8k5  ", 0},
@@ -295,7 +297,7 @@ class MicTXView : public View {
         }};
 
     NumberField field_squelch{
-        {23 * 8, 25 * 8},
+        {23 * 8, (25 * 8)+2},
         2,
         {0, 99},
         1,
@@ -303,11 +305,11 @@ class MicTXView : public View {
     };
 
     FrequencyField field_rxfrequency{
-        {10 * 8, 25 * 8},
+        {10 * 8, (25 * 8)+2},
     };
 
     NumberField field_rxlna{
-        {9 * 8, 27 * 8},
+        {9 * 8, (27 * 8)+2 },
         2,
         {0, 40},
         8,
@@ -315,7 +317,7 @@ class MicTXView : public View {
     };
 
     NumberField field_rxvga{
-        {16 * 8, 27 * 8},
+        {16 * 8, (27 * 8)+2},
         2,
         {0, 62},
         2,
@@ -323,7 +325,7 @@ class MicTXView : public View {
     };
 
     NumberField field_rxamp{
-        {24 * 8, 27 * 8},
+        {24 * 8, (27 * 8)+2},
         1,
         {0, 1},
         1,

--- a/firmware/application/apps/ui_mictx.hpp
+++ b/firmware/application/apps/ui_mictx.hpp
@@ -124,14 +124,14 @@ class MicTXView : public View {
         {{12 * 8, 10 * 8}, "ATT:", Color::light_grey()},
         {{20 * 8, 10 * 8}, "DEC:", Color::light_grey()},
         {{3 * 8, (13 * 8) - 5}, "TONE KEY:", Color::light_grey()},
-        {{3 * 8, (18 * 8) -1}, "======== Receiver ========", Color::green()},
-        {{5 * 8, (23 * 8)+2}, "VOL:", Color::light_grey()},
-        {{14 * 8,(23 * 8)+2}, "RXBW:", Color::light_grey()},  // we remove the label "FM" because we will display all MOD types RX_BW.
-        {{20 * 8, (25 * 8)+2}, "SQ:", Color::light_grey()},
-        {{5 * 8, (25 * 8)+2}, "F_RX:", Color::light_grey()},
-        {{5 * 8, (27 * 8)+2}, "LNA:", Color::light_grey()},
-        {{12 * 8, (27 * 8)+2}, "VGA:", Color::light_grey()},
-        {{19 * 8, (27 * 8)+2}, "AMP:", Color::light_grey()}};
+        {{3 * 8, (18 * 8) - 1}, "======== Receiver ========", Color::green()},
+        {{5 * 8, (23 * 8) + 2}, "VOL:", Color::light_grey()},
+        {{14 * 8, (23 * 8) + 2}, "RXBW:", Color::light_grey()},  // we remove the label "FM" because we will display all MOD types RX_BW.
+        {{20 * 8, (25 * 8) + 2}, "SQ:", Color::light_grey()},
+        {{5 * 8, (25 * 8) + 2}, "F_RX:", Color::light_grey()},
+        {{5 * 8, (27 * 8) + 2}, "LNA:", Color::light_grey()},
+        {{12 * 8, (27 * 8) + 2}, "VGA:", Color::light_grey()},
+        {{19 * 8, (27 * 8) + 2}, "AMP:", Color::light_grey()}};
     Labels labels_AK4951{
         {{3 * 8, 1 * 8}, "MIC-GAIN:", Color::light_grey()},
         {{17 * 8, 1 * 8}, "ALC", Color::light_grey()},
@@ -143,14 +143,14 @@ class MicTXView : public View {
         {{12 * 8, 10 * 8}, "ATT:", Color::light_grey()},
         {{20 * 8, 10 * 8}, "DEC:", Color::light_grey()},
         {{3 * 8, (13 * 8) - 5}, "TONE KEY:", Color::light_grey()},
-        {{3 * 8, (18 * 8) -1}, "======== Receiver ========", Color::green()},
-        {{(5 * 8) , (23 * 8)+2}, "VOL:", Color::light_grey()},
-        {{14 * 8, (23 * 8)+2}, "RXBW:", Color::light_grey()},  // we remove the label "FM" because we will display all MOD types RX_BW.
-        {{20 * 8, (25 * 8)+2}, "SQ:", Color::light_grey()},
-        {{5 * 8, (25 * 8)+2}, "F_RX:", Color::light_grey()},
-        {{5 * 8, (27 * 8)+2}, "LNA:", Color::light_grey()},
-        {{12 * 8, (27 * 8)+2}, "VGA:", Color::light_grey()},
-        {{19 * 8, (27 * 8)+2}, "AMP:", Color::light_grey()}};
+        {{3 * 8, (18 * 8) - 1}, "======== Receiver ========", Color::green()},
+        {{(5 * 8), (23 * 8) + 2}, "VOL:", Color::light_grey()},
+        {{14 * 8, (23 * 8) + 2}, "RXBW:", Color::light_grey()},  // we remove the label "FM" because we will display all MOD types RX_BW.
+        {{20 * 8, (25 * 8) + 2}, "SQ:", Color::light_grey()},
+        {{5 * 8, (25 * 8) + 2}, "F_RX:", Color::light_grey()},
+        {{5 * 8, (27 * 8) + 2}, "LNA:", Color::light_grey()},
+        {{12 * 8, (27 * 8) + 2}, "VGA:", Color::light_grey()},
+        {{19 * 8, (27 * 8) + 2}, "AMP:", Color::light_grey()}};
 
     VuMeter vumeter{
         {0 * 8, 1 * 8, 2 * 8, 33 * 8},
@@ -280,7 +280,7 @@ class MicTXView : public View {
         false};
 
     NumberField field_volume{
-        {9 * 8, (23 * 8)+2},
+        {9 * 8, (23 * 8) + 2},
         2,
         {0, 99},
         1,
@@ -288,7 +288,7 @@ class MicTXView : public View {
     };
 
     OptionsField field_rxbw{
-        {19 * 8, (23 * 8)+2},
+        {19 * 8, (23 * 8) + 2},
         3,
         {
             {" NFM1:8k5  ", 0},
@@ -297,7 +297,7 @@ class MicTXView : public View {
         }};
 
     NumberField field_squelch{
-        {23 * 8, (25 * 8)+2},
+        {23 * 8, (25 * 8) + 2},
         2,
         {0, 99},
         1,
@@ -305,11 +305,11 @@ class MicTXView : public View {
     };
 
     FrequencyField field_rxfrequency{
-        {10 * 8, (25 * 8)+2},
+        {10 * 8, (25 * 8) + 2},
     };
 
     NumberField field_rxlna{
-        {9 * 8, (27 * 8)+2 },
+        {9 * 8, (27 * 8) + 2},
         2,
         {0, 40},
         8,
@@ -317,7 +317,7 @@ class MicTXView : public View {
     };
 
     NumberField field_rxvga{
-        {16 * 8, (27 * 8)+2},
+        {16 * 8, (27 * 8) + 2},
         2,
         {0, 62},
         2,
@@ -325,7 +325,7 @@ class MicTXView : public View {
     };
 
     NumberField field_rxamp{
-        {24 * 8, (27 * 8)+2},
+        {24 * 8, (27 * 8) + 2},
         1,
         {0, 1},
         1,


### PR DESCRIPTION
Hello , This is minor GUI change to the Mic App ,
just trying to separate on top , Transmitter related issues, and in bottom part Receiver related issues.
(before it was a little mixed ),
Tone Key CTCSS now is using one line , (not two as before )
Roger Beep tick box , is moved to the TX parameter side .(before it was in a mixed feature line TX / RX ) .
No feature code change , just GUI .
Already confirmed in H1R2 and H2R4. (left side before this PR, right side , after that PR)
(hopefully this time no clang format issues) .

![image](https://github.com/eried/portapack-mayhem/assets/86470699/7a87b810-9f87-47cc-9ac9-c5beb17761c3)

![image](https://github.com/eried/portapack-mayhem/assets/86470699/71fd4f3e-97b0-4ae9-a10b-2573aa7a7ffc)
