### PR TITLE
freqlist: add back correct highlight

### DIFF
--- a/firmware/application/ui/ui_freqlist.cpp
+++ b/firmware/application/ui/ui_freqlist.cpp
@@ -75,18 +75,22 @@ void FreqManUIList::paint(Painter& painter) {
     uint8_t nb_lines = 0;
     for (uint8_t it = current_index; it < freqlist_db.size(); it++) {
         uint8_t line_height = (int)nb_lines * char_height;
-        if (line_height < (r.height() - char_height)) {
+        if (line_height < (r.height() - char_height)) {  // line is within the widget
             std::string description = freqman_item_string(freqlist_db[it], 30);
-            // line is within the widget
-            painter.draw_string(
-                {0, r.location().y() + (int)nb_lines * char_height},
-                *text_color, description);
             if (nb_lines == highlighted_index) {
                 const Rect r_highlighted_freq{0, r.location().y() + (int)nb_lines * char_height, 240, char_height};
-                painter.draw_rectangle(
+                painter.fill_rectangle(
                     r_highlighted_freq,
                     Color::white());
+                painter.draw_string(
+                    {0, r.location().y() + (int)nb_lines * char_height},
+                    style_highlight, description);
+            } else {
+                painter.draw_string(
+                    {0, r.location().y() + (int)nb_lines * char_height},
+                    *text_color, description);
             }
+
             nb_lines++;
         } else {
             // rect is filled, we can break

--- a/firmware/application/ui/ui_freqlist.hpp
+++ b/firmware/application/ui/ui_freqlist.hpp
@@ -66,6 +66,11 @@ class FreqManUIList : public Widget {
         .background = Color::black(),
         .foreground = Color::white(),
     };
+    Style style_highlight{
+        .font = font::fixed_8x16,
+        .background = Color::white(),
+        .foreground = Color::black(),
+    };
     Style style_yellow{
         .font = font::fixed_8x16,
         .background = Color::black(),


### PR DESCRIPTION
This add back the classic highlight entry in freqlists.
For a remainder the new freqlist widget was just circling highlighted entry with a white rectangle. This is now a white rectangle with black text on it.

Solve point 1. in https://github.com/eried/portapack-mayhem/issues/1113

![image](https://github.com/eried/portapack-mayhem/assets/3157857/de79aa88-e174-4e69-9da0-1aafa97ac83f)
