### PR TITLE
Pmem reset

### DIFF
--- a/firmware/application/portapack.cpp
+++ b/firmware/application/portapack.cpp
@@ -469,12 +469,12 @@ bool init() {
     i2c0.start(i2c_config_fast_clock);
     chThdSleepMilliseconds(10);
 
-    /* Cache some configuration data from persistent memory. */
-    persistent_memory::cache::init();
-
     touch::adc::init();
     controls_init();
     chThdSleepMilliseconds(10);
+
+    /* Cache some configuration data from persistent memory. */
+    persistent_memory::cache::init();
 
     clock_manager.set_reference_ppb(persistent_memory::correction_ppb());
     clock_manager.enable_if_clocks();

--- a/firmware/application/portapack.cpp
+++ b/firmware/application/portapack.cpp
@@ -233,20 +233,23 @@ static PortaPackModel portapack_model() {
 
     if (!model.is_valid()) {
         const auto switches_state = get_switches_state();
-        if (switches_state[(size_t)ui::KeyEvent::Up]) {
-            save_config(1);
-            // model = PortaPackModel::R2_20170522; // Commented these out as they should be set down below anyway
-        } else if (switches_state[(size_t)ui::KeyEvent::Down]) {
-            save_config(2);
-            // model = PortaPackModel::R1_20150901;
-        } else if (switches_state[(size_t)ui::KeyEvent::Left]) {
-            save_config(3);
-            // model = PortaPackModel::R1_20150901;
-        } else if (switches_state[(size_t)ui::KeyEvent::Right]) {
-            save_config(4);
-            // model = PortaPackModel::R2_20170522;
-        } else if (switches_state[(size_t)ui::KeyEvent::Select]) {
-            save_config(0);
+        // Only save config if no other multi key boot action is triggered (like pmem reset)
+        if (switches_state.count() == 1) {
+            if (switches_state[(size_t)ui::KeyEvent::Up]) {
+                save_config(1);
+                // model = PortaPackModel::R2_20170522; // Commented these out as they should be set down below anyway
+            } else if (switches_state[(size_t)ui::KeyEvent::Down]) {
+                save_config(2);
+                // model = PortaPackModel::R1_20150901;
+            } else if (switches_state[(size_t)ui::KeyEvent::Left]) {
+                save_config(3);
+                // model = PortaPackModel::R1_20150901;
+            } else if (switches_state[(size_t)ui::KeyEvent::Right]) {
+                save_config(4);
+                // model = PortaPackModel::R2_20170522;
+            } else if (switches_state[(size_t)ui::KeyEvent::Select]) {
+                save_config(0);
+            }
         }
 
         if (load_config() == 1) {

--- a/firmware/common/portapack_persistent_memory.cpp
+++ b/firmware/common/portapack_persistent_memory.cpp
@@ -39,6 +39,8 @@
 #include <fstream>
 #include "file.hpp"
 
+#include "irq_controls.hpp"
+
 using namespace std;
 
 namespace portapack {
@@ -445,7 +447,7 @@ void defaults() {
 }
 
 void init() {
-    if (backup_ram->is_valid()) {
+    if (!get_switches_state().test(4) && backup_ram->is_valid()) {
         // Copy valid persistent data into cache.
         cached_backup_ram = *backup_ram;
 

--- a/firmware/common/portapack_persistent_memory.cpp
+++ b/firmware/common/portapack_persistent_memory.cpp
@@ -447,7 +447,7 @@ void defaults() {
 }
 
 void init() {
-    if (!get_switches_state().test(4) && backup_ram->is_valid()) {
+    if (!get_switches_state()[(size_t)ui::KeyEvent::Select] && backup_ram->is_valid()) {
         // Copy valid persistent data into cache.
         cached_backup_ram = *backup_ram;
 

--- a/firmware/common/portapack_persistent_memory.cpp
+++ b/firmware/common/portapack_persistent_memory.cpp
@@ -447,7 +447,8 @@ void defaults() {
 }
 
 void init() {
-    if (!get_switches_state()[(size_t)ui::KeyEvent::Select] && backup_ram->is_valid()) {
+    const auto switches_state = get_switches_state();
+    if (!(switches_state[(size_t)ui::KeyEvent::Left] && switches_state[(size_t)ui::KeyEvent::Right]) && backup_ram->is_valid()) {
         // Copy valid persistent data into cache.
         cached_backup_ram = *backup_ram;
 


### PR DESCRIPTION
Ignore pmem contents during startup if the select key is being held down.
This could solve boot hangups that typically happen after flashing.
Checked and compatible with hardware selection keys.
If one wants to both select (or keep selecting) a hw version, while ignoring pmem both the right direction and select keys has to be held down.