### PR TITLE
Fix crash when empty FreqMan files (#1113) and Fix missing Comma when editing text (#1125)

### DIFF
--- a/firmware/application/apps/ui_freqman.cpp
+++ b/firmware/application/apps/ui_freqman.cpp
@@ -277,9 +277,9 @@ FrequencyManagerView::FrequencyManagerView(
     };
 
     button_edit_freq.on_select = [this, &nav](Button&) {
-        if (database.empty()) 
+        if (database.empty()) {
             database.push_back({0, 0, "", SINGLE});
-
+        }
         auto new_view = nav.push<FrequencyKeypadView>(database[menu_view.get_index()].frequency_a);
         new_view->on_changed = [this](rf::Frequency f) {
             on_edit_freq(f);
@@ -287,9 +287,9 @@ FrequencyManagerView::FrequencyManagerView(
     };
 
     button_edit_desc.on_select = [this, &nav](Button&) {
-        if (database.empty()) 
+        if (database.empty()) {
             database.push_back({0, 0, "", SINGLE});
-
+        }
         desc_buffer = database[menu_view.get_index()].description;
         on_edit_desc(nav);
     };

--- a/firmware/application/apps/ui_freqman.cpp
+++ b/firmware/application/apps/ui_freqman.cpp
@@ -226,8 +226,13 @@ void FrequencyManagerView::on_new_category(NavigationView& nav) {
 }
 
 void FrequencyManagerView::on_delete() {
-    database.erase(database.begin() + menu_view.get_index());
-    save_freqman_file(file_list[categories[current_category_id].second], database);
+    if (database.empty()) {
+        delete_freqman_file(file_list[categories[current_category_id].second]);
+        refresh_list();
+    } else {
+        database.erase(database.begin() + menu_view.get_index());
+        save_freqman_file(file_list[categories[current_category_id].second], database);
+    }
     change_category(current_category_id);
 }
 
@@ -272,6 +277,9 @@ FrequencyManagerView::FrequencyManagerView(
     };
 
     button_edit_freq.on_select = [this, &nav](Button&) {
+        if (database.empty()) 
+            database.push_back({0, 0, "", SINGLE});
+
         auto new_view = nav.push<FrequencyKeypadView>(database[menu_view.get_index()].frequency_a);
         new_view->on_changed = [this](rf::Frequency f) {
             on_edit_freq(f);
@@ -279,6 +287,9 @@ FrequencyManagerView::FrequencyManagerView(
     };
 
     button_edit_desc.on_select = [this, &nav](Button&) {
+        if (database.empty()) 
+            database.push_back({0, 0, "", SINGLE});
+
         desc_buffer = database[menu_view.get_index()].description;
         on_edit_desc(nav);
     };

--- a/firmware/application/freqman.cpp
+++ b/firmware/application/freqman.cpp
@@ -281,6 +281,13 @@ bool get_freq_string(freqman_entry& entry, std::string& item_string) {
     return true;
 }
 
+bool delete_freqman_file(std::string& file_stem) {
+    File freqman_file;
+    std::string freq_file_path = "/FREQMAN/" + file_stem + ".TXT";
+    delete_file(freq_file_path);
+    return false;
+}
+
 bool save_freqman_file(std::string& file_stem, freqman_db& db) {
     File freqman_file;
     std::string freq_file_path = "/FREQMAN/" + file_stem + ".TXT";

--- a/firmware/application/freqman.hpp
+++ b/firmware/application/freqman.hpp
@@ -98,6 +98,7 @@ using freqman_db = std::vector<freqman_entry>;
 bool load_freqman_file(std::string& file_stem, freqman_db& db);
 bool load_freqman_file_ex(std::string& file_stem, freqman_db& db, bool load_freqs, bool load_ranges, bool load_hamradios, uint8_t limit);
 bool get_freq_string(freqman_entry& entry, std::string& item_string);
+bool delete_freqman_file(std::string& file_stem);
 bool save_freqman_file(std::string& file_stem, freqman_db& db);
 bool create_freqman_file(std::string& file_stem, File& freqman_file);
 

--- a/firmware/application/ui/ui_alphanum.hpp
+++ b/firmware/application/ui/ui_alphanum.hpp
@@ -43,8 +43,8 @@ class AlphanumView : public TextEntryView {
     bool on_encoder(const EncoderEvent delta) override;
 
    private:
-    const char* const keys_upper = "ABCDEFGHIJKLMNOPQRSTUVWXYZ' .<";
-    const char* const keys_lower = "abcdefghijklmnopqrstuvwxyz' .<";
+    const char* const keys_upper = "ABCDEFGHIJKLMNOPQRSTUVWXYZ, .<";
+    const char* const keys_lower = "abcdefghijklmnopqrstuvwxyz, .<";
     const char* const keys_digit = "0123456789!\"#'()*+-/:;=>?@[\\]<";
 
     const std::pair<std::string, const char*> key_sets[3] = {


### PR DESCRIPTION
Fixed "M0 hard fault" when an Empty frequency list file is selected and the DELETE button is pressed, or Frequency or Description is edited.

@gullradriel  Please review this change proposal.