### PR TITLE
Add AudioVolumeField -- cleanup

### DIFF
--- a/firmware/application/apps/analog_audio_app.cpp
+++ b/firmware/application/apps/analog_audio_app.cpp
@@ -198,11 +198,6 @@ AnalogAudioView::AnalogAudioView(
         this->on_show_options_modulation();
     };
 
-    field_volume.set_value((receiver_model.headphone_volume() - audio::headphone::volume_range().max).decibel() + 99);
-    field_volume.on_change = [this](int32_t v) {
-        this->on_headphone_volume_changed(v);
-    };
-
     record_view.on_error = [&nav](std::string message) {
         nav.display_modal("Error", message);
     };
@@ -389,11 +384,6 @@ void AnalogAudioView::on_frequency_step_changed(rf::Frequency f) {
 
 void AnalogAudioView::on_reference_ppm_correction_changed(int32_t v) {
     persistent_memory::set_correction_ppb(v * 1000);
-}
-
-void AnalogAudioView::on_headphone_volume_changed(int32_t v) {
-    const auto new_volume = volume_t::decibel(v - 99) + audio::headphone::volume_range().max;
-    receiver_model.set_headphone_volume(new_volume);
 }
 
 void AnalogAudioView::update_modulation(const ReceiverModel::Mode modulation) {

--- a/firmware/application/apps/analog_audio_app.hpp
+++ b/firmware/application/apps/analog_audio_app.hpp
@@ -207,13 +207,8 @@ class AnalogAudioView : public View {
             {"SPEC", toUType(ReceiverModel::Mode::SpectrumAnalysis)},
         }};
 
-    NumberField field_volume{
-        {28 * 8, 0 * 16},
-        2,
-        {0, 99},
-        1,
-        ' ',
-    };
+    AudioVolumeField field_volume{
+        {28 * 8, 0 * 16}};
 
     Text text_ctcss{
         {19 * 8, 1 * 16, 11 * 8, 1 * 16},
@@ -239,7 +234,6 @@ class AnalogAudioView : public View {
     void on_show_options_modulation();
     void on_frequency_step_changed(rf::Frequency f);
     void on_reference_ppm_correction_changed(int32_t v);
-    void on_headphone_volume_changed(int32_t v);
     void on_edit_frequency();
 
     void remove_options_widget();

--- a/firmware/application/apps/analog_tv_app.cpp
+++ b/firmware/application/apps/analog_tv_app.cpp
@@ -100,11 +100,6 @@ AnalogTvView::AnalogTvView(
         this->on_show_options_modulation();
     };
 
-    field_volume.set_value(0);
-    field_volume.on_change = [this](int32_t v) {
-        this->on_headphone_volume_changed(v);
-    };
-
     tv.on_select = [this](int32_t offset) {
         field_frequency.set_value(receiver_model.tuning_frequency() + offset);
     };
@@ -223,11 +218,6 @@ void AnalogTvView::on_frequency_step_changed(rf::Frequency f) {
 
 void AnalogTvView::on_reference_ppm_correction_changed(int32_t v) {
     persistent_memory::set_correction_ppb(v * 1000);
-}
-
-void AnalogTvView::on_headphone_volume_changed(int32_t v) {
-    (void)v;  // avoid warning
-              // tv::TVView::set_headphone_volume(this,v);
 }
 
 void AnalogTvView::update_modulation(const ReceiverModel::Mode modulation) {

--- a/firmware/application/apps/analog_tv_app.hpp
+++ b/firmware/application/apps/analog_tv_app.hpp
@@ -98,13 +98,8 @@ class AnalogTvView : public View {
             {"TV ", toUType(ReceiverModel::Mode::WidebandFMAudio)},
         }};
 
-    NumberField field_volume{
-        {27 * 8, 0 * 16},
-        3,
-        {0, 255},
-        1,
-        ' ',
-    };
+    AudioVolumeField field_volume{
+        {27 * 8, 0 * 16}};
 
     std::unique_ptr<Widget> options_widget{};
 
@@ -118,7 +113,6 @@ class AnalogTvView : public View {
     void on_show_options_modulation();
     void on_frequency_step_changed(rf::Frequency f);
     void on_reference_ppm_correction_changed(int32_t v);
-    void on_headphone_volume_changed(int32_t v);
     void on_edit_frequency();
 
     void remove_options_widget();

--- a/firmware/application/apps/pocsag_app.cpp
+++ b/firmware/application/apps/pocsag_app.cpp
@@ -204,7 +204,7 @@ void POCSAGAppView::on_packet(const POCSAGPacketMessage* message) {
 
     // TODO: make setting.
     // Log raw data whatever it contains
-    if (logger && logging)
+    if (logger && logging())
         logger->log_raw_data(message->packet, target_frequency());
 }
 

--- a/firmware/application/apps/pocsag_app.hpp
+++ b/firmware/application/apps/pocsag_app.hpp
@@ -52,20 +52,18 @@ class POCSAGAppView : public View {
     POCSAGAppView(NavigationView& nav);
     ~POCSAGAppView();
 
-    void set_parent_rect(const Rect new_parent_rect) override;
-    void focus() override;
-
     std::string title() const override { return "POCSAG RX"; };
 
    private:
     static constexpr uint32_t initial_target_frequency = 466175000;
 
+    bool logging() const { return check_log.value(); };
+    bool ignore() const { return check_ignore.value(); };
+
     // app save settings
     std::app_settings settings{};
     std::app_settings::AppSettings app_settings{};
 
-    bool logging{false};
-    bool ignore{false};
     uint32_t last_address = 0xFFFFFFFF;
     pocsag::POCSAGState pocsag_state{};
 
@@ -88,13 +86,9 @@ class POCSAGAppView : public View {
     FrequencyField field_frequency{
         {0 * 8, 0 * 8},
     };
-    NumberField field_volume{
-        {28 * 8, 0 * 16},
-        2,
-        {0, 99},
-        1,
-        ' ',
-    };
+
+    AudioVolumeField field_volume{
+        {28 * 8, 0 * 16}};
 
     Checkbox check_ignore{
         {0 * 8, 21},
@@ -105,10 +99,11 @@ class POCSAGAppView : public View {
         {13 * 8, 25},
         7,
         SymField::SYMFIELD_DEC};
+
     Checkbox check_log{
         {240 - 8 * 8, 21},
         3,
-        "LOG",
+        "Log",
         false};
 
     Console console{
@@ -121,8 +116,6 @@ class POCSAGAppView : public View {
     void update_freq(rf::Frequency f);
 
     void on_packet(const POCSAGPacketMessage* message);
-
-    void on_headphone_volume_changed(int32_t v);
 
     uint32_t target_frequency() const;
     void set_target_frequency(const uint32_t new_value);

--- a/firmware/application/apps/ui_about_simple.cpp
+++ b/firmware/application/apps/ui_about_simple.cpp
@@ -33,7 +33,7 @@ void AboutView::update() {
                 console.writeln("heurist1,intoxsick,ckuethe");
                 console.writeln("notpike,jLynx,zigad");
                 console.writeln("MichalLeonBorsuk,jimilinuxguy");
-                console.writeln("kallanreed");
+                console.writeln("kallanreed,bernd-herzog");
                 console.writeln("");
                 break;
 

--- a/firmware/application/apps/ui_about_simple.cpp
+++ b/firmware/application/apps/ui_about_simple.cpp
@@ -33,6 +33,7 @@ void AboutView::update() {
                 console.writeln("heurist1,intoxsick,ckuethe");
                 console.writeln("notpike,jLynx,zigad");
                 console.writeln("MichalLeonBorsuk,jimilinuxguy");
+                console.writeln("kallanreed");
                 console.writeln("");
                 break;
 

--- a/firmware/application/apps/ui_level.cpp
+++ b/firmware/application/apps/ui_level.cpp
@@ -68,9 +68,6 @@ LevelView::LevelView(NavigationView& nav)
 
     rssi.set_vertical_rssi(true);
 
-    field_volume.on_change = [this](int32_t v) { this->on_headphone_volume_changed(v); };
-    field_volume.set_value((receiver_model.headphone_volume() - audio::headphone::volume_range().max).decibel() + 99);
-
     change_mode(NFM_MODULATION);              // Start on AM
     field_mode.set_by_value(NFM_MODULATION);  // Reflect the mode into the manual selector
 
@@ -135,7 +132,7 @@ LevelView::LevelView(NavigationView& nav)
             audio::output::stop();
         } else if (v == 1) {
             audio::output::start();
-            this->on_headphone_volume_changed((receiver_model.headphone_volume() - audio::headphone::volume_range().max).decibel() + 99);
+            receiver_model.set_headphone_volume(receiver_model.headphone_volume());  // TODO: Needed?
         } else {
         }
     };
@@ -156,11 +153,6 @@ LevelView::LevelView(NavigationView& nav)
     freqman_set_step_option_short(step_mode);
     freq_stats_rssi.set_style(&style_white);
     freq_stats_db.set_style(&style_white);
-}
-
-void LevelView::on_headphone_volume_changed(int32_t v) {
-    const auto new_volume = volume_t::decibel(v - 99) + audio::headphone::volume_range().max;
-    receiver_model.set_headphone_volume(new_volume);
 }
 
 void LevelView::on_statistics_update(const ChannelStatistics& statistics) {

--- a/firmware/application/apps/ui_level.hpp
+++ b/firmware/application/apps/ui_level.hpp
@@ -117,109 +117,103 @@ class LevelView : public View {
     RFAmpField field_rf_amp{
         {18 * 8, 0 * 16}};
 
-    NumberField field_volume{
-        {24 * 8, 0 * 16},
-        2,
-        {0, 99},
-        1,
-        ' ',
+    AudioVolumeField field_volume {
+        {24 * 8, 0 * 16};
+
+        OptionsField field_bw{
+            {3 * 8, 1 * 16},
+            6,
+            {}};
+
+        OptionsField field_mode{
+            {15 * 8, 1 * 16},
+            3,
+            {}};
+
+        OptionsField step_mode{
+            {16 * 8, 2 * 16 + 4},
+            12,
+            {}};
+
+        ButtonWithEncoder button_frequency{
+            {0 * 8, 2 * 16 + 8, 15 * 8, 1 * 8},
+            ""};
+
+        OptionsField audio_mode{
+            {21 * 8, 1 * 16},
+            9,
+            {
+                {"audio off", 0},
+                {"audio on", 1}
+                //{"tone on", 2},
+                //{"tone off", 2},
+            }};
+
+        Text text_ctcss{
+            {22 * 8, 3 * 16 + 4, 14 * 8, 1 * 8},
+            ""};
+
+        // RSSI: XX/XX/XXX,dt: XX
+        Text freq_stats_rssi{
+            {0 * 8, 3 * 16 + 4, 22 * 8, 14},
+        };
+
+        // Power: -XXX db
+        Text freq_stats_db{
+            {0 * 8, 4 * 16 + 4, 14 * 8, 14},
+        };
+
+        OptionsField peak_mode{
+            {40 + 10 * 8, 4 * 16 + 4},
+            10,
+            {
+                {"peak:none", 0},
+                {"peak:0.25s", 250},
+                {"peak:0.5s", 500},
+                {"peak:1s", 1000},
+                {"peak:3s", 3000},
+                {"peak:5s", 5000},
+                {"peak:10s", 10000},
+            }};
+        OptionsField rssi_resolution{
+            {44 + 20 * 8, 4 * 16 + 4},
+            4,
+            {
+                {"16x", 16},
+                {"32x", 32},
+                {"64x", 64},
+                {"128x", 128},
+                {"240x", 240},
+            }};
+
+        RSSIGraph rssi_graph{
+            // 240x320  =>
+            {0, 5 * 16 + 4, 240 - 5 * 8, 320 - (5 * 16 + 4)},
+        };
+
+        RSSI rssi{
+            // 240x320  =>
+            {240 - 5 * 8, 5 * 16 + 4, 5 * 8, 320 - (5 * 16 + 4)},
+        };
+
+        void handle_coded_squelch(const uint32_t value);
+
+        MessageHandlerRegistration message_handler_coded_squelch{
+            Message::ID::CodedSquelch,
+            [this](const Message* const p) {
+                const auto message = *reinterpret_cast<const CodedSquelchMessage*>(p);
+                this->handle_coded_squelch(message.value);
+            }};
+
+        MessageHandlerRegistration message_handler_stats{
+            Message::ID::ChannelStatistics,
+            [this](const Message* const p) {
+                this->on_statistics_update(static_cast<const ChannelStatisticsMessage*>(p)->statistics);
+            }};
+        // app save settings
+        std::app_settings settings{};
+        std::app_settings::AppSettings app_settings{};
     };
-
-    OptionsField field_bw{
-        {3 * 8, 1 * 16},
-        6,
-        {}};
-
-    OptionsField field_mode{
-        {15 * 8, 1 * 16},
-        3,
-        {}};
-
-    OptionsField step_mode{
-        {16 * 8, 2 * 16 + 4},
-        12,
-        {}};
-
-    ButtonWithEncoder button_frequency{
-        {0 * 8, 2 * 16 + 8, 15 * 8, 1 * 8},
-        ""};
-
-    OptionsField audio_mode{
-        {21 * 8, 1 * 16},
-        9,
-        {
-            {"audio off", 0},
-            {"audio on", 1}
-            //{"tone on", 2},
-            //{"tone off", 2},
-        }};
-
-    Text text_ctcss{
-        {22 * 8, 3 * 16 + 4, 14 * 8, 1 * 8},
-        ""};
-
-    // RSSI: XX/XX/XXX,dt: XX
-    Text freq_stats_rssi{
-        {0 * 8, 3 * 16 + 4, 22 * 8, 14},
-    };
-
-    // Power: -XXX db
-    Text freq_stats_db{
-        {0 * 8, 4 * 16 + 4, 14 * 8, 14},
-    };
-
-    OptionsField peak_mode{
-        {40 + 10 * 8, 4 * 16 + 4},
-        10,
-        {
-            {"peak:none", 0},
-            {"peak:0.25s", 250},
-            {"peak:0.5s", 500},
-            {"peak:1s", 1000},
-            {"peak:3s", 3000},
-            {"peak:5s", 5000},
-            {"peak:10s", 10000},
-        }};
-    OptionsField rssi_resolution{
-        {44 + 20 * 8, 4 * 16 + 4},
-        4,
-        {
-            {"16x", 16},
-            {"32x", 32},
-            {"64x", 64},
-            {"128x", 128},
-            {"240x", 240},
-        }};
-
-    RSSIGraph rssi_graph{
-        // 240x320  =>
-        {0, 5 * 16 + 4, 240 - 5 * 8, 320 - (5 * 16 + 4)},
-    };
-
-    RSSI rssi{
-        // 240x320  =>
-        {240 - 5 * 8, 5 * 16 + 4, 5 * 8, 320 - (5 * 16 + 4)},
-    };
-
-    void handle_coded_squelch(const uint32_t value);
-    void on_headphone_volume_changed(int32_t v);
-
-    MessageHandlerRegistration message_handler_coded_squelch{
-        Message::ID::CodedSquelch,
-        [this](const Message* const p) {
-            const auto message = *reinterpret_cast<const CodedSquelchMessage*>(p);
-            this->handle_coded_squelch(message.value);
-        }};
-
-    MessageHandlerRegistration message_handler_stats{
-        Message::ID::ChannelStatistics,
-        [this](const Message* const p) {
-            this->on_statistics_update(static_cast<const ChannelStatisticsMessage*>(p)->statistics);
-        }};
-    // app save settings
-    std::app_settings settings{};
-    std::app_settings::AppSettings app_settings{};
-};
 
 } /* namespace ui */
 

--- a/firmware/application/apps/ui_level.hpp
+++ b/firmware/application/apps/ui_level.hpp
@@ -117,103 +117,103 @@ class LevelView : public View {
     RFAmpField field_rf_amp{
         {18 * 8, 0 * 16}};
 
-    AudioVolumeField field_volume {
-        {24 * 8, 0 * 16};
+    AudioVolumeField field_volume{
+        {24 * 8, 0 * 16}};
 
-        OptionsField field_bw{
-            {3 * 8, 1 * 16},
-            6,
-            {}};
+    OptionsField field_bw{
+        {3 * 8, 1 * 16},
+        6,
+        {}};
 
-        OptionsField field_mode{
-            {15 * 8, 1 * 16},
-            3,
-            {}};
+    OptionsField field_mode{
+        {15 * 8, 1 * 16},
+        3,
+        {}};
 
-        OptionsField step_mode{
-            {16 * 8, 2 * 16 + 4},
-            12,
-            {}};
+    OptionsField step_mode{
+        {16 * 8, 2 * 16 + 4},
+        12,
+        {}};
 
-        ButtonWithEncoder button_frequency{
-            {0 * 8, 2 * 16 + 8, 15 * 8, 1 * 8},
-            ""};
+    ButtonWithEncoder button_frequency{
+        {0 * 8, 2 * 16 + 8, 15 * 8, 1 * 8},
+        ""};
 
-        OptionsField audio_mode{
-            {21 * 8, 1 * 16},
-            9,
-            {
-                {"audio off", 0},
-                {"audio on", 1}
-                //{"tone on", 2},
-                //{"tone off", 2},
-            }};
+    OptionsField audio_mode{
+        {21 * 8, 1 * 16},
+        9,
+        {
+            {"audio off", 0},
+            {"audio on", 1}
+            //{"tone on", 2},
+            //{"tone off", 2},
+        }};
 
-        Text text_ctcss{
-            {22 * 8, 3 * 16 + 4, 14 * 8, 1 * 8},
-            ""};
+    Text text_ctcss{
+        {22 * 8, 3 * 16 + 4, 14 * 8, 1 * 8},
+        ""};
 
-        // RSSI: XX/XX/XXX,dt: XX
-        Text freq_stats_rssi{
-            {0 * 8, 3 * 16 + 4, 22 * 8, 14},
-        };
-
-        // Power: -XXX db
-        Text freq_stats_db{
-            {0 * 8, 4 * 16 + 4, 14 * 8, 14},
-        };
-
-        OptionsField peak_mode{
-            {40 + 10 * 8, 4 * 16 + 4},
-            10,
-            {
-                {"peak:none", 0},
-                {"peak:0.25s", 250},
-                {"peak:0.5s", 500},
-                {"peak:1s", 1000},
-                {"peak:3s", 3000},
-                {"peak:5s", 5000},
-                {"peak:10s", 10000},
-            }};
-        OptionsField rssi_resolution{
-            {44 + 20 * 8, 4 * 16 + 4},
-            4,
-            {
-                {"16x", 16},
-                {"32x", 32},
-                {"64x", 64},
-                {"128x", 128},
-                {"240x", 240},
-            }};
-
-        RSSIGraph rssi_graph{
-            // 240x320  =>
-            {0, 5 * 16 + 4, 240 - 5 * 8, 320 - (5 * 16 + 4)},
-        };
-
-        RSSI rssi{
-            // 240x320  =>
-            {240 - 5 * 8, 5 * 16 + 4, 5 * 8, 320 - (5 * 16 + 4)},
-        };
-
-        void handle_coded_squelch(const uint32_t value);
-
-        MessageHandlerRegistration message_handler_coded_squelch{
-            Message::ID::CodedSquelch,
-            [this](const Message* const p) {
-                const auto message = *reinterpret_cast<const CodedSquelchMessage*>(p);
-                this->handle_coded_squelch(message.value);
-            }};
-
-        MessageHandlerRegistration message_handler_stats{
-            Message::ID::ChannelStatistics,
-            [this](const Message* const p) {
-                this->on_statistics_update(static_cast<const ChannelStatisticsMessage*>(p)->statistics);
-            }};
-        // app save settings
-        std::app_settings settings{};
-        std::app_settings::AppSettings app_settings{};
+    // RSSI: XX/XX/XXX,dt: XX
+    Text freq_stats_rssi{
+        {0 * 8, 3 * 16 + 4, 22 * 8, 14},
     };
+
+    // Power: -XXX db
+    Text freq_stats_db{
+        {0 * 8, 4 * 16 + 4, 14 * 8, 14},
+    };
+
+    OptionsField peak_mode{
+        {40 + 10 * 8, 4 * 16 + 4},
+        10,
+        {
+            {"peak:none", 0},
+            {"peak:0.25s", 250},
+            {"peak:0.5s", 500},
+            {"peak:1s", 1000},
+            {"peak:3s", 3000},
+            {"peak:5s", 5000},
+            {"peak:10s", 10000},
+        }};
+    OptionsField rssi_resolution{
+        {44 + 20 * 8, 4 * 16 + 4},
+        4,
+        {
+            {"16x", 16},
+            {"32x", 32},
+            {"64x", 64},
+            {"128x", 128},
+            {"240x", 240},
+        }};
+
+    RSSIGraph rssi_graph{
+        // 240x320  =>
+        {0, 5 * 16 + 4, 240 - 5 * 8, 320 - (5 * 16 + 4)},
+    };
+
+    RSSI rssi{
+        // 240x320  =>
+        {240 - 5 * 8, 5 * 16 + 4, 5 * 8, 320 - (5 * 16 + 4)},
+    };
+
+    void handle_coded_squelch(const uint32_t value);
+
+    MessageHandlerRegistration message_handler_coded_squelch{
+        Message::ID::CodedSquelch,
+        [this](const Message* const p) {
+            const auto message = *reinterpret_cast<const CodedSquelchMessage*>(p);
+            this->handle_coded_squelch(message.value);
+        }};
+
+    MessageHandlerRegistration message_handler_stats{
+        Message::ID::ChannelStatistics,
+        [this](const Message* const p) {
+            this->on_statistics_update(static_cast<const ChannelStatisticsMessage*>(p)->statistics);
+        }};
+    // app save settings
+    std::app_settings settings{};
+    std::app_settings::AppSettings app_settings{};
+};
 
 } /* namespace ui */
 

--- a/firmware/application/apps/ui_mictx.cpp
+++ b/firmware/application/apps/ui_mictx.cpp
@@ -196,13 +196,6 @@ void MicTXView::rxaudio(bool is_on) {
     }
 }
 
-void MicTXView::on_headphone_volume_changed(int32_t v) {
-    // if (rx_enabled) {
-    const auto new_volume = volume_t::decibel(v - 99) + audio::headphone::volume_range().max;
-    receiver_model.set_headphone_volume(new_volume);
-    //}
-}
-
 void MicTXView::set_ptt_visibility(bool v) {
     tx_button.hidden(!v);
 }
@@ -525,9 +518,6 @@ MicTXView::MicTXView(
         rxaudio(v);   // Activate-Deactivate audio rx accordingly
         set_dirty();  // Refresh interface
     };
-
-    field_volume.set_value((receiver_model.headphone_volume() - audio::headphone::volume_range().max).decibel() + 99);
-    field_volume.on_change = [this](int32_t v) { this->on_headphone_volume_changed(v); };
 
     field_rxbw.on_change = [this](size_t, int32_t v) {
         if (!(enable_am || enable_usb || enable_lsb || enable_dsb || enable_wfm)) {

--- a/firmware/application/apps/ui_mictx.hpp
+++ b/firmware/application/apps/ui_mictx.hpp
@@ -76,7 +76,6 @@ class MicTXView : public View {
     void configure_baseband();
 
     void rxaudio(bool is_on);
-    void on_headphone_volume_changed(int32_t v);
 
     void set_ptt_visibility(bool v);
 
@@ -279,13 +278,8 @@ class MicTXView : public View {
         "F  TX=RX",
         false};
 
-    NumberField field_volume{
-        {9 * 8, (23 * 8) + 2},
-        2,
-        {0, 99},
-        1,
-        ' ',
-    };
+    AudioVolumeField field_volume{
+        {9 * 8, (23 * 8) + 2}};
 
     OptionsField field_rxbw{
         {19 * 8, (23 * 8) + 2},

--- a/firmware/application/apps/ui_recon.cpp
+++ b/firmware/application/apps/ui_recon.cpp
@@ -250,7 +250,7 @@ bool ReconView::recon_save_config_to_sd() {
 
 void ReconView::audio_output_start() {
     audio::output::start();
-    this->on_headphone_volume_changed((receiver_model.headphone_volume() - audio::headphone::volume_range().max).decibel() + 99);
+    receiver_model.set_headphone_volume(receiver_model.headphone_volume());
 }
 
 void ReconView::recon_redraw() {
@@ -868,10 +868,6 @@ ReconView::ReconView(NavigationView& nav)
         squelch = v;
     };
 
-    field_volume.on_change = [this](int32_t v) {
-        this->on_headphone_volume_changed(v);
-    };
-
     // PRE-CONFIGURATION:
     button_scanner_mode.set_style(&style_blue);
     button_scanner_mode.set_text("RECON");
@@ -885,8 +881,6 @@ ReconView::ReconView(NavigationView& nav)
     field_wait.set_value(wait);
     field_lock_wait.set_value(recon_lock_duration);
     colorize_waits();
-
-    field_volume.set_value((receiver_model.headphone_volume() - audio::headphone::volume_range().max).decibel() + 99);
 
     // fill modulation and step options
     freqman_set_modulation_option(field_mode);
@@ -1299,11 +1293,6 @@ void ReconView::on_stepper_delta(int32_t v) {
 
     freq_lock = 0;
     timer = 0;
-}
-
-void ReconView::on_headphone_volume_changed(int32_t v) {
-    const auto new_volume = volume_t::decibel(v - 99) + audio::headphone::volume_range().max;
-    receiver_model.set_headphone_volume(new_volume);
 }
 
 size_t ReconView::change_mode(freqman_index_t new_mod) {

--- a/firmware/application/apps/ui_recon.hpp
+++ b/firmware/application/apps/ui_recon.hpp
@@ -195,165 +195,165 @@ class ReconView : public View {
     RFAmpField field_rf_amp{
         {18 * 8, 0 * 16}};
 
-    AudioVolumeField field_volume {
+    AudioVolumeField field_volume{
         {24 * 8, 0 * 16}};
 
-        OptionsField field_bw{
-            {3 * 8, 1 * 16},
-            6,
-            {}};
+    OptionsField field_bw{
+        {3 * 8, 1 * 16},
+        6,
+        {}};
 
-        NumberField field_squelch{
-            {12 * 8, 1 * 16},
-            3,
-            {-90, 20},
-            1,
-            ' ',
-        };
-
-        NumberField field_wait{
-            {20 * 8, 1 * 16},
-            5,
-            {-RECON_MAX_LOCK_DURATION, RECON_MAX_LOCK_DURATION},
-            STATS_UPDATE_INTERVAL,
-            ' ',
-        };
-
-        NumberField field_lock_wait{
-            {26 * 8, 1 * 16},
-            4,
-            {RECON_MIN_LOCK_DURATION, RECON_MAX_LOCK_DURATION},
-            STATS_UPDATE_INTERVAL,
-            ' ',
-        };
-
-        RSSI rssi{
-            {0 * 16, 2 * 16, SCREEN_W - 8 * 8 + 4, 14},
-        };
-
-        ButtonWithEncoder text_cycle{
-            {0, 3 * 16, 4 * 8, 16},
-            ""};
-
-        // "/XXX -XXX db" =>  12 chars max
-        Text text_max{
-            {4 * 8, 3 * 16, 12 * 8, 16},
-        };
-
-        // "XX/XX" =>  5 chars max
-        Text text_nb_locks{
-            {16 * 8, 3 * 16, 5 * 8, 16},
-        };
-
-        Text desc_cycle{
-            {0, 4 * 16, SCREEN_W, 16},
-        };
-
-        Text big_display{
-            // Show frequency in text mode
-            {0, 5 * 16, 23 * 8, 16},
-        };
-
-        Text freq_stats{
-            // Show frequency stats in text mode
-            {0, 6 * 16, 23 * 8, 16},
-        };
-
-        // TIMER: 9999
-        Text text_timer{
-            // Show frequency stats in text mode
-            {0, 7 * 16, 11 * 8, 16},
-        };
-
-        // T: Senn. 32.000k
-        Text text_ctcss{
-            {12 * 8 + 4, 7 * 16, 14 * 8, 1 * 8},
-            ""};
-
-        Button button_config{
-            {SCREEN_W - 7 * 8, 2 * 16, 7 * 8, 28},
-            "CONFIG"};
-
-        Button button_looking_glass{
-            {SCREEN_W - 7 * 8, 5 * 16, 7 * 8, 28},
-            "GLASS"};
-
-        // Button can be RECON or SCANNER
-        Button button_scanner_mode{
-            {SCREEN_W - 7 * 8, 8 * 16, 7 * 8, 28},
-            "RECON"};
-
-        Text file_name{
-            // show file used
-            {0, 8 * 16 + 6, SCREEN_W - 7 * 8, 16},
-        };
-
-        ButtonWithEncoder button_manual_start{
-            {0 * 8, 11 * 16, 11 * 8, 28},
-            ""};
-
-        ButtonWithEncoder button_manual_end{
-            {12 * 8 - 6, 11 * 16, 11 * 8, 28},
-            ""};
-
-        Button button_manual_recon{
-            {23 * 8 - 3, 11 * 16, 7 * 8, 28},
-            "SEARCH"};
-
-        OptionsField field_mode{
-            {5 * 8, (26 * 8) + 4},
-            6,
-            {}};
-
-        OptionsField step_mode{
-            {17 * 8, (26 * 8) + 4},
-            12,
-            {}};
-
-        ButtonWithEncoder button_pause{
-            {0, (15 * 16) - 4, 72, 28},
-            "PAUSE"};
-
-        Button button_audio_app{
-            {84, (15 * 16) - 4, 72, 28},
-            "AUDIO"};
-
-        ButtonWithEncoder button_add{
-            {168, (15 * 16) - 4, 72, 28},
-            "<STORE>"};
-
-        Button button_dir{
-            {0, (35 * 8) - 4, 34, 28},
-            "FW>"};
-
-        Button button_restart{
-            {38, (35 * 8) - 4, 34, 28},
-            "RST"};
-
-        Button button_mic_app{
-            {84, (35 * 8) - 4, 72, 28},
-            "MIC TX"};
-
-        ButtonWithEncoder button_remove{
-            {168, (35 * 8) - 4, 72, 28},
-            "<REMOVE>"};
-
-        MessageHandlerRegistration message_handler_coded_squelch{
-            Message::ID::CodedSquelch,
-            [this](const Message* const p) {
-                const auto message = *reinterpret_cast<const CodedSquelchMessage*>(p);
-                this->handle_coded_squelch(message.value);
-            }};
-
-        MessageHandlerRegistration message_handler_stats{
-            Message::ID::ChannelStatistics,
-            [this](const Message* const p) {
-                this->on_statistics_update(static_cast<const ChannelStatisticsMessage*>(p)->statistics);
-            }};
-        // app save settings
-        std::app_settings settings{};
-        std::app_settings::AppSettings app_settings{};
+    NumberField field_squelch{
+        {12 * 8, 1 * 16},
+        3,
+        {-90, 20},
+        1,
+        ' ',
     };
+
+    NumberField field_wait{
+        {20 * 8, 1 * 16},
+        5,
+        {-RECON_MAX_LOCK_DURATION, RECON_MAX_LOCK_DURATION},
+        STATS_UPDATE_INTERVAL,
+        ' ',
+    };
+
+    NumberField field_lock_wait{
+        {26 * 8, 1 * 16},
+        4,
+        {RECON_MIN_LOCK_DURATION, RECON_MAX_LOCK_DURATION},
+        STATS_UPDATE_INTERVAL,
+        ' ',
+    };
+
+    RSSI rssi{
+        {0 * 16, 2 * 16, SCREEN_W - 8 * 8 + 4, 14},
+    };
+
+    ButtonWithEncoder text_cycle{
+        {0, 3 * 16, 4 * 8, 16},
+        ""};
+
+    // "/XXX -XXX db" =>  12 chars max
+    Text text_max{
+        {4 * 8, 3 * 16, 12 * 8, 16},
+    };
+
+    // "XX/XX" =>  5 chars max
+    Text text_nb_locks{
+        {16 * 8, 3 * 16, 5 * 8, 16},
+    };
+
+    Text desc_cycle{
+        {0, 4 * 16, SCREEN_W, 16},
+    };
+
+    Text big_display{
+        // Show frequency in text mode
+        {0, 5 * 16, 23 * 8, 16},
+    };
+
+    Text freq_stats{
+        // Show frequency stats in text mode
+        {0, 6 * 16, 23 * 8, 16},
+    };
+
+    // TIMER: 9999
+    Text text_timer{
+        // Show frequency stats in text mode
+        {0, 7 * 16, 11 * 8, 16},
+    };
+
+    // T: Senn. 32.000k
+    Text text_ctcss{
+        {12 * 8 + 4, 7 * 16, 14 * 8, 1 * 8},
+        ""};
+
+    Button button_config{
+        {SCREEN_W - 7 * 8, 2 * 16, 7 * 8, 28},
+        "CONFIG"};
+
+    Button button_looking_glass{
+        {SCREEN_W - 7 * 8, 5 * 16, 7 * 8, 28},
+        "GLASS"};
+
+    // Button can be RECON or SCANNER
+    Button button_scanner_mode{
+        {SCREEN_W - 7 * 8, 8 * 16, 7 * 8, 28},
+        "RECON"};
+
+    Text file_name{
+        // show file used
+        {0, 8 * 16 + 6, SCREEN_W - 7 * 8, 16},
+    };
+
+    ButtonWithEncoder button_manual_start{
+        {0 * 8, 11 * 16, 11 * 8, 28},
+        ""};
+
+    ButtonWithEncoder button_manual_end{
+        {12 * 8 - 6, 11 * 16, 11 * 8, 28},
+        ""};
+
+    Button button_manual_recon{
+        {23 * 8 - 3, 11 * 16, 7 * 8, 28},
+        "SEARCH"};
+
+    OptionsField field_mode{
+        {5 * 8, (26 * 8) + 4},
+        6,
+        {}};
+
+    OptionsField step_mode{
+        {17 * 8, (26 * 8) + 4},
+        12,
+        {}};
+
+    ButtonWithEncoder button_pause{
+        {0, (15 * 16) - 4, 72, 28},
+        "PAUSE"};
+
+    Button button_audio_app{
+        {84, (15 * 16) - 4, 72, 28},
+        "AUDIO"};
+
+    ButtonWithEncoder button_add{
+        {168, (15 * 16) - 4, 72, 28},
+        "<STORE>"};
+
+    Button button_dir{
+        {0, (35 * 8) - 4, 34, 28},
+        "FW>"};
+
+    Button button_restart{
+        {38, (35 * 8) - 4, 34, 28},
+        "RST"};
+
+    Button button_mic_app{
+        {84, (35 * 8) - 4, 72, 28},
+        "MIC TX"};
+
+    ButtonWithEncoder button_remove{
+        {168, (35 * 8) - 4, 72, 28},
+        "<REMOVE>"};
+
+    MessageHandlerRegistration message_handler_coded_squelch{
+        Message::ID::CodedSquelch,
+        [this](const Message* const p) {
+            const auto message = *reinterpret_cast<const CodedSquelchMessage*>(p);
+            this->handle_coded_squelch(message.value);
+        }};
+
+    MessageHandlerRegistration message_handler_stats{
+        Message::ID::ChannelStatistics,
+        [this](const Message* const p) {
+            this->on_statistics_update(static_cast<const ChannelStatisticsMessage*>(p)->statistics);
+        }};
+    // app save settings
+    std::app_settings settings{};
+    std::app_settings::AppSettings app_settings{};
+};
 
 } /* namespace ui */
 

--- a/firmware/application/apps/ui_recon.hpp
+++ b/firmware/application/apps/ui_recon.hpp
@@ -112,7 +112,6 @@ class ReconView : public View {
     void recon_resume();
     void frequency_file_load(bool stop_all_before = false);
     void on_statistics_update(const ChannelStatistics& statistics);
-    void on_headphone_volume_changed(int32_t v);
     void on_index_delta(int32_t v);
     void on_stepper_delta(int32_t v);
     void colorize_waits();
@@ -196,170 +195,165 @@ class ReconView : public View {
     RFAmpField field_rf_amp{
         {18 * 8, 0 * 16}};
 
-    NumberField field_volume{
-        {24 * 8, 0 * 16},
-        2,
-        {0, 99},
-        1,
-        ' ',
+    AudioVolumeField field_volume {
+        {24 * 8, 0 * 16}};
+
+        OptionsField field_bw{
+            {3 * 8, 1 * 16},
+            6,
+            {}};
+
+        NumberField field_squelch{
+            {12 * 8, 1 * 16},
+            3,
+            {-90, 20},
+            1,
+            ' ',
+        };
+
+        NumberField field_wait{
+            {20 * 8, 1 * 16},
+            5,
+            {-RECON_MAX_LOCK_DURATION, RECON_MAX_LOCK_DURATION},
+            STATS_UPDATE_INTERVAL,
+            ' ',
+        };
+
+        NumberField field_lock_wait{
+            {26 * 8, 1 * 16},
+            4,
+            {RECON_MIN_LOCK_DURATION, RECON_MAX_LOCK_DURATION},
+            STATS_UPDATE_INTERVAL,
+            ' ',
+        };
+
+        RSSI rssi{
+            {0 * 16, 2 * 16, SCREEN_W - 8 * 8 + 4, 14},
+        };
+
+        ButtonWithEncoder text_cycle{
+            {0, 3 * 16, 4 * 8, 16},
+            ""};
+
+        // "/XXX -XXX db" =>  12 chars max
+        Text text_max{
+            {4 * 8, 3 * 16, 12 * 8, 16},
+        };
+
+        // "XX/XX" =>  5 chars max
+        Text text_nb_locks{
+            {16 * 8, 3 * 16, 5 * 8, 16},
+        };
+
+        Text desc_cycle{
+            {0, 4 * 16, SCREEN_W, 16},
+        };
+
+        Text big_display{
+            // Show frequency in text mode
+            {0, 5 * 16, 23 * 8, 16},
+        };
+
+        Text freq_stats{
+            // Show frequency stats in text mode
+            {0, 6 * 16, 23 * 8, 16},
+        };
+
+        // TIMER: 9999
+        Text text_timer{
+            // Show frequency stats in text mode
+            {0, 7 * 16, 11 * 8, 16},
+        };
+
+        // T: Senn. 32.000k
+        Text text_ctcss{
+            {12 * 8 + 4, 7 * 16, 14 * 8, 1 * 8},
+            ""};
+
+        Button button_config{
+            {SCREEN_W - 7 * 8, 2 * 16, 7 * 8, 28},
+            "CONFIG"};
+
+        Button button_looking_glass{
+            {SCREEN_W - 7 * 8, 5 * 16, 7 * 8, 28},
+            "GLASS"};
+
+        // Button can be RECON or SCANNER
+        Button button_scanner_mode{
+            {SCREEN_W - 7 * 8, 8 * 16, 7 * 8, 28},
+            "RECON"};
+
+        Text file_name{
+            // show file used
+            {0, 8 * 16 + 6, SCREEN_W - 7 * 8, 16},
+        };
+
+        ButtonWithEncoder button_manual_start{
+            {0 * 8, 11 * 16, 11 * 8, 28},
+            ""};
+
+        ButtonWithEncoder button_manual_end{
+            {12 * 8 - 6, 11 * 16, 11 * 8, 28},
+            ""};
+
+        Button button_manual_recon{
+            {23 * 8 - 3, 11 * 16, 7 * 8, 28},
+            "SEARCH"};
+
+        OptionsField field_mode{
+            {5 * 8, (26 * 8) + 4},
+            6,
+            {}};
+
+        OptionsField step_mode{
+            {17 * 8, (26 * 8) + 4},
+            12,
+            {}};
+
+        ButtonWithEncoder button_pause{
+            {0, (15 * 16) - 4, 72, 28},
+            "PAUSE"};
+
+        Button button_audio_app{
+            {84, (15 * 16) - 4, 72, 28},
+            "AUDIO"};
+
+        ButtonWithEncoder button_add{
+            {168, (15 * 16) - 4, 72, 28},
+            "<STORE>"};
+
+        Button button_dir{
+            {0, (35 * 8) - 4, 34, 28},
+            "FW>"};
+
+        Button button_restart{
+            {38, (35 * 8) - 4, 34, 28},
+            "RST"};
+
+        Button button_mic_app{
+            {84, (35 * 8) - 4, 72, 28},
+            "MIC TX"};
+
+        ButtonWithEncoder button_remove{
+            {168, (35 * 8) - 4, 72, 28},
+            "<REMOVE>"};
+
+        MessageHandlerRegistration message_handler_coded_squelch{
+            Message::ID::CodedSquelch,
+            [this](const Message* const p) {
+                const auto message = *reinterpret_cast<const CodedSquelchMessage*>(p);
+                this->handle_coded_squelch(message.value);
+            }};
+
+        MessageHandlerRegistration message_handler_stats{
+            Message::ID::ChannelStatistics,
+            [this](const Message* const p) {
+                this->on_statistics_update(static_cast<const ChannelStatisticsMessage*>(p)->statistics);
+            }};
+        // app save settings
+        std::app_settings settings{};
+        std::app_settings::AppSettings app_settings{};
     };
-
-    OptionsField field_bw{
-        {3 * 8, 1 * 16},
-        6,
-        {}};
-
-    NumberField field_squelch{
-        {12 * 8, 1 * 16},
-        3,
-        {-90, 20},
-        1,
-        ' ',
-    };
-
-    NumberField field_wait{
-        {20 * 8, 1 * 16},
-        5,
-        {-RECON_MAX_LOCK_DURATION, RECON_MAX_LOCK_DURATION},
-        STATS_UPDATE_INTERVAL,
-        ' ',
-    };
-
-    NumberField field_lock_wait{
-        {26 * 8, 1 * 16},
-        4,
-        {RECON_MIN_LOCK_DURATION, RECON_MAX_LOCK_DURATION},
-        STATS_UPDATE_INTERVAL,
-        ' ',
-    };
-
-    RSSI rssi{
-        {0 * 16, 2 * 16, SCREEN_W - 8 * 8 + 4, 14},
-    };
-
-    ButtonWithEncoder text_cycle{
-        {0, 3 * 16, 4 * 8, 16},
-        ""};
-
-    // "/XXX -XXX db" =>  12 chars max
-    Text text_max{
-        {4 * 8, 3 * 16, 12 * 8, 16},
-    };
-
-    // "XX/XX" =>  5 chars max
-    Text text_nb_locks{
-        {16 * 8, 3 * 16, 5 * 8, 16},
-    };
-
-    Text desc_cycle{
-        {0, 4 * 16, SCREEN_W, 16},
-    };
-
-    Text big_display{
-        // Show frequency in text mode
-        {0, 5 * 16, 23 * 8, 16},
-    };
-
-    Text freq_stats{
-        // Show frequency stats in text mode
-        {0, 6 * 16, 23 * 8, 16},
-    };
-
-    // TIMER: 9999
-    Text text_timer{
-        // Show frequency stats in text mode
-        {0, 7 * 16, 11 * 8, 16},
-    };
-
-    // T: Senn. 32.000k
-    Text text_ctcss{
-        {12 * 8 + 4, 7 * 16, 14 * 8, 1 * 8},
-        ""};
-
-    Button button_config{
-        {SCREEN_W - 7 * 8, 2 * 16, 7 * 8, 28},
-        "CONFIG"};
-
-    Button button_looking_glass{
-        {SCREEN_W - 7 * 8, 5 * 16, 7 * 8, 28},
-        "GLASS"};
-
-    // Button can be RECON or SCANNER
-    Button button_scanner_mode{
-        {SCREEN_W - 7 * 8, 8 * 16, 7 * 8, 28},
-        "RECON"};
-
-    Text file_name{
-        // show file used
-        {0, 8 * 16 + 6, SCREEN_W - 7 * 8, 16},
-    };
-
-    ButtonWithEncoder button_manual_start{
-        {0 * 8, 11 * 16, 11 * 8, 28},
-        ""};
-
-    ButtonWithEncoder button_manual_end{
-        {12 * 8 - 6, 11 * 16, 11 * 8, 28},
-        ""};
-
-    Button button_manual_recon{
-        {23 * 8 - 3, 11 * 16, 7 * 8, 28},
-        "SEARCH"};
-
-    OptionsField field_mode{
-        {5 * 8, (26 * 8) + 4},
-        6,
-        {}};
-
-    OptionsField step_mode{
-        {17 * 8, (26 * 8) + 4},
-        12,
-        {}};
-
-    ButtonWithEncoder button_pause{
-        {0, (15 * 16) - 4, 72, 28},
-        "PAUSE"};
-
-    Button button_audio_app{
-        {84, (15 * 16) - 4, 72, 28},
-        "AUDIO"};
-
-    ButtonWithEncoder button_add{
-        {168, (15 * 16) - 4, 72, 28},
-        "<STORE>"};
-
-    Button button_dir{
-        {0, (35 * 8) - 4, 34, 28},
-        "FW>"};
-
-    Button button_restart{
-        {38, (35 * 8) - 4, 34, 28},
-        "RST"};
-
-    Button button_mic_app{
-        {84, (35 * 8) - 4, 72, 28},
-        "MIC TX"};
-
-    ButtonWithEncoder button_remove{
-        {168, (35 * 8) - 4, 72, 28},
-        "<REMOVE>"};
-
-    MessageHandlerRegistration message_handler_coded_squelch{
-        Message::ID::CodedSquelch,
-        [this](const Message* const p) {
-            const auto message = *reinterpret_cast<const CodedSquelchMessage*>(p);
-            this->handle_coded_squelch(message.value);
-        }};
-
-    MessageHandlerRegistration message_handler_stats{
-        Message::ID::ChannelStatistics,
-        [this](const Message* const p) {
-            this->on_statistics_update(static_cast<const ChannelStatisticsMessage*>(p)->statistics);
-        }};
-    // app save settings
-    std::app_settings settings{};
-    std::app_settings::AppSettings app_settings{};
-};
 
 } /* namespace ui */
 

--- a/firmware/application/apps/ui_scanner.hpp
+++ b/firmware/application/apps/ui_scanner.hpp
@@ -134,7 +134,6 @@ class ScannerView : public View {
     void bigdisplay_update(int32_t);
     void update_squelch_while_paused(int32_t max_db);
     void on_statistics_update(const ChannelStatistics& statistics);
-    void on_headphone_volume_changed(int32_t v);
     void handle_retune(int64_t freq, uint32_t freq_idx);
 
     jammer::jammer_range_t frequency_range{false, 0, 0};  // perfect for manual scan task too...
@@ -182,13 +181,8 @@ class ScannerView : public View {
     RFAmpField field_rf_amp{
         {18 * 8, 0 * 16}};
 
-    NumberField field_volume{
-        {24 * 8, 0 * 16},
-        2,
-        {0, 99},
-        1,
-        ' ',
-    };
+    AudioVolumeField field_volume{
+        {24 * 8, 0 * 16}};
 
     OptionsField field_bw{
         {3 * 8, 1 * 16},

--- a/firmware/application/apps/ui_sonde.cpp
+++ b/firmware/application/apps/ui_sonde.cpp
@@ -128,13 +128,6 @@ SondeView::SondeView(NavigationView& nav) {
     if (logger)
         logger->append(LOG_ROOT_DIR "/SONDE.TXT");
 
-    // initialize audio:
-    field_volume.set_value((receiver_model.headphone_volume() - audio::headphone::volume_range().max).decibel() + 99);
-
-    field_volume.on_change = [this](int32_t v) {
-        this->on_headphone_volume_changed(v);
-    };
-
     audio::output::start();
     audio::output::speaker_unmute();
 
@@ -249,11 +242,6 @@ void SondeView::on_packet(const sonde::Packet& packet) {
             baseband::request_beep();
         }
     }
-}
-
-void SondeView::on_headphone_volume_changed(int32_t v) {
-    const auto new_volume = volume_t::decibel(v - 99) + audio::headphone::volume_range().max;
-    receiver_model.set_headphone_volume(new_volume);
 }
 
 void SondeView::set_target_frequency(const uint32_t new_value) {

--- a/firmware/application/apps/ui_sonde.hpp
+++ b/firmware/application/apps/ui_sonde.hpp
@@ -109,13 +109,8 @@ class SondeView : public View {
         {21 * 8, 0, 6 * 8, 4},
     };
 
-    NumberField field_volume{
-        {28 * 8, 0 * 16},
-        2,
-        {0, 99},
-        1,
-        ' ',
-    };
+    AudioVolumeField field_volume{
+        {28 * 8, 0 * 16}};
 
     Checkbox check_beep{
         {22 * 8, 6 * 16},
@@ -181,7 +176,6 @@ class SondeView : public View {
         }};
 
     void on_packet(const sonde::Packet& packet);
-    void on_headphone_volume_changed(int32_t v);
     char* float_to_char(float x, char* p);
     void set_target_frequency(const uint32_t new_value);
 

--- a/firmware/application/receiver_model.cpp
+++ b/firmware/application/receiver_model.cpp
@@ -35,6 +35,7 @@ using namespace portapack;
 #include "dsp_fir_taps.hpp"
 #include "dsp_iir.hpp"
 #include "dsp_iir_config.hpp"
+#include "utility.hpp"
 
 namespace {
 
@@ -154,6 +155,17 @@ void ReceiverModel::set_headphone_volume(volume_t v) {
     update_headphone_volume();
 }
 
+int32_t ReceiverModel::normalized_headphone_volume() const {
+    return (headphone_volume_ - audio::headphone::volume_range().max).decibel() + 99;
+}
+
+void ReceiverModel::set_normalized_headphone_volume(int32_t v) {
+    // TODO: Linear map instead to ensure 0 is minimal value.
+    v = clip<int32_t>(v, 0, 99);
+    auto new_volume = volume_t::decibel(v - 99) + audio::headphone::volume_range().max;
+    set_headphone_volume(new_volume);
+}
+
 uint8_t ReceiverModel::squelch_level() const {
     return squelch_level_;
 }
@@ -265,9 +277,6 @@ void ReceiverModel::update_sampling_rate() {
 }
 
 void ReceiverModel::update_headphone_volume() {
-    // TODO: Manipulating audio codec here, and in ui_receiver.cpp. Good to do
-    // both?
-
     audio::headphone::set_volume(headphone_volume_);
 }
 

--- a/firmware/application/receiver_model.hpp
+++ b/firmware/application/receiver_model.hpp
@@ -74,6 +74,10 @@ class ReceiverModel {
     volume_t headphone_volume() const;
     void set_headphone_volume(volume_t v);
 
+    /* Volume range 0-99, normalized for audio HW. */
+    int32_t normalized_headphone_volume() const;
+    void set_normalized_headphone_volume(int32_t v);
+
     uint8_t squelch_level() const;
     void set_squelch_level(uint8_t v);
 

--- a/firmware/application/ui/ui_receiver.cpp
+++ b/firmware/application/ui/ui_receiver.cpp
@@ -381,4 +381,22 @@ void VGAGainField::on_focus() {
     }
 }
 
+/* AudioVolumeField *******************************************************/
+
+AudioVolumeField::AudioVolumeField(
+    Point parent_pos)
+    : NumberField{
+          parent_pos,
+          /* length */ 2,
+          /* range */ {0, 99},
+          /* step */ 1,
+          /* fill char */ ' ',
+      } {
+    set_value(receiver_model.normalized_headphone_volume());
+
+    on_change = [](int32_t v) {
+        receiver_model.normalized_headphone_volume(v);
+    };
+}
+
 } /* namespace ui */

--- a/firmware/application/ui/ui_receiver.cpp
+++ b/firmware/application/ui/ui_receiver.cpp
@@ -390,12 +390,11 @@ AudioVolumeField::AudioVolumeField(
           /* length */ 2,
           /* range */ {0, 99},
           /* step */ 1,
-          /* fill char */ ' ',
-      } {
+          /* fill char */ ' '} {
     set_value(receiver_model.normalized_headphone_volume());
 
     on_change = [](int32_t v) {
-        receiver_model.normalized_headphone_volume(v);
+        receiver_model.set_normalized_headphone_volume(v);
     };
 }
 

--- a/firmware/application/ui/ui_receiver.hpp
+++ b/firmware/application/ui/ui_receiver.hpp
@@ -337,6 +337,11 @@ class VGAGainField : public NumberField {
     void on_focus() override;
 };
 
+class AudioVolumeField : public NumberField {
+   public:
+    VGAGainField(Point parent_pos);
+};
+
 } /* namespace ui */
 
 #endif /*__UI_RECEIVER_H__*/

--- a/firmware/application/ui/ui_receiver.hpp
+++ b/firmware/application/ui/ui_receiver.hpp
@@ -339,7 +339,7 @@ class VGAGainField : public NumberField {
 
 class AudioVolumeField : public NumberField {
    public:
-    VGAGainField(Point parent_pos);
+    AudioVolumeField(Point parent_pos);
 };
 
 } /* namespace ui */

--- a/firmware/common/utility.hpp
+++ b/firmware/common/utility.hpp
@@ -94,13 +94,22 @@ int fast_int_magnitude(int y, int x);
 int int_atan2(int y, int x);
 int32_t int16_sin_s4(int32_t x);
 
+/* Returns value constrained to min and max. */
+template <class T>
+constexpr const T& clip(const T& value, const T& minimum, const T& maximum) {
+    return std::max(std::min(value, maximum), minimum);
+}
+
+// TODO: need to decide if this is inclusive or exclusive.
+// The implementations are different and cause the subtle
+// bugs mentioned below.
 template <class T>
 struct range_t {
     const T minimum;
     const T maximum;
 
     constexpr const T& clip(const T& value) const {
-        return std::max(std::min(value, maximum), minimum);
+        return ::clip(value, minimum, maximum);
     }
 
     constexpr void reset_if_outside(T& value, const T& reset_value) const {


### PR DESCRIPTION
I noticed that many apps all the the same copy-pasta around handling the audio volume.
This consolidates all that code into a Widget so not every app needs to care about managing the audio level directly.

Reduced the image by 1376 bytes.