### PR TITLE
Disallow Focus positioning to Empty lists #1097

### DIFF
--- a/firmware/application/recent_entries.hpp
+++ b/firmware/application/recent_entries.hpp
@@ -128,7 +128,6 @@ class RecentEntriesTable : public Widget {
     RecentEntriesTable(
         Entries& recent)
         : recent{recent} {
-        set_focusable(true);
     }
 
     void paint(Painter& painter) override {
@@ -151,6 +150,7 @@ class RecentEntriesTable : public Widget {
             const auto item_style = (has_focus() && is_selected_key) ? s.invert() : s;
             draw(entry, target_rect, painter, item_style);
             target_rect += {0, target_rect.height()};
+            set_focusable(true);
         }
 
         painter.fill_rectangle(

--- a/firmware/application/recent_entries.hpp
+++ b/firmware/application/recent_entries.hpp
@@ -137,6 +137,8 @@ class RecentEntriesTable : public Widget {
         Rect target_rect{r.location(), {r.width(), s.font.line_height()}};
         const size_t visible_item_count = r.height() / s.font.line_height();
 
+        set_focusable(!recent.empty());
+
         auto selected = find(recent, selected_key);
         if (selected == std::end(recent)) {
             selected = std::begin(recent);
@@ -150,7 +152,6 @@ class RecentEntriesTable : public Widget {
             const auto item_style = (has_focus() && is_selected_key) ? s.invert() : s;
             draw(entry, target_rect, painter, item_style);
             target_rect += {0, target_rect.height()};
-            set_focusable(true);
         }
 
         painter.fill_rectangle(


### PR DESCRIPTION
Instead of making a "Recent Entries" list focusable upon empty list creation, delay focus-ability until at least one entry is known to be in the list.

Moving this one line fixes an issue with focus disappearing when the down button is pressed multiple times when the list is empty in the SEARCH, ADS-B, AIS, ERT, TPMS, APRS RX (LIST screen), and FLASH UTILITY apps.