### PR TITLE
Gcc12 related fixes

### DIFF
--- a/firmware/application/CMakeLists.txt
+++ b/firmware/application/CMakeLists.txt
@@ -27,6 +27,8 @@
 
 enable_language(C CXX ASM)
 
+include(CheckCXXCompilerFlag)
+
 project(application)
 
 # Compiler options here.
@@ -36,7 +38,13 @@ set(USE_OPT "-Os -g --specs=nano.specs")
 set(USE_COPT "-std=gnu99")
 
 # C++ specific options here (added to USE_OPT).
-set(USE_CPPOPT "-std=c++17 -fno-rtti -fno-exceptions -Weffc++ -Wuninitialized -Wno-volatile")
+check_cxx_compiler_flag("-std=c++20" cpp20_supported)
+if(cpp20_supported)
+	set(USE_CPPOPT "-std=c++20")
+else()
+	set(USE_CPPOPT "-std=c++17")
+endif()
+set(USE_CPPOPT "${USE_CPPOPT} -fno-rtti -fno-exceptions -Weffc++ -Wuninitialized -Wno-volatile")
 
 # Enable this if you want the linker to remove unused code and data
 set(USE_LINK_GC yes)

--- a/firmware/application/CMakeLists.txt
+++ b/firmware/application/CMakeLists.txt
@@ -36,7 +36,7 @@ set(USE_OPT "-Os -g --specs=nano.specs")
 set(USE_COPT "-std=gnu99")
 
 # C++ specific options here (added to USE_OPT).
-set(USE_CPPOPT "-std=c++17 -fno-rtti -fno-exceptions -Weffc++ -Wuninitialized")
+set(USE_CPPOPT "-std=c++17 -fno-rtti -fno-exceptions -Weffc++ -Wuninitialized -Wno-volatile")
 
 # Enable this if you want the linker to remove unused code and data
 set(USE_LINK_GC yes)

--- a/firmware/application/apps/tpms_app.hpp
+++ b/firmware/application/apps/tpms_app.hpp
@@ -38,10 +38,6 @@
 
 namespace std {
 
-constexpr bool operator==(const tpms::TransponderID& lhs, const tpms::TransponderID& rhs) {
-    return (lhs.value() == rhs.value());
-}
-
 } /* namespace std */
 
 struct TPMSRecentEntry {

--- a/firmware/application/hw/max283x.hpp
+++ b/firmware/application/hw/max283x.hpp
@@ -22,6 +22,8 @@
 #ifndef __MAX283X_H__
 #define __MAX283X_H__
 
+#include <array>
+
 #include "rf_path.hpp"
 
 namespace max283x {

--- a/firmware/application/rf_path.cpp
+++ b/firmware/application/rf_path.cpp
@@ -162,8 +162,8 @@ constexpr ConfigAmp config_amp(
     const Direction direction,
     const Band band) {
     return {{
-        {.direction = direction, .band = band, .amplify = false},
-        {.direction = direction, .band = band, .amplify = true},
+        Config(direction, band, false),
+        Config(direction, band, true),
     }};
 }
 

--- a/firmware/application/ui/ui_geomap.cpp
+++ b/firmware/application/ui/ui_geomap.cpp
@@ -136,7 +136,7 @@ GeoMap::GeoMap(
 }
 
 void GeoMap::paint(Painter& painter) {
-    u_int16_t line;
+    uint16_t line;
     std::array<ui::Color, 240> map_line_buffer;
     const auto r = screen_rect();
 

--- a/firmware/baseband/CMakeLists.txt
+++ b/firmware/baseband/CMakeLists.txt
@@ -36,7 +36,7 @@ set(USE_OPT "-O3 -g -falign-functions=16 -fno-math-errno --specs=nano.specs")
 set(USE_COPT "-std=gnu99")
 
 # C++ specific options here (added to USE_OPT).
-set(USE_CPPOPT "-std=c++17 -fno-rtti -fno-exceptions -Weffc++ -Wuninitialized")
+set(USE_CPPOPT "-std=c++17 -fno-rtti -fno-exceptions -Weffc++ -Wuninitialized -Wno-volatile")
 
 # Enable this if you want the linker to remove unused code and data
 set(USE_LINK_GC yes)

--- a/firmware/baseband/CMakeLists.txt
+++ b/firmware/baseband/CMakeLists.txt
@@ -27,6 +27,8 @@
 
 enable_language(C CXX ASM)
 
+include(CheckCXXCompilerFlag)
+
 project(baseband_shared)
 
 # Compiler options here.
@@ -36,7 +38,13 @@ set(USE_OPT "-O3 -g -falign-functions=16 -fno-math-errno --specs=nano.specs")
 set(USE_COPT "-std=gnu99")
 
 # C++ specific options here (added to USE_OPT).
-set(USE_CPPOPT "-std=c++17 -fno-rtti -fno-exceptions -Weffc++ -Wuninitialized -Wno-volatile")
+check_cxx_compiler_flag("-std=c++20" cpp20_supported)
+if(cpp20_supported)
+	set(USE_CPPOPT "-std=c++20")
+else()
+	set(USE_CPPOPT "-std=c++17")
+endif()
+set(USE_CPPOPT "${USE_CPPOPT} -fno-rtti -fno-exceptions -Weffc++ -Wuninitialized -Wno-volatile")
 
 # Enable this if you want the linker to remove unused code and data
 set(USE_LINK_GC yes)

--- a/firmware/common/jtag_tap.cpp
+++ b/firmware/common/jtag_tap.cpp
@@ -24,6 +24,7 @@
 #include "utility.hpp"
 
 #include <string>
+#include <array>
 
 namespace jtag {
 namespace tap {

--- a/firmware/common/pocsag_packet.hpp
+++ b/firmware/common/pocsag_packet.hpp
@@ -25,6 +25,7 @@
 
 #include <cstdint>
 #include <cstddef>
+#include <array>
 
 #include "baseband.hpp"
 

--- a/firmware/common/tonesets.hpp
+++ b/firmware/common/tonesets.hpp
@@ -24,6 +24,7 @@
 #define __TONESETS_H__
 
 #include <memory>
+#include <array>
 
 #define TONES_SAMPLERATE 1536000
 #define TONES_DELTA_COEF(sr) ((1ULL << 32) / sr)

--- a/firmware/common/tpms_packet.hpp
+++ b/firmware/common/tpms_packet.hpp
@@ -60,6 +60,10 @@ class TransponderID {
         return id_;
     }
 
+    constexpr bool operator==(const TransponderID &other) const {
+        return id_ == other.id_;
+    }
+
    private:
     uint32_t id_;
 };

--- a/firmware/common/tpms_packet.hpp
+++ b/firmware/common/tpms_packet.hpp
@@ -60,7 +60,7 @@ class TransponderID {
         return id_;
     }
 
-    constexpr bool operator==(const TransponderID &other) const {
+    constexpr bool operator==(const TransponderID& other) const {
         return id_ == other.id_;
     }
 


### PR DESCRIPTION
Make the code compile with gcc12
- Compile with -std=c++20 when available
- Missing includes
- Little fixes
- Suppress volatile warnings

Switch to c++20 was necessary due to the usage of std::string.c_str() inside constexpr code. This only became standard in c++20 and the new gcc complains about it when trying to compile with -std=c++17 :(

To preserve the ability of compiling with older gcc I used check_cxx_compiler_flag and only enable c++20 if the compiler can handle it. Tested and works with gcc9.2 and gcc12.2, would be great if you could test it with in-between versions!