### PR TITLE
simplifications, better precision, less sleeps

### DIFF
--- a/firmware/application/apps/ui_looking_glass_app.cpp
+++ b/firmware/application/apps/ui_looking_glass_app.cpp
@@ -99,10 +99,7 @@ void GlassView::retune() {
     // Tune rx for this new slice directly because the model
     // saves to persistent memory which is slower.
     radio::set_tuning_frequency(f_center);
-    if (!pixel_index)
-        chThdSleepMilliseconds(10);  // stabilize drawing
-    else
-        chThdSleepMilliseconds(5);         // stabilize freq
+    chThdSleepMilliseconds(5);             // stabilize freq
     baseband::spectrum_streaming_start();  // Do the RX
 }
 

--- a/firmware/application/apps/ui_looking_glass_app.cpp
+++ b/firmware/application/apps/ui_looking_glass_app.cpp
@@ -63,6 +63,7 @@ void GlassView::get_max_power(const ChannelSpectrum& spectrum, uint8_t bin, uint
 rf::Frequency GlassView::get_freq_from_bin_pos(uint8_t pos) {
     rf::Frequency freq_at_pos = 0;
     if (mode == LOOKING_GLASS_SINGLEPASS) {
+        // starting from the middle, minus 8 ignored bin on each side. Since pos is [-120,120] after the (pos - 120), it's divided by SCREEN_W(240)/2 => 120
         freq_at_pos = f_center_ini + ((pos - 120) * ((looking_glass_range - ((16 * looking_glass_range) / SPEC_NB_BINS)) / 2)) / (SCREEN_W / 2);
     } else
         freq_at_pos = f_min - (offset * each_bin_size) + (pos * looking_glass_range) / SCREEN_W;

--- a/firmware/application/apps/ui_looking_glass_app.cpp
+++ b/firmware/application/apps/ui_looking_glass_app.cpp
@@ -167,9 +167,7 @@ void GlassView::add_spectrum_pixel(uint8_t power) {
 // Apparently, the spectrum object returns an array of SPEC_NB_BINS (256) bins
 // Each having the radio signal power for it's corresponding frequency slot
 void GlassView::on_channel_spectrum(const ChannelSpectrum& spectrum) {
-    // no stop on single pass as there is no retune
-    if (mode != LOOKING_GLASS_SINGLEPASS)
-        baseband::spectrum_streaming_stop();
+    baseband::spectrum_streaming_stop();
     // Convert bins of this spectrum slice into a representative max_power and when enough, into pixels
     // we actually need SCREEN_W (240) of those bins
     for (bin = 0; bin < bin_length; bin++) {
@@ -193,7 +191,8 @@ void GlassView::on_channel_spectrum(const ChannelSpectrum& spectrum) {
                 if (mode != LOOKING_GLASS_SINGLEPASS) {
                     f_center = f_center_ini;
                     retune();
-                }
+                } else
+                    baseband::spectrum_streaming_start();
                 return;  // signal a new line
             }
             bins_Hz_size -= marker_pixel_step;  // reset bins size, but carrying the eventual excess Hz into next pixel
@@ -202,7 +201,8 @@ void GlassView::on_channel_spectrum(const ChannelSpectrum& spectrum) {
     if (mode != LOOKING_GLASS_SINGLEPASS) {
         f_center += looking_glass_step;
         retune();
-    }
+    } else
+        baseband::spectrum_streaming_start();
 }
 
 void GlassView::on_hide() {

--- a/firmware/application/apps/ui_looking_glass_app.hpp
+++ b/firmware/application/apps/ui_looking_glass_app.hpp
@@ -89,7 +89,10 @@ class GlassView : public View {
     };
 
     std::vector<preset_entry> presets_db{};
+    void clip_min(int32_t v);
+    void clip_max(int32_t v);
     void get_max_power(const ChannelSpectrum& spectrum, uint8_t bin, uint8_t& max_power);
+    rf::Frequency get_freq_from_bin_pos(uint8_t pos);
     void on_marker_change();
     int64_t next_mult_of(int64_t num, int64_t multiplier);
     void adjust_range(int64_t* f_min, int64_t* f_max, int64_t width);


### PR DESCRIPTION
-Reduced the code a little by factorizing a few blocks into funcs
-Took out unneeded sleeps
-Worked around the marker precision

Fix https://github.com/eried/portapack-mayhem/issues/1077