### PR TITLE
moved pmem setting restore before top bar is loaded

### DIFF
--- a/firmware/application/apps/ui_settings.cpp
+++ b/firmware/application/apps/ui_settings.cpp
@@ -446,14 +446,14 @@ SetPersistentMemoryView::SetPersistentMemoryView(NavigationView& nav) {
     add_children({&text_pmem_about,
                   &text_pmem_informations,
                   &text_pmem_status,
-                  &check_load_mem_at_startup,
+                  &check_use_sdcard_for_pmem,
                   &button_save_mem_to_file,
                   &button_load_mem_from_file,
                   &button_load_mem_defaults,
                   &button_return});
 
-    check_load_mem_at_startup.set_value(portapack::persistent_memory::should_use_sdcard_for_pmem());
-    check_load_mem_at_startup.on_select = [this](Checkbox&, bool v) {
+    check_use_sdcard_for_pmem.set_value(portapack::persistent_memory::should_use_sdcard_for_pmem());
+    check_use_sdcard_for_pmem.on_select = [this](Checkbox&, bool v) {
         File pmem_flag_file_handle;
         std::string pmem_flag_file = PMEM_FILEFLAG;
         if (v) {

--- a/firmware/application/apps/ui_settings.cpp
+++ b/firmware/application/apps/ui_settings.cpp
@@ -452,10 +452,10 @@ SetPersistentMemoryView::SetPersistentMemoryView(NavigationView& nav) {
                   &button_load_mem_defaults,
                   &button_return});
 
-    check_load_mem_at_startup.set_value(portapack::persistent_memory::save_load_pmem_from_sdcard_flag());
+    check_load_mem_at_startup.set_value(portapack::persistent_memory::should_use_sdcard_for_pmem());
     check_load_mem_at_startup.on_select = [this](Checkbox&, bool v) {
         File pmem_flag_file_handle;
-        std::string pmem_flag_file = "/SETTINGS/PMEM_FILEFLAG";
+        std::string pmem_flag_file = PMEM_FILEFLAG;
         if (v) {
             auto result = pmem_flag_file_handle.open(pmem_flag_file);
             if (result.is_valid()) {
@@ -479,7 +479,7 @@ SetPersistentMemoryView::SetPersistentMemoryView(NavigationView& nav) {
     };
 
     button_save_mem_to_file.on_select = [&nav, this](Button&) {
-        if (!portapack::persistent_memory::save_persistent_settings_to_file("SETTINGS/pmem_settings")) {
+        if (!portapack::persistent_memory::save_persistent_settings_to_file()) {
             text_pmem_status.set("!problem saving settings!");
         } else {
             text_pmem_status.set("settings saved");
@@ -487,7 +487,7 @@ SetPersistentMemoryView::SetPersistentMemoryView(NavigationView& nav) {
     };
 
     button_load_mem_from_file.on_select = [&nav, this](Button&) {
-        if (!portapack::persistent_memory::load_persistent_settings_from_file("SETTINGS/pmem_settings")) {
+        if (!portapack::persistent_memory::load_persistent_settings_from_file()) {
             text_pmem_status.set("!problem loading settings!");
         } else {
             text_pmem_status.set("settings loaded");

--- a/firmware/application/apps/ui_settings.cpp
+++ b/firmware/application/apps/ui_settings.cpp
@@ -452,18 +452,7 @@ SetPersistentMemoryView::SetPersistentMemoryView(NavigationView& nav) {
                   &button_load_mem_defaults,
                   &button_return});
 
-    bool load_mem_at_startup = false;
-    File pmem_flag_file_handle;
-
-    std::string folder = "SETTINGS";
-    make_new_directory(folder);
-
-    std::string pmem_flag_file = "/SETTINGS/PMEM_FILEFLAG";
-    auto result = pmem_flag_file_handle.open(pmem_flag_file);
-    if (!result.is_valid()) {
-        load_mem_at_startup = true;
-    }
-    check_load_mem_at_startup.set_value(load_mem_at_startup);
+    check_load_mem_at_startup.set_value(portapack::persistent_memory::save_load_pmem_from_sdcard_flag());
     check_load_mem_at_startup.on_select = [this](Checkbox&, bool v) {
         File pmem_flag_file_handle;
         std::string pmem_flag_file = "/SETTINGS/PMEM_FILEFLAG";

--- a/firmware/application/apps/ui_settings.hpp
+++ b/firmware/application/apps/ui_settings.hpp
@@ -485,10 +485,10 @@ class SetPersistentMemoryView : public View {
         {0, 3 * 16, 240, 16},
         ""};
 
-    Checkbox check_load_mem_at_startup{
+    Checkbox check_use_sdcard_for_pmem{
         {18, 6 * 16},
         19,
-        "load from sd at startup"};
+        "use sdcard for p.mem"};
 
     Button button_save_mem_to_file{
         {0, 8 * 16, 240, 32},

--- a/firmware/application/ui_navigation.cpp
+++ b/firmware/application/ui_navigation.cpp
@@ -126,6 +126,13 @@ SystemStatusView::SystemStatusView(
         &sd_card_status_view,
     });
 
+    File pmem_flag_file_handle;
+    std::string pmem_flag_file = "/SETTINGS/PMEM_FILEFLAG";
+    auto result = pmem_flag_file_handle.open(pmem_flag_file);
+    if (!result.is_valid()) {
+        portapack::persistent_memory::load_persistent_settings_from_file("SETTINGS/pmem_settings");
+    }
+
     if (portapack::persistent_memory::config_speaker())
         button_speaker.hidden(false);
     else
@@ -691,13 +698,6 @@ SystemView::SystemView(
         } else {*/
 
     navigation_view.push<SystemMenuView>();
-
-    File pmem_flag_file_handle;
-    std::string pmem_flag_file = "/SETTINGS/PMEM_FILEFLAG";
-    auto result = pmem_flag_file_handle.open(pmem_flag_file);
-    if (!result.is_valid()) {
-        portapack::persistent_memory::load_persistent_settings_from_file("SETTINGS/pmem_settings");
-    }
 
     if (portapack::persistent_memory::config_splash()) {
         navigation_view.push<BMPView>();

--- a/firmware/application/ui_navigation.cpp
+++ b/firmware/application/ui_navigation.cpp
@@ -126,8 +126,8 @@ SystemStatusView::SystemStatusView(
         &sd_card_status_view,
     });
 
-    if (portapack::persistent_memory::save_load_pmem_from_sdcard_flag()) {
-        portapack::persistent_memory::load_persistent_settings_from_file("SETTINGS/pmem_settings");
+    if (portapack::persistent_memory::should_use_sdcard_for_pmem()) {
+        portapack::persistent_memory::load_persistent_settings_from_file();
     }
 
     if (portapack::persistent_memory::config_speaker())
@@ -160,8 +160,8 @@ SystemStatusView::SystemStatusView(
     refresh();
 
     button_back.on_select = [this](ImageButton&) {
-        if (portapack::persistent_memory::save_load_pmem_from_sdcard_flag()) {
-            portapack::persistent_memory::save_persistent_settings_to_file("SETTINGS/pmem_settings");
+        if (portapack::persistent_memory::should_use_sdcard_for_pmem()) {
+            portapack::persistent_memory::save_persistent_settings_to_file();
         }
         if (this->on_back)
             this->on_back();

--- a/firmware/application/ui_navigation.cpp
+++ b/firmware/application/ui_navigation.cpp
@@ -126,10 +126,7 @@ SystemStatusView::SystemStatusView(
         &sd_card_status_view,
     });
 
-    File pmem_flag_file_handle;
-    std::string pmem_flag_file = "/SETTINGS/PMEM_FILEFLAG";
-    auto result = pmem_flag_file_handle.open(pmem_flag_file);
-    if (!result.is_valid()) {
+    if (portapack::persistent_memory::save_load_pmem_from_sdcard_flag()) {
         portapack::persistent_memory::load_persistent_settings_from_file("SETTINGS/pmem_settings");
     }
 
@@ -163,6 +160,9 @@ SystemStatusView::SystemStatusView(
     refresh();
 
     button_back.on_select = [this](ImageButton&) {
+        if (portapack::persistent_memory::save_load_pmem_from_sdcard_flag()) {
+            portapack::persistent_memory::save_persistent_settings_to_file("SETTINGS/pmem_settings");
+        }
         if (this->on_back)
             this->on_back();
     };

--- a/firmware/common/portapack_persistent_memory.cpp
+++ b/firmware/common/portapack_persistent_memory.cpp
@@ -820,6 +820,16 @@ void set_encoder_dial_sensitivity(uint8_t v) {
     data->encoder_dial_sensitivity = v;
 }
 
+bool save_load_pmem_from_sdcard_flag() {
+    File pmem_flag_file_handle;
+    std::string pmem_flag_file = "/SETTINGS/PMEM_FILEFLAG";
+    auto result = pmem_flag_file_handle.open(pmem_flag_file);
+    if (!result.is_valid()) {
+        return true;
+    }
+    return false;
+}
+
 // sd persisting settings
 int save_persistent_settings_to_file(std::string filename) {
     delete_file(filename);

--- a/firmware/common/portapack_persistent_memory.cpp
+++ b/firmware/common/portapack_persistent_memory.cpp
@@ -820,18 +820,13 @@ void set_encoder_dial_sensitivity(uint8_t v) {
     data->encoder_dial_sensitivity = v;
 }
 
-bool save_load_pmem_from_sdcard_flag() {
-    File pmem_flag_file_handle;
-    std::string pmem_flag_file = "/SETTINGS/PMEM_FILEFLAG";
-    auto result = pmem_flag_file_handle.open(pmem_flag_file);
-    if (!result.is_valid()) {
-        return true;
-    }
-    return false;
+bool should_use_sdcard_for_pmem() {
+    return std::filesystem::file_exists(PMEM_FILEFLAG);
 }
 
 // sd persisting settings
-int save_persistent_settings_to_file(std::string filename) {
+int save_persistent_settings_to_file() {
+    std::string filename = PMEM_SETTING_FILE;
     delete_file(filename);
     File outfile;
     auto result = outfile.create(filename);
@@ -842,7 +837,8 @@ int save_persistent_settings_to_file(std::string filename) {
     return true;
 }
 
-int load_persistent_settings_from_file(std::string filename) {
+int load_persistent_settings_from_file() {
+    std::string filename = PMEM_SETTING_FILE;
     File infile;
     auto result = infile.open(filename);
     if (!result.is_valid()) {

--- a/firmware/common/portapack_persistent_memory.hpp
+++ b/firmware/common/portapack_persistent_memory.hpp
@@ -32,6 +32,11 @@
 #include "modems.hpp"
 #include "serializer.hpp"
 
+// persistant memory from/to sdcard flag file
+#define PMEM_FILEFLAG "/SETTINGS/PMEM_FILEFLAG"
+// persistant memory from/to sdcard flag file
+#define PMEM_SETTING_FILE "/SETTINGS/pmem_settings"
+
 using namespace modems;
 using namespace serializer;
 
@@ -244,9 +249,9 @@ void set_recon_load_hamradios(const bool v);
 void set_recon_match_mode(const bool v);
 
 // sd persisting settings
-bool save_load_pmem_from_sdcard_flag();
-int save_persistent_settings_to_file(std::string filename);
-int load_persistent_settings_from_file(std::string filename);
+bool should_use_sdcard_for_pmem();
+int save_persistent_settings_to_file();
+int load_persistent_settings_from_file();
 
 } /* namespace persistent_memory */
 

--- a/firmware/common/portapack_persistent_memory.hpp
+++ b/firmware/common/portapack_persistent_memory.hpp
@@ -244,6 +244,7 @@ void set_recon_load_hamradios(const bool v);
 void set_recon_match_mode(const bool v);
 
 // sd persisting settings
+bool save_load_pmem_from_sdcard_flag();
 int save_persistent_settings_to_file(std::string filename);
 int load_persistent_settings_from_file(std::string filename);
 


### PR DESCRIPTION
Since top bar is loaded before the rest of the menu, I had to move pmem settings restore just before the top bar is set.
Fix for https://github.com/eried/portapack-mayhem/issues/1099