### PR TITLE
WFM bandwidth widget dial direction (clockwise==increasing) & OptionsField widget change (circular list)

### DIFF
--- a/firmware/application/apps/analog_audio_app.cpp
+++ b/firmware/application/apps/analog_audio_app.cpp
@@ -54,8 +54,8 @@ AMOptionsView::AMOptionsView(
     });
 
     freqman_set_bandwidth_option(AM_MODULATION, options_config);  // adding the common message from freqman.cpp to the options_config
-    options_config.set_selected_index(receiver_model.am_configuration());
-    options_config.on_change = [this](size_t n, OptionsField::value_t) {
+    options_config.set_by_value(receiver_model.am_configuration());
+    options_config.on_change = [this](size_t, OptionsField::value_t n) {
         receiver_model.set_am_configuration(n);
     };
 }
@@ -74,8 +74,8 @@ NBFMOptionsView::NBFMOptionsView(
                   &field_squelch});
 
     freqman_set_bandwidth_option(NFM_MODULATION, options_config);  // adding the common message from freqman.cpp to the options_config
-    options_config.set_selected_index(receiver_model.nbfm_configuration());
-    options_config.on_change = [this](size_t n, OptionsField::value_t) {
+    options_config.set_by_value(receiver_model.nbfm_configuration());
+    options_config.on_change = [this](size_t, OptionsField::value_t n) {
         receiver_model.set_nbfm_configuration(n);
     };
 
@@ -99,8 +99,8 @@ WFMOptionsView::WFMOptionsView(
     });
 
     freqman_set_bandwidth_option(WFM_MODULATION, options_config);  // adding the common message from freqman.cpp to the options_config
-    options_config.set_selected_index(receiver_model.wfm_configuration());
-    options_config.on_change = [this](size_t n, OptionsField::value_t) {
+    options_config.set_by_value(receiver_model.wfm_configuration());
+    options_config.on_change = [this](size_t, OptionsField::value_t n) {
         receiver_model.set_wfm_configuration(n);
     };
 }

