### PR TITLE
Consolidate styles

### DIFF
--- a/firmware/application/CMakeLists.txt
+++ b/firmware/application/CMakeLists.txt
@@ -221,6 +221,7 @@ set(CPPSRC
 	ui/ui_freqlist.cpp
 	ui/ui_tv.cpp
 	ui/ui_spectrum.cpp
+	ui/ui_styles.cpp
 	ui/ui_tabview.cpp
 	ui/ui_textentry.cpp
 	ui/ui_transmitter.cpp

--- a/firmware/application/apps/analog_audio_app.cpp
+++ b/firmware/application/apps/analog_audio_app.cpp
@@ -42,6 +42,8 @@ namespace ui {
 
 /* AMOptionsView *********************************************************/
 
+static const Style& style_options_group = Styles::style_bg_blue;
+
 AMOptionsView::AMOptionsView(
     const Rect parent_rect,
     const Style* const style)

--- a/firmware/application/apps/analog_audio_app.cpp
+++ b/firmware/application/apps/analog_audio_app.cpp
@@ -42,7 +42,7 @@ namespace ui {
 
 /* AMOptionsView *********************************************************/
 
-static const Style& style_options_group = Styles::style_bg_blue;
+static const Style& style_options_group = Styles::bg_blue;
 
 AMOptionsView::AMOptionsView(
     const Rect parent_rect,

--- a/firmware/application/apps/analog_audio_app.hpp
+++ b/firmware/application/apps/analog_audio_app.hpp
@@ -28,17 +28,11 @@
 #include "ui_receiver.hpp"
 #include "ui_spectrum.hpp"
 #include "ui_record_view.hpp"
-#include "ui_font_fixed_8x16.hpp"
+#include "ui_styles.hpp"
 #include "app_settings.hpp"
 #include "tone_key.hpp"
 
 namespace ui {
-
-constexpr Style style_options_group{
-    .font = font::fixed_8x16,
-    .background = Color::blue(),
-    .foreground = Color::white(),
-};
 
 class AMOptionsView : public View {
    public:

--- a/firmware/application/apps/analog_tv_app.cpp
+++ b/firmware/application/apps/analog_tv_app.cpp
@@ -41,7 +41,7 @@ namespace ui {
 
 /* AnalogTvView *******************************************************/
 
-static const Style& style_options_group_new = Styles::style_bg_blue;
+static const Style& style_options_group_new = Styles::bg_blue;
 
 AnalogTvView::AnalogTvView(
     NavigationView& nav)

--- a/firmware/application/apps/analog_tv_app.cpp
+++ b/firmware/application/apps/analog_tv_app.cpp
@@ -41,6 +41,8 @@ namespace ui {
 
 /* AnalogTvView *******************************************************/
 
+static const Style& style_options_group_new = Styles::style_bg_blue;
+
 AnalogTvView::AnalogTvView(
     NavigationView& nav)
     : nav_(nav) {

--- a/firmware/application/apps/analog_tv_app.hpp
+++ b/firmware/application/apps/analog_tv_app.hpp
@@ -29,18 +29,12 @@
 #include "ui_receiver.hpp"
 #include "ui_tv.hpp"
 #include "ui_record_view.hpp"
+#include "ui_styles.hpp"
 #include "app_settings.hpp"
-#include "ui_font_fixed_8x16.hpp"
 
 #include "tone_key.hpp"
 
 namespace ui {
-
-constexpr Style style_options_group_new{
-    .font = font::fixed_8x16,
-    .background = Color::blue(),
-    .foreground = Color::white(),
-};
 
 class AnalogTvView : public View {
    public:

--- a/firmware/application/apps/lge_app.hpp
+++ b/firmware/application/apps/lge_app.hpp
@@ -24,7 +24,6 @@
 #include "ui_widget.hpp"
 #include "ui_navigation.hpp"
 #include "ui_transmitter.hpp"
-#include "ui_font_fixed_8x16.hpp"
 #include "rfm69.hpp"
 
 #include "message.hpp"

--- a/firmware/application/apps/ui_about.hpp
+++ b/firmware/application/apps/ui_about.hpp
@@ -25,7 +25,6 @@
 
 #include "ui_widget.hpp"
 #include "ui_navigation.hpp"
-#include "ui_font_fixed_8x16.hpp"
 
 #include <cstdint>
 

--- a/firmware/application/apps/ui_about_simple.hpp
+++ b/firmware/application/apps/ui_about_simple.hpp
@@ -3,7 +3,6 @@
 
 #include "ui_widget.hpp"
 #include "ui_navigation.hpp"
-#include "ui_font_fixed_8x16.hpp"
 
 #include <cstdint>
 

--- a/firmware/application/apps/ui_adsb_rx.hpp
+++ b/firmware/application/apps/ui_adsb_rx.hpp
@@ -24,7 +24,6 @@
 
 #include "ui_receiver.hpp"
 #include "ui_geomap.hpp"
-#include "ui_font_fixed_8x16.hpp"
 #include "string_format.hpp"
 
 #include "file.hpp"

--- a/firmware/application/apps/ui_aprs_tx.hpp
+++ b/firmware/application/apps/ui_aprs_tx.hpp
@@ -24,7 +24,6 @@
 #include "ui_textentry.hpp"
 #include "ui_widget.hpp"
 #include "ui_navigation.hpp"
-#include "ui_font_fixed_8x16.hpp"
 #include "ui_transmitter.hpp"
 
 #include "message.hpp"

--- a/firmware/application/apps/ui_bht_tx.hpp
+++ b/firmware/application/apps/ui_bht_tx.hpp
@@ -25,7 +25,6 @@
 #include "ui_tabview.hpp"
 #include "ui_navigation.hpp"
 #include "ui_transmitter.hpp"
-#include "ui_font_fixed_8x16.hpp"
 
 #include "bht.hpp"
 #include "bitmap.hpp"

--- a/firmware/application/apps/ui_coasterp.hpp
+++ b/firmware/application/apps/ui_coasterp.hpp
@@ -24,7 +24,6 @@
 #include "ui_widget.hpp"
 #include "ui_navigation.hpp"
 #include "ui_transmitter.hpp"
-#include "ui_font_fixed_8x16.hpp"
 
 #include "message.hpp"
 #include "transmitter_model.hpp"

--- a/firmware/application/apps/ui_encoders.hpp
+++ b/firmware/application/apps/ui_encoders.hpp
@@ -195,17 +195,6 @@ class EncodersView : public View {
     void start_tx(const bool scan);
     void on_tx_progress(const uint32_t progress, const bool done);
 
-    /*const Style style_address {
-                .font = font::fixed_8x16,
-                .background = Color::black(),
-                .foreground = Color::red(),
-        };
-        const Style style_data {
-                .font = font::fixed_8x16,
-                .background = Color::black(),
-                .foreground = Color::blue(),
-        };*/
-
     Rect view_rect = {0, 4 * 8, 240, 168};
 
     EncodersConfigView view_config{nav_, view_rect};

--- a/firmware/application/apps/ui_jammer.cpp
+++ b/firmware/application/apps/ui_jammer.cpp
@@ -36,8 +36,6 @@ void RangeView::focus() {
     check_enabled.focus();
 }
 
-extern constexpr Style RangeView::style_info;
-
 void RangeView::update_start(rf::Frequency f) {
     // Change everything except max
     frequency_range.min = f;
@@ -199,9 +197,6 @@ void JammerView::set_jammer_channel(uint32_t i, uint32_t width, uint64_t center,
     jammer_channels[i].center = center;
     jammer_channels[i].duration = 30720 * duration;
 }
-
-extern constexpr Style JammerView::style_val;
-extern constexpr Style JammerView::style_cancel;
 
 void JammerView::start_tx() {
     uint32_t c, i = 0;

--- a/firmware/application/apps/ui_jammer.hpp
+++ b/firmware/application/apps/ui_jammer.hpp
@@ -22,7 +22,7 @@
 
 #include "ui.hpp"
 #include "ui_widget.hpp"
-#include "ui_font_fixed_8x16.hpp"
+#include "ui_styles.hpp"
 #include "ui_navigation.hpp"
 #include "ui_tabview.hpp"
 #include "transmitter_model.hpp"
@@ -52,11 +52,7 @@ class RangeView : public View {
     uint32_t width{};
     rf::Frequency center{};
 
-    static constexpr Style style_info{
-        .font = font::fixed_8x16,
-        .background = Color::black(),
-        .foreground = Color::grey(),
-    };
+    const Style& style_info = Styles::style_grey;
 
     Labels labels{
         {{2 * 8, 8 * 8 + 4}, "Start", Color::light_grey()},
@@ -117,16 +113,8 @@ class JammerView : public View {
     int16_t mscounter = 0;   // euquiq: Internal ms counter for do_timer()
     lfsr_word_t lfsr_v = 1;  // euquiq: Used to generate "random" Jitter
 
-    static constexpr Style style_val{
-        .font = font::fixed_8x16,
-        .background = Color::black(),
-        .foreground = Color::green(),
-    };
-    static constexpr Style style_cancel{
-        .font = font::fixed_8x16,
-        .background = Color::black(),
-        .foreground = Color::red(),
-    };
+    const Style& style_val = Styles::style_green;
+    const Style& style_cancel = Styles::style_red;
 
     RangeView view_range_a{nav_};
     RangeView view_range_b{nav_};

--- a/firmware/application/apps/ui_jammer.hpp
+++ b/firmware/application/apps/ui_jammer.hpp
@@ -52,7 +52,7 @@ class RangeView : public View {
     uint32_t width{};
     rf::Frequency center{};
 
-    const Style& style_info = Styles::style_grey;
+    const Style& style_info = Styles::grey;
 
     Labels labels{
         {{2 * 8, 8 * 8 + 4}, "Start", Color::light_grey()},
@@ -113,8 +113,8 @@ class JammerView : public View {
     int16_t mscounter = 0;   // euquiq: Internal ms counter for do_timer()
     lfsr_word_t lfsr_v = 1;  // euquiq: Used to generate "random" Jitter
 
-    const Style& style_val = Styles::style_green;
-    const Style& style_cancel = Styles::style_red;
+    const Style& style_val = Styles::green;
+    const Style& style_cancel = Styles::red;
 
     RangeView view_range_a{nav_};
     RangeView view_range_b{nav_};

--- a/firmware/application/apps/ui_level.cpp
+++ b/firmware/application/apps/ui_level.cpp
@@ -151,8 +151,8 @@ LevelView::LevelView(NavigationView& nav)
     // FILL STEP OPTIONS
     freqman_set_modulation_option(field_mode);
     freqman_set_step_option_short(step_mode);
-    freq_stats_rssi.set_style(&style_white);
-    freq_stats_db.set_style(&style_white);
+    freq_stats_rssi.set_style(&Styles::style_default);
+    freq_stats_db.set_style(&Styles::style_default);
 }
 
 void LevelView::on_statistics_update(const ChannelStatistics& statistics) {

--- a/firmware/application/apps/ui_level.cpp
+++ b/firmware/application/apps/ui_level.cpp
@@ -151,8 +151,8 @@ LevelView::LevelView(NavigationView& nav)
     // FILL STEP OPTIONS
     freqman_set_modulation_option(field_mode);
     freqman_set_step_option_short(step_mode);
-    freq_stats_rssi.set_style(&Styles::style_default);
-    freq_stats_db.set_style(&Styles::style_default);
+    freq_stats_rssi.set_style(&Styles::white);
+    freq_stats_db.set_style(&Styles::white);
 }
 
 void LevelView::on_statistics_update(const ChannelStatistics& statistics) {

--- a/firmware/application/apps/ui_level.hpp
+++ b/firmware/application/apps/ui_level.hpp
@@ -27,7 +27,7 @@
 #include "ui.hpp"
 #include "receiver_model.hpp"
 #include "ui_receiver.hpp"
-#include "ui_font_fixed_8x16.hpp"
+#include "ui_styles.hpp"
 #include "freqman.hpp"
 #include "analog_audio_app.hpp"
 #include "audio.hpp"
@@ -48,47 +48,7 @@ class LevelView : public View {
 
     void focus() override;
 
-    const Style style_grey{
-        // level
-        .font = font::fixed_8x16,
-        .background = Color::black(),
-        .foreground = Color::grey(),
-    };
 
-    const Style style_white{
-        // level
-        .font = font::fixed_8x16,
-        .background = Color::black(),
-        .foreground = Color::white(),
-    };
-
-    const Style style_yellow{
-        // Found signal
-        .font = font::fixed_8x16,
-        .background = Color::black(),
-        .foreground = Color::yellow(),
-    };
-
-    const Style style_green{
-        // Found signal
-        .font = font::fixed_8x16,
-        .background = Color::black(),
-        .foreground = Color::green(),
-    };
-
-    const Style style_red{
-        // erasing freq
-        .font = font::fixed_8x16,
-        .background = Color::black(),
-        .foreground = Color::red(),
-    };
-
-    const Style style_blue{
-        // quick level, wait == 0
-        .font = font::fixed_8x16,
-        .background = Color::black(),
-        .foreground = Color::blue(),
-    };
 
     std::string title() const override { return "Level"; };
 

--- a/firmware/application/apps/ui_level.hpp
+++ b/firmware/application/apps/ui_level.hpp
@@ -48,8 +48,6 @@ class LevelView : public View {
 
     void focus() override;
 
-
-
     std::string title() const override { return "Level"; };
 
    private:

--- a/firmware/application/apps/ui_looking_glass_app.cpp
+++ b/firmware/application/apps/ui_looking_glass_app.cpp
@@ -490,11 +490,11 @@ GlassView::GlassView(
     button_range.on_select = [this](Button&) {
         if (locked_range) {
             locked_range = false;
-            button_range.set_style(&style_white);
+            button_range.set_style(&Styles::style_default);
             button_range.set_text(" " + to_string_dec_uint(search_span) + " ");
         } else {
             locked_range = true;
-            button_range.set_style(&style_red);
+            button_range.set_style(&Styles::style_red);
             button_range.set_text(">" + to_string_dec_uint(search_span) + "<");
         }
     };

--- a/firmware/application/apps/ui_looking_glass_app.cpp
+++ b/firmware/application/apps/ui_looking_glass_app.cpp
@@ -490,11 +490,11 @@ GlassView::GlassView(
     button_range.on_select = [this](Button&) {
         if (locked_range) {
             locked_range = false;
-            button_range.set_style(&Styles::style_default);
+            button_range.set_style(&Styles::white);
             button_range.set_text(" " + to_string_dec_uint(search_span) + " ");
         } else {
             locked_range = true;
-            button_range.set_style(&Styles::style_red);
+            button_range.set_style(&Styles::red);
             button_range.set_text(">" + to_string_dec_uint(search_span) + "<");
         }
     };

--- a/firmware/application/apps/ui_looking_glass_app.hpp
+++ b/firmware/application/apps/ui_looking_glass_app.hpp
@@ -31,6 +31,7 @@
 #include "ui_widget.hpp"
 #include "ui_navigation.hpp"
 #include "ui_receiver.hpp"
+#include "ui_styles.hpp"
 #include "string_format.hpp"
 #include "analog_audio_app.hpp"
 #include "spectrum_color_lut.hpp"
@@ -72,20 +73,6 @@ class GlassView : public View {
         rf::Frequency min{};
         rf::Frequency max{};
         std::string label{};
-    };
-
-    const Style style_white{
-        // free range
-        .font = font::fixed_8x16,
-        .background = Color::black(),
-        .foreground = Color::white(),
-    };
-
-    const Style style_red{
-        // locked range
-        .font = font::fixed_8x16,
-        .background = Color::black(),
-        .foreground = Color::red(),
     };
 
     std::vector<preset_entry> presets_db{};

--- a/firmware/application/apps/ui_numbers.hpp
+++ b/firmware/application/apps/ui_numbers.hpp
@@ -27,7 +27,6 @@
 #include "ui_widget.hpp"
 #include "ui_receiver.hpp"
 #include "ui_navigation.hpp"
-#include "ui_font_fixed_8x16.hpp"
 #include "rtc_time.hpp"
 #include "clock_manager.hpp"
 #include "baseband_api.hpp"
@@ -62,11 +61,6 @@ class NumbersStationView : public View {
         MESSAGE,
         SIGNOFF
     };
-
-    Style style_red{
-        .font = font::fixed_8x16,
-        .background = Color::black(),
-        .foreground = Color::red()};
 
     typedef struct {
         char code;

--- a/firmware/application/apps/ui_nuoptix.hpp
+++ b/firmware/application/apps/ui_nuoptix.hpp
@@ -25,7 +25,6 @@
 
 #include "ui.hpp"
 #include "ui_widget.hpp"
-#include "ui_font_fixed_8x16.hpp"
 #include "baseband_api.hpp"
 #include "ui_navigation.hpp"
 #include "ui_transmitter.hpp"

--- a/firmware/application/apps/ui_recon.cpp
+++ b/firmware/application/apps/ui_recon.cpp
@@ -55,23 +55,23 @@ void ReconView::reset_indexes() {
 void ReconView::colorize_waits() {
     // colorize wait on match
     if (wait == 0) {
-        field_wait.set_style(&style_blue);
+        field_wait.set_style(&Styles::style_blue);
     } else if (wait >= 500) {
-        field_wait.set_style(&style_white);
+        field_wait.set_style(&Styles::style_default);
     } else if (wait > -500 && wait < 500) {
-        field_wait.set_style(&style_red);
+        field_wait.set_style(&Styles::style_red);
     } else if (wait <= -500) {
-        field_wait.set_style(&style_green);
+        field_wait.set_style(&Styles::style_green);
     }
     // colorize lock time if in SPARSE mode as in continuous the lock_wait time is disarmed at first lock count
     if (recon_match_mode == RECON_MATCH_SPARSE) {
         if ((recon_lock_duration / STATS_UPDATE_INTERVAL) <= recon_lock_nb_match) {
-            field_lock_wait.set_style(&style_yellow);
+            field_lock_wait.set_style(&Styles::style_yellow);
         } else {
-            field_lock_wait.set_style(&style_white);
+            field_lock_wait.set_style(&Styles::style_default);
         }
     } else {
-        field_lock_wait.set_style(&style_white);
+        field_lock_wait.set_style(&Styles::style_default);
     }
 }
 
@@ -263,17 +263,17 @@ void ReconView::recon_redraw() {
         text_nb_locks.set(to_string_dec_uint(freq_lock) + "/" + to_string_dec_uint(recon_lock_nb_match));
         if (freq_lock == 0) {
             // NO FREQ LOCK, ONGOING STANDARD SCANNING
-            big_display.set_style(&style_white);
+            big_display.set_style(&Styles::style_default);
             if (recon)
                 button_pause.set_text("<PAUSE>");
             else
                 button_pause.set_text("<RESUME>");
         } else if (freq_lock == 1 && recon_lock_nb_match != 1) {
             // STARTING LOCK FREQ
-            big_display.set_style(&style_yellow);
+            big_display.set_style(&Styles::style_yellow);
             button_pause.set_text("<SKPLCK>");
         } else if (freq_lock >= recon_lock_nb_match) {
-            big_display.set_style(&style_green);
+            big_display.set_style(&Styles::style_green);
             button_pause.set_text("<UNLOCK>");
             // FREQ IS STRONG: GREEN and recon will pause when on_statistics_update()
             if ((!scanner_mode) && autosave && frequency_list.size() > 0) {
@@ -716,18 +716,18 @@ ReconView::ReconView(NavigationView& nav)
 
             frequency_list.push_back(manual_freq_entry);
 
-            big_display.set_style(&style_white);  // Back to white color
+            big_display.set_style(&Styles::style_default);  // Back to white color
 
-            freq_stats.set_style(&style_white);
+            freq_stats.set_style(&Styles::style_default);
             freq_stats.set("0/0/0");
 
             text_cycle.set_text("1");
             text_max.set("/1");
-            button_scanner_mode.set_style(&style_white);
+            button_scanner_mode.set_style(&Styles::style_default);
             button_scanner_mode.set_text("MSEARCH");
-            file_name.set_style(&style_white);
+            file_name.set_style(&Styles::style_default);
             file_name.set("MANUAL RANGE RECON");
-            desc_cycle.set_style(&style_white);
+            desc_cycle.set_style(&Styles::style_default);
 
             last_entry.modulation = -1;
             last_entry.bandwidth = -1;
@@ -767,12 +767,12 @@ ReconView::ReconView(NavigationView& nav)
             recon_resume();
         }
         if (scanner_mode) {
-            file_name.set_style(&style_red);
-            button_scanner_mode.set_style(&style_red);
+            file_name.set_style(&Styles::style_red);
+            button_scanner_mode.set_style(&Styles::style_red);
             button_scanner_mode.set_text("SCANNER");
         } else {
-            file_name.set_style(&style_blue);
-            button_scanner_mode.set_style(&style_blue);
+            file_name.set_style(&Styles::style_blue);
+            button_scanner_mode.set_style(&Styles::style_blue);
             button_scanner_mode.set_text("RECON");
         }
     };
@@ -792,12 +792,12 @@ ReconView::ReconView(NavigationView& nav)
         manual_mode = false;
         if (scanner_mode) {
             scanner_mode = false;
-            button_scanner_mode.set_style(&style_blue);
+            button_scanner_mode.set_style(&Styles::style_blue);
             button_scanner_mode.set_text("RECON");
             button_remove.set_text("DELETE");
         } else {
             scanner_mode = true;
-            button_scanner_mode.set_style(&style_red);
+            button_scanner_mode.set_style(&Styles::style_red);
             button_scanner_mode.set_text("SCANNER");
             button_scanner_mode.set_text("REMOVE");
         }
@@ -861,7 +861,7 @@ ReconView::ReconView(NavigationView& nav)
     };
 
     // PRE-CONFIGURATION:
-    button_scanner_mode.set_style(&style_blue);
+    button_scanner_mode.set_style(&Styles::style_blue);
     button_scanner_mode.set_text("RECON");
     file_name.set("=>");
 
@@ -907,31 +907,31 @@ void ReconView::frequency_file_load(bool stop_all_before) {
     std::string file_input = input_file;                // default recon mode
     if (scanner_mode) {
         file_input = output_file;
-        file_name.set_style(&style_red);
-        button_scanner_mode.set_style(&style_red);
+        file_name.set_style(&Styles::style_red);
+        button_scanner_mode.set_style(&Styles::style_red);
         button_scanner_mode.set_text("SCANNER");
     } else {
-        file_name.set_style(&style_blue);
-        button_scanner_mode.set_style(&style_blue);
+        file_name.set_style(&Styles::style_blue);
+        button_scanner_mode.set_style(&Styles::style_blue);
         button_scanner_mode.set_text("RECON");
     }
-    desc_cycle.set_style(&style_white);
+    desc_cycle.set_style(&Styles::style_default);
     if (!load_freqman_file_ex(file_input, frequency_list, load_freqs, load_ranges, load_hamradios, RECON_FREQMAN_MAX_PER_FILE)) {
-        file_name.set_style(&style_red);
-        desc_cycle.set_style(&style_red);
+        file_name.set_style(&Styles::style_red);
+        desc_cycle.set_style(&Styles::style_red);
         desc_cycle.set(" NO " + file_input + ".TXT FILE ...");
         file_name.set("=> NO DATA");
     } else {
         file_name.set("=> " + file_input);
         if (frequency_list.size() == 0) {
-            file_name.set_style(&style_red);
-            desc_cycle.set_style(&style_red);
+            file_name.set_style(&Styles::style_red);
+            desc_cycle.set_style(&Styles::style_red);
             desc_cycle.set("/0 no entries in list");
             file_name.set("BadOrEmpty " + file_input);
         } else {
             if (frequency_list.size() > RECON_FREQMAN_MAX_PER_FILE) {
-                file_name.set_style(&style_yellow);
-                desc_cycle.set_style(&style_yellow);
+                file_name.set_style(&Styles::style_yellow);
+                desc_cycle.set_style(&Styles::style_yellow);
             }
         }
     }
@@ -1024,7 +1024,7 @@ void ReconView::on_statistics_update(const ChannelStatistics& statistics) {
             continuous_lock = false;
             freq_lock = 0;
             timer = recon_lock_duration;
-            big_display.set_style(&style_white);
+            big_display.set_style(&Styles::style_default);
         }
         if (freq_lock < recon_lock_nb_match)  // LOCKING
         {
@@ -1239,7 +1239,7 @@ void ReconView::recon_pause() {
 
     audio_output_start();
 
-    big_display.set_style(&style_white);
+    big_display.set_style(&Styles::style_default);
     button_pause.set_text("<RESUME>");  // PAUSED, show resume
 }
 
@@ -1251,7 +1251,7 @@ void ReconView::recon_resume() {
 
     audio::output::stop();
 
-    big_display.set_style(&style_white);
+    big_display.set_style(&Styles::style_default);
     button_pause.set_text("<PAUSE>");
 }
 

--- a/firmware/application/apps/ui_recon.cpp
+++ b/firmware/application/apps/ui_recon.cpp
@@ -55,23 +55,23 @@ void ReconView::reset_indexes() {
 void ReconView::colorize_waits() {
     // colorize wait on match
     if (wait == 0) {
-        field_wait.set_style(&Styles::style_blue);
+        field_wait.set_style(&Styles::blue);
     } else if (wait >= 500) {
-        field_wait.set_style(&Styles::style_default);
+        field_wait.set_style(&Styles::white);
     } else if (wait > -500 && wait < 500) {
-        field_wait.set_style(&Styles::style_red);
+        field_wait.set_style(&Styles::red);
     } else if (wait <= -500) {
-        field_wait.set_style(&Styles::style_green);
+        field_wait.set_style(&Styles::green);
     }
     // colorize lock time if in SPARSE mode as in continuous the lock_wait time is disarmed at first lock count
     if (recon_match_mode == RECON_MATCH_SPARSE) {
         if ((recon_lock_duration / STATS_UPDATE_INTERVAL) <= recon_lock_nb_match) {
-            field_lock_wait.set_style(&Styles::style_yellow);
+            field_lock_wait.set_style(&Styles::yellow);
         } else {
-            field_lock_wait.set_style(&Styles::style_default);
+            field_lock_wait.set_style(&Styles::white);
         }
     } else {
-        field_lock_wait.set_style(&Styles::style_default);
+        field_lock_wait.set_style(&Styles::white);
     }
 }
 
@@ -263,17 +263,17 @@ void ReconView::recon_redraw() {
         text_nb_locks.set(to_string_dec_uint(freq_lock) + "/" + to_string_dec_uint(recon_lock_nb_match));
         if (freq_lock == 0) {
             // NO FREQ LOCK, ONGOING STANDARD SCANNING
-            big_display.set_style(&Styles::style_default);
+            big_display.set_style(&Styles::white);
             if (recon)
                 button_pause.set_text("<PAUSE>");
             else
                 button_pause.set_text("<RESUME>");
         } else if (freq_lock == 1 && recon_lock_nb_match != 1) {
             // STARTING LOCK FREQ
-            big_display.set_style(&Styles::style_yellow);
+            big_display.set_style(&Styles::yellow);
             button_pause.set_text("<SKPLCK>");
         } else if (freq_lock >= recon_lock_nb_match) {
-            big_display.set_style(&Styles::style_green);
+            big_display.set_style(&Styles::green);
             button_pause.set_text("<UNLOCK>");
             // FREQ IS STRONG: GREEN and recon will pause when on_statistics_update()
             if ((!scanner_mode) && autosave && frequency_list.size() > 0) {
@@ -716,18 +716,18 @@ ReconView::ReconView(NavigationView& nav)
 
             frequency_list.push_back(manual_freq_entry);
 
-            big_display.set_style(&Styles::style_default);  // Back to white color
+            big_display.set_style(&Styles::white);  // Back to white color
 
-            freq_stats.set_style(&Styles::style_default);
+            freq_stats.set_style(&Styles::white);
             freq_stats.set("0/0/0");
 
             text_cycle.set_text("1");
             text_max.set("/1");
-            button_scanner_mode.set_style(&Styles::style_default);
+            button_scanner_mode.set_style(&Styles::white);
             button_scanner_mode.set_text("MSEARCH");
-            file_name.set_style(&Styles::style_default);
+            file_name.set_style(&Styles::white);
             file_name.set("MANUAL RANGE RECON");
-            desc_cycle.set_style(&Styles::style_default);
+            desc_cycle.set_style(&Styles::white);
 
             last_entry.modulation = -1;
             last_entry.bandwidth = -1;
@@ -767,12 +767,12 @@ ReconView::ReconView(NavigationView& nav)
             recon_resume();
         }
         if (scanner_mode) {
-            file_name.set_style(&Styles::style_red);
-            button_scanner_mode.set_style(&Styles::style_red);
+            file_name.set_style(&Styles::red);
+            button_scanner_mode.set_style(&Styles::red);
             button_scanner_mode.set_text("SCANNER");
         } else {
-            file_name.set_style(&Styles::style_blue);
-            button_scanner_mode.set_style(&Styles::style_blue);
+            file_name.set_style(&Styles::blue);
+            button_scanner_mode.set_style(&Styles::blue);
             button_scanner_mode.set_text("RECON");
         }
     };
@@ -792,12 +792,12 @@ ReconView::ReconView(NavigationView& nav)
         manual_mode = false;
         if (scanner_mode) {
             scanner_mode = false;
-            button_scanner_mode.set_style(&Styles::style_blue);
+            button_scanner_mode.set_style(&Styles::blue);
             button_scanner_mode.set_text("RECON");
             button_remove.set_text("DELETE");
         } else {
             scanner_mode = true;
-            button_scanner_mode.set_style(&Styles::style_red);
+            button_scanner_mode.set_style(&Styles::red);
             button_scanner_mode.set_text("SCANNER");
             button_scanner_mode.set_text("REMOVE");
         }
@@ -861,7 +861,7 @@ ReconView::ReconView(NavigationView& nav)
     };
 
     // PRE-CONFIGURATION:
-    button_scanner_mode.set_style(&Styles::style_blue);
+    button_scanner_mode.set_style(&Styles::blue);
     button_scanner_mode.set_text("RECON");
     file_name.set("=>");
 
@@ -907,31 +907,31 @@ void ReconView::frequency_file_load(bool stop_all_before) {
     std::string file_input = input_file;                // default recon mode
     if (scanner_mode) {
         file_input = output_file;
-        file_name.set_style(&Styles::style_red);
-        button_scanner_mode.set_style(&Styles::style_red);
+        file_name.set_style(&Styles::red);
+        button_scanner_mode.set_style(&Styles::red);
         button_scanner_mode.set_text("SCANNER");
     } else {
-        file_name.set_style(&Styles::style_blue);
-        button_scanner_mode.set_style(&Styles::style_blue);
+        file_name.set_style(&Styles::blue);
+        button_scanner_mode.set_style(&Styles::blue);
         button_scanner_mode.set_text("RECON");
     }
-    desc_cycle.set_style(&Styles::style_default);
+    desc_cycle.set_style(&Styles::white);
     if (!load_freqman_file_ex(file_input, frequency_list, load_freqs, load_ranges, load_hamradios, RECON_FREQMAN_MAX_PER_FILE)) {
-        file_name.set_style(&Styles::style_red);
-        desc_cycle.set_style(&Styles::style_red);
+        file_name.set_style(&Styles::red);
+        desc_cycle.set_style(&Styles::red);
         desc_cycle.set(" NO " + file_input + ".TXT FILE ...");
         file_name.set("=> NO DATA");
     } else {
         file_name.set("=> " + file_input);
         if (frequency_list.size() == 0) {
-            file_name.set_style(&Styles::style_red);
-            desc_cycle.set_style(&Styles::style_red);
+            file_name.set_style(&Styles::red);
+            desc_cycle.set_style(&Styles::red);
             desc_cycle.set("/0 no entries in list");
             file_name.set("BadOrEmpty " + file_input);
         } else {
             if (frequency_list.size() > RECON_FREQMAN_MAX_PER_FILE) {
-                file_name.set_style(&Styles::style_yellow);
-                desc_cycle.set_style(&Styles::style_yellow);
+                file_name.set_style(&Styles::yellow);
+                desc_cycle.set_style(&Styles::yellow);
             }
         }
     }
@@ -1024,7 +1024,7 @@ void ReconView::on_statistics_update(const ChannelStatistics& statistics) {
             continuous_lock = false;
             freq_lock = 0;
             timer = recon_lock_duration;
-            big_display.set_style(&Styles::style_default);
+            big_display.set_style(&Styles::white);
         }
         if (freq_lock < recon_lock_nb_match)  // LOCKING
         {
@@ -1239,7 +1239,7 @@ void ReconView::recon_pause() {
 
     audio_output_start();
 
-    big_display.set_style(&Styles::style_default);
+    big_display.set_style(&Styles::white);
     button_pause.set_text("<RESUME>");  // PAUSED, show resume
 }
 
@@ -1251,7 +1251,7 @@ void ReconView::recon_resume() {
 
     audio::output::stop();
 
-    big_display.set_style(&Styles::style_default);
+    big_display.set_style(&Styles::white);
     button_pause.set_text("<PAUSE>");
 }
 

--- a/firmware/application/apps/ui_recon.hpp
+++ b/firmware/application/apps/ui_recon.hpp
@@ -27,7 +27,7 @@
 #include "ui.hpp"
 #include "receiver_model.hpp"
 #include "ui_receiver.hpp"
-#include "ui_font_fixed_8x16.hpp"
+#include "ui_styles.hpp"
 #include "freqman.hpp"
 #include "analog_audio_app.hpp"
 #include "audio.hpp"
@@ -52,48 +52,6 @@ class ReconView : public View {
     ~ReconView();
 
     void focus() override;
-
-    const Style style_grey{
-        // recon
-        .font = font::fixed_8x16,
-        .background = Color::black(),
-        .foreground = Color::grey(),
-    };
-
-    const Style style_white{
-        // recon
-        .font = font::fixed_8x16,
-        .background = Color::black(),
-        .foreground = Color::white(),
-    };
-
-    const Style style_yellow{
-        // found signal
-        .font = font::fixed_8x16,
-        .background = Color::black(),
-        .foreground = Color::yellow(),
-    };
-
-    const Style style_green{
-        // Found signal
-        .font = font::fixed_8x16,
-        .background = Color::black(),
-        .foreground = Color::green(),
-    };
-
-    const Style style_red{
-        // erasing freq
-        .font = font::fixed_8x16,
-        .background = Color::black(),
-        .foreground = Color::red(),
-    };
-
-    const Style style_blue{
-        // quick recon, wait == 0
-        .font = font::fixed_8x16,
-        .background = Color::black(),
-        .foreground = Color::blue(),
-    };
 
     std::string title() const override { return "Recon"; };
 

--- a/firmware/application/apps/ui_scanner.cpp
+++ b/firmware/application/apps/ui_scanner.cpp
@@ -179,16 +179,16 @@ void ScannerView::bigdisplay_update(int32_t v) {
 
         switch (bigdisplay_current_color) {
             case BDC_GREY:
-                big_display.set_style(&Styles::style_grey);
+                big_display.set_style(&Styles::grey);
                 break;
             case BDC_YELLOW:
-                big_display.set_style(&Styles::style_yellow);
+                big_display.set_style(&Styles::yellow);
                 break;
             case BDC_GREEN:
-                big_display.set_style(&Styles::style_green);
+                big_display.set_style(&Styles::green);
                 break;
             case BDC_RED:
-                big_display.set_style(&Styles::style_red);
+                big_display.set_style(&Styles::red);
                 break;
             default:
                 break;
@@ -254,10 +254,10 @@ void ScannerView::show_max_index() {  // show total number of freqs to scan
     text_current_index.set("---");
 
     if (frequency_list.size() == FREQMAN_MAX_PER_FILE) {
-        text_max_index.set_style(&Styles::style_red);
+        text_max_index.set_style(&Styles::red);
         text_max_index.set("/ " + to_string_dec_uint(FREQMAN_MAX_PER_FILE) + " (DB MAX!)");
     } else {
-        text_max_index.set_style(&Styles::style_grey);
+        text_max_index.set_style(&Styles::grey);
         text_max_index.set("/ " + to_string_dec_uint(frequency_list.size()));
     }
 }

--- a/firmware/application/apps/ui_scanner.cpp
+++ b/firmware/application/apps/ui_scanner.cpp
@@ -179,16 +179,16 @@ void ScannerView::bigdisplay_update(int32_t v) {
 
         switch (bigdisplay_current_color) {
             case BDC_GREY:
-                big_display.set_style(&style_grey);
+                big_display.set_style(&Styles::style_grey);
                 break;
             case BDC_YELLOW:
-                big_display.set_style(&style_yellow);
+                big_display.set_style(&Styles::style_yellow);
                 break;
             case BDC_GREEN:
-                big_display.set_style(&style_green);
+                big_display.set_style(&Styles::style_green);
                 break;
             case BDC_RED:
-                big_display.set_style(&style_red);
+                big_display.set_style(&Styles::style_red);
                 break;
             default:
                 break;
@@ -254,10 +254,10 @@ void ScannerView::show_max_index() {  // show total number of freqs to scan
     text_current_index.set("---");
 
     if (frequency_list.size() == FREQMAN_MAX_PER_FILE) {
-        text_max_index.set_style(&style_red);
+        text_max_index.set_style(&Styles::style_red);
         text_max_index.set("/ " + to_string_dec_uint(FREQMAN_MAX_PER_FILE) + " (DB MAX!)");
     } else {
-        text_max_index.set_style(&style_grey);
+        text_max_index.set_style(&Styles::style_grey);
         text_max_index.set("/ " + to_string_dec_uint(frequency_list.size()));
     }
 }

--- a/firmware/application/apps/ui_scanner.hpp
+++ b/firmware/application/apps/ui_scanner.hpp
@@ -23,7 +23,7 @@
 #include "ui.hpp"
 #include "receiver_model.hpp"
 #include "ui_receiver.hpp"
-#include "ui_font_fixed_8x16.hpp"
+#include "ui_styles.hpp"
 #include "freqman.hpp"
 #include "analog_audio_app.hpp"
 #include "audio.hpp"
@@ -86,34 +86,6 @@ class ScannerView : public View {
     ~ScannerView();
 
     void focus() override;
-
-    const Style style_grey{
-        // scanning
-        .font = font::fixed_8x16,
-        .background = Color::black(),
-        .foreground = Color::grey(),
-    };
-
-    const Style style_yellow{
-        // Found signal
-        .font = font::fixed_8x16,
-        .background = Color::black(),
-        .foreground = Color::dark_yellow(),
-    };
-
-    const Style style_green{
-        // Found signal
-        .font = font::fixed_8x16,
-        .background = Color::black(),
-        .foreground = Color::green(),
-    };
-
-    const Style style_red{
-        // erasing freq
-        .font = font::fixed_8x16,
-        .background = Color::black(),
-        .foreground = Color::red(),
-    };
 
     std::string title() const override { return "Scanner"; };
     std::vector<rf::Frequency> frequency_list{};

--- a/firmware/application/apps/ui_search.cpp
+++ b/firmware/application/apps/ui_search.cpp
@@ -117,7 +117,7 @@ void SearchView::do_detection() {
                         recent_entries_view.set_dirty();
 
                         text_infos.set("Locked ! ");
-                        big_display.set_style(&style_locked);
+                        big_display.set_style(&Styles::style_green);
 
                         locked = true;
                         locked_bin = bin_max;
@@ -152,7 +152,7 @@ void SearchView::do_detection() {
                 recent_entries_view.set_dirty();
 
                 text_infos.set("Listening");
-                big_display.set_style(&style_grey);
+                big_display.set_style(&Styles::style_grey);
             }
         }
     }
@@ -362,11 +362,11 @@ SearchView::SearchView(
         nav.push<FrequencyKeypadView>(entry.frequency);
     };
 
-    text_mean.set_style(&style_grey);
-    text_slices.set_style(&style_grey);
-    text_rate.set_style(&style_grey);
-    progress_timers.set_style(&style_grey);
-    big_display.set_style(&style_grey);
+    text_mean.set_style(&Styles::style_grey);
+    text_slices.set_style(&Styles::style_grey);
+    text_rate.set_style(&Styles::style_grey);
+    progress_timers.set_style(&Styles::style_grey);
+    big_display.set_style(&Styles::style_grey);
 
     check_snap.set_value(true);
     options_snap.set_selected_index(1);  // 12.5kHz

--- a/firmware/application/apps/ui_search.cpp
+++ b/firmware/application/apps/ui_search.cpp
@@ -117,7 +117,7 @@ void SearchView::do_detection() {
                         recent_entries_view.set_dirty();
 
                         text_infos.set("Locked ! ");
-                        big_display.set_style(&Styles::style_green);
+                        big_display.set_style(&Styles::green);
 
                         locked = true;
                         locked_bin = bin_max;
@@ -152,7 +152,7 @@ void SearchView::do_detection() {
                 recent_entries_view.set_dirty();
 
                 text_infos.set("Listening");
-                big_display.set_style(&Styles::style_grey);
+                big_display.set_style(&Styles::grey);
             }
         }
     }
@@ -362,11 +362,11 @@ SearchView::SearchView(
         nav.push<FrequencyKeypadView>(entry.frequency);
     };
 
-    text_mean.set_style(&Styles::style_grey);
-    text_slices.set_style(&Styles::style_grey);
-    text_rate.set_style(&Styles::style_grey);
-    progress_timers.set_style(&Styles::style_grey);
-    big_display.set_style(&Styles::style_grey);
+    text_mean.set_style(&Styles::grey);
+    text_slices.set_style(&Styles::grey);
+    text_rate.set_style(&Styles::grey);
+    progress_timers.set_style(&Styles::grey);
+    big_display.set_style(&Styles::grey);
 
     check_snap.set_value(true);
     options_snap.set_selected_index(1);  // 12.5kHz

--- a/firmware/application/apps/ui_search.hpp
+++ b/firmware/application/apps/ui_search.hpp
@@ -25,7 +25,7 @@
 #include "spectrum_color_lut.hpp"
 
 #include "ui_receiver.hpp"
-#include "ui_font_fixed_8x16.hpp"
+#include "ui_styles.hpp"
 #include "recent_entries.hpp"
 
 namespace ui {
@@ -89,19 +89,6 @@ class SearchView : public View {
 
    private:
     NavigationView& nav_;
-
-    const Style style_grey{
-        // For informations and lost signal
-        .font = font::fixed_8x16,
-        .background = Color::black(),
-        .foreground = Color::grey(),
-    };
-
-    const Style style_locked{
-        .font = font::fixed_8x16,
-        .background = Color::black(),
-        .foreground = Color::green(),
-    };
 
     struct slice_t {
         rf::Frequency center_frequency;

--- a/firmware/application/apps/ui_settings.cpp
+++ b/firmware/application/apps/ui_settings.cpp
@@ -129,9 +129,9 @@ SetRadioView::SetRadioView(
     value_source.set(source_name);
     value_source_frequency.set(to_string_dec_uint(reference.frequency / 1000000, 2) + "." + to_string_dec_uint((reference.frequency % 1000000) / 100, 4, '0') + " MHz");
 
-    label_source.set_style(&Styles::style_default);
-    value_source.set_style(&Styles::style_default);
-    value_source_frequency.set_style(&Styles::style_default);
+    label_source.set_style(&Styles::style_light_grey);
+    value_source.set_style(&Styles::style_light_grey);
+    value_source_frequency.set_style(&Styles::style_light_grey);
 
     add_children({
         &label_source,
@@ -169,7 +169,7 @@ SetRadioView::SetRadioView(
     };
 
     field_clkout_freq.set_value(portapack::persistent_memory::clkout_freq());
-    value_freq_step.set_style(&Styles::style_default);
+    value_freq_step.set_style(&Styles::style_light_grey);
 
     field_clkout_freq.on_select = [this](NumberField&) {
         freq_step_khz++;

--- a/firmware/application/apps/ui_settings.cpp
+++ b/firmware/application/apps/ui_settings.cpp
@@ -129,9 +129,9 @@ SetRadioView::SetRadioView(
     value_source.set(source_name);
     value_source_frequency.set(to_string_dec_uint(reference.frequency / 1000000, 2) + "." + to_string_dec_uint((reference.frequency % 1000000) / 100, 4, '0') + " MHz");
 
-    label_source.set_style(&Styles::style_light_grey);
-    value_source.set_style(&Styles::style_light_grey);
-    value_source_frequency.set_style(&Styles::style_light_grey);
+    label_source.set_style(&Styles::light_grey);
+    value_source.set_style(&Styles::light_grey);
+    value_source_frequency.set_style(&Styles::light_grey);
 
     add_children({
         &label_source,
@@ -169,7 +169,7 @@ SetRadioView::SetRadioView(
     };
 
     field_clkout_freq.set_value(portapack::persistent_memory::clkout_freq());
-    value_freq_step.set_style(&Styles::style_light_grey);
+    value_freq_step.set_style(&Styles::light_grey);
 
     field_clkout_freq.on_select = [this](NumberField&) {
         freq_step_khz++;

--- a/firmware/application/apps/ui_settings.cpp
+++ b/firmware/application/apps/ui_settings.cpp
@@ -36,7 +36,7 @@ using portapack::receiver_model;
 using namespace portapack;
 
 #include "string_format.hpp"
-#include "ui_font_fixed_8x16.hpp"
+#include "ui_styles.hpp"
 #include "cpld_update.hpp"
 
 #include "freqman.hpp"
@@ -129,9 +129,9 @@ SetRadioView::SetRadioView(
     value_source.set(source_name);
     value_source_frequency.set(to_string_dec_uint(reference.frequency / 1000000, 2) + "." + to_string_dec_uint((reference.frequency % 1000000) / 100, 4, '0') + " MHz");
 
-    label_source.set_style(&style_text);
-    value_source.set_style(&style_text);
-    value_source_frequency.set_style(&style_text);
+    label_source.set_style(&Styles::style_default);
+    value_source.set_style(&Styles::style_default);
+    value_source_frequency.set_style(&Styles::style_default);
 
     add_children({
         &label_source,
@@ -169,7 +169,7 @@ SetRadioView::SetRadioView(
     };
 
     field_clkout_freq.set_value(portapack::persistent_memory::clkout_freq());
-    value_freq_step.set_style(&style_text);
+    value_freq_step.set_style(&Styles::style_default);
 
     field_clkout_freq.on_select = [this](NumberField&) {
         freq_step_khz++;

--- a/firmware/application/apps/ui_settings.hpp
+++ b/firmware/application/apps/ui_settings.hpp
@@ -127,11 +127,6 @@ class SetRadioView : public View {
     std::string title() const override { return "Radio"; };
 
    private:
-    const Style style_text{
-        .font = font::fixed_8x16,
-        .background = Color::black(),
-        .foreground = Color::light_grey(),
-    };
     uint8_t freq_step_khz = 3;
 
     Text label_source{

--- a/firmware/application/apps/ui_sigfrx.cpp
+++ b/firmware/application/apps/ui_sigfrx.cpp
@@ -131,9 +131,9 @@ SIGFRXView::SIGFRXView(
                   &text_data,
                   &button_exit});
 
-    text_type.set_style(&style_white);
-    text_channel.set_style(&style_white);
-    text_data.set_style(&style_white);
+    text_type.set_style(&style_inverted);
+    text_channel.set_style(&style_inverted);
+    text_data.set_style(&style_inverted);
 
     button_exit.on_select = [&nav](Button&) {
         nav.pop();

--- a/firmware/application/apps/ui_sigfrx.cpp
+++ b/firmware/application/apps/ui_sigfrx.cpp
@@ -131,9 +131,9 @@ SIGFRXView::SIGFRXView(
                   &text_data,
                   &button_exit});
 
-    text_type.set_style(&style_inverted);
-    text_channel.set_style(&style_inverted);
-    text_data.set_style(&style_inverted);
+    text_type.set_style(&Styles::bg_white);
+    text_channel.set_style(&Styles::bg_white);
+    text_data.set_style(&Styles::bg_white);
 
     button_exit.on_select = [&nav](Button&) {
         nav.pop();

--- a/firmware/application/apps/ui_sigfrx.hpp
+++ b/firmware/application/apps/ui_sigfrx.hpp
@@ -24,6 +24,7 @@
 #include "ui_widget.hpp"
 #include "ui_painter.hpp"
 #include "ui_menu.hpp"
+#include "ui_styles.hpp"
 #include "ui_navigation.hpp"
 #include "clock_manager.hpp"
 #include "message.hpp"
@@ -48,6 +49,8 @@ class SIGFRXView : public View {
    private:
     uint8_t last_channel;
     uint8_t detect_counter = 0;
+
+    const Style style_white = Styles::style_default.invert();
 
     const uint16_t sigfrx_marks[18] = {
         10, 8, 0,

--- a/firmware/application/apps/ui_sigfrx.hpp
+++ b/firmware/application/apps/ui_sigfrx.hpp
@@ -50,7 +50,7 @@ class SIGFRXView : public View {
     uint8_t last_channel;
     uint8_t detect_counter = 0;
 
-    const Style style_white = Styles::style_default.invert();
+    const Style style_inverted = Styles::white.invert();
 
     const uint16_t sigfrx_marks[18] = {
         10, 8, 0,

--- a/firmware/application/apps/ui_sigfrx.hpp
+++ b/firmware/application/apps/ui_sigfrx.hpp
@@ -25,7 +25,6 @@
 #include "ui_painter.hpp"
 #include "ui_menu.hpp"
 #include "ui_navigation.hpp"
-#include "ui_font_fixed_8x16.hpp"
 #include "clock_manager.hpp"
 #include "message.hpp"
 #include "rf_path.hpp"
@@ -49,11 +48,6 @@ class SIGFRXView : public View {
    private:
     uint8_t last_channel;
     uint8_t detect_counter = 0;
-
-    const Style style_white{
-        .font = font::fixed_8x16,
-        .background = Color::white(),
-        .foreground = Color::black()};
 
     const uint16_t sigfrx_marks[18] = {
         10, 8, 0,

--- a/firmware/application/apps/ui_sigfrx.hpp
+++ b/firmware/application/apps/ui_sigfrx.hpp
@@ -50,8 +50,6 @@ class SIGFRXView : public View {
     uint8_t last_channel;
     uint8_t detect_counter = 0;
 
-    const Style style_inverted = Styles::white.invert();
-
     const uint16_t sigfrx_marks[18] = {
         10, 8, 0,
         60, 52, 90,

--- a/firmware/application/apps/ui_spectrum_painter_text.cpp
+++ b/firmware/application/apps/ui_spectrum_painter_text.cpp
@@ -20,6 +20,7 @@
  */
 
 #include "ui_spectrum_painter_text.hpp"
+#include "ui_font_fixed_8x16.hpp"
 #include "cpld_update.hpp"
 #include "bmp.hpp"
 #include "baseband_api.hpp"
@@ -28,7 +29,6 @@
 #include "io_file.hpp"
 #include "file.hpp"
 #include "portapack_persistent_memory.hpp"
-#include "ui_font_fixed_8x16.hpp"
 
 namespace ui {
 

--- a/firmware/application/apps/ui_ss_viewer.cpp
+++ b/firmware/application/apps/ui_ss_viewer.cpp
@@ -47,12 +47,12 @@ void ScreenshotViewer::paint(Painter& painter) {
     painter.fill_rectangle({0, 0, pixel_width, pixel_height}, Color::black());
 
     auto show_invalid = [&]() {
-        painter.draw_string({10, 160}, Styles::style_default, "Not a valid screenshot.");
+        painter.draw_string({10, 160}, Styles::white, "Not a valid screenshot.");
     };
 
     auto error = file.open(path_);
     if (error) {
-        painter.draw_string({10, 160}, Styles::style_default, error->what());
+        painter.draw_string({10, 160}, Styles::white, error->what());
         return;
     }
 

--- a/firmware/application/apps/ui_ss_viewer.cpp
+++ b/firmware/application/apps/ui_ss_viewer.cpp
@@ -42,21 +42,17 @@ bool ScreenshotViewer::on_key(KeyEvent) {
 void ScreenshotViewer::paint(Painter& painter) {
     constexpr size_t pixel_width = 240;
     constexpr size_t pixel_height = 320;
-    Style style_default{
-        .font = ui::font::fixed_8x16,
-        .background = ui::Color::black(),
-        .foreground = ui::Color::white()};
     File file{};
 
     painter.fill_rectangle({0, 0, pixel_width, pixel_height}, Color::black());
 
     auto show_invalid = [&]() {
-        painter.draw_string({10, 160}, style_default, "Not a valid screenshot.");
+        painter.draw_string({10, 160}, Styles::style_default, "Not a valid screenshot.");
     };
 
     auto error = file.open(path_);
     if (error) {
-        painter.draw_string({10, 160}, style_default, error->what());
+        painter.draw_string({10, 160}, Styles::style_default, error->what());
         return;
     }
 

--- a/firmware/application/apps/ui_sstvtx.hpp
+++ b/firmware/application/apps/ui_sstvtx.hpp
@@ -27,7 +27,6 @@
 #include "ui_widget.hpp"
 #include "ui_receiver.hpp"
 #include "ui_navigation.hpp"
-#include "ui_font_fixed_8x16.hpp"
 #include "baseband_api.hpp"
 #include "ui_transmitter.hpp"
 #include "message.hpp"

--- a/firmware/application/apps/ui_text_editor.cpp
+++ b/firmware/application/apps/ui_text_editor.cpp
@@ -205,7 +205,7 @@ void TextViewer::paint_text(Painter& painter, uint32_t line, uint16_t col) {
         if (result && *result > 0)
             painter.draw_string(
                 {0, r.top() + (int)i * char_height},
-                Styles::style_small, {buffer, *result});
+                Styles::white_small, {buffer, *result});
 
         // Clear empty line sections. This is less visually jarring than full clear.
         int32_t clear_width = max_col - (result ? *result : 0);
@@ -214,7 +214,7 @@ void TextViewer::paint_text(Painter& painter, uint32_t line, uint16_t col) {
                 {(max_col - clear_width) * char_width,
                  r.top() + (int)i * char_height,
                  clear_width * char_width, char_height},
-                Styles::style_small.background);
+                Styles::white_small.background);
     }
 }
 
@@ -235,8 +235,8 @@ void TextViewer::paint_cursor(Painter& painter) {
     };
 
     // Clear old cursor. CONSIDER: XOR cursor?
-    draw_cursor(paint_state_.line, paint_state_.col, Styles::style_small.background);
-    draw_cursor(cursor_.line, cursor_.col, Styles::style_small.foreground);
+    draw_cursor(paint_state_.line, paint_state_.col, Styles::white_small.background);
+    draw_cursor(cursor_.line, cursor_.col, Styles::white_small.foreground);
     paint_state_.line = cursor_.line;
     paint_state_.col = cursor_.col;
 }

--- a/firmware/application/apps/ui_text_editor.cpp
+++ b/firmware/application/apps/ui_text_editor.cpp
@@ -205,7 +205,7 @@ void TextViewer::paint_text(Painter& painter, uint32_t line, uint16_t col) {
         if (result && *result > 0)
             painter.draw_string(
                 {0, r.top() + (int)i * char_height},
-                style_text, {buffer, *result});
+                Styles::style_small, {buffer, *result});
 
         // Clear empty line sections. This is less visually jarring than full clear.
         int32_t clear_width = max_col - (result ? *result : 0);
@@ -214,7 +214,7 @@ void TextViewer::paint_text(Painter& painter, uint32_t line, uint16_t col) {
                 {(max_col - clear_width) * char_width,
                  r.top() + (int)i * char_height,
                  clear_width * char_width, char_height},
-                style_text.background);
+                Styles::style_small.background);
     }
 }
 
@@ -235,8 +235,8 @@ void TextViewer::paint_cursor(Painter& painter) {
     };
 
     // Clear old cursor. CONSIDER: XOR cursor?
-    draw_cursor(paint_state_.line, paint_state_.col, style_text.background);
-    draw_cursor(cursor_.line, cursor_.col, style_text.foreground);
+    draw_cursor(paint_state_.line, paint_state_.col, Styles::style_small.background);
+    draw_cursor(cursor_.line, cursor_.col, Styles::style_small.foreground);
     paint_state_.line = cursor_.line;
     paint_state_.col = cursor_.col;
 }

--- a/firmware/application/apps/ui_text_editor.hpp
+++ b/firmware/application/apps/ui_text_editor.hpp
@@ -27,9 +27,9 @@
 #define __UI_TEXT_EDITOR_H__
 
 #include "ui.hpp"
-#include "ui_font_fixed_5x8.hpp"
 #include "ui_navigation.hpp"
 #include "ui_painter.hpp"
+#include "ui_styles.hpp"
 #include "ui_widget.hpp"
 
 #include "file_wrapper.hpp"
@@ -78,11 +78,6 @@ class TextViewer : public Widget {
    private:
     static constexpr int8_t char_width = 5;
     static constexpr int8_t char_height = 8;
-    static constexpr Style style_text{
-        .font = font::fixed_5x8,
-        .background = Color::black(),
-        .foreground = Color::white(),
-    };
 
     const uint8_t max_line = 32;
     const uint8_t max_col = 48;

--- a/firmware/application/apps/ui_tone_search.hpp
+++ b/firmware/application/apps/ui_tone_search.hpp
@@ -23,7 +23,6 @@
 #include "receiver_model.hpp"
 
 #include "ui_receiver.hpp"
-#include "ui_font_fixed_8x16.hpp"
 
 namespace ui {
 

--- a/firmware/application/debug.cpp
+++ b/firmware/application/debug.cpp
@@ -50,17 +50,17 @@ void draw_guru_meditation_header(uint8_t source, const char* hint) {
         Color::black());
 
     // NOTE: in situations like a hard fault it seems not possible to write strings longer than 16 characters.
-    painter.draw_string({48, 24}, Styles::style_default, "M? Guru");
-    painter.draw_string({48 + 8 * 8, 24}, Styles::style_default, "Meditation");
+    painter.draw_string({48, 24}, Styles::white, "M? Guru");
+    painter.draw_string({48 + 8 * 8, 24}, Styles::white, "Meditation");
 
     if (source == CORTEX_M0)
-        painter.draw_string({48 + 8, 24}, Styles::style_default, "0");
+        painter.draw_string({48 + 8, 24}, Styles::white, "0");
 
     if (source == CORTEX_M4)
-        painter.draw_string({48 + 8, 24}, Styles::style_default, "4");
+        painter.draw_string({48 + 8, 24}, Styles::white, "4");
 
-    painter.draw_string({15, 55}, Styles::style_default, "Hint: ");
-    painter.draw_string({15 + 8 * 8, 55}, Styles::style_default, hint);
+    painter.draw_string({15, 55}, Styles::white, "Hint: ");
+    painter.draw_string({15 + 8 * 8, 55}, Styles::white, hint);
 }
 
 void draw_guru_meditation(uint8_t source, const char* hint) {
@@ -113,8 +113,8 @@ void draw_guru_meditation(uint8_t source, const char* hint, struct extctx* ctxp,
 void draw_line(int32_t y_offset, const char* label, regarm_t value) {
     Painter painter;
 
-    painter.draw_string({15, y_offset}, Styles::style_default, label);
-    painter.draw_string({15 + 8 * 8, y_offset}, Styles::style_default, to_string_hex((uint32_t)value, 8));
+    painter.draw_string({15, y_offset}, Styles::white, label);
+    painter.draw_string({15 + 8 * 8, y_offset}, Styles::white, to_string_hex((uint32_t)value, 8));
 }
 
 void runtime_error(LED led) {

--- a/firmware/application/debug.cpp
+++ b/firmware/application/debug.cpp
@@ -26,10 +26,11 @@
 #include <hal.h>
 #include <string>
 
-#include "ui_painter.hpp"
 #include "portapack.hpp"
-#include "ui_font_fixed_8x16.hpp"
 #include "string_format.hpp"
+#include "ui_styles.hpp"
+
+using namespace ui;
 
 void runtime_error(LED);
 std::string number_to_hex_string(uint32_t);
@@ -37,33 +38,29 @@ void draw_line(int32_t, const char*, regarm_t);
 static bool error_shown = false;
 
 void draw_guru_meditation_header(uint8_t source, const char* hint) {
-    ui::Painter painter;
-    ui::Style style_default{
-        .font = ui::font::fixed_8x16,
-        .background = ui::Color::black(),
-        .foreground = ui::Color::white()};
+    Painter painter;
 
     painter.fill_rectangle(
         {0, 0, portapack::display.width(), portapack::display.height()},
-        ui::Color::red());
+        Color::red());
 
     constexpr int border = 8;
     painter.fill_rectangle(
         {border, border, portapack::display.width() - (border * 2), portapack::display.height() - (border * 2)},
-        ui::Color::black());
+        Color::black());
 
     // NOTE: in situations like a hard fault it seems not possible to write strings longer than 16 characters.
-    painter.draw_string({48, 24}, style_default, "M? Guru");
-    painter.draw_string({48 + 8 * 8, 24}, style_default, "Meditation");
+    painter.draw_string({48, 24}, Styles::style_default, "M? Guru");
+    painter.draw_string({48 + 8 * 8, 24}, Styles::style_default, "Meditation");
 
     if (source == CORTEX_M0)
-        painter.draw_string({48 + 8, 24}, style_default, "0");
+        painter.draw_string({48 + 8, 24}, Styles::style_default, "0");
 
     if (source == CORTEX_M4)
-        painter.draw_string({48 + 8, 24}, style_default, "4");
+        painter.draw_string({48 + 8, 24}, Styles::style_default, "4");
 
-    painter.draw_string({15, 55}, style_default, "Hint: ");
-    painter.draw_string({15 + 8 * 8, 55}, style_default, hint);
+    painter.draw_string({15, 55}, Styles::style_default, "Hint: ");
+    painter.draw_string({15 + 8 * 8, 55}, Styles::style_default, hint);
 }
 
 void draw_guru_meditation(uint8_t source, const char* hint) {
@@ -114,14 +111,10 @@ void draw_guru_meditation(uint8_t source, const char* hint, struct extctx* ctxp,
 }
 
 void draw_line(int32_t y_offset, const char* label, regarm_t value) {
-    ui::Painter painter;
-    ui::Style style_default{
-        .font = ui::font::fixed_8x16,
-        .background = ui::Color::black(),
-        .foreground = ui::Color::white()};
+    Painter painter;
 
-    painter.draw_string({15, y_offset}, style_default, label);
-    painter.draw_string({15 + 8 * 8, y_offset}, style_default, to_string_hex((uint32_t)value, 8));
+    painter.draw_string({15, y_offset}, Styles::style_default, label);
+    painter.draw_string({15 + 8 * 8, y_offset}, Styles::style_default, to_string_hex((uint32_t)value, 8));
 }
 
 void runtime_error(LED led) {

--- a/firmware/application/event_m0.cpp
+++ b/firmware/application/event_m0.cpp
@@ -42,7 +42,6 @@ using namespace lpc43xx;
 
 #include <array>
 
-#include "ui_font_fixed_8x16.hpp"
 #include "ui_navigation.hpp"
 
 extern "C" {

--- a/firmware/application/recent_entries.hpp
+++ b/firmware/application/recent_entries.hpp
@@ -23,7 +23,6 @@
 #define __RECENT_ENTRIES_H__
 
 #include "ui_widget.hpp"
-#include "ui_font_fixed_8x16.hpp"
 
 #include <cstddef>
 #include <cstdint>

--- a/firmware/application/ui/ui_freqlist.cpp
+++ b/firmware/application/ui/ui_freqlist.cpp
@@ -84,7 +84,7 @@ void FreqManUIList::paint(Painter& painter) {
                     Color::white());
                 painter.draw_string(
                     {0, r.location().y() + (int)nb_lines * char_height},
-                    style_highlight, description);
+                    Styles::bg_white, description);
             } else {
                 painter.draw_string(
                     {0, r.location().y() + (int)nb_lines * char_height},

--- a/firmware/application/ui/ui_freqlist.cpp
+++ b/firmware/application/ui/ui_freqlist.cpp
@@ -69,9 +69,9 @@ void FreqManUIList::paint(Painter& painter) {
     if (freqlist_db.size() == 0)
         return;
     // coloration if file is too big
-    Style* text_color = &style_default;
+    auto text_color = &Styles::style_default;
     if (freqlist_db.size() > FREQMAN_MAX_PER_FILE)
-        text_color = &style_yellow;
+        text_color = &Styles::style_yellow;
     uint8_t nb_lines = 0;
     for (uint8_t it = current_index; it < freqlist_db.size(); it++) {
         uint8_t line_height = (int)nb_lines * char_height;

--- a/firmware/application/ui/ui_freqlist.cpp
+++ b/firmware/application/ui/ui_freqlist.cpp
@@ -69,9 +69,9 @@ void FreqManUIList::paint(Painter& painter) {
     if (freqlist_db.size() == 0)
         return;
     // coloration if file is too big
-    auto text_color = &Styles::style_default;
+    auto text_color = &Styles::white;
     if (freqlist_db.size() > FREQMAN_MAX_PER_FILE)
-        text_color = &Styles::style_yellow;
+        text_color = &Styles::yellow;
     uint8_t nb_lines = 0;
     for (uint8_t it = current_index; it < freqlist_db.size(); it++) {
         uint8_t line_height = (int)nb_lines * char_height;

--- a/firmware/application/ui/ui_freqlist.hpp
+++ b/firmware/application/ui/ui_freqlist.hpp
@@ -23,9 +23,9 @@
 #define __UI_FREQLIST_H__
 
 #include "ui.hpp"
-#include "ui_font_fixed_5x8.hpp"
 #include "ui_widget.hpp"
 #include "ui_painter.hpp"
+#include "ui_styles.hpp"
 #include "event_m0.hpp"
 #include "message.hpp"
 #include "freqman.hpp"
@@ -61,16 +61,6 @@ class FreqManUIList : public Widget {
     void set_db(freqman_db& db);
 
    private:
-    Style style_default{
-        .font = font::fixed_8x16,
-        .background = Color::black(),
-        .foreground = Color::white(),
-    };
-    Style style_yellow{
-        .font = font::fixed_8x16,
-        .background = Color::black(),
-        .foreground = Color::yellow(),
-    };
     static constexpr int8_t char_height = 16;
     bool instant_exec_{false};
     freqman_db freqlist_db{};

--- a/firmware/application/ui/ui_geomap.hpp
+++ b/firmware/application/ui/ui_geomap.hpp
@@ -26,7 +26,6 @@
 #include "ui.hpp"
 #include "file.hpp"
 #include "ui_navigation.hpp"
-#include "ui_font_fixed_8x16.hpp"
 
 #include "portapack.hpp"
 

--- a/firmware/application/ui/ui_qrcode.hpp
+++ b/firmware/application/ui/ui_qrcode.hpp
@@ -26,7 +26,6 @@
 #include "ui.hpp"
 
 #include "ui_navigation.hpp"
-#include "ui_font_fixed_8x16.hpp"
 #include "qrcodegen.hpp"
 #include "portapack.hpp"
 

--- a/firmware/application/ui/ui_styles.cpp
+++ b/firmware/application/ui/ui_styles.cpp
@@ -26,73 +26,73 @@
 
 using namespace ui;
 
-const Style Styles::style_default{
+const Style Styles::white{
     .font = ui::font::fixed_8x16,
     .background = ui::Color::black(),
     .foreground = ui::Color::white(),
 };
 
-const Style Styles::style_small{
+const Style Styles::white_small{
     .font = font::fixed_5x8,
     .background = Color::black(),
     .foreground = Color::white(),
 };
 
-const Style Styles::style_grey{
-    .font = font::fixed_8x16,
-    .background = Color::black(),
-    .foreground = Color::grey(),
-};
-
-const Style Styles::style_yellow{
+const Style Styles::yellow{
     .font = font::fixed_8x16,
     .background = Color::black(),
     .foreground = Color::yellow(),
 };
 
-const Style Styles::style_green{
+const Style Styles::green{
     .font = font::fixed_8x16,
     .background = Color::black(),
     .foreground = Color::green(),
 };
 
-const Style Styles::style_red{
+const Style Styles::red{
     .font = font::fixed_8x16,
     .background = Color::black(),
     .foreground = Color::red(),
 };
 
-const Style Styles::style_blue{
+const Style Styles::blue{
     .font = font::fixed_8x16,
     .background = Color::black(),
     .foreground = Color::blue(),
 };
 
-const Style Styles::style_bg_blue{
+const Style Styles::bg_blue{
     .font = font::fixed_8x16,
     .background = Color::blue(),
     .foreground = Color::white(),
 };
 
-const Style Styles::style_dark_grey{
-    .font = font::fixed_8x16,
-    .background = Color::black(),
-    .foreground = Color::dark_grey(),
-};
-
-const Style Styles::style_bg_dark_grey{
-    .font = font::fixed_8x16,
-    .background = Color::dark_grey(),
-    .foreground = Color::white(),
-};
-
-const Style Styles::style_light_grey{
+const Style Styles::light_grey{
     .font = font::fixed_8x16,
     .background = Color::black(),
     .foreground = Color::light_grey(),
 };
 
-const Style Styles::style_orange{
+const Style Styles::grey{
+    .font = font::fixed_8x16,
+    .background = Color::black(),
+    .foreground = Color::grey(),
+};
+
+const Style Styles::dark_grey{
+    .font = font::fixed_8x16,
+    .background = Color::black(),
+    .foreground = Color::dark_grey(),
+};
+
+const Style Styles::bg_dark_grey{
+    .font = font::fixed_8x16,
+    .background = Color::dark_grey(),
+    .foreground = Color::white(),
+};
+
+const Style Styles::orange{
     .font = font::fixed_8x16,
     .background = Color::black(),
     .foreground = Color::orange(),

--- a/firmware/application/ui/ui_styles.cpp
+++ b/firmware/application/ui/ui_styles.cpp
@@ -80,6 +80,12 @@ const Style Styles::style_dark_grey{
     .foreground = Color::dark_grey(),
 };
 
+const Style Styles::style_bg_dark_grey{
+    .font = font::fixed_8x16,
+    .background = Color::dark_grey(),
+    .foreground = Color::white(),
+};
+
 const Style Styles::style_light_grey{
     .font = font::fixed_8x16,
     .background = Color::black(),

--- a/firmware/application/ui/ui_styles.cpp
+++ b/firmware/application/ui/ui_styles.cpp
@@ -32,6 +32,12 @@ const Style Styles::white{
     .foreground = ui::Color::white(),
 };
 
+const Style Styles::bg_white{
+    .font = ui::font::fixed_8x16,
+    .background = ui::Color::white(),
+    .foreground = ui::Color::black(),
+};
+
 const Style Styles::white_small{
     .font = font::fixed_5x8,
     .background = Color::black(),

--- a/firmware/application/ui/ui_styles.cpp
+++ b/firmware/application/ui/ui_styles.cpp
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2023 Kyle Reed
+ *
+ * This file is part of PortaPack.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#include "ui_styles.hpp"
+#include "ui_painter.hpp"
+#include "ui_font_fixed_5x8.hpp"
+#include "ui_font_fixed_8x16.hpp"
+
+using namespace ui;
+
+const Style Styles::style_default{
+    .font = ui::font::fixed_8x16,
+    .background = ui::Color::black(),
+    .foreground = ui::Color::white()
+};
+
+const Style Styles::style_small{
+    .font = font::fixed_5x8,
+    .background = Color::black(),
+    .foreground = Color::white(),
+};
+
+const Style Styles::style_grey{
+    .font = font::fixed_8x16,
+    .background = Color::black(),
+    .foreground = Color::grey(),
+};
+
+const Style Styles::style_yellow{
+    .font = font::fixed_8x16,
+    .background = Color::black(),
+    .foreground = Color::yellow(),
+};
+
+const Style Styles::style_green{
+    .font = font::fixed_8x16,
+    .background = Color::black(),
+    .foreground = Color::green(),
+};
+
+const Style Styles::style_red{
+    .font = font::fixed_8x16,
+    .background = Color::black(),
+    .foreground = Color::red(),
+};
+
+const Style Styles::style_blue{
+    .font = font::fixed_8x16,
+    .background = Color::black(),
+    .foreground = Color::blue(),
+};
+
+const Style Styles::style_bg_blue{
+    .font = font::fixed_8x16,
+    .background = Color::blue(),
+    .foreground = Color::white(),
+};
+
+const Style Styles::style_dark_grey{
+    .font = font::fixed_8x16,
+    .background = Color::black(),
+    .foreground = Color::dark_grey(),
+};
+
+const Style Styles::style_light_grey{
+    .font = font::fixed_8x16,
+    .background = Color::black(),
+    .foreground = Color::light_grey(),
+};
+
+const Style Styles::style_orange{
+    .font = font::fixed_8x16,
+    .background = Color::black(),
+    .foreground = Color::orange(),
+};

--- a/firmware/application/ui/ui_styles.cpp
+++ b/firmware/application/ui/ui_styles.cpp
@@ -29,7 +29,7 @@ using namespace ui;
 const Style Styles::style_default{
     .font = ui::font::fixed_8x16,
     .background = ui::Color::black(),
-    .foreground = ui::Color::white()
+    .foreground = ui::Color::white(),
 };
 
 const Style Styles::style_small{

--- a/firmware/application/ui/ui_styles.hpp
+++ b/firmware/application/ui/ui_styles.hpp
@@ -28,41 +28,41 @@ namespace ui {
 
 class Styles {
    public:
-    /* The default font, white on black background. */
-    static const Style style_default;
+    /* White foreground. */
+    static const Style white;
 
-    /* The small font, white on black background. */
-    static const Style style_small;
-
-    /* Grey foreground. */
-    static const Style style_grey;
+    /* White foreground, small font. */
+    static const Style white_small;
 
     /* Yellow foreground. */
-    static const Style style_yellow;
+    static const Style yellow;
 
     /* Green foreground. */
-    static const Style style_green;
+    static const Style green;
 
     /* Red foreground. */
-    static const Style style_red;
+    static const Style red;
 
     /* Blue foreground. */
-    static const Style style_blue;
+    static const Style blue;
 
     /* Blue background. */
-    static const Style style_bg_blue;
-
-    /* Dark grey foreground. */
-    static const Style style_dark_grey;
-
-    /* Dark grey background. */
-    static const Style style_bg_dark_grey;
+    static const Style bg_blue;
 
     /* Light grey foreground. */
-    static const Style style_light_grey;
+    static const Style light_grey;
+
+    /* Grey foreground. */
+    static const Style grey;
+
+    /* Dark grey foreground. */
+    static const Style dark_grey;
+
+    /* Dark grey background. */
+    static const Style bg_dark_grey;
 
     /* Orange foreground. */
-    static const Style style_orange;
+    static const Style orange;
 };
 
 }  // namespace ui

--- a/firmware/application/ui/ui_styles.hpp
+++ b/firmware/application/ui/ui_styles.hpp
@@ -55,6 +55,9 @@ class Styles {
     /* Dark grey foreground. */
     static const Style style_dark_grey;
 
+    /* Dark grey background. */
+    static const Style style_bg_dark_grey;
+
     /* Light grey foreground. */
     static const Style style_light_grey;
 

--- a/firmware/application/ui/ui_styles.hpp
+++ b/firmware/application/ui/ui_styles.hpp
@@ -31,6 +31,9 @@ class Styles {
     /* White foreground. */
     static const Style white;
 
+    /* White background. */
+    static const Style bg_white;
+
     /* White foreground, small font. */
     static const Style white_small;
 

--- a/firmware/application/ui/ui_styles.hpp
+++ b/firmware/application/ui/ui_styles.hpp
@@ -19,29 +19,49 @@
  * Boston, MA 02110-1301, USA.
  */
 
-#ifndef __UI_SS_VIEWER_H__
-#define __UI_SS_VIEWER_H__
+#ifndef __UI_STYLES_H__
+#define __UI_STYLES_H__
 
-#include "ui.hpp"
-#include "ui_navigation.hpp"
 #include "ui_painter.hpp"
-#include "ui_styles.hpp"
-#include "ui_widget.hpp"
-#include "file.hpp"
 
 namespace ui {
 
-class ScreenshotViewer : public View {
+class Styles {
    public:
-    ScreenshotViewer(NavigationView& nav, const std::filesystem::path& path);
-    bool on_key(KeyEvent key) override;
-    void paint(Painter& painter) override;
+    /* The default font, white on black background. */
+    static const Style style_default;
 
-   private:
-    NavigationView& nav_;
-    std::filesystem::path path_{};
+    /* The small font, white on black background. */
+    static const Style style_small;
+
+    /* Grey foreground. */
+    static const Style style_grey;
+
+    /* Yellow foreground. */
+    static const Style style_yellow;
+
+    /* Green foreground. */
+    static const Style style_green;
+
+    /* Red foreground. */
+    static const Style style_red;
+
+    /* Blue foreground. */
+    static const Style style_blue;
+
+    /* Blue background. */
+    static const Style style_bg_blue;
+
+    /* Dark grey foreground. */
+    static const Style style_dark_grey;
+
+    /* Light grey foreground. */
+    static const Style style_light_grey;
+
+    /* Orange foreground. */
+    static const Style style_orange;
 };
 
 }  // namespace ui
 
-#endif  // __UI_SS_VIEWER_H__
+#endif /*__UI_STYLES_H__*/

--- a/firmware/application/ui/ui_tabview.cpp
+++ b/firmware/application/ui/ui_tabview.cpp
@@ -21,7 +21,7 @@
  */
 
 #include "ui_tabview.hpp"
-#include  "ui_font_fixed_8x16.hpp"
+#include "ui_font_fixed_8x16.hpp"
 
 #include "portapack.hpp"
 using namespace portapack;

--- a/firmware/application/ui/ui_tabview.cpp
+++ b/firmware/application/ui/ui_tabview.cpp
@@ -21,6 +21,7 @@
  */
 
 #include "ui_tabview.hpp"
+#include  "ui_font_fixed_8x16.hpp"
 
 #include "portapack.hpp"
 using namespace portapack;

--- a/firmware/application/ui/ui_transmitter.hpp
+++ b/firmware/application/ui/ui_transmitter.hpp
@@ -26,9 +26,9 @@
 #include "ui.hpp"
 #include "ui_navigation.hpp"
 #include "ui_painter.hpp"
+#include "ui_styles.hpp"
 #include "ui_widget.hpp"
 #include "ui_receiver.hpp"
-#include "ui_font_fixed_8x16.hpp"
 
 #include "rf_path.hpp"
 
@@ -73,36 +73,13 @@ class TransmitterView : public View {
     void set_transmitting(const bool transmitting);
 
    private:
-    const Style style_start{
-        .font = font::fixed_8x16,
-        .background = Color::black(),
-        .foreground = Color::green(),
-    };
-    const Style style_stop{
-        .font = font::fixed_8x16,
-        .background = Color::black(),
-        .foreground = Color::red(),
-    };
-    const Style style_locked{
-        .font = font::fixed_8x16,
-        .background = Color::black(),
-        .foreground = Color::dark_grey(),
-    };
-    const Style style_power_low{
-        .font = font::fixed_8x16,
-        .background = Color::black(),
-        .foreground = Color::yellow(),
-    };
-    const Style style_power_med{
-        .font = font::fixed_8x16,
-        .background = Color::black(),
-        .foreground = Color::orange(),
-    };
-    const Style style_power_high{
-        .font = font::fixed_8x16,
-        .background = Color::black(),
-        .foreground = Color::red(),
-    };
+
+    const Style& style_start = Styles::style_green;
+    const Style style_stop = Styles::style_red;
+    const Style style_locked = Styles::style_dark_grey;
+    const Style style_power_low = Styles::style_yellow;
+    const Style style_power_med = Styles::style_orange;
+    const Style style_power_high = Styles::style_red;
 
     bool lock_{false};
     bool transmitting_{false};
@@ -168,21 +145,9 @@ class TransmitterView2 : public View {
     void paint(Painter& painter) override;
 
    private:
-    const Style style_power_low{
-        .font = font::fixed_8x16,
-        .background = Color::black(),
-        .foreground = Color::yellow(),
-    };
-    const Style style_power_med{
-        .font = font::fixed_8x16,
-        .background = Color::black(),
-        .foreground = Color::orange(),
-    };
-    const Style style_power_high{
-        .font = font::fixed_8x16,
-        .background = Color::black(),
-        .foreground = Color::red(),
-    };
+    const Style& style_power_low = Styles::style_yellow;
+    const Style& style_power_med = Styles::style_orange;
+    const Style& style_power_high = Styles::style_red;
 
     Text text_gain_amp{
         {0, 3 * 8, 5 * 8, 1 * 16},

--- a/firmware/application/ui/ui_transmitter.hpp
+++ b/firmware/application/ui/ui_transmitter.hpp
@@ -73,7 +73,6 @@ class TransmitterView : public View {
     void set_transmitting(const bool transmitting);
 
    private:
-
     const Style& style_start = Styles::style_green;
     const Style style_stop = Styles::style_red;
     const Style style_locked = Styles::style_dark_grey;

--- a/firmware/application/ui/ui_transmitter.hpp
+++ b/firmware/application/ui/ui_transmitter.hpp
@@ -73,12 +73,12 @@ class TransmitterView : public View {
     void set_transmitting(const bool transmitting);
 
    private:
-    const Style& style_start = Styles::style_green;
-    const Style style_stop = Styles::style_red;
-    const Style style_locked = Styles::style_dark_grey;
-    const Style style_power_low = Styles::style_yellow;
-    const Style style_power_med = Styles::style_orange;
-    const Style style_power_high = Styles::style_red;
+    const Style& style_start = Styles::green;
+    const Style style_stop = Styles::red;
+    const Style style_locked = Styles::dark_grey;
+    const Style style_power_low = Styles::yellow;
+    const Style style_power_med = Styles::orange;
+    const Style style_power_high = Styles::red;
 
     bool lock_{false};
     bool transmitting_{false};
@@ -144,9 +144,9 @@ class TransmitterView2 : public View {
     void paint(Painter& painter) override;
 
    private:
-    const Style& style_power_low = Styles::style_yellow;
-    const Style& style_power_med = Styles::style_orange;
-    const Style& style_power_high = Styles::style_red;
+    const Style& style_power_low = Styles::yellow;
+    const Style& style_power_med = Styles::orange;
+    const Style& style_power_high = Styles::red;
 
     Text text_gain_amp{
         {0, 3 * 8, 5 * 8, 1 * 16},

--- a/firmware/application/ui_loadmodule.hpp
+++ b/firmware/application/ui_loadmodule.hpp
@@ -26,7 +26,6 @@
 #include "ui_menu.hpp"
 #include "ui_navigation.hpp"
 #include "core_control.hpp"
-#include "ui_font_fixed_8x16.hpp"
 
 namespace ui {
 

--- a/firmware/application/ui_navigation.cpp
+++ b/firmware/application/ui_navigation.cpp
@@ -143,7 +143,7 @@ SystemStatusView::SystemStatusView(
     }
 
     button_back.id = -1;  // Special ID used by FocusManager
-    title.set_style(&Styles::style_dark_grey);
+    title.set_style(&Styles::style_bg_dark_grey);
 
     if (portapack::persistent_memory::stealth_mode())
         button_stealth.set_foreground(ui::Color::green());

--- a/firmware/application/ui_navigation.cpp
+++ b/firmware/application/ui_navigation.cpp
@@ -44,6 +44,7 @@
 #include "ui_debug.hpp"
 #include "ui_encoders.hpp"
 #include "ui_fileman.hpp"
+#include "ui_font_fixed_8x16.hpp"
 #include "ui_freqman.hpp"
 #include "ui_jammer.hpp"
 // #include "ui_keyfob.hpp"
@@ -65,6 +66,7 @@
 #include "ui_siggen.hpp"
 #include "ui_sonde.hpp"
 #include "ui_sstvtx.hpp"
+#include "ui_styles.hpp"
 // #include "ui_test.hpp"
 #include "ui_text_editor.hpp"
 #include "ui_tone_search.hpp"
@@ -104,11 +106,6 @@ namespace ui {
 SystemStatusView::SystemStatusView(
     NavigationView& nav)
     : nav_(nav) {
-    static constexpr Style style_systemstatus{
-        .font = font::fixed_8x16,
-        .background = Color::dark_grey(),
-        .foreground = Color::white(),
-    };
 
     add_children({
         &backdrop,
@@ -147,7 +144,7 @@ SystemStatusView::SystemStatusView(
     }
 
     button_back.id = -1;  // Special ID used by FocusManager
-    title.set_style(&style_systemstatus);
+    title.set_style(&Styles::style_dark_grey);
 
     if (portapack::persistent_memory::stealth_mode())
         button_stealth.set_foreground(ui::Color::green());
@@ -645,17 +642,12 @@ SystemMenuView::SystemMenuView(NavigationView& nav) {
 
 /* SystemView ************************************************************/
 
-static constexpr ui::Style style_default{
-    .font = ui::font::fixed_8x16,
-    .background = ui::Color::black(),
-    .foreground = ui::Color::white()};
-
 SystemView::SystemView(
     Context& context,
     const Rect parent_rect)
     : View{parent_rect},
       context_(context) {
-    set_style(&style_default);
+    set_style(&ui::Styles::style_default);
 
     constexpr ui::Dim status_view_height = 16;
     constexpr ui::Dim info_view_height = 16;

--- a/firmware/application/ui_navigation.cpp
+++ b/firmware/application/ui_navigation.cpp
@@ -106,7 +106,6 @@ namespace ui {
 SystemStatusView::SystemStatusView(
     NavigationView& nav)
     : nav_(nav) {
-
     add_children({
         &backdrop,
         &button_back,

--- a/firmware/application/ui_navigation.cpp
+++ b/firmware/application/ui_navigation.cpp
@@ -143,7 +143,7 @@ SystemStatusView::SystemStatusView(
     }
 
     button_back.id = -1;  // Special ID used by FocusManager
-    title.set_style(&Styles::style_bg_dark_grey);
+    title.set_style(&Styles::bg_dark_grey);
 
     if (portapack::persistent_memory::stealth_mode())
         button_stealth.set_foreground(ui::Color::green());
@@ -646,7 +646,7 @@ SystemView::SystemView(
     const Rect parent_rect)
     : View{parent_rect},
       context_(context) {
-    set_style(&ui::Styles::style_default);
+    set_style(&ui::Styles::white);
 
     constexpr ui::Dim status_view_height = 16;
     constexpr ui::Dim info_view_height = 16;

--- a/firmware/common/ui_widget.hpp
+++ b/firmware/common/ui_widget.hpp
@@ -27,7 +27,6 @@
 #include "ui_text.hpp"
 #include "ui_painter.hpp"
 #include "ui_focus.hpp"
-#include "ui_font_fixed_8x16.hpp"
 #include "rtc_time.hpp"
 #include "radio.hpp"
 


### PR DESCRIPTION
Consolidate Style object into shared, named instanced like we have for Colors. Saves 430 bytes on the image and cleans up a lot of code.

Should have no functional changes. Lots of files, but all the changes are simple.