### PR TITLE
fixing edit freq,edit desc, delete freq

### DIFF
--- a/firmware/application/apps/ui_freqman.cpp
+++ b/firmware/application/apps/ui_freqman.cpp
@@ -88,14 +88,12 @@ void FreqManBaseView::change_category(int32_t category_id) {
     current_category_id = category_id;
 
     std::vector<freqman_entry>().swap(database);
-    menu_view.set_db(database);
 
     if (!load_freqman_file(file_list[categories[current_category_id].second], database)) {
         error_ = ERROR_ACCESS;
-    } else {
-        menu_view.set_db(database);
-        menu_view.set_dirty();
     }
+    menu_view.set_db(database);
+    menu_view.set_dirty();
     if (!database.size()) {
         if (on_refresh_widgets)
             on_refresh_widgets(true);

--- a/firmware/application/apps/ui_freqman.hpp
+++ b/firmware/application/apps/ui_freqman.hpp
@@ -49,14 +49,13 @@ class FreqManBaseView : public View {
     std::function<void(int32_t category_id)> on_change_category{nullptr};
     std::function<void(void)> on_select_frequency{nullptr};
     std::function<void(bool)> on_refresh_widgets{nullptr};
-    std::vector<std::string> file_list{};
-    int32_t current_category_id{0};
 
-    void populate_categories();
+    void get_freqman_files();
     void change_category(int32_t category_id);
     void refresh_list();
 
     freqman_db database{};
+    std::vector<std::string> file_list{};
 
     Labels label_category{
         {{0, 4}, "Category:", Color::light_grey()}};
@@ -77,6 +76,8 @@ class FreqManBaseView : public View {
     Button button_exit{
         {20 * 8, 34 * 8, 10 * 8, 4 * 8},
         "Exit"};
+
+   private:
 };
 
 class FrequencySaveView : public FreqManBaseView {

--- a/firmware/application/apps/ui_freqman.hpp
+++ b/firmware/application/apps/ui_freqman.hpp
@@ -74,7 +74,7 @@ class FreqManBaseView : public View {
     };
 
     Button button_exit{
-        {20 * 8, 34 * 8, 10 * 8, 4 * 8},
+        {16 * 8, 34 * 8, 14 * 8, 4 * 8},
         "Exit"};
 
    private:
@@ -155,7 +155,7 @@ class FrequencyManagerView : public FreqManBaseView {
         "Description"};
 
     Button button_delete{
-        {18 * 8, 27 * 8, 12 * 8, 32},
+        {16 * 8, 29 * 8, 14 * 8, 32},
         "Delete"};
 };
 

--- a/firmware/application/freqman.cpp
+++ b/firmware/application/freqman.cpp
@@ -86,22 +86,6 @@ options_t freqman_entry_steps_short = {
     {"500kHz", 500000},
     {"1MHz", 1000000}};
 
-std::vector<std::string> get_freqman_files() {
-    std::vector<std::string> file_list;
-
-    auto files = scan_root_files(u"FREQMAN", u"*.TXT");
-
-    for (auto file : files) {
-        std::string file_name = file.stem().string();
-        // don't propose tmp / hidden files in freqman's list
-        if (file_name.length() && file_name[0] != '.') {
-            file_list.emplace_back(file_name);
-        }
-    }
-
-    return file_list;
-};
-
 bool load_freqman_file(std::string& file_stem, freqman_db& db) {
     return load_freqman_file_ex(file_stem, db, true, true, true, FREQMAN_MAX_PER_FILE);
 }
@@ -299,26 +283,15 @@ bool get_freq_string(freqman_entry& entry, std::string& item_string) {
 
 bool save_freqman_file(std::string& file_stem, freqman_db& db) {
     File freqman_file;
-
-    std::string freq_file_path = "FREQMAN/" + file_stem + ".TXT";
-    std::string tmp_freq_file_path = "FREQMAN/" + file_stem + ".TXT.TMP";
-
-    if (!db.size()) {
-        delete_file("FREQMAN/" + file_stem + ".TXT");
-        return true;
-    }
-
-    delete_file(tmp_freq_file_path);
-    auto result = freqman_file.open(tmp_freq_file_path);
+    std::string freq_file_path = "/FREQMAN/" + file_stem + ".TXT";
+    delete_file(freq_file_path);
+    auto result = freqman_file.create(freq_file_path);
     if (!result.is_valid()) {
         for (size_t n = 0; n < db.size(); n++) {
-            std::string item_string;
-            auto& entry = db[n];
-            get_freq_string(entry, item_string);
-            freqman_file.write_line(item_string);
+            std::string line;
+            get_freq_string(db[n], line);
+            freqman_file.write_line(line);
         }
-        delete_file(freq_file_path);
-        rename_file(tmp_freq_file_path, freq_file_path);
         return true;
     }
     return false;

--- a/firmware/application/freqman.hpp
+++ b/firmware/application/freqman.hpp
@@ -95,7 +95,6 @@ struct freqman_entry {
 
 using freqman_db = std::vector<freqman_entry>;
 
-std::vector<std::string> get_freqman_files();
 bool load_freqman_file(std::string& file_stem, freqman_db& db);
 bool load_freqman_file_ex(std::string& file_stem, freqman_db& db, bool load_freqs, bool load_ranges, bool load_hamradios, uint8_t limit);
 bool get_freq_string(freqman_entry& entry, std::string& item_string);

--- a/firmware/application/ui/ui_freqlist.cpp
+++ b/firmware/application/ui/ui_freqlist.cpp
@@ -54,7 +54,7 @@ void FreqManUIList::set_highlighted_index(int index) {
 }
 
 uint8_t FreqManUIList::get_index() {
-    return current_index + highlighted_index ;
+    return current_index + highlighted_index;
 }
 
 void FreqManUIList::paint(Painter& painter) {
@@ -104,22 +104,17 @@ void FreqManUIList::paint(Painter& painter) {
 
 void FreqManUIList::set_db(freqman_db& db) {
     freqlist_db = db;
-    if( db.size() == 0 )
-    {
+    if (db.size() == 0) {
         current_index = 0;
         highlighted_index = 0;
-    }
-    else
-    {
-        if( (unsigned)(current_index + highlighted_index) >= db.size() )
-        {
-            current_index =  db.size() - 1 - highlighted_index ;
+    } else {
+        if ((unsigned)(current_index + highlighted_index) >= db.size()) {
+            current_index = db.size() - 1 - highlighted_index;
         }
-        if( current_index < 0 )
-        {
-            current_index = 0 ;
-            if( highlighted_index > 0 )
-                highlighted_index -- ;
+        if (current_index < 0) {
+            current_index = 0;
+            if (highlighted_index > 0)
+                highlighted_index--;
         }
     }
 }

--- a/firmware/application/ui/ui_freqlist.cpp
+++ b/firmware/application/ui/ui_freqlist.cpp
@@ -54,7 +54,7 @@ void FreqManUIList::set_highlighted_index(int index) {
 }
 
 uint8_t FreqManUIList::get_index() {
-    return current_index + highlighted_index;
+    return current_index + highlighted_index ;
 }
 
 void FreqManUIList::paint(Painter& painter) {
@@ -104,8 +104,24 @@ void FreqManUIList::paint(Painter& painter) {
 
 void FreqManUIList::set_db(freqman_db& db) {
     freqlist_db = db;
-    current_index = 0;
-    highlighted_index = 0;
+    if( db.size() == 0 )
+    {
+        current_index = 0;
+        highlighted_index = 0;
+    }
+    else
+    {
+        if( (unsigned)(current_index + highlighted_index) >= db.size() )
+        {
+            current_index =  db.size() - 1 - highlighted_index ;
+        }
+        if( current_index < 0 )
+        {
+            current_index = 0 ;
+            if( highlighted_index > 0 )
+                highlighted_index -- ;
+        }
+    }
 }
 
 void FreqManUIList::on_focus() {

--- a/firmware/application/ui/ui_freqlist.hpp
+++ b/firmware/application/ui/ui_freqlist.hpp
@@ -56,8 +56,9 @@ class FreqManUIList : public Widget {
     bool on_touch(const TouchEvent event) override;
     bool on_encoder(EncoderEvent delta) override;
 
-    void set_highlighted_index(int index);  // set highlighted_index and return capped highlighted_index value to set in caller
+    void set_highlighted_index(int index);  // internal set highlighted_index in list handler
     uint8_t get_index();                    // return highlighed + index
+    uint8_t set_index(uint8_t index);       // try to set current_index + highlighed from index, return capped index
     void set_db(freqman_db& db);
 
    private:


### PR DESCRIPTION
This PR fix freqman basic functionalities: 
-edit freq
-edit description
-delete freq
-delete button aligned with other buttons
-exit button aligned with delete button
-stay on same position after an edit/a delete, only change highlight if out of position

Fix rest of issues in https://github.com/eried/portapack-mayhem/issues/1113
