### PR TITLE
Add edit support for Notepad

### DIFF
--- a/firmware/application/apps/ui_text_editor.cpp
+++ b/firmware/application/apps/ui_text_editor.cpp
@@ -335,7 +335,7 @@ TextEditorView::TextEditorView(NavigationView& nav)
         if (viewer.offset() < file_->size() - 1)
             file_->insert_line(viewer.line());
         else
-            file_->insert_line(-1);  // add after last line.
+            file_->insert_line(-1);  // Add after last line.
 
         refresh_ui();
         hide_menu(true);

--- a/firmware/application/apps/ui_text_editor.cpp
+++ b/firmware/application/apps/ui_text_editor.cpp
@@ -346,8 +346,12 @@ TextEditorView::TextEditorView(NavigationView& nav)
             show_file_picker();
         });*/
         // HACK: above should work but it's faulting.
-        show_save_prompt(nullptr);
-        show_file_picker(false);
+        if (!file_dirty_) {
+            show_file_picker();
+        } else {
+            show_save_prompt(nullptr);
+            show_file_picker(false);
+        }
     };
 
     menu.on_save() = [this]() {

--- a/firmware/application/apps/ui_text_editor.hpp
+++ b/firmware/application/apps/ui_text_editor.hpp
@@ -201,6 +201,7 @@ class TextEditorView : public View {
     TextEditorView(
         NavigationView& nav,
         const std::filesystem::path& path);
+    ~TextEditorView();
 
     std::string title() const override {
         return "Notepad";
@@ -213,15 +214,24 @@ class TextEditorView : public View {
     std::string edit_line_buffer_{};
 
     void open_file(const std::filesystem::path& path);
+    void save_file();
     void refresh_ui();
     void update_position();
     void hide_menu(bool hidden = true);
     void show_file_picker();
     void show_edit_line();
     void show_nyi();
+    void show_save_prompt(std::function<void()> continuation);
+
+    void create_temp_file() const;
+    void delete_temp_file() const;
+    void save_temp_file();
+    std::filesystem::path get_temp_path() const;
 
     NavigationView& nav_;
     std::unique_ptr<FileWrapper> file_{};
+    std::filesystem::path path_{};
+    bool file_dirty_{false};
 
     TextViewer viewer{
         /* 272 = 320 - 16 (top bar) - 32 (bottom controls) */

--- a/firmware/application/apps/ui_text_editor.hpp
+++ b/firmware/application/apps/ui_text_editor.hpp
@@ -66,6 +66,7 @@ class TextViewer : public Widget {
 
     uint32_t line() const { return cursor_.line; }
     uint32_t col() const { return cursor_.col; }
+    uint32_t offset() const;
 
     // Gets the length of the current line.
     uint16_t line_length();

--- a/firmware/application/apps/ui_text_editor.hpp
+++ b/firmware/application/apps/ui_text_editor.hpp
@@ -223,6 +223,7 @@ class TextEditorView : public View {
     void show_nyi();
     void show_save_prompt(std::function<void()> continuation);
 
+    void prepare_for_write();
     void create_temp_file() const;
     void delete_temp_file() const;
     void save_temp_file();
@@ -232,6 +233,7 @@ class TextEditorView : public View {
     std::unique_ptr<FileWrapper> file_{};
     std::filesystem::path path_{};
     bool file_dirty_{false};
+    bool has_temp_file_{false};
 
     TextViewer viewer{
         /* 272 = 320 - 16 (top bar) - 32 (bottom controls) */

--- a/firmware/application/apps/ui_text_editor.hpp
+++ b/firmware/application/apps/ui_text_editor.hpp
@@ -67,6 +67,9 @@ class TextViewer : public Widget {
     uint32_t line() const { return cursor_.line; }
     uint32_t col() const { return cursor_.col; }
 
+    // Gets the length of the current line.
+    uint16_t line_length();
+
    private:
     static constexpr int8_t char_width = 5;
     static constexpr int8_t char_height = 8;
@@ -88,9 +91,6 @@ class TextViewer : public Widget {
     void paint_cursor(Painter& painter);
 
     void reset_file(FileWrapper* file = nullptr);
-
-    // Gets the length of the current line.
-    uint16_t line_length();
 
     FileWrapper* file_{};
 
@@ -209,11 +209,15 @@ class TextEditorView : public View {
     void on_show() override;
 
    private:
+    static constexpr size_t max_edit_length = 1024;
+    std::string edit_line_buffer_{};
+
     void open_file(const std::filesystem::path& path);
     void refresh_ui();
     void update_position();
     void hide_menu(bool hidden = true);
     void show_file_picker();
+    void show_edit_line();
     void show_nyi();
 
     NavigationView& nav_;

--- a/firmware/application/apps/ui_text_editor.hpp
+++ b/firmware/application/apps/ui_text_editor.hpp
@@ -19,6 +19,10 @@
  * Boston, MA 02110-1301, USA.
  */
 
+/* TODO:
+ * - Busy indicator while reading files.
+ */
+
 #ifndef __UI_TEXT_EDITOR_H__
 #define __UI_TEXT_EDITOR_H__
 

--- a/firmware/application/apps/ui_text_editor.hpp
+++ b/firmware/application/apps/ui_text_editor.hpp
@@ -219,7 +219,7 @@ class TextEditorView : public View {
     void refresh_ui();
     void update_position();
     void hide_menu(bool hidden = true);
-    void show_file_picker();
+    void show_file_picker(bool immediate = true);
     void show_edit_line();
     void show_nyi();
     void show_save_prompt(std::function<void()> continuation);

--- a/firmware/application/file.hpp
+++ b/firmware/application/file.hpp
@@ -369,7 +369,7 @@ class File {
     File& operator=(const File&) = delete;
 
     // TODO: Return Result<>.
-    Optional<Error> open(const std::filesystem::path& filename);
+    Optional<Error> open(const std::filesystem::path& filename, bool read_only = true);
     Optional<Error> append(const std::filesystem::path& filename);
     Optional<Error> create(const std::filesystem::path& filename);
 
@@ -377,6 +377,7 @@ class File {
     Result<Size> write(const void* data, Size bytes_to_write);
 
     Result<Offset> seek(uint64_t Offset);
+    Result<Offset> truncate();
     // Timestamp created_date() const;
     Size size() const;
 

--- a/firmware/application/file.hpp
+++ b/firmware/application/file.hpp
@@ -320,13 +320,8 @@ class File {
             return value_;
         }
 
-        /* Allows value to be moved out of the Result. */
-        T take() {
-            if (is_error())
-                return {};
-            T temp;
-            std::swap(temp, value_);
-            return temp;
+        T&& operator*() && {
+            return std::move(value_);
         }
 
         Error error() const {

--- a/firmware/application/file_wrapper.hpp
+++ b/firmware/application/file_wrapper.hpp
@@ -135,12 +135,15 @@ class BufferWrapper {
      * Only really useful for unit testing or diagnostics. */
     Offset start_line() { return start_line_; };
 
-    /* Inserts a line before the specified line. */
+    /* Inserts a line before the specified line or at the
+     * end of the buffer if line >= line_count. */
     void insert_line(Line line) {
         auto range = line_range(line);
 
         if (range)
             replace_range({range->start, range->start}, "\n");
+        else if (line >= line_count_)
+            replace_range({(Offset)size(), (Offset)size()}, "\n");
     }
 
     /* Deletes the specified line. */
@@ -420,7 +423,7 @@ class BufferWrapper {
             wrapped_->seek(offset + delta);
             result = wrapped_->write(buffer, *result);
 
-            if (result.is_error() || result < buffer_size)
+            if (result.is_error() || *result < buffer_size)
                 break;
 
             offset += *result;

--- a/firmware/application/file_wrapper.hpp
+++ b/firmware/application/file_wrapper.hpp
@@ -427,7 +427,6 @@ class BufferWrapper {
         }
 
         // Delete the extra bytes at the end of the file.
-        //wrapped_->seek(wrapped_->size() + delta);
         wrapped_->truncate();
     }
 
@@ -463,6 +462,20 @@ class FileWrapper : public BufferWrapper<File, 64> {
 
     /* Underlying file. */
     File& file() { return file_; }
+
+    /* Swaps out the underlying file for the specified file.
+     * The swapped file is expected have the same contents.
+     * For copy-on-write scenario with a temp file. */
+    bool assume_file(const std::filesystem::path& path) {
+        File file;
+        auto error = file.open(path, /*read_only*/ false);
+
+        if (error)
+            return false;
+
+        file_ = std::move(file);
+        return true;
+    }
 
    private:
     FileWrapper() {}

--- a/firmware/application/file_wrapper.hpp
+++ b/firmware/application/file_wrapper.hpp
@@ -228,6 +228,8 @@ class BufferWrapper {
         // to tell where the dirty regions are. After the
         // dirty region, it should be possible to fixup
         // the line_count data.
+        // TODO: seems like shrink/expand could do this while
+        // they are running.
 
         line_count_ = start_line_;
         Offset offset = start_offset_;

--- a/firmware/application/ui_navigation.cpp
+++ b/firmware/application/ui_navigation.cpp
@@ -432,15 +432,15 @@ void NavigationView::pop(bool update) {
 
     // Can't pop last item from stack.
     if (view_stack.size() > 1) {
-        auto& top = view_stack.back();
-        if (top.on_pop)
-            top.on_pop();
+        auto on_pop = view_stack.back().on_pop;
 
         free_view();
         view_stack.pop_back();
 
         if (update)
             update_view();
+
+        if (on_pop) on_pop();
     }
 }
 

--- a/firmware/application/ui_navigation.cpp
+++ b/firmware/application/ui_navigation.cpp
@@ -500,6 +500,18 @@ void NavigationView::focus() {
     }
 }
 
+bool NavigationView::set_on_pop(std::function<void()> on_pop) {
+    if (view_stack.size() <= 1)
+        return false;
+
+    auto& top = view_stack.back();
+    if (top.on_pop)
+        return false;
+
+    top.on_pop = on_pop;
+    return true;
+}
+
 /* ReceiversMenuView *****************************************************/
 
 ReceiversMenuView::ReceiversMenuView(NavigationView& nav) {

--- a/firmware/application/ui_navigation.cpp
+++ b/firmware/application/ui_navigation.cpp
@@ -425,30 +425,15 @@ View* NavigationView::push_view(std::unique_ptr<View> new_view) {
     return p;
 }
 
-void NavigationView::pop(bool update) {
-    if (view() == modal_view) {
-        modal_view = nullptr;
-    }
-
-    // Can't pop last item from stack.
-    if (view_stack.size() > 1) {
-        auto on_pop = view_stack.back().on_pop;
-
-        free_view();
-        view_stack.pop_back();
-
-        if (update)
-            update_view();
-
-        if (on_pop) on_pop();
-    }
+void NavigationView::pop() {
+    pop(true);
 }
 
 void NavigationView::pop_modal() {
     // Pop modal view + underlying app view.
     // TODO: this shouldn't be necessary.
     pop(false);
-    pop();
+    pop(true);
 }
 
 void NavigationView::display_modal(
@@ -465,6 +450,25 @@ void NavigationView::display_modal(
     /* If a modal view is already visible, don't display another */
     if (!modal_view) {
         modal_view = push<ModalMessageView>(title, message, type, on_choice);
+    }
+}
+
+void NavigationView::pop(bool update) {
+    if (view() == modal_view) {
+        modal_view = nullptr;
+    }
+
+    // Can't pop last item from stack.
+    if (view_stack.size() > 1) {
+        auto on_pop = view_stack.back().on_pop;
+
+        free_view();
+        view_stack.pop_back();
+
+        if (update)
+            update_view();
+
+        if (on_pop) on_pop();
     }
 }
 

--- a/firmware/application/ui_navigation.hpp
+++ b/firmware/application/ui_navigation.hpp
@@ -75,9 +75,11 @@ class NavigationView : public View {
 
     // Pushes a new view under the current on the stack so the current view returns into this new one.
     template <class T, class... Args>
-    void push_under_current(Args&&... args) {
+    T* push_under_current(Args&&... args) {
         auto new_view = std::unique_ptr<View>(new T(*this, std::forward<Args>(args)...));
+        auto new_view_ptr = new_view.get();
         view_stack.insert(view_stack.end() - 1, ViewState{std::move(new_view), {}});
+        return reinterpret_cast<T*>(new_view_ptr);
     }
 
     template <class T, class... Args>
@@ -89,7 +91,7 @@ class NavigationView : public View {
     void push(View* v);
     void replace(View* v);
 
-    void pop(bool update = true);
+    void pop();
     void pop_modal();
 
     void display_modal(const std::string& title, const std::string& message);
@@ -122,6 +124,7 @@ class NavigationView : public View {
 
     Widget* view() const;
 
+    void pop(bool update);
     void free_view();
     void update_view();
     View* push_view(std::unique_ptr<View> new_view);

--- a/firmware/application/ui_navigation.hpp
+++ b/firmware/application/ui_navigation.hpp
@@ -101,17 +101,7 @@ class NavigationView : public View {
 
     /* Sets the 'on_pop' handler for the current view.
      * Returns true if the handler was bound successfully. */
-    bool set_on_pop(std::function<void()> on_pop) {
-        if (view_stack.size() <= 1)
-            return false;
-
-        auto& top = view_stack.back();
-        if (top.on_pop)
-            return false;
-
-        top.on_pop = on_pop;
-        return true;
-    }
+    bool set_on_pop(std::function<void()> on_pop);
 
    private:
     struct ViewState {

--- a/firmware/common/optional.hpp
+++ b/firmware/common/optional.hpp
@@ -43,10 +43,8 @@ class Optional {
     const T& value() const& { return value_; }
     const T& operator*() const& { return value_; }
 
-    T&& value() && { return value_; }
-    T&& operator*() && { return value_; }
-    const T&& value() const&& { return value_; }
-    const T&& operator*() const&& { return value_; }
+    T&& value() && { return std::move(value_); }
+    T&& operator*() && { return std::move(value_); }
 
     T* operator->() { return &value_; }
     const T* operator->() const { return &value_; }

--- a/firmware/common/ui_painter.cpp
+++ b/firmware/common/ui_painter.cpp
@@ -35,18 +35,27 @@ Style Style::invert() const {
         .foreground = background};
 }
 
-int Painter::draw_char(const Point p, const Style& style, const char c) {
+int Painter::draw_char(Point p, const Style& style, char c) {
     const auto glyph = style.font.glyph(c);
     display.draw_glyph(p, glyph, style.foreground, style.background);
     return glyph.advance().x();
 }
 
-int Painter::draw_string(Point p, const Font& font, const Color foreground, const Color background, const std::string& text) {
+int Painter::draw_string(Point p, const Style& style, std::string_view text) {
+    return draw_string(p, style.font, style.foreground, style.background, text);
+}
+
+int Painter::draw_string(
+    Point p,
+    const Font& font,
+    Color foreground,
+    Color background,
+    std::string_view text) {
     bool escape = false;
     size_t width = 0;
     Color pen = foreground;
 
-    for (const auto c : text) {
+    for (auto c : text) {
         if (escape) {
             if (c <= 15)
                 pen = term_colors[c & 15];
@@ -65,48 +74,45 @@ int Painter::draw_string(Point p, const Font& font, const Color foreground, cons
             }
         }
     }
+
     return width;
 }
 
-int Painter::draw_string(Point p, const Style& style, const std::string& text) {
-    return draw_string(p, style.font, style.foreground, style.background, text);
-}
-
-void Painter::draw_bitmap(const Point p, const Bitmap& bitmap, const Color foreground, const Color background) {
+void Painter::draw_bitmap(Point p, const Bitmap& bitmap, Color foreground, Color background) {
     display.draw_bitmap(p, bitmap.size, bitmap.data, foreground, background);
 }
 
-void Painter::draw_hline(Point p, int width, const Color c) {
+void Painter::draw_hline(Point p, int width, Color c) {
     display.fill_rectangle({p, {width, 1}}, c);
 }
 
-void Painter::draw_vline(Point p, int height, const Color c) {
+void Painter::draw_vline(Point p, int height, Color c) {
     display.fill_rectangle({p, {1, height}}, c);
 }
 
-void Painter::draw_rectangle(const Rect r, const Color c) {
+void Painter::draw_rectangle(Rect r, Color c) {
     draw_hline(r.location(), r.width(), c);
     draw_vline({r.left(), r.top() + 1}, r.height() - 2, c);
     draw_vline({r.left() + r.width() - 1, r.top() + 1}, r.height() - 2, c);
     draw_hline({r.left(), r.top() + r.height() - 1}, r.width(), c);
 }
 
-void Painter::fill_rectangle(const Rect r, const Color c) {
+void Painter::fill_rectangle(Rect r, Color c) {
     display.fill_rectangle(r, c);
 }
 
-void Painter::fill_rectangle_unrolled8(const Rect r, const Color c) {
+void Painter::fill_rectangle_unrolled8(Rect r, Color c) {
     display.fill_rectangle_unrolled8(r, c);
 }
 
-void Painter::paint_widget_tree(Widget* const w) {
+void Painter::paint_widget_tree(Widget* w) {
     if (ui::is_dirty()) {
         paint_widget(w);
         ui::dirty_clear();
     }
 }
 
-void Painter::paint_widget(Widget* const w) {
+void Painter::paint_widget(Widget* w) {
     if (w->hidden()) {
         // Mark widget (and all children) as invisible.
         w->visible(false);

--- a/firmware/common/ui_painter.hpp
+++ b/firmware/common/ui_painter.hpp
@@ -25,7 +25,7 @@
 #include "ui.hpp"
 #include "ui_text.hpp"
 
-#include <string>
+#include <string_view>
 
 namespace ui {
 
@@ -46,24 +46,24 @@ class Painter {
     Painter(const Painter&) = delete;
     Painter(Painter&&) = delete;
 
-    int draw_char(const Point p, const Style& style, const char c);
+    int draw_char(Point p, const Style& style, char c);
 
-    int draw_string(Point p, const Font& font, const Color foreground, const Color background, const std::string& text);
-    int draw_string(Point p, const Style& style, const std::string& text);
+    int draw_string(Point p, const Style& style, std::string_view text);
+    int draw_string(Point p, const Font& font, Color foreground, Color background, std::string_view text);
 
-    void draw_bitmap(const Point p, const Bitmap& bitmap, const Color background, const Color foreground);
+    void draw_bitmap(Point p, const Bitmap& bitmap, Color background, Color foreground);
 
-    void draw_rectangle(const Rect r, const Color c);
-    void fill_rectangle(const Rect r, const Color c);
-    void fill_rectangle_unrolled8(const Rect r, const Color c);
+    void draw_rectangle(Rect r, Color c);
+    void fill_rectangle(Rect r, Color c);
+    void fill_rectangle_unrolled8(Rect r, Color c);
 
-    void paint_widget_tree(Widget* const w);
+    void paint_widget_tree(Widget* w);
 
-    void draw_hline(Point p, int width, const Color c);
-    void draw_vline(Point p, int height, const Color c);
+    void draw_hline(Point p, int width, Color c);
+    void draw_vline(Point p, int height, Color c);
 
    private:
-    void paint_widget(Widget* const w);
+    void paint_widget(Widget* w);
 };
 
 } /* namespace ui */

--- a/firmware/test/application/test_file_wrapper.cpp
+++ b/firmware/test/application/test_file_wrapper.cpp
@@ -27,6 +27,8 @@
 #include <cstdio>
 #include <string>
 
+// TODO: truncate basically puts an EOF at the R/W pos.
+
 /* Mocks the File interface with a backing string. */
 class MockFile {
    public:


### PR DESCRIPTION
This adds basic edit support to Notepad. The first edit is slow because it copies the original file to a temp file so it can be edited. Edits on large files are slow because they require two passed over the file content. 1 to expand/contract the file content to accommodate the edit and 2 to re-index the newlines. It should be possible to cut this down to a single pass.

Implemented:
- Copy on write so that the open file for view scenario is as fast as possible.
- Add/delete line and edit line.
- Changed FileWrapper to get text into passed in buffer instead of always allocating a new string.
- Adding a MockFile that more accurately represents FatFs, and unit tests for the implemented edits.
- Support for opening a file RW mode and truncating files.
- Fixes for r-value Optional and Result types.
- Cleaned up Painter API (remove unnecessary `const`) and use std::string_view to avoid allocations when drawing text.
- Change to navigation to add an "on_pop" handler that can be registered per View... still not quite right. 😞 

Still to do:
- Cut/Copy/Paste
- More efficient edit updating
- Figure out why the view nav stuff is faulting.

See wiki page: https://github.com/eried/portapack-mayhem/wiki/Notepad