### PR TITLE
pmem debug

### DIFF
--- a/firmware/application/apps/ui_debug.cpp
+++ b/firmware/application/apps/ui_debug.cpp
@@ -399,7 +399,7 @@ DebugPmemView::DebugPmemView(NavigationView& nav)
     registers_widget.set_parent_rect({0, 32, 240, 192});
 
     text_checksum.set_parent_rect({16, 240, 208, 16});
-    text_checksum.set("Size: " + std::to_string(portapack::persistent_memory::data_size()) + " CRC: " + to_string_hex(data.check_value, 8));
+    text_checksum.set("Size: " + to_string_dec_uint(portapack::persistent_memory::data_size()) + " CRC: " + to_string_hex(data.check_value, 8));
 
     button_ok.on_select = [&nav](Button&) {
         nav.pop();

--- a/firmware/application/apps/ui_debug.cpp
+++ b/firmware/application/apps/ui_debug.cpp
@@ -394,11 +394,8 @@ DebugPmemView::DebugPmemView(NavigationView& nav)
 
     add_children({&text_page, &registers_widget, &text_checksum, &button_ok});
 
-    text_page.set_parent_rect({16, 16, 208, 16});
-
     registers_widget.set_parent_rect({0, 32, 240, 192});
 
-    text_checksum.set_parent_rect({16, 240, 208, 16});
     text_checksum.set("Size: " + to_string_dec_uint(portapack::persistent_memory::data_size()) + " CRC: " + to_string_hex(data.check_value, 8));
 
     button_ok.on_select = [&nav](Button&) {

--- a/firmware/application/apps/ui_debug.cpp
+++ b/firmware/application/apps/ui_debug.cpp
@@ -381,8 +381,55 @@ DebugMenuView::DebugMenuView(NavigationView& nav) {
         {"Peripherals", ui::Color::dark_cyan(), &bitmap_icon_peripherals, [&nav]() { nav.push<DebugPeripheralsMenuView>(); }},
         {"Temperature", ui::Color::dark_cyan(), &bitmap_icon_temperature, [&nav]() { nav.push<TemperatureView>(); }},
         {"Buttons Test", ui::Color::dark_cyan(), &bitmap_icon_controls, [&nav]() { nav.push<DebugControlsView>(); }},
+        {"Pmem", ui::Color::dark_cyan(), &bitmap_icon_memory, [&nav]() { nav.push<DebugPmemView>(); }},
     });
     set_max_rows(2);  // allow wider buttons
+}
+
+/* DebugPmemView *********************************************************/
+
+DebugPmemView::DebugPmemView(NavigationView& nav)
+    : data{*reinterpret_cast<pmem_data*>(memory::map::backup_ram.base())}, registers_widget(RegistersWidgetConfig{page_size, 8}, std::bind(&DebugPmemView::registers_widget_feed, this, std::placeholders::_1)) {
+    static_assert(sizeof(pmem_data) == memory::map::backup_ram.size());
+
+    add_children({&text_page, &registers_widget, &text_checksum, &button_ok});
+
+    text_page.set_parent_rect({16, 16, 208, 16});
+
+    registers_widget.set_parent_rect({0, 32, 240, 192});
+
+    text_checksum.set_parent_rect({16, 240, 208, 16});
+    text_checksum.set("Size: " + std::to_string(portapack::persistent_memory::data_size()) + " CRC: " + to_string_hex(data.check_value, 8));
+
+    button_ok.on_select = [&nav](Button&) {
+        nav.pop();
+    };
+
+    update();
+}
+
+bool DebugPmemView::on_encoder(const EncoderEvent delta) {
+    page = std::max(0l, std::min((int32_t)page_max, page + delta));
+
+    update();
+
+    return true;
+}
+
+void DebugPmemView::focus() {
+    button_ok.focus();
+}
+
+void DebugPmemView::update() {
+    text_page.set(to_string_hex(page_size * page, 2) + "+");
+    registers_widget.update();
+}
+
+uint32_t DebugPmemView::registers_widget_feed(const size_t register_number) {
+    if (page_size * page + register_number >= memory::map::backup_ram.size()) {
+        return 0xff;
+    }
+    return data.regfile[(page_size * page + register_number) / 4] >> (register_number % 4 * 8);
 }
 
 /*DebugLCRView::DebugLCRView(NavigationView& nav, std::string lcr_string) {

--- a/firmware/application/apps/ui_debug.hpp
+++ b/firmware/application/apps/ui_debug.hpp
@@ -30,6 +30,7 @@
 
 #include "rffc507x.hpp"
 #include "portapack.hpp"
+#include "memory_map.hpp"
 
 #include <functional>
 #include <utility>
@@ -261,6 +262,39 @@ class DebugControlsView : public View {
     Button button_done{
         {72, 264, 96, 24},
         "Done"};
+};
+
+class DebugPmemView : public View {
+   public:
+    DebugPmemView(NavigationView& nav);
+    void focus() override;
+    bool on_encoder(const EncoderEvent delta) override;
+    std::string title() const override { return "Pmem"; }
+    int32_t page{0};
+    static constexpr uint8_t page_size{96};  // Must be multiply of 4 otherwise bit shifting for register view wont work properly
+    static constexpr uint8_t page_max{(portapack::memory::map::backup_ram.size() + page_size - 1) / page_size - 1};
+
+   private:
+    struct pmem_data {
+        uint32_t regfile[63];
+        uint32_t check_value;
+    };
+
+    const pmem_data& data;
+
+    Text text_page{};
+
+    RegistersWidget registers_widget;
+
+    Text text_checksum{};
+
+    Button button_ok{
+        {240 / 3, 270, 240 / 3, 24},
+        "OK",
+    };
+
+    void update();
+    uint32_t registers_widget_feed(const size_t register_number);
 };
 
 /*class DebugLCRView : public View {

--- a/firmware/application/apps/ui_debug.hpp
+++ b/firmware/application/apps/ui_debug.hpp
@@ -270,9 +270,6 @@ class DebugPmemView : public View {
     void focus() override;
     bool on_encoder(const EncoderEvent delta) override;
     std::string title() const override { return "Pmem"; }
-    int32_t page{0};
-    static constexpr uint8_t page_size{96};  // Must be multiply of 4 otherwise bit shifting for register view wont work properly
-    static constexpr uint8_t page_max{(portapack::memory::map::backup_ram.size() + page_size - 1) / page_size - 1};
 
    private:
     struct pmem_data {
@@ -280,13 +277,18 @@ class DebugPmemView : public View {
         uint32_t check_value;
     };
 
+    static constexpr uint8_t page_size{96};  // Must be multiply of 4 otherwise bit shifting for register view wont work properly
+    static constexpr uint8_t page_max{(portapack::memory::map::backup_ram.size() + page_size - 1) / page_size - 1};
+
+    int32_t page{0};
+
     const pmem_data& data;
 
-    Text text_page{};
+    Text text_page{{16, 16, 208, 16}};
 
     RegistersWidget registers_widget;
 
-    Text text_checksum{};
+    Text text_checksum{{16, 240, 208, 16}};
 
     Button button_ok{
         {240 / 3, 270, 240 / 3, 24},

--- a/firmware/common/portapack_persistent_memory.cpp
+++ b/firmware/common/portapack_persistent_memory.cpp
@@ -867,5 +867,9 @@ int load_persistent_settings_from_file() {
     return false;
 }
 
+size_t data_size() {
+    return sizeof(data_t);
+}
+
 } /* namespace persistent_memory */
 } /* namespace portapack */

--- a/firmware/common/portapack_persistent_memory.hpp
+++ b/firmware/common/portapack_persistent_memory.hpp
@@ -257,6 +257,8 @@ bool should_use_sdcard_for_pmem();
 int save_persistent_settings_to_file();
 int load_persistent_settings_from_file();
 
+size_t data_size();
+
 } /* namespace persistent_memory */
 
 } /* namespace portapack */


### PR DESCRIPTION
Adds a new debug menu that displays the contents of the persistent memory area.
Due to screen limitations its showing 96 bytes at once, and can be scrolled with the encoder. On the last page there is some padding at the end filled with FF-s after the pmem area ends.
Below the bytes in addition it displays the current size of data_t in bytes (the actual used size of pmem) and also the checksum stored at the end of pmem.
![SCR_0011](https://github.com/eried/portapack-mayhem/assets/125336/4d8affec-b38d-4055-b5fd-7679f070a8a4)