### PR TITLE
Dsp fatfs fix

### DIFF
--- a/firmware/baseband/dsp_goertzel.hpp
+++ b/firmware/baseband/dsp_goertzel.hpp
@@ -35,7 +35,7 @@ class GoertzelDetector {
 
    private:
     float coefficient{};
-    int16_t s[2]{0};
+    int16_t s[3]{0};
 };
 
 } /* namespace dsp */

--- a/firmware/chibios-portapack/ext/fatfs/src/ff.c
+++ b/firmware/chibios-portapack/ext/fatfs/src/ff.c
@@ -1835,7 +1835,7 @@ void gen_numname (
 		if (c > '9') c += 7;
 		ns[i--] = c;
 		seq /= 16;
-	} while (seq);
+	} while (seq && i != 0);
 	ns[i] = '~';
 
 	/* Append the number */


### PR DESCRIPTION
This fix the following potentially dangerous warnings:

```
portapack-mayhem/firmware/baseband/dsp_goertzel.cpp: In member function 'float dsp::GoertzelDetector::execute(const buffer_s16_t&)':
portapack-mayhem/firmware/baseband/dsp_goertzel.cpp:41:12: warning: array subscript 2 is above array bounds of 'int16_t [2]' {aka 'short int [2]'} [-Warray-bounds]
   41 |         s[2] = s[1];
      |         ~~~^
In file included from portapack-mayhem/firmware/baseband/dsp_goertzel.cpp:23:
portapack-mayhem/firmware/baseband/dsp_goertzel.hpp:38:13: note: while referencing 'dsp::GoertzelDetector::s'
   38 |     int16_t s[2]{0};
      |             ^
```
      
and

```
portapack-mayhem/firmware/baseband/dsp_goertzel.cpp: In member function 'float dsp::GoertzelDetector::execute(const buffer_s16_t&)':
portapack-mayhem/firmware/baseband/dsp_goertzel.cpp:41:12: warning: array subscript 2 is above array bounds of 'int16_t [2]' {aka 'short int [2]'} [-Warray-bounds]
   41 |         s[2] = s[1];
      |         ~~~^
In file included from portapack-mayhem/firmware/baseband/dsp_goertzel.cpp:23:
portapack-mayhem/firmware/baseband/dsp_goertzel.hpp:38:13: note: while referencing 'dsp::GoertzelDetector::s'
   38 |     int16_t s[2]{0};
      |             ^

```


