### PR TITLE
fix pmem -> make backup_ram_t data members volatile

### DIFF
--- a/firmware/application/apps/ui_debug.cpp
+++ b/firmware/application/apps/ui_debug.cpp
@@ -25,6 +25,7 @@
 
 #include "radio.hpp"
 #include "string_format.hpp"
+#include "crc.hpp"
 
 #include "audio.hpp"
 
@@ -388,15 +389,28 @@ DebugMenuView::DebugMenuView(NavigationView& nav) {
 
 /* DebugPmemView *********************************************************/
 
+uint32_t pmem_checksum(volatile const uint32_t data[63]) {
+    CRC<32> crc{0x04c11db7, 0xffffffff, 0xffffffff};
+    for (size_t i = 0; i < 63; i++) {
+        const auto word = data[i];
+        crc.process_byte((word >> 0) & 0xff);
+        crc.process_byte((word >> 8) & 0xff);
+        crc.process_byte((word >> 16) & 0xff);
+        crc.process_byte((word >> 24) & 0xff);
+    }
+    return crc.checksum();
+}
+
 DebugPmemView::DebugPmemView(NavigationView& nav)
     : data{*reinterpret_cast<pmem_data*>(memory::map::backup_ram.base())}, registers_widget(RegistersWidgetConfig{page_size, 8}, std::bind(&DebugPmemView::registers_widget_feed, this, std::placeholders::_1)) {
     static_assert(sizeof(pmem_data) == memory::map::backup_ram.size());
 
-    add_children({&text_page, &registers_widget, &text_checksum, &button_ok});
+    add_children({&text_page, &registers_widget, &text_checksum, &text_checksum2, &button_ok});
 
     registers_widget.set_parent_rect({0, 32, 240, 192});
 
-    text_checksum.set("Size: " + to_string_dec_uint(portapack::persistent_memory::data_size()) + " CRC: " + to_string_hex(data.check_value, 8));
+    text_checksum.set("Size: " + to_string_dec_uint(portapack::persistent_memory::data_size(), 3) + "  CRC: " + to_string_hex(data.check_value, 8));
+    text_checksum2.set("Calculated CRC: " + to_string_hex(pmem_checksum(data.regfile), 8));
 
     button_ok.on_select = [&nav](Button&) {
         nav.pop();

--- a/firmware/application/apps/ui_debug.cpp
+++ b/firmware/application/apps/ui_debug.cpp
@@ -382,7 +382,7 @@ DebugMenuView::DebugMenuView(NavigationView& nav) {
         {"Peripherals", ui::Color::dark_cyan(), &bitmap_icon_peripherals, [&nav]() { nav.push<DebugPeripheralsMenuView>(); }},
         {"Temperature", ui::Color::dark_cyan(), &bitmap_icon_temperature, [&nav]() { nav.push<TemperatureView>(); }},
         {"Buttons Test", ui::Color::dark_cyan(), &bitmap_icon_controls, [&nav]() { nav.push<DebugControlsView>(); }},
-        {"Pmem", ui::Color::dark_cyan(), &bitmap_icon_memory, [&nav]() { nav.push<DebugPmemView>(); }},
+        {"P.mem", ui::Color::dark_cyan(), &bitmap_icon_memory, [&nav]() { nav.push<DebugPmemView>(); }},
     });
     set_max_rows(2);  // allow wider buttons
 }

--- a/firmware/application/apps/ui_debug.hpp
+++ b/firmware/application/apps/ui_debug.hpp
@@ -269,7 +269,7 @@ class DebugPmemView : public View {
     DebugPmemView(NavigationView& nav);
     void focus() override;
     bool on_encoder(const EncoderEvent delta) override;
-    std::string title() const override { return "Pmem"; }
+    std::string title() const override { return "P.mem"; }
 
    private:
     struct pmem_data {

--- a/firmware/application/apps/ui_debug.hpp
+++ b/firmware/application/apps/ui_debug.hpp
@@ -282,13 +282,14 @@ class DebugPmemView : public View {
 
     int32_t page{0};
 
-    const pmem_data& data;
+    volatile const pmem_data& data;
 
     Text text_page{{16, 16, 208, 16}};
 
     RegistersWidget registers_widget;
 
-    Text text_checksum{{16, 240, 208, 16}};
+    Text text_checksum{{16, 232, 208, 16}};
+    Text text_checksum2{{16, 248, 208, 16}};
 
     Button button_ok{
         {240 / 3, 270, 240 / 3, 24},

--- a/firmware/common/portapack_persistent_memory.cpp
+++ b/firmware/common/portapack_persistent_memory.cpp
@@ -354,8 +354,8 @@ struct data_t {
 
 struct backup_ram_t {
    private:
-    uint32_t regfile[63];
-    uint32_t check_value;
+    volatile uint32_t regfile[63];
+    volatile uint32_t check_value;
 
     static void copy(const backup_ram_t& src, backup_ram_t& dst) {
         for (size_t i = 0; i < 63; i++) {


### PR DESCRIPTION
plus add calculated crc to the pmem debug screen

Soo the issue with pmem on newer gcc was that its data members werent declared volatile and seemingly writes to it got optimized out..

After adding volatile everything seems to work smooth.

We also loose some optimization potential as the cached settings use the same type (backup_ram_t) as what we use to read the p.mem area, which now also becomes volatile. 