--- a/firmware/application/apps/ui_level.cpp
+++ b/firmware/application/apps/ui_level.cpp
@@ -191,11 +191,11 @@ size_t LevelView::change_mode(freqman_index_t new_mod) {
         case AM_MODULATION:
             freqman_set_bandwidth_option(new_mod, field_bw);
             // bw DSB (0) default
-            field_bw.set_selected_index(0);
+            field_bw.set_by_value(0);
             baseband::run_image(portapack::spi_flash::image_tag_am_audio);
             receiver_model.set_modulation(ReceiverModel::Mode::AMAudio);
-            receiver_model.set_am_configuration(field_bw.selected_index());
-            field_bw.on_change = [this](size_t n, OptionsField::value_t) { receiver_model.set_am_configuration(n); };
+            receiver_model.set_am_configuration(field_bw.selected_index_value());
+            field_bw.on_change = [this](size_t, OptionsField::value_t n) { receiver_model.set_am_configuration(n); };
             receiver_model.set_sampling_rate(3072000);
             receiver_model.set_baseband_bandwidth(1750000);
             text_ctcss.set("             ");
@@ -203,22 +203,22 @@ size_t LevelView::change_mode(freqman_index_t new_mod) {
         case NFM_MODULATION:
             freqman_set_bandwidth_option(new_mod, field_bw);
             // bw 16k (2) default
-            field_bw.set_selected_index(2);
+            field_bw.set_by_value(2);
             baseband::run_image(portapack::spi_flash::image_tag_nfm_audio);
             receiver_model.set_modulation(ReceiverModel::Mode::NarrowbandFMAudio);
-            receiver_model.set_nbfm_configuration(field_bw.selected_index());
-            field_bw.on_change = [this](size_t n, OptionsField::value_t) { receiver_model.set_nbfm_configuration(n); };
+            receiver_model.set_nbfm_configuration(field_bw.selected_index_value());
+            field_bw.on_change = [this](size_t, OptionsField::value_t n) { receiver_model.set_nbfm_configuration(n); };
             receiver_model.set_sampling_rate(3072000);
             receiver_model.set_baseband_bandwidth(1750000);
             break;
         case WFM_MODULATION:
             freqman_set_bandwidth_option(new_mod, field_bw);
             // bw 200k (0) only/default
-            field_bw.set_selected_index(0);
+            field_bw.set_by_value(0);
             baseband::run_image(portapack::spi_flash::image_tag_wfm_audio);
             receiver_model.set_modulation(ReceiverModel::Mode::WidebandFMAudio);
-            receiver_model.set_wfm_configuration(field_bw.selected_index());
-            field_bw.on_change = [this](size_t n, OptionsField::value_t) { receiver_model.set_wfm_configuration(n); };
+            receiver_model.set_wfm_configuration(field_bw.selected_index_value());
+            field_bw.on_change = [this](size_t, OptionsField::value_t n) { receiver_model.set_wfm_configuration(n); };
             receiver_model.set_sampling_rate(3072000);
             receiver_model.set_baseband_bandwidth(1750000);
             text_ctcss.set("             ");

--- a/firmware/application/apps/ui_recon.cpp
+++ b/firmware/application/apps/ui_recon.cpp
@@ -1306,11 +1306,11 @@ size_t ReconView::change_mode(freqman_index_t new_mod) {
         case AM_MODULATION:
             freqman_set_bandwidth_option(new_mod, field_bw);
             // bw DSB (0) default
-            field_bw.set_selected_index(0);
+            field_bw.set_by_value(0);
             baseband::run_image(portapack::spi_flash::image_tag_am_audio);
             receiver_model.set_modulation(ReceiverModel::Mode::AMAudio);
-            receiver_model.set_am_configuration(field_bw.selected_index());
-            field_bw.on_change = [this](size_t n, OptionsField::value_t) { receiver_model.set_am_configuration(n); };
+            receiver_model.set_am_configuration(field_bw.selected_index_value());
+            field_bw.on_change = [this](size_t, OptionsField::value_t n) { receiver_model.set_am_configuration(n); };
             receiver_model.set_sampling_rate(3072000);
             receiver_model.set_baseband_bandwidth(1750000);
             text_ctcss.set("             ");
@@ -1318,22 +1318,22 @@ size_t ReconView::change_mode(freqman_index_t new_mod) {
         case NFM_MODULATION:
             freqman_set_bandwidth_option(new_mod, field_bw);
             // bw 16k (2) default
-            field_bw.set_selected_index(2);
+            field_bw.set_by_value(2);
             baseband::run_image(portapack::spi_flash::image_tag_nfm_audio);
             receiver_model.set_modulation(ReceiverModel::Mode::NarrowbandFMAudio);
-            receiver_model.set_nbfm_configuration(field_bw.selected_index());
-            field_bw.on_change = [this](size_t n, OptionsField::value_t) { receiver_model.set_nbfm_configuration(n); };
+            receiver_model.set_nbfm_configuration(field_bw.selected_index_value());
+            field_bw.on_change = [this](size_t, OptionsField::value_t n) { receiver_model.set_nbfm_configuration(n); };
             receiver_model.set_sampling_rate(3072000);
             receiver_model.set_baseband_bandwidth(1750000);
             break;
         case WFM_MODULATION:
             freqman_set_bandwidth_option(new_mod, field_bw);
             // bw 200k (0) default
-            field_bw.set_selected_index(0);
+            field_bw.set_by_value(0);
             baseband::run_image(portapack::spi_flash::image_tag_wfm_audio);
             receiver_model.set_modulation(ReceiverModel::Mode::WidebandFMAudio);
-            receiver_model.set_wfm_configuration(field_bw.selected_index());
-            field_bw.on_change = [this](size_t n, OptionsField::value_t) { receiver_model.set_wfm_configuration(n); };
+            receiver_model.set_wfm_configuration(field_bw.selected_index_value());
+            field_bw.on_change = [this](size_t, OptionsField::value_t n) { receiver_model.set_wfm_configuration(n); };
             receiver_model.set_sampling_rate(3072000);
             receiver_model.set_baseband_bandwidth(1750000);
             text_ctcss.set("             ");

--- a/firmware/application/apps/ui_scanner.cpp
+++ b/firmware/application/apps/ui_scanner.cpp
@@ -759,9 +759,9 @@ void ScannerView::change_mode(freqman_index_t new_mod) {  // Before this, do a s
             freqman_set_bandwidth_option(new_mod, field_bw);
             baseband::run_image(portapack::spi_flash::image_tag_am_audio);
             receiver_model.set_modulation(ReceiverModel::Mode::AMAudio);
-            field_bw.set_selected_index(0);
-            receiver_model.set_am_configuration(field_bw.selected_index());
-            field_bw.on_change = [this](size_t n, OptionsField::value_t) { receiver_model.set_am_configuration(n); };
+            field_bw.set_by_value(0);
+            receiver_model.set_am_configuration(field_bw.selected_index_value());
+            field_bw.on_change = [this](size_t, OptionsField::value_t n) { receiver_model.set_am_configuration(n); };
             receiver_model.set_sampling_rate(3072000);
             receiver_model.set_baseband_bandwidth(1750000);
             break;
@@ -769,9 +769,9 @@ void ScannerView::change_mode(freqman_index_t new_mod) {  // Before this, do a s
             freqman_set_bandwidth_option(new_mod, field_bw);
             baseband::run_image(portapack::spi_flash::image_tag_nfm_audio);
             receiver_model.set_modulation(ReceiverModel::Mode::NarrowbandFMAudio);
-            field_bw.set_selected_index(2);
-            receiver_model.set_nbfm_configuration(field_bw.selected_index());
-            field_bw.on_change = [this](size_t n, OptionsField::value_t) { receiver_model.set_nbfm_configuration(n); };
+            field_bw.set_by_value(2);
+            receiver_model.set_nbfm_configuration(field_bw.selected_index_value());
+            field_bw.on_change = [this](size_t, OptionsField::value_t n) { receiver_model.set_nbfm_configuration(n); };
             receiver_model.set_sampling_rate(3072000);
             receiver_model.set_baseband_bandwidth(1750000);
             break;
@@ -779,9 +779,9 @@ void ScannerView::change_mode(freqman_index_t new_mod) {  // Before this, do a s
             freqman_set_bandwidth_option(new_mod, field_bw);
             baseband::run_image(portapack::spi_flash::image_tag_wfm_audio);
             receiver_model.set_modulation(ReceiverModel::Mode::WidebandFMAudio);
-            field_bw.set_selected_index(0);
-            receiver_model.set_wfm_configuration(field_bw.selected_index());
-            field_bw.on_change = [this](size_t n, OptionsField::value_t) { receiver_model.set_wfm_configuration(n); };
+            field_bw.set_by_value(0);
+            receiver_model.set_wfm_configuration(field_bw.selected_index_value());
+            field_bw.on_change = [this](size_t, OptionsField::value_t n) { receiver_model.set_wfm_configuration(n); };
             receiver_model.set_sampling_rate(3072000);
             receiver_model.set_baseband_bandwidth(2000000);
             break;

--- a/firmware/application/freqman.cpp
+++ b/firmware/application/freqman.cpp
@@ -43,11 +43,10 @@ options_t freqman_entry_bandwidths[4] = {
      {"8k5", 0},
      {"11k", 1},
      {"16k", 2}},
-    {
-        // WFM
-        {"200k", 0},
-        {"180k", 1},
-        {"40k", 2},
+    {// WFM
+     {"40k", 2},
+     {"180k", 1},
+     {"200k", 0},
     }};
 
 options_t freqman_entry_steps = {

--- a/firmware/application/freqman.cpp
+++ b/firmware/application/freqman.cpp
@@ -43,10 +43,11 @@ options_t freqman_entry_bandwidths[4] = {
      {"8k5", 0},
      {"11k", 1},
      {"16k", 2}},
-    {// WFM
-     {"40k", 2},
-     {"180k", 1},
-     {"200k", 0},
+    {
+        // WFM
+        {"40k", 2},
+        {"180k", 1},
+        {"200k", 0},
     }};
 
 options_t freqman_entry_steps = {

--- a/firmware/common/ui_widget.cpp
+++ b/firmware/common/ui_widget.cpp
@@ -1477,7 +1477,13 @@ void OptionsField::on_focus() {
 }
 
 bool OptionsField::on_encoder(const EncoderEvent delta) {
-    set_selected_index(selected_index() + delta);
+    int32_t new_value = selected_index() + delta;
+    if (new_value < 0)
+        new_value = options.size() - 1;
+    else if ((size_t)new_value >= options.size())
+        new_value = 0;
+
+    set_selected_index(new_value);
     return true;
 }
 


### PR DESCRIPTION
When turning the dial to select Bandwidth in WFM mode, a clockwise turn would result in Lower bandwidth value, and a counterclockwise turn would result in a Higher bandwidth value.  This was bugging me because it was backwards from the dial operation for every other option field (and every other dial in other real world products).

With this change, the second parameter in the freqman_entry_bandwidths table (which gets copied to the bandwidth OptionsField by freqman_set_bandwidth_option) is being used now to specify the bandwidth index into the receiver_model, versus being ignored as it was previously.

BTW...  An alternative to this implementation would be to reorder the bandwidth options in the receiver model to match the ascending order of the BW options in my updated freqman.cpp, but I felt that I should leave receiver_model alone so that the meaning of the bandwidth index values would not be changed in any other places where receiver_model was used (including any saved app_settings files).  In my implementation, only those apps that call freqman_set_bandwidth_option are affected.

Same change was made for AM & NFM for consistency, but I did not reorder the bandwidth options for those modes (it will now be simpler to do so if desired, however, by simply rearranging the lines in freqman.cpp).