### PR TITLE
code cleaning, fast and slow mode adjustement, dc pixels displayed

### DIFF
--- a/firmware/application/apps/ui_looking_glass_app.cpp
+++ b/firmware/application/apps/ui_looking_glass_app.cpp
@@ -235,7 +235,7 @@ void GlassView::on_range_changed() {
         // view is made in multiple pass, use original bin picking
         mode = scan_type.selected_index_value();
         if (mode == LOOKING_GLASS_FASTSCAN) {
-            offset = 8 ;
+            offset = 8;
             ignore_dc = SPEC_NB_BINS - SCREEN_W - offset;
             bin_length = SCREEN_W;
         } else {  // if( mode == LOOKING_GLASS_SLOWSCAN )

--- a/firmware/application/apps/ui_looking_glass_app.cpp
+++ b/firmware/application/apps/ui_looking_glass_app.cpp
@@ -235,11 +235,11 @@ void GlassView::on_range_changed() {
         // view is made in multiple pass, use original bin picking
         mode = scan_type.selected_index_value();
         if (mode == LOOKING_GLASS_FASTSCAN) {
-            offset = 6;
+            offset = 8 ;
             ignore_dc = SPEC_NB_BINS - SCREEN_W - offset;
             bin_length = SCREEN_W;
         } else {  // if( mode == LOOKING_GLASS_SLOWSCAN )
-            offset = 134;
+            offset = 132;
             bin_length = 80;
             ignore_dc = 0;
         }

--- a/firmware/application/apps/ui_looking_glass_app.hpp
+++ b/firmware/application/apps/ui_looking_glass_app.hpp
@@ -37,6 +37,7 @@
 #include "spectrum_color_lut.hpp"
 
 namespace ui {
+
 #define LOOKING_GLASS_SLICE_WIDTH_MAX 20000000
 #define MHZ_DIV 1000000
 
@@ -81,10 +82,7 @@ class GlassView : public View {
     void get_max_power(const ChannelSpectrum& spectrum, uint8_t bin, uint8_t& max_power);
     rf::Frequency get_freq_from_bin_pos(uint8_t pos);
     void on_marker_change();
-    int64_t next_mult_of(int64_t num, int64_t multiplier);
-    void adjust_range(int64_t* f_min, int64_t* f_max, int64_t width);
     void retune();
-    bool move_to_next_position();
     void on_channel_spectrum(const ChannelSpectrum& spectrum);
     void do_timers();
     void on_range_changed();

--- a/firmware/application/apps/ui_looking_glass_app.hpp
+++ b/firmware/application/apps/ui_looking_glass_app.hpp
@@ -83,6 +83,7 @@ class GlassView : public View {
     rf::Frequency get_freq_from_bin_pos(uint8_t pos);
     void on_marker_change();
     void retune();
+    bool process_bins(uint8_t* powerlevel);
     void on_channel_spectrum(const ChannelSpectrum& spectrum);
     void do_timers();
     void on_range_changed();


### PR DESCRIPTION
-After a lot of testings, rounding are not doing any better job => removed
-Not displaying the 'ignore dc spike' pixels is making the marker calculation wrong so they are now displayed with a hack
-DC spike FastMode hack: color is (last value before the spike + next value after the spike) / 2
-Marker have been tested with a +-1 pixel precision in single pass, fast mode, slow mode
-Aligned fast and slow mode as much as possible
