### PR TITLE
Increase text brightness for aged flights in ADS-B RX

### DIFF
--- a/firmware/application/apps/ui_adsb_rx.cpp
+++ b/firmware/application/apps/ui_adsb_rx.cpp
@@ -53,7 +53,7 @@ void RecentEntriesTable<AircraftRecentEntries>::draw(
         target_color = Color::light_grey();
     } else {
         aged_color = 0x08;
-        target_color = Color::dark_grey();
+        target_color = Color::grey();
     }
 
     std::string entry_string = "\x1B";


### PR DESCRIPTION
IMO, "dark_grey" text on a black background is almost unreadable in a lighted room, especially if the screen is slightly tilted.  This PR proposes a slight increase in brightness for text lines for "aged" flights in ADS-B RX, while still leaving 3 levels of brightness according to the time since the last signal was received.  (I think this is the only app that displayed "dark_grey" text on a black background.)

Please compare these two photos:
![IMG_0555](https://github.com/eried/portapack-mayhem/assets/129641948/50ddacc9-702c-4dc3-81ea-75679961de10)
![IMG_0554](https://github.com/eried/portapack-mayhem/assets/129641948/444ffb22-0f87-4d39-9a9a-29a97f2d4b46)
