### PR TITLE
add dockerfile-nogit-arm

### DIFF
--- a/dockerfile-nogit-arm
+++ b/dockerfile-nogit-arm
@@ -1,0 +1,41 @@
+FROM ubuntu:xenial
+
+# Set location to download ARM toolkit from.
+# This will need to be changed over time or replaced with a static link to the latest release.
+ENV ARMBINURL=https://developer.arm.com/-/media/Files/downloads/gnu-rm/9-2019q4/gcc-arm-none-eabi-9-2019-q4-major-aarch64-linux.tar.bz2?revision=4583ce78-e7e7-459a-ad9f-bff8e94839f1&rev=4583ce78e7e7459aad9fbff8e94839f1&hash=C9B942D74CEA05FF9DE28380F267BB7D3F3B17A6 \
+	PATH=$HOME/bin:$PATH:/opt/build/armbin/bin
+
+#Create volume /havoc/bin for compiled firmware binaries
+VOLUME /havoc
+WORKDIR /havoc/firmware
+
+# Fetch dependencies from APT
+RUN apt-get update && \
+	apt-get install -y git tar wget dfu-util cmake python3 ccache bzip2 liblz4-tool curl && \
+	apt-get -qy autoremove
+
+#Install current pip from PyPa
+RUN curl https://bootstrap.pypa.io/pip/3.4/get-pip.py -o get-pip.py && \
+	python3 get-pip.py
+
+#Fetch additional dependencies from Python 3.x pip
+RUN pip install pyyaml
+RUN ln -s /usr/bin/python3 /usr/bin/python && \
+	ln -s /usr/bin/pip3 /usr/bin/pip
+
+ENV LANG C.UTF-8
+ENV LC_ALL C.UTF-8
+
+# Grab the GNU ARM toolchain from arm.com
+# Then extract contents to /opt/build/armbin/
+RUN mkdir /opt/build && cd /opt/build && \
+	wget -O gcc-arm-none-eabi $ARMBINURL && \
+	mkdir armbin && \
+	tar --strip=1 -xjvf gcc-arm-none-eabi -C armbin
+
+# Configure CCACHE
+RUN mkdir ~/bin && cd ~/bin && \
+	for tool in gcc g++ cpp c++;do ln -s $(which ccache) arm-none-eabi-$tool;done
+
+CMD cd .. && cd build && \
+	cmake .. && make firmware


### PR DESCRIPTION
The currently available docker files need to run in x86 emulation to work properly which is terribly slow, this adds a new dockerfile dockerfile-nogit-arm that downloads the native arm toolchain with the same version as the other nogit dockerfile that works on aarc64 docker hosts.