### PR TITLE
App settings revamp

### DIFF
--- a/firmware/application/app_settings.cpp
+++ b/firmware/application/app_settings.cpp
@@ -224,12 +224,12 @@ void copy_from_radio_model(AppSettings& settings) {
 SettingsManager::SettingsManager(std::string app_name, Mode mode)
     : app_name_{std::move(app_name)},
       settings_{},
-      valid_{false} {
+      loaded_{false} {
     settings_.mode = mode;
     auto result = load_settings(app_name_, settings_);
 
     if (result == ResultCode::Ok) {
-        valid_ = true;
+        loaded_ = true;
         copy_to_radio_model(settings_);
     }
 }

--- a/firmware/application/app_settings.cpp
+++ b/firmware/application/app_settings.cpp
@@ -185,8 +185,16 @@ void copy_to_radio_model(const AppSettings& settings) {
     if (flags_enabled(settings.mode, Mode::TX))
         transmitter_model.configure_from_app_settings(settings);
 
-    if (flags_enabled(settings.mode, Mode::RX))
+    if (flags_enabled(settings.mode, Mode::RX)) {
         receiver_model.configure_from_app_settings(settings);
+        receiver_model.set_configuration_without_init(
+            static_cast<ReceiverModel::Mode>(settings.modulation),
+            settings.step,
+            settings.am_config_index,
+            settings.nbfm_config_index,
+            settings.wfm_config_index,
+            settings.squelch);
+    }
 
     receiver_model.set_frequency_step(settings.volume);
     receiver_model.set_normalized_headphone_volume(settings.volume);
@@ -214,6 +222,11 @@ void copy_from_radio_model(AppSettings& settings) {
         settings.vga = receiver_model.vga();
         settings.rx_amp = receiver_model.rf_amp();
         settings.squelch = receiver_model.squelch_level();
+
+        settings.modulation = static_cast<uint8_t>(receiver_model.modulation());
+        settings.am_config_index = receiver_model.am_configuration();
+        settings.nbfm_config_index = receiver_model.nbfm_configuration();
+        settings.wfm_config_index = receiver_model.wfm_configuration();
     }
 
     settings.step = receiver_model.frequency_step();

--- a/firmware/application/app_settings.cpp
+++ b/firmware/application/app_settings.cpp
@@ -59,7 +59,6 @@ static void write_setting(File& file, std::string_view setting_name, const T& va
 namespace setting {
 constexpr std::string_view baseband_bandwidth = "baseband_bandwidth="sv;
 constexpr std::string_view sampling_rate = "sampling_rate="sv;
-constexpr std::string_view channel_bandwidth = "channel_bandwidth="sv;
 constexpr std::string_view lna = "lna="sv;
 constexpr std::string_view vga = "vga="sv;
 constexpr std::string_view rx_amp = "rx_amp="sv;
@@ -73,42 +72,50 @@ constexpr std::string_view am_config_index = "am_config_index="sv;
 constexpr std::string_view nbfm_config_index = "nbfm_config_index="sv;
 constexpr std::string_view wfm_config_index = "wfm_config_index="sv;
 constexpr std::string_view squelch = "squelch="sv;
+constexpr std::string_view volume = "volume="sv;
 }  // namespace setting
 
-AppSettingsResult load_settings(const std::string& app_name, AppSettings& settings) {
+// TODO: Only load/save values that are declared used.
+// This will prevent switching apps from changing setting unnecessarily.
+// TODO: track which values are actually read.
+
+ResultCode load_settings(const std::string& app_name, AppSettings& settings) {
     if (!portapack::persistent_memory::load_app_settings())
-        return AppSettingsResult::SettingsDisabled;
+        return ResultCode::SettingsDisabled;
 
     auto file_path = fs::path{settings_folder} / app_name + u".ini";
     auto data = File::read_file(file_path);
 
     if (!data)
-        return AppSettingsResult::LoadFailed;
+        return ResultCode::LoadFailed;
+
+    if (settings.mode == Mode::TX) {
+        read_setting(*data, setting::tx_frequency, settings.tx_frequency);
+        read_setting(*data, setting::tx_amp, settings.tx_amp);
+        read_setting(*data, setting::tx_gain, settings.tx_gain);
+    } else {
+        read_setting(*data, setting::rx_frequency, settings.rx_frequency);
+        read_setting(*data, setting::rx_amp, settings.rx_amp);
+        read_setting(*data, setting::step, settings.step);
+        read_setting(*data, setting::modulation, settings.modulation);
+        read_setting(*data, setting::am_config_index, settings.am_config_index);
+        read_setting(*data, setting::nbfm_config_index, settings.nbfm_config_index);
+        read_setting(*data, setting::wfm_config_index, settings.wfm_config_index);
+        read_setting(*data, setting::squelch, settings.squelch);
+    }
 
     read_setting(*data, setting::baseband_bandwidth, settings.baseband_bandwidth);
     read_setting(*data, setting::sampling_rate, settings.sampling_rate);
-    read_setting(*data, setting::channel_bandwidth, settings.channel_bandwidth);
     read_setting(*data, setting::lna, settings.lna);
     read_setting(*data, setting::vga, settings.vga);
-    read_setting(*data, setting::rx_amp, settings.rx_amp);
-    read_setting(*data, setting::tx_amp, settings.tx_amp);
-    read_setting(*data, setting::tx_gain, settings.tx_gain);
+    read_setting(*data, setting::volume, settings.volume);
 
-    read_setting(*data, setting::rx_frequency, settings.rx_frequency);
-    read_setting(*data, setting::tx_frequency, settings.tx_frequency);
-    read_setting(*data, setting::step, settings.step);
-    read_setting(*data, setting::modulation, settings.modulation);
-    read_setting(*data, setting::am_config_index, settings.am_config_index);
-    read_setting(*data, setting::nbfm_config_index, settings.nbfm_config_index);
-    read_setting(*data, setting::wfm_config_index, settings.wfm_config_index);
-    read_setting(*data, setting::squelch, settings.squelch);
-
-    return AppSettingsResult::Ok;
+    return ResultCode::Ok;
 }
 
-AppSettingsResult save_settings(const std::string& app_name, AppSettings& settings) {
+ResultCode save_settings(const std::string& app_name, AppSettings& settings) {
     if (portapack::persistent_memory::save_app_settings())
-        return AppSettingsResult::SettingsDisabled;
+        return ResultCode::SettingsDisabled;
 
     File settings_file;
     auto file_path = fs::path{settings_folder} / app_name + u".ini";
@@ -116,52 +123,94 @@ AppSettingsResult save_settings(const std::string& app_name, AppSettings& settin
 
     auto error = settings_file.create(file_path);
     if (error)
-        return AppSettingsResult::SaveFailed;
+        return ResultCode::SaveFailed;
+
+    if (settings.mode == Mode::TX) {
+        write_setting(settings_file, setting::tx_frequency, settings.tx_frequency);
+        write_setting(settings_file, setting::tx_amp, settings.tx_amp);
+        write_setting(settings_file, setting::tx_gain, settings.tx_gain);
+    } else {
+        write_setting(settings_file, setting::rx_frequency, settings.rx_frequency);
+        write_setting(settings_file, setting::rx_amp, settings.rx_amp);
+        write_setting(settings_file, setting::step, settings.step);
+        write_setting(settings_file, setting::modulation, settings.modulation);
+        write_setting(settings_file, setting::am_config_index, settings.am_config_index);
+        write_setting(settings_file, setting::nbfm_config_index, settings.nbfm_config_index);
+        write_setting(settings_file, setting::wfm_config_index, settings.wfm_config_index);
+        write_setting(settings_file, setting::squelch, settings.squelch);
+    }
 
     write_setting(settings_file, setting::baseband_bandwidth, settings.baseband_bandwidth);
     write_setting(settings_file, setting::sampling_rate, settings.sampling_rate);
-    write_setting(settings_file, setting::channel_bandwidth, settings.channel_bandwidth);
     write_setting(settings_file, setting::lna, settings.lna);
     write_setting(settings_file, setting::vga, settings.vga);
-    write_setting(settings_file, setting::rx_amp, settings.rx_amp);
-    write_setting(settings_file, setting::tx_amp, settings.tx_amp);
-    write_setting(settings_file, setting::tx_gain, settings.tx_gain);
+    write_setting(settings_file, setting::volume, settings.volume);
 
-    write_setting(settings_file, setting::rx_frequency, settings.rx_frequency);
-    write_setting(settings_file, setting::tx_frequency, settings.tx_frequency);
-    write_setting(settings_file, setting::step, settings.step);
-    write_setting(settings_file, setting::modulation, settings.modulation);
-    write_setting(settings_file, setting::am_config_index, settings.am_config_index);
-    write_setting(settings_file, setting::nbfm_config_index, settings.nbfm_config_index);
-    write_setting(settings_file, setting::wfm_config_index, settings.wfm_config_index);
-    write_setting(settings_file, setting::squelch, settings.squelch);
-
-    return AppSettingsResult::Ok;
+    return ResultCode::Ok;
 }
 
 void copy_to_radio_model(const AppSettings& settings) {
-    // TODO
+    if (settings.mode == Mode::TX) {
+        transmitter_model.set_tuning_frequency(settings.tx_frequency);
+        transmitter_model.set_baseband_bandwidth(settings.baseband_bandwidth);
+        transmitter_model.set_tx_gain(settings.tx_gain);
+        transmitter_model.set_rf_amp(settings.tx_amp);
+
+        // TODO: Do these make sense for TX?
+        transmitter_model.set_lna(settings.lna);
+        transmitter_model.set_vga(settings.vga);
+        transmitter_model.set_sampling_rate(settings.sampling_rate);
+
+    } else {
+        receiver_model.set_tuning_frequency(settings.rx_frequency);
+        receiver_model.set_baseband_bandwidth(settings.baseband_bandwidth);
+        receiver_model.set_sampling_rate(settings.sampling_rate);
+        receiver_model.set_lna(settings.lna);
+        receiver_model.set_vga(settings.vga);
+        receiver_model.set_rf_amp(settings.rx_amp);
+        receiver_model.set_squelch_level(settings.squelch);
+    }
+
+    receiver_model.set_normalized_headphone_volume(settings.volume);
 }
 
 void copy_from_radio_model(AppSettings& settings) {
-    settings.baseband_bandwidth = receiver_model.baseband_bandwidth();
-    settings.sampling_rate = receiver_model.receiver_model.sampling_rate();
-    settings.channel_bandwidth = transmitter_model.channel_bandwidth();
-    settings.lna = receiver_model.lna();
-    settings.vga = receiver_model.vga();
-    settings.rx_amp = receiver_model.rf_amp();
-    settings.tx_amp = transmitter_model.rf_amp();
-    settings.tx_gain = transmitter_model.tx_gain();
+    if (settings.mode == Mode::TX) {
+        settings.tx_frequency = transmitter_model.tuning_frequency();
+        settings.baseband_bandwidth = transmitter_model.baseband_bandwidth();
+        settings.tx_amp = transmitter_model.rf_amp();
+        settings.tx_gain = transmitter_model.tx_gain();
+
+        // TODO: Do these make sense for TX?
+        settings.sampling_rate = transmitter_model.sampling_rate();
+        settings.lna = transmitter_model.lna();
+        settings.vga = transmitter_model.vga();
+    } else {
+        settings.rx_frequency = receiver_model.tuning_frequency();
+        settings.baseband_bandwidth = receiver_model.baseband_bandwidth();
+        settings.sampling_rate = receiver_model.sampling_rate();
+        settings.lna = receiver_model.lna();
+        settings.vga = receiver_model.vga();
+        settings.rx_amp = receiver_model.rf_amp();
+        settings.squelch = receiver_model.squelch_level();
+    }
+
+    settings.volume = receiver_model.normalized_headphone_volume();
 }
 
-/* AutoAppSettings *************************************************/
-AutoAppSettings::AutoAppSettings(std::string application)
-    : app_name_{std::move(application)},
-      settings_{} {
-    load_settings(app_name_, settings_);
+/* SettingsManager *************************************************/
+SettingsManager::SettingsManager(std::string app_name, Mode mode)
+    : app_name_{std::move(app_name)},
+      settings_{},
+      valid_{false} {
+    settings_.mode = mode;
+    auto result = load_settings(app_name_, settings_);
+    valid_ = result == ResultCode::Ok;
+
+    copy_to_radio_model(settings_);
 }
 
-AutoAppSettings::~AutoAppSettings() {
+SettingsManager::~SettingsManager() {
     copy_from_radio_model(settings_);
     save_settings(app_name_, settings_);
 }

--- a/firmware/application/app_settings.hpp
+++ b/firmware/application/app_settings.hpp
@@ -42,8 +42,9 @@ enum class ResultCode : uint8_t {
 };
 
 enum class Mode : uint8_t {
-    RX,
-    TX
+    RX = 0x01,
+    TX = 0x02,
+    RX_TX = 0x03, // Both TX/RX
 };
 
 // TODO: separate types for TX/RX or union?
@@ -56,6 +57,7 @@ struct AppSettings {
     uint8_t rx_amp;
     uint8_t tx_amp;
     uint8_t tx_gain;
+    uint32_t channel_bandwidth;
     uint32_t rx_frequency;
     uint32_t tx_frequency;
     uint32_t step;
@@ -93,7 +95,7 @@ class SettingsManager {
     bool valid() const { return valid_; }
     Mode mode() const { return settings_.mode; }
 
-    AppSettings& get() { return settings_; }
+    AppSettings& raw() { return settings_; }
 
    private:
     std::string app_name_;

--- a/firmware/application/app_settings.hpp
+++ b/firmware/application/app_settings.hpp
@@ -44,7 +44,7 @@ enum class ResultCode : uint8_t {
 enum class Mode : uint8_t {
     RX = 0x01,
     TX = 0x02,
-    RX_TX = 0x03, // Both TX/RX
+    RX_TX = 0x03,  // Both TX/RX
 };
 
 // TODO: separate types for TX/RX or union?

--- a/firmware/application/app_settings.hpp
+++ b/firmware/application/app_settings.hpp
@@ -92,7 +92,8 @@ class SettingsManager {
     SettingsManager(SettingsManager&&) = delete;
     SettingsManager& operator=(SettingsManager&&) = delete;
 
-    bool valid() const { return valid_; }
+    /* True if settings were successfully loaded from file. */
+    bool loaded() const { return loaded_; }
     Mode mode() const { return settings_.mode; }
 
     AppSettings& raw() { return settings_; }
@@ -100,7 +101,7 @@ class SettingsManager {
    private:
     std::string app_name_;
     AppSettings settings_;
-    bool valid_;
+    bool loaded_;
 };
 
 }  // namespace app_settings

--- a/firmware/application/apps/acars_app.cpp
+++ b/firmware/application/apps/acars_app.cpp
@@ -55,11 +55,6 @@ void ACARSLogger::log_raw_data(const acars::Packet& packet, const uint32_t frequ
 
 namespace ui {
 
-void ACARSAppView::update_freq(rf::Frequency f) {
-    set_target_frequency(f);
-    portapack::persistent_memory::set_tuned_frequency(f);  // Maybe not ?
-}
-
 ACARSAppView::ACARSAppView(NavigationView& nav) {
     baseband::run_image(portapack::spi_flash::image_tag_acars);
 
@@ -76,17 +71,15 @@ ACARSAppView::ACARSAppView(NavigationView& nav) {
     receiver_model.set_baseband_bandwidth(1750000);
     receiver_model.enable();
 
-    field_frequency.set_value(receiver_model.tuning_frequency());
-    update_freq(receiver_model.tuning_frequency());
+    field_frequency.set_value(receiver_model.target_frequency());
     field_frequency.set_step(receiver_model.frequency_step());
     field_frequency.on_change = [this](rf::Frequency f) {
-        update_freq(f);
+        receiver_model.set_target_frequency(f);
     };
     field_frequency.on_edit = [this, &nav]() {
         // TODO: Provide separate modal method/scheme?
-        auto new_view = nav.push<FrequencyKeypadView>(receiver_model.tuning_frequency());
+        auto new_view = nav.push<FrequencyKeypadView>(receiver_model.target_frequency());
         new_view->on_changed = [this](rf::Frequency f) {
-            update_freq(f);
             field_frequency.set_value(f);
         };
     };
@@ -132,16 +125,7 @@ void ACARSAppView::on_packet(const acars::Packet& packet) {
 
     // Log raw data whatever it contains
     if (logger && logging)
-        logger->log_raw_data(packet, target_frequency());
-}
-
-void ACARSAppView::set_target_frequency(const uint32_t new_value) {
-    target_frequency_ = new_value;
-    receiver_model.set_tuning_frequency(new_value);
-}
-
-uint32_t ACARSAppView::target_frequency() const {
-    return target_frequency_;
+        logger->log_raw_data(packet, receiver_model.target_frequency());
 }
 
 } /* namespace ui */

--- a/firmware/application/apps/acars_app.hpp
+++ b/firmware/application/apps/acars_app.hpp
@@ -23,10 +23,10 @@
 #ifndef __ACARS_APP_H__
 #define __ACARS_APP_H__
 
+#include "app_settings.hpp"
 #include "ui_widget.hpp"
 #include "ui_receiver.hpp"
 #include "ui_rssi.hpp"
-
 #include "log_file.hpp"
 
 #include "acars_packet.hpp"
@@ -56,6 +56,9 @@ class ACARSAppView : public View {
     std::string title() const override { return "ACARS (WIP)"; };
 
    private:
+    app_settings::SettingsManager settings_{
+        "rx_acars.hpp", app_settings::Mode::RX};
+
     bool logging{false};
     uint32_t packet_counter{0};
 
@@ -86,14 +89,7 @@ class ACARSAppView : public View {
 
     std::unique_ptr<ACARSLogger> logger{};
 
-    uint32_t target_frequency_{};
-
-    void update_freq(rf::Frequency f);
-
     void on_packet(const acars::Packet& packet);
-
-    uint32_t target_frequency() const;
-    void set_target_frequency(const uint32_t new_value);
 
     MessageHandlerRegistration message_handler_packet{
         Message::ID::ACARSPacket,

--- a/firmware/application/apps/ais_app.cpp
+++ b/firmware/application/apps/ais_app.cpp
@@ -382,6 +382,9 @@ AISAppView::AISAppView(NavigationView& nav)
 
     recent_entry_detail_view.hidden(true);
 
+    if (!settings_.loaded())
+        receiver_model.set_target_frequency(initial_target_frequency);
+
     receiver_model.set_sampling_rate(sampling_rate);
     receiver_model.set_baseband_bandwidth(baseband_bandwidth);
     receiver_model.enable();

--- a/firmware/application/apps/ais_app.cpp
+++ b/firmware/application/apps/ais_app.cpp
@@ -380,15 +380,15 @@ AISAppView::AISAppView(NavigationView& nav)
         &recent_entry_detail_view,
     });
 
-    // load app settings
-    auto rc = settings.load("rx_ais", &app_settings);
-    if (rc == SETTINGS_OK) {
-        field_lna.set_value(app_settings.lna);
-        field_vga.set_value(app_settings.vga);
-        field_rf_amp.set_value(app_settings.rx_amp);
-        target_frequency_ = app_settings.rx_frequency;
-    } else
-        target_frequency_ = initial_target_frequency;
+    // // load app settings
+    // auto rc = settings.load("rx_ais", &app_settings);
+    // if (rc == SETTINGS_OK) {
+    //     field_lna.set_value(app_settings.lna);
+    //     field_vga.set_value(app_settings.vga);
+    //     field_rf_amp.set_value(app_settings.rx_amp);
+    //     target_frequency_ = app_settings.rx_frequency;
+    // } else
+    //     target_frequency_ = initial_target_frequency;
 
     recent_entry_detail_view.hidden(true);
 
@@ -416,9 +416,9 @@ AISAppView::AISAppView(NavigationView& nav)
 }
 
 AISAppView::~AISAppView() {
-    // save app settings
-    app_settings.rx_frequency = target_frequency_;
-    settings.save("rx_ais", &app_settings);
+    // // save app settings
+    // app_settings.rx_frequency = target_frequency_;
+    // settings.save("rx_ais", &app_settings);
 
     receiver_model.disable();
 

--- a/firmware/application/apps/ais_app.cpp
+++ b/firmware/application/apps/ais_app.cpp
@@ -283,8 +283,8 @@ AISRecentEntryDetailView::AISRecentEntryDetailView(NavigationView& nav) {
     });
 
     button_done.on_select = [this](const ui::Button&) {
-        if (this->on_close) {
-            this->on_close();
+        if (on_close) {
+            on_close();
         }
     };
 
@@ -380,33 +380,22 @@ AISAppView::AISAppView(NavigationView& nav)
         &recent_entry_detail_view,
     });
 
-    // // load app settings
-    // auto rc = settings.load("rx_ais", &app_settings);
-    // if (rc == SETTINGS_OK) {
-    //     field_lna.set_value(app_settings.lna);
-    //     field_vga.set_value(app_settings.vga);
-    //     field_rf_amp.set_value(app_settings.rx_amp);
-    //     target_frequency_ = app_settings.rx_frequency;
-    // } else
-    //     target_frequency_ = initial_target_frequency;
-
     recent_entry_detail_view.hidden(true);
 
-    receiver_model.set_tuning_frequency(tuning_frequency());
     receiver_model.set_sampling_rate(sampling_rate);
     receiver_model.set_baseband_bandwidth(baseband_bandwidth);
     receiver_model.enable();
 
     options_channel.on_change = [this](size_t, OptionsField::value_t v) {
-        this->on_frequency_changed(v);
+        receiver_model.set_target_frequency(v);
     };
-    options_channel.set_by_value(target_frequency());
+    options_channel.set_by_value(receiver_model.target_frequency());
 
     recent_entries_view.on_select = [this](const AISRecentEntry& entry) {
-        this->on_show_detail(entry);
+        on_show_detail(entry);
     };
     recent_entry_detail_view.on_close = [this]() {
-        this->on_show_list();
+        on_show_list();
     };
 
     logger = std::make_unique<AISLogger>();
@@ -416,12 +405,7 @@ AISAppView::AISAppView(NavigationView& nav)
 }
 
 AISAppView::~AISAppView() {
-    // // save app settings
-    // app_settings.rx_frequency = target_frequency_;
-    // settings.save("rx_ais", &app_settings);
-
     receiver_model.disable();
-
     baseband::shutdown();
 }
 
@@ -463,23 +447,6 @@ void AISAppView::on_show_detail(const AISRecentEntry& entry) {
     recent_entry_detail_view.hidden(false);
     recent_entry_detail_view.set_entry(entry);
     recent_entry_detail_view.focus();
-}
-
-void AISAppView::on_frequency_changed(const uint32_t new_target_frequency) {
-    set_target_frequency(new_target_frequency);
-}
-
-void AISAppView::set_target_frequency(const uint32_t new_value) {
-    target_frequency_ = new_value;
-    receiver_model.set_tuning_frequency(tuning_frequency());
-}
-
-uint32_t AISAppView::target_frequency() const {
-    return target_frequency_;
-}
-
-uint32_t AISAppView::tuning_frequency() const {
-    return target_frequency() - (sampling_rate / 4);
 }
 
 } /* namespace ui */

--- a/firmware/application/apps/ais_app.hpp
+++ b/firmware/application/apps/ais_app.hpp
@@ -168,9 +168,8 @@ class AISAppView : public View {
     static constexpr uint32_t sampling_rate = 2457600;
     static constexpr uint32_t baseband_bandwidth = 1750000;
 
-    // app save settings
-    std::app_settings settings{};
-    std::app_settings::AppSettings app_settings{};
+    app_settings::SettingsManager settings_{
+        "rx_ais", app_settings::Mode::RX};
 
     NavigationView& nav_;
 

--- a/firmware/application/apps/ais_app.hpp
+++ b/firmware/application/apps/ais_app.hpp
@@ -164,7 +164,6 @@ class AISAppView : public View {
     std::string title() const override { return "AIS RX"; };
 
    private:
-    static constexpr uint32_t initial_target_frequency = 162025000;
     static constexpr uint32_t sampling_rate = 2457600;
     static constexpr uint32_t baseband_bandwidth = 1750000;
 
@@ -224,18 +223,10 @@ class AISAppView : public View {
             }
         }};
 
-    uint32_t target_frequency_ = initial_target_frequency;
 
     void on_packet(const ais::Packet& packet);
     void on_show_list();
     void on_show_detail(const AISRecentEntry& entry);
-
-    void on_frequency_changed(const uint32_t new_target_frequency);
-
-    uint32_t target_frequency() const;
-    void set_target_frequency(const uint32_t new_value);
-
-    uint32_t tuning_frequency() const;
 };
 
 } /* namespace ui */

--- a/firmware/application/apps/ais_app.hpp
+++ b/firmware/application/apps/ais_app.hpp
@@ -223,7 +223,6 @@ class AISAppView : public View {
             }
         }};
 
-
     void on_packet(const ais::Packet& packet);
     void on_show_list();
     void on_show_detail(const AISRecentEntry& entry);

--- a/firmware/application/apps/ais_app.hpp
+++ b/firmware/application/apps/ais_app.hpp
@@ -154,9 +154,6 @@ class AISAppView : public View {
     ~AISAppView();
 
     void set_parent_rect(const Rect new_parent_rect) override;
-
-    // Prevent painting of region covered entirely by a child.
-    // TODO: Add flag to View that specifies view does not need to be cleared before painting.
     void paint(Painter&) override{};
 
     void focus() override;
@@ -164,6 +161,7 @@ class AISAppView : public View {
     std::string title() const override { return "AIS RX"; };
 
    private:
+    static constexpr uint32_t initial_target_frequency = 162025000;
     static constexpr uint32_t sampling_rate = 2457600;
     static constexpr uint32_t baseband_bandwidth = 1750000;
 

--- a/firmware/application/apps/analog_audio_app.cpp
+++ b/firmware/application/apps/analog_audio_app.cpp
@@ -149,32 +149,19 @@ AnalogAudioView::AnalogAudioView(
                   &record_view,
                   &waterfall});
 
-    // Set on_change before initialising the field
-    field_frequency.on_change = [this](rf::Frequency f) {
-        this->on_target_frequency_changed(f);
-    };
-
-    // // load app settings
-    // auto rc = settings.load("rx_audio", &app_settings);
-    // if (rc == SETTINGS_OK) {
-    //     field_lna.set_value(app_settings.lna);
-    //     field_vga.set_value(app_settings.vga);
-    //     receiver_model.set_rf_amp(app_settings.rx_amp);
-    //     // field_frequency.set_value(app_settings.rx_frequency);
-    //     receiver_model.set_configuration_without_init(static_cast<ReceiverModel::Mode>(app_settings.modulation), app_settings.step, app_settings.am_config_index, app_settings.nbfm_config_index, app_settings.wfm_config_index, app_settings.squelch);
-    // }
-    field_frequency.set_value(receiver_model.target_frequency());
-
     // Filename Datetime and Frequency
     record_view.set_filename_date_frequency(true);
 
+    field_frequency.set_value(receiver_model.target_frequency());
+    field_frequency.on_change = [this](rf::Frequency f) {
+        receiver_model.set_target_frequency(f);
+    };
     field_frequency.set_step(receiver_model.frequency_step());
     field_frequency.on_edit = [this, &nav]() {
         // TODO: Provide separate modal method/scheme?
         auto new_view = nav.push<FrequencyKeypadView>(receiver_model.target_frequency());
         new_view->on_changed = [this](rf::Frequency f) {
-            this->on_target_frequency_changed(f);
-            this->field_frequency.set_value(f);
+            field_frequency.set_value(f);
         };
     };
 
@@ -277,10 +264,6 @@ void AnalogAudioView::set_parent_rect(const Rect new_parent_rect) {
 
 void AnalogAudioView::focus() {
     field_frequency.focus();
-}
-
-void AnalogAudioView::on_target_frequency_changed(rf::Frequency f) {
-    receiver_model.set_target_frequency(f);
 }
 
 void AnalogAudioView::on_baseband_bandwidth_changed(uint32_t bandwidth_hz) {

--- a/firmware/application/apps/analog_audio_app.cpp
+++ b/firmware/application/apps/analog_audio_app.cpp
@@ -151,7 +151,7 @@ AnalogAudioView::AnalogAudioView(
 
     // Set on_change before initialising the field
     field_frequency.on_change = [this](rf::Frequency f) {
-        this->on_tuning_frequency_changed(f);
+        this->on_target_frequency_changed(f);
     };
 
     // // load app settings
@@ -163,7 +163,7 @@ AnalogAudioView::AnalogAudioView(
     //     // field_frequency.set_value(app_settings.rx_frequency);
     //     receiver_model.set_configuration_without_init(static_cast<ReceiverModel::Mode>(app_settings.modulation), app_settings.step, app_settings.am_config_index, app_settings.nbfm_config_index, app_settings.wfm_config_index, app_settings.squelch);
     // }
-    field_frequency.set_value(receiver_model.tuning_frequency());
+    field_frequency.set_value(receiver_model.target_frequency());
 
     // Filename Datetime and Frequency
     record_view.set_filename_date_frequency(true);
@@ -171,9 +171,9 @@ AnalogAudioView::AnalogAudioView(
     field_frequency.set_step(receiver_model.frequency_step());
     field_frequency.on_edit = [this, &nav]() {
         // TODO: Provide separate modal method/scheme?
-        auto new_view = nav.push<FrequencyKeypadView>(receiver_model.tuning_frequency());
+        auto new_view = nav.push<FrequencyKeypadView>(receiver_model.target_frequency());
         new_view->on_changed = [this](rf::Frequency f) {
-            this->on_tuning_frequency_changed(f);
+            this->on_target_frequency_changed(f);
             this->field_frequency.set_value(f);
         };
     };
@@ -205,7 +205,7 @@ AnalogAudioView::AnalogAudioView(
     };
 
     waterfall.on_select = [this](int32_t offset) {
-        field_frequency.set_value(receiver_model.tuning_frequency() + offset);
+        field_frequency.set_value(receiver_model.target_frequency() + offset);
     };
 
     audio::output::start();
@@ -279,8 +279,8 @@ void AnalogAudioView::focus() {
     field_frequency.focus();
 }
 
-void AnalogAudioView::on_tuning_frequency_changed(rf::Frequency f) {
-    receiver_model.set_tuning_frequency(f);
+void AnalogAudioView::on_target_frequency_changed(rf::Frequency f) {
+    receiver_model.set_target_frequency(f);
 }
 
 void AnalogAudioView::on_baseband_bandwidth_changed(uint32_t bandwidth_hz) {

--- a/firmware/application/apps/analog_audio_app.cpp
+++ b/firmware/application/apps/analog_audio_app.cpp
@@ -154,15 +154,15 @@ AnalogAudioView::AnalogAudioView(
         this->on_tuning_frequency_changed(f);
     };
 
-    // load app settings
-    auto rc = settings.load("rx_audio", &app_settings);
-    if (rc == SETTINGS_OK) {
-        field_lna.set_value(app_settings.lna);
-        field_vga.set_value(app_settings.vga);
-        receiver_model.set_rf_amp(app_settings.rx_amp);
-        // field_frequency.set_value(app_settings.rx_frequency);
-        receiver_model.set_configuration_without_init(static_cast<ReceiverModel::Mode>(app_settings.modulation), app_settings.step, app_settings.am_config_index, app_settings.nbfm_config_index, app_settings.wfm_config_index, app_settings.squelch);
-    }
+    // // load app settings
+    // auto rc = settings.load("rx_audio", &app_settings);
+    // if (rc == SETTINGS_OK) {
+    //     field_lna.set_value(app_settings.lna);
+    //     field_vga.set_value(app_settings.vga);
+    //     receiver_model.set_rf_amp(app_settings.rx_amp);
+    //     // field_frequency.set_value(app_settings.rx_frequency);
+    //     receiver_model.set_configuration_without_init(static_cast<ReceiverModel::Mode>(app_settings.modulation), app_settings.step, app_settings.am_config_index, app_settings.nbfm_config_index, app_settings.wfm_config_index, app_settings.squelch);
+    // }
     field_frequency.set_value(receiver_model.tuning_frequency());
 
     // Filename Datetime and Frequency
@@ -238,18 +238,18 @@ void AnalogAudioView::set_spec_trigger(uint16_t trigger) {
 }
 
 AnalogAudioView::~AnalogAudioView() {
-    // save app settings
-    app_settings.rx_frequency = field_frequency.value();
-    app_settings.lna = receiver_model.lna();
-    app_settings.vga = receiver_model.vga();
-    app_settings.rx_amp = receiver_model.rf_amp();
-    app_settings.step = receiver_model.frequency_step();
-    app_settings.modulation = (uint8_t)receiver_model.modulation();
-    app_settings.am_config_index = receiver_model.am_configuration();
-    app_settings.nbfm_config_index = receiver_model.nbfm_configuration();
-    app_settings.wfm_config_index = receiver_model.wfm_configuration();
-    app_settings.squelch = receiver_model.squelch_level();
-    settings.save("rx_audio", &app_settings);
+    // // save app settings
+    // app_settings.rx_frequency = field_frequency.value();
+    // app_settings.lna = receiver_model.lna();
+    // app_settings.vga = receiver_model.vga();
+    // app_settings.rx_amp = receiver_model.rf_amp();
+    // app_settings.step = receiver_model.frequency_step();
+    // app_settings.modulation = (uint8_t)receiver_model.modulation();
+    // app_settings.am_config_index = receiver_model.am_configuration();
+    // app_settings.nbfm_config_index = receiver_model.nbfm_configuration();
+    // app_settings.wfm_config_index = receiver_model.wfm_configuration();
+    // app_settings.squelch = receiver_model.squelch_level();
+    // settings.save("rx_audio", &app_settings);
 
     // TODO: Manipulating audio codec here, and in ui_receiver.cpp. Good to do
     // both?

--- a/firmware/application/apps/analog_audio_app.hpp
+++ b/firmware/application/apps/analog_audio_app.hpp
@@ -219,7 +219,7 @@ class AnalogAudioView : public View {
 
     spectrum::WaterfallWidget waterfall{true};
 
-    void on_tuning_frequency_changed(rf::Frequency f);
+    void on_target_frequency_changed(rf::Frequency f);
     void on_baseband_bandwidth_changed(uint32_t bandwidth_hz);
     void on_modulation_changed(const ReceiverModel::Mode modulation);
     void on_show_options_frequency();

--- a/firmware/application/apps/analog_audio_app.hpp
+++ b/firmware/application/apps/analog_audio_app.hpp
@@ -155,9 +155,8 @@ class AnalogAudioView : public View {
    private:
     static constexpr ui::Dim header_height = 3 * 16;
 
-    // app save settings
-    std::app_settings settings{};
-    std::app_settings::AppSettings app_settings{};
+    app_settings::SettingsManager settings_{
+        "rx_audio", app_settings::Mode::RX};
 
     const Rect options_view_rect{0 * 8, 1 * 16, 30 * 8, 1 * 16};
     const Rect nbfm_view_rect{0 * 8, 1 * 16, 18 * 8, 1 * 16};

--- a/firmware/application/apps/analog_audio_app.hpp
+++ b/firmware/application/apps/analog_audio_app.hpp
@@ -219,7 +219,6 @@ class AnalogAudioView : public View {
 
     spectrum::WaterfallWidget waterfall{true};
 
-    void on_target_frequency_changed(rf::Frequency f);
     void on_baseband_bandwidth_changed(uint32_t bandwidth_hz);
     void on_modulation_changed(const ReceiverModel::Mode modulation);
     void on_show_options_frequency();

--- a/firmware/application/apps/analog_tv_app.hpp
+++ b/firmware/application/apps/analog_tv_app.hpp
@@ -98,7 +98,7 @@ class AnalogTvView : public View {
 
     tv::TVWidget tv{};
 
-    void on_tuning_frequency_changed(rf::Frequency f);
+    void on_target_frequency_changed(rf::Frequency f);
     void on_baseband_bandwidth_changed(uint32_t bandwidth_hz);
     void on_modulation_changed(const ReceiverModel::Mode modulation);
     void on_show_options_frequency();

--- a/firmware/application/apps/analog_tv_app.hpp
+++ b/firmware/application/apps/analog_tv_app.hpp
@@ -52,9 +52,8 @@ class AnalogTvView : public View {
    private:
     static constexpr ui::Dim header_height = 3 * 16;
 
-    // app save settings
-    std::app_settings settings{};
-    std::app_settings::AppSettings app_settings{};
+    app_settings::SettingsManager settings_{
+        "rx_tv", app_settings::Mode::RX};
 
     const Rect options_view_rect{0 * 8, 1 * 16, 30 * 8, 1 * 16};
     const Rect nbfm_view_rect{0 * 8, 1 * 16, 18 * 8, 1 * 16};

--- a/firmware/application/apps/capture_app.cpp
+++ b/firmware/application/apps/capture_app.cpp
@@ -52,16 +52,16 @@ CaptureAppView::CaptureAppView(NavigationView& nav) {
     receiver_model.set_baseband_bandwidth(1750000);
     //-------------------
 
-    field_frequency.set_value(receiver_model.tuning_frequency());
+    field_frequency.set_value(receiver_model.target_frequency());
     field_frequency.set_step(receiver_model.frequency_step());
     field_frequency.on_change = [this](rf::Frequency f) {
-        this->on_tuning_frequency_changed(f);
+        this->on_target_frequency_changed(f);
     };
     field_frequency.on_edit = [this, &nav]() {
         // TODO: Provide separate modal method/scheme?
-        auto new_view = nav.push<FrequencyKeypadView>(receiver_model.tuning_frequency());
+        auto new_view = nav.push<FrequencyKeypadView>(receiver_model.target_frequency());
         new_view->on_changed = [this](rf::Frequency f) {
-            this->on_tuning_frequency_changed(f);
+            this->on_target_frequency_changed(f);
             this->field_frequency.set_value(f);
         };
     };
@@ -162,8 +162,8 @@ void CaptureAppView::focus() {
     record_view.focus();
 }
 
-void CaptureAppView::on_tuning_frequency_changed(rf::Frequency f) {
-    receiver_model.set_tuning_frequency(f);
+void CaptureAppView::on_target_frequency_changed(rf::Frequency f) {
+    receiver_model.set_target_frequency(f);
 }
 
 } /* namespace ui */

--- a/firmware/application/apps/capture_app.hpp
+++ b/firmware/application/apps/capture_app.hpp
@@ -67,7 +67,7 @@ class CaptureAppView : public View {
     uint32_t sampling_rate = 0;
     uint32_t anti_alias_baseband_bandwidth_filter = 2500000;  // we rename the previous var , and change type static constexpr to normal var.
 
-    void on_tuning_frequency_changed(rf::Frequency f);
+    void on_target_frequency_changed(rf::Frequency f);
 
     Labels labels{
         {{0 * 8, 1 * 16}, "Rate:", Color::light_grey()},

--- a/firmware/application/apps/ert_app.cpp
+++ b/firmware/application/apps/ert_app.cpp
@@ -110,15 +110,7 @@ ERTAppView::ERTAppView(NavigationView&) {
         &recent_entries_view,
     });
 
-    // load app settings
-    auto rc = settings.load("rx_ert", &app_settings);
-    if (rc == SETTINGS_OK) {
-        field_lna.set_value(app_settings.lna);
-        field_vga.set_value(app_settings.vga);
-        field_rf_amp.set_value(app_settings.rx_amp);
-    }
-
-    receiver_model.set_tuning_frequency(initial_target_frequency);
+    receiver_model.set_target_frequency(initial_target_frequency);
     receiver_model.set_sampling_rate(sampling_rate);
     receiver_model.set_baseband_bandwidth(baseband_bandwidth);
     receiver_model.enable();
@@ -130,11 +122,7 @@ ERTAppView::ERTAppView(NavigationView&) {
 }
 
 ERTAppView::~ERTAppView() {
-    // save app settings
-    settings.save("rx_ert", &app_settings);
-
     receiver_model.disable();
-
     baseband::shutdown();
 }
 

--- a/firmware/application/apps/ert_app.hpp
+++ b/firmware/application/apps/ert_app.hpp
@@ -129,9 +129,8 @@ class ERTAppView : public View {
     ERTRecentEntries recent{};
     std::unique_ptr<ERTLogger> logger{};
 
-    // app save settings
-    std::app_settings settings{};
-    std::app_settings::AppSettings app_settings{};
+    app_settings::SettingsManager settings_{
+        "rx_ert", app_settings::Mode::RX};
 
     const RecentEntriesColumns columns{{
         {"ID", 10},

--- a/firmware/application/apps/gps_sim_app.cpp
+++ b/firmware/application/apps/gps_sim_app.cpp
@@ -183,27 +183,24 @@ GpsSimAppView::GpsSimAppView(
         &text_duration,
         &progressbar,
         &field_frequency,
-        &tx_view,  // now it handles previous rfgain , rfamp.
+        &tx_view,  // now it handles previous rfgain, rfamp.
         &check_loop,
         &button_play,
         &waterfall,
     });
 
-    field_frequency.set_value(target_frequency());
-    field_frequency.set_step(receiver_model.frequency_step());
+    field_frequency.set_value(transmitter_model.target_frequency());
+    field_frequency.set_step(5000);
     field_frequency.on_change = [this](rf::Frequency f) {
-        this->on_target_frequency_changed(f);
+        transmitter_model.set_target_frequency(f);
     };
     field_frequency.on_edit = [this, &nav]() {
         // TODO: Provide separate modal method/scheme?
-        auto new_view = nav.push<FrequencyKeypadView>(this->target_frequency());
+        auto new_view = nav.push<FrequencyKeypadView>(transmitter_model.target_frequency());
         new_view->on_changed = [this](rf::Frequency f) {
-            this->on_target_frequency_changed(f);
             this->field_frequency.set_value(f);
         };
     };
-
-    field_frequency.set_step(5000);
 
     button_play.on_select = [this](ImageButton&) {
         this->toggle();
@@ -237,19 +234,6 @@ void GpsSimAppView::set_parent_rect(const Rect new_parent_rect) {
 
     const ui::Rect waterfall_rect{0, header_height, new_parent_rect.width(), new_parent_rect.height() - header_height};
     waterfall.set_parent_rect(waterfall_rect);
-}
-
-void GpsSimAppView::on_target_frequency_changed(rf::Frequency f) {
-    set_target_frequency(f);
-}
-
-void GpsSimAppView::set_target_frequency(const rf::Frequency new_value) {
-    persistent_memory::set_tuned_frequency(new_value);
-    ;
-}
-
-rf::Frequency GpsSimAppView::target_frequency() const {
-    return persistent_memory::tuned_frequency();
 }
 
 } /* namespace ui */

--- a/firmware/application/apps/gps_sim_app.hpp
+++ b/firmware/application/apps/gps_sim_app.hpp
@@ -27,15 +27,16 @@
 #define SHORT_UI true
 #define NORMAL_UI false
 
+#include "app_settings.hpp"
 #include "ui_widget.hpp"
 #include "ui_navigation.hpp"
 #include "ui_receiver.hpp"
 #include "replay_thread.hpp"
 #include "ui_spectrum.hpp"
+#include "ui_transmitter.hpp"
 
 #include <string>
 #include <memory>
-#include "ui_transmitter.hpp"
 
 namespace ui {
 
@@ -52,6 +53,8 @@ class GpsSimAppView : public View {
 
    private:
     NavigationView& nav_;
+    app_settings::SettingsManager settings_{
+        "tx_gps", app_settings::Mode::TX};
 
     static constexpr ui::Dim header_height = 3 * 16;
 

--- a/firmware/application/apps/gps_sim_app.hpp
+++ b/firmware/application/apps/gps_sim_app.hpp
@@ -66,11 +66,7 @@ class GpsSimAppView : public View {
     const size_t buffer_count{3};
 
     void on_file_changed(std::filesystem::path new_file_path);
-    void on_target_frequency_changed(rf::Frequency f);
     void on_tx_progress(const uint32_t progress);
-
-    void set_target_frequency(const rf::Frequency new_value);
-    rf::Frequency target_frequency() const;
 
     void toggle();
     void start();

--- a/firmware/application/apps/lge_app.hpp
+++ b/firmware/application/apps/lge_app.hpp
@@ -49,9 +49,8 @@ class LGEView : public View {
         ALL
     };
 
-    // app save settings
-    std::app_settings settings{};
-    std::app_settings::AppSettings app_settings{};
+    app_settings::SettingsManager settings_{
+        "tx_lge", app_settings::Mode::TX};
 
     tx_modes tx_mode = IDLE;
 

--- a/firmware/application/apps/pocsag_app.cpp
+++ b/firmware/application/apps/pocsag_app.cpp
@@ -174,10 +174,10 @@ void POCSAGAppView::on_packet(const POCSAGPacketMessage* message) {
                 console.write(pocsag_state.output);
             }
 
-            /*if (logger && logging())
+            if (logger && logging())
                 logger->log_decoded(message->packet, to_string_dec_uint(pocsag_state.address) +
                                                          " F" + to_string_dec_uint(pocsag_state.function) +
-                                                         " Alpha: " + pocsag_state.output);*/
+                                                         " Alpha: " + pocsag_state.output);
         }
     }
 

--- a/firmware/application/apps/pocsag_app.cpp
+++ b/firmware/application/apps/pocsag_app.cpp
@@ -74,6 +74,7 @@ POCSAGAppView::POCSAGAppView(NavigationView& nav) {
     receiver_model.set_baseband_bandwidth(1750000);
     receiver_model.enable();
 
+    field_frequency.set_value(receiver_model.target_frequency());
     field_frequency.on_change = [this](rf::Frequency f) {
         receiver_model.set_target_frequency(f);
     };
@@ -103,6 +104,10 @@ POCSAGAppView::POCSAGAppView(NavigationView& nav) {
     audio::output::unmute();
 
     baseband::set_pocsag();
+}
+
+void POCSAGAppView::focus() {
+    check_log.focus();
 }
 
 POCSAGAppView::~POCSAGAppView() {
@@ -169,10 +174,10 @@ void POCSAGAppView::on_packet(const POCSAGPacketMessage* message) {
                 console.write(pocsag_state.output);
             }
 
-            if (logger && logging())
+            /*if (logger && logging())
                 logger->log_decoded(message->packet, to_string_dec_uint(pocsag_state.address) +
                                                          " F" + to_string_dec_uint(pocsag_state.function) +
-                                                         " Alpha: " + pocsag_state.output);
+                                                         " Alpha: " + pocsag_state.output);*/
         }
     }
 

--- a/firmware/application/apps/pocsag_app.cpp
+++ b/firmware/application/apps/pocsag_app.cpp
@@ -79,19 +79,19 @@ POCSAGAppView::POCSAGAppView(NavigationView& nav) {
         update_freq(f);
     };
 
-    // load app settings TODO: needed?
-    auto rc = settings.load("rx_pocsag", &app_settings);
-    if (rc == SETTINGS_OK) {
-        field_lna.set_value(app_settings.lna);
-        field_vga.set_value(app_settings.vga);
-        field_rf_amp.set_value(app_settings.rx_amp);
-        field_frequency.set_value(app_settings.rx_frequency);
-    } else {
-        field_lna.set_value(receiver_model.lna());
-        field_vga.set_value(receiver_model.vga());
-        field_rf_amp.set_value(receiver_model.rf_amp());
-        field_frequency.set_value(receiver_model.tuning_frequency());
-    }
+    // // load app settings TODO: needed?
+    // auto rc = settings.load("rx_pocsag", &app_settings);
+    // if (rc == SETTINGS_OK) {
+    //     field_lna.set_value(app_settings.lna);
+    //     field_vga.set_value(app_settings.vga);
+    //     field_rf_amp.set_value(app_settings.rx_amp);
+    //     field_frequency.set_value(app_settings.rx_frequency);
+    // } else {
+    //     field_lna.set_value(receiver_model.lna());
+    //     field_vga.set_value(receiver_model.vga());
+    //     field_rf_amp.set_value(receiver_model.rf_amp());
+    //     field_frequency.set_value(receiver_model.tuning_frequency());
+    // }
 
     receiver_model.set_modulation(ReceiverModel::Mode::NarrowbandFMAudio);
     receiver_model.set_sampling_rate(3072000);
@@ -128,9 +128,9 @@ POCSAGAppView::POCSAGAppView(NavigationView& nav) {
 }
 
 POCSAGAppView::~POCSAGAppView() {
-    // save app settings
-    app_settings.rx_frequency = field_frequency.value();
-    settings.save("rx_pocsag", &app_settings);
+    // // save app settings
+    // app_settings.rx_frequency = field_frequency.value();
+    // settings.save("rx_pocsag", &app_settings);
 
     audio::output::stop();
 

--- a/firmware/application/apps/pocsag_app.hpp
+++ b/firmware/application/apps/pocsag_app.hpp
@@ -55,8 +55,6 @@ class POCSAGAppView : public View {
     std::string title() const override { return "POCSAG RX"; };
 
    private:
-    static constexpr uint32_t initial_target_frequency = 466175000;
-
     bool logging() const { return check_log.value(); };
     bool ignore() const { return check_ignore.value(); };
 
@@ -110,14 +108,7 @@ class POCSAGAppView : public View {
 
     std::unique_ptr<POCSAGLogger> logger{};
 
-    uint32_t target_frequency_ = initial_target_frequency;
-
-    void update_freq(rf::Frequency f);
-
     void on_packet(const POCSAGPacketMessage* message);
-
-    uint32_t target_frequency() const;
-    void set_target_frequency(const uint32_t new_value);
 
     MessageHandlerRegistration message_handler_packet{
         Message::ID::POCSAGPacket,

--- a/firmware/application/apps/pocsag_app.hpp
+++ b/firmware/application/apps/pocsag_app.hpp
@@ -53,6 +53,7 @@ class POCSAGAppView : public View {
     ~POCSAGAppView();
 
     std::string title() const override { return "POCSAG RX"; };
+    void focus() override;
 
    private:
     bool logging() const { return check_log.value(); };

--- a/firmware/application/apps/pocsag_app.hpp
+++ b/firmware/application/apps/pocsag_app.hpp
@@ -60,9 +60,8 @@ class POCSAGAppView : public View {
     bool logging() const { return check_log.value(); };
     bool ignore() const { return check_ignore.value(); };
 
-    // app save settings
-    std::app_settings settings{};
-    std::app_settings::AppSettings app_settings{};
+    app_settings::SettingsManager settings_{
+        "rx_pocsag", app_settings::Mode::RX};
 
     uint32_t last_address = 0xFFFFFFFF;
     pocsag::POCSAGState pocsag_state{};

--- a/firmware/application/apps/replay_app.cpp
+++ b/firmware/application/apps/replay_app.cpp
@@ -194,17 +194,16 @@ ReplayAppView::ReplayAppView(
         &waterfall,
     });
 
-    field_frequency.set_value(target_frequency());
+    field_frequency.set_value(transmitter_model.target_frequency());
     field_frequency.set_step(receiver_model.frequency_step());
     field_frequency.on_change = [this](rf::Frequency f) {
-        this->on_target_frequency_changed(f);
+        transmitter_model.set_target_frequency(f);
     };
     field_frequency.on_edit = [this, &nav]() {
         // TODO: Provide separate modal method/scheme?
-        auto new_view = nav.push<FrequencyKeypadView>(this->target_frequency());
+        auto new_view = nav.push<FrequencyKeypadView>(transmitter_model.target_frequency());
         new_view->on_changed = [this](rf::Frequency f) {
-            this->on_target_frequency_changed(f);
-            this->field_frequency.set_value(f);
+            field_frequency.set_value(f);
         };
     };
 
@@ -245,18 +244,6 @@ void ReplayAppView::set_parent_rect(const Rect new_parent_rect) {
 
     const ui::Rect waterfall_rect{0, header_height, new_parent_rect.width(), new_parent_rect.height() - header_height};
     waterfall.set_parent_rect(waterfall_rect);
-}
-
-void ReplayAppView::on_target_frequency_changed(rf::Frequency f) {
-    set_target_frequency(f);
-}
-
-void ReplayAppView::set_target_frequency(const rf::Frequency new_value) {
-    persistent_memory::set_tuned_frequency(new_value);
-}
-
-rf::Frequency ReplayAppView::target_frequency() const {
-    return persistent_memory::tuned_frequency();
 }
 
 } /* namespace ui */

--- a/firmware/application/apps/replay_app.hpp
+++ b/firmware/application/apps/replay_app.hpp
@@ -53,7 +53,7 @@ class ReplayAppView : public View {
    private:
     NavigationView& nav_;
     app_settings::SettingsManager settings_{
-        "tx_replay", app_settings::Mode::TX);
+        "tx_replay", app_settings::Mode::TX};
 
     static constexpr ui::Dim header_height = 3 * 16;
 

--- a/firmware/application/apps/replay_app.hpp
+++ b/firmware/application/apps/replay_app.hpp
@@ -26,15 +26,16 @@
 #define SHORT_UI true
 #define NORMAL_UI false
 
+#include "app_settings.hpp"
 #include "ui_widget.hpp"
 #include "ui_navigation.hpp"
 #include "ui_receiver.hpp"
 #include "replay_thread.hpp"
 #include "ui_spectrum.hpp"
+#include "ui_transmitter.hpp"
 
 #include <string>
 #include <memory>
-#include "ui_transmitter.hpp"
 
 namespace ui {
 
@@ -51,6 +52,8 @@ class ReplayAppView : public View {
 
    private:
     NavigationView& nav_;
+    app_settings::SettingsManager settings_{
+        "tx_replay", app_settings::Mode::TX);
 
     static constexpr ui::Dim header_height = 3 * 16;
 
@@ -62,11 +65,7 @@ class ReplayAppView : public View {
     const size_t buffer_count{3};
 
     void on_file_changed(std::filesystem::path new_file_path);
-    void on_target_frequency_changed(rf::Frequency f);
     void on_tx_progress(const uint32_t progress);
-
-    void set_target_frequency(const rf::Frequency new_value);
-    rf::Frequency target_frequency() const;
 
     void toggle();
     void start();

--- a/firmware/application/apps/soundboard_app.cpp
+++ b/firmware/application/apps/soundboard_app.cpp
@@ -235,15 +235,6 @@ SoundBoardView::SoundBoardView(
                   &button_next_page,
                   &tx_view});
 
-    // load app settings
-    auto rc = settings.load("tx_soundboard", &app_settings);
-    if (rc == SETTINGS_OK) {
-        transmitter_model.set_rf_amp(app_settings.tx_amp);
-        transmitter_model.set_channel_bandwidth(app_settings.channel_bandwidth);
-        transmitter_model.set_tuning_frequency(app_settings.tx_frequency);
-        transmitter_model.set_tx_gain(app_settings.tx_gain);
-    }
-
     refresh_list();
 
     button_next_page.on_select = [this](Button&) {
@@ -266,9 +257,9 @@ SoundBoardView::SoundBoardView(
     check_random.set_value(false);
 
     tx_view.on_edit_frequency = [this, &nav]() {
-        auto new_view = nav.push<FrequencyKeypadView>(receiver_model.tuning_frequency());
+        auto new_view = nav.push<FrequencyKeypadView>(transmitter_model.target_frequency());
         new_view->on_changed = [this](rf::Frequency f) {
-            transmitter_model.set_tuning_frequency(f);
+            transmitter_model.set_target_frequency(f);
         };
     };
 
@@ -283,10 +274,6 @@ SoundBoardView::SoundBoardView(
 }
 
 SoundBoardView::~SoundBoardView() {
-    // save app settings
-    app_settings.tx_frequency = transmitter_model.tuning_frequency();
-    settings.save("tx_soundboard", &app_settings);
-
     stop();
     transmitter_model.disable();
     hackrf::cpld::load_sram_no_verify();  // to leave all RX ok, without ghost signal problem at the exit.

--- a/firmware/application/apps/soundboard_app.hpp
+++ b/firmware/application/apps/soundboard_app.hpp
@@ -49,11 +49,10 @@ class SoundBoardView : public View {
     std::string title() const override { return "Soundbrd TX"; };
 
    private:
-    NavigationView& nav_;
+    app_settings::SettingsManager settings_{
+        "tx_soundboard", app_settings::Mode::TX};
 
-    // app save settings
-    std::app_settings settings{};
-    std::app_settings::AppSettings app_settings{};
+    NavigationView& nav_;
 
     enum tx_modes {
         NORMAL = 0,

--- a/firmware/application/apps/tpms_app.cpp
+++ b/firmware/application/apps/tpms_app.cpp
@@ -157,6 +157,9 @@ TPMSAppView::TPMSAppView(NavigationView&) {
                   &field_vga,
                   &recent_entries_view});
 
+    if (!settings_.loaded())
+        receiver_model.set_sampling_rate(initial_target_frequency);
+
     receiver_model.set_sampling_rate(sampling_rate);
     receiver_model.set_baseband_bandwidth(baseband_bandwidth);
     receiver_model.enable();

--- a/firmware/application/apps/tpms_app.hpp
+++ b/firmware/application/apps/tpms_app.hpp
@@ -101,6 +101,7 @@ class TPMSAppView : public View {
     std::string title() const override { return "TPMS RX"; };
 
    private:
+    static constexpr uint32_t initial_target_frequency = 315000000;
     static constexpr uint32_t sampling_rate = 2457600;
     static constexpr uint32_t baseband_bandwidth = 1750000;
 

--- a/firmware/application/apps/tpms_app.hpp
+++ b/firmware/application/apps/tpms_app.hpp
@@ -101,7 +101,6 @@ class TPMSAppView : public View {
     std::string title() const override { return "TPMS RX"; };
 
    private:
-    static constexpr uint32_t initial_target_frequency = 315000000;
     static constexpr uint32_t sampling_rate = 2457600;
     static constexpr uint32_t baseband_bandwidth = 1750000;
 
@@ -170,18 +169,9 @@ class TPMSAppView : public View {
     }};
     TPMSRecentEntriesView recent_entries_view{columns, recent};
 
-    uint32_t target_frequency_ = initial_target_frequency;
-
     void on_packet(const tpms::Packet& packet);
     void on_show_list();
     void update_view();
-
-    void on_band_changed(const uint32_t new_band_frequency);
-
-    uint32_t target_frequency() const;
-    void set_target_frequency(const uint32_t new_value);
-
-    uint32_t tuning_frequency() const;
 };
 
 } /* namespace ui */

--- a/firmware/application/apps/tpms_app.hpp
+++ b/firmware/application/apps/tpms_app.hpp
@@ -105,9 +105,8 @@ class TPMSAppView : public View {
     static constexpr uint32_t sampling_rate = 2457600;
     static constexpr uint32_t baseband_bandwidth = 1750000;
 
-    // app save settings
-    std::app_settings settings{};
-    std::app_settings::AppSettings app_settings{};
+    app_settings::SettingsManager settings_{
+        "rx_tpms", app_settings::Mode::RX};
 
     MessageHandlerRegistration message_handler_packet{
         Message::ID::TPMSPacket,

--- a/firmware/application/apps/ui_about_demo.cpp
+++ b/firmware/application/apps/ui_about_demo.cpp
@@ -47,7 +47,7 @@ using namespace portapack;
 namespace ui {
 
 void AboutView::on_show() {
-    transmitter_model.set_tuning_frequency(1337000000);  // TODO: Change
+    transmitter_model.set_target_frequency(1337000000);  // TODO: Change
     transmitter_model.set_baseband_configuration({
         .mode = 0,
         .sampling_rate = 1536000,

--- a/firmware/application/apps/ui_adsb_rx.cpp
+++ b/firmware/application/apps/ui_adsb_rx.cpp
@@ -288,13 +288,6 @@ void ADSBRxView::focus() {
 }
 
 ADSBRxView::~ADSBRxView() {
-    receiver_model.set_tuning_frequency(prevFreq);  // Restore previous frequency on exit
-
-    // save app settings
-    settings.save("rx_adsb", &app_settings);
-
-    // TODO: once all apps keep there own settin previous frequency logic can be removed
-    receiver_model.set_tuning_frequency(prevFreq);
     rtc_time::signal_tick_second -= signal_token_tick_second;
     receiver_model.disable();
     baseband::shutdown();
@@ -502,17 +495,6 @@ ADSBRxView::ADSBRxView(NavigationView& nav) {
                   &rssi,
                   &recent_entries_view});
 
-    // load app settings
-    auto rc = settings.load("rx_adsb", &app_settings);
-    if (rc == SETTINGS_OK) {
-        field_lna.set_value(app_settings.lna);
-        field_vga.set_value(app_settings.vga);
-        field_rf_amp.set_value(app_settings.rx_amp);
-    } else {
-        field_lna.set_value(40);
-        field_vga.set_value(40);
-    }
-
     recent_entries_view.set_parent_rect({0, 16, 240, 272});
     recent_entries_view.on_select = [this, &nav](const AircraftRecentEntry& entry) {
         detailed_entry_key = entry.key();
@@ -528,11 +510,9 @@ ADSBRxView::ADSBRxView(NavigationView& nav) {
         on_tick_second();
     };
 
-    prevFreq = receiver_model.tuning_frequency();  // Store previous frequency on creation
-
     baseband::set_adsb();
 
-    receiver_model.set_tuning_frequency(1090000000);
+    receiver_model.set_target_frequency(1090000000);
     receiver_model.set_modulation(ReceiverModel::Mode::SpectrumAnalysis);
     receiver_model.set_sampling_rate(2000000);
     receiver_model.set_baseband_bandwidth(2500000);

--- a/firmware/application/apps/ui_adsb_rx.hpp
+++ b/firmware/application/apps/ui_adsb_rx.hpp
@@ -343,7 +343,6 @@ class ADSBRxView : public View {
     app_settings::SettingsManager settings_{
         "rx_adsb", app_settings::Mode::RX};
 
-    rf::Frequency prevFreq = {0};
     std::unique_ptr<ADSBLogger> logger{};
     void on_frame(const ADSBFrameMessage* message);
     void on_tick_second();

--- a/firmware/application/apps/ui_adsb_rx.hpp
+++ b/firmware/application/apps/ui_adsb_rx.hpp
@@ -340,6 +340,9 @@ class ADSBRxView : public View {
     void sort_entries_by_state();
 
    private:
+    app_settings::SettingsManager settings_{
+        "rx_adsb", app_settings::Mode::RX};
+
     rf::Frequency prevFreq = {0};
     std::unique_ptr<ADSBLogger> logger{};
     void on_frame(const ADSBFrameMessage* message);
@@ -350,9 +353,6 @@ class ADSBRxView : public View {
 
 #define MARKER_UPDATE_SECONDS (5)
     int ticksSinceMarkerRefresh{MARKER_UPDATE_SECONDS - 1};
-    // app save settings
-    std::app_settings settings{};
-    std::app_settings::AppSettings app_settings{};
 
     const RecentEntriesColumns columns{{{"ICAO/Call", 9},
                                         {"Lvl", 3},

--- a/firmware/application/apps/ui_adsb_tx.cpp
+++ b/firmware/application/apps/ui_adsb_tx.cpp
@@ -278,7 +278,7 @@ ADSBTxView::~ADSBTxView() {
     settings.save("tx_adsb", &app_settings);
 
     transmitter_model.disable();
-    hackrf::cpld::load_sram_no_verify();  // to leave all RX ok, withouth ghost signal problem at the exit .
+    hackrf::cpld::load_sram_no_verify();  // to leave all RX ok, withouth ghost signal problem at the exit.
     baseband::shutdown();                 // better this function at the end, not load_sram() that sometimes produces hang up.
 }
 
@@ -336,7 +336,7 @@ ADSBTxView::ADSBTxView(
     }
 
     tx_view.on_edit_frequency = [this, &nav]() {
-        auto new_view = nav.push<FrequencyKeypadView>(receiver_model.tuning_frequency());
+        auto new_view = nav.push<FrequencyKeypadView>(transmitter_model.tuning_frequency());
         new_view->on_changed = [this](rf::Frequency f) {
             transmitter_model.set_tuning_frequency(f);
         };

--- a/firmware/application/apps/ui_adsb_tx.cpp
+++ b/firmware/application/apps/ui_adsb_tx.cpp
@@ -273,10 +273,6 @@ void ADSBTxView::focus() {
 }
 
 ADSBTxView::~ADSBTxView() {
-    // save app settings
-    app_settings.tx_frequency = transmitter_model.tuning_frequency();
-    settings.save("tx_adsb", &app_settings);
-
     transmitter_model.disable();
     hackrf::cpld::load_sram_no_verify();  // to leave all RX ok, withouth ghost signal problem at the exit.
     baseband::shutdown();                 // better this function at the end, not load_sram() that sometimes produces hang up.
@@ -327,18 +323,10 @@ ADSBTxView::ADSBTxView(
                   &text_frame,
                   &tx_view});
 
-    // load app settings
-    auto rc = settings.load("tx_adsb", &app_settings);
-    if (rc == SETTINGS_OK) {
-        transmitter_model.set_tuning_frequency(app_settings.tx_frequency);
-        transmitter_model.set_rf_amp(app_settings.tx_amp);
-        transmitter_model.set_tx_gain(app_settings.tx_gain);
-    }
-
     tx_view.on_edit_frequency = [this, &nav]() {
-        auto new_view = nav.push<FrequencyKeypadView>(transmitter_model.tuning_frequency());
+        auto new_view = nav.push<FrequencyKeypadView>(transmitter_model.target_frequency());
         new_view->on_changed = [this](rf::Frequency f) {
-            transmitter_model.set_tuning_frequency(f);
+            transmitter_model.set_target_frequency(f);
         };
     };
 

--- a/firmware/application/apps/ui_adsb_tx.hpp
+++ b/firmware/application/apps/ui_adsb_tx.hpp
@@ -201,9 +201,8 @@ class ADSBTxView : public View {
                 -1
         };*/
 
-    // app save settings
-    std::app_settings settings{};
-    std::app_settings::AppSettings app_settings{};
+    app_settings::SettingsManager settings_{
+        "tx_adsb", app_settings::Mode::TX};
 
     // tx_modes tx_mode = IDLE;
     NavigationView& nav_;

--- a/firmware/application/apps/ui_afsk_rx.hpp
+++ b/firmware/application/apps/ui_afsk_rx.hpp
@@ -57,9 +57,8 @@ class AFSKRxView : public View {
    private:
     void on_data(uint32_t value, bool is_data);
 
-    // app save settings
-    std::app_settings settings{};
-    std::app_settings::AppSettings app_settings{};
+    app_settings::SettingsManager settings_{
+        "rx_afsk", app_settings::Mode::RX};
 
     uint8_t console_color{0};
     uint32_t prev_value{0};

--- a/firmware/application/apps/ui_aprs_rx.hpp
+++ b/firmware/application/apps/ui_aprs_rx.hpp
@@ -187,9 +187,8 @@ class APRSRxView : public View {
     void on_data(uint32_t value, bool is_data);
     bool reset_console = false;
 
-    // app save settings
-    std::app_settings settings{};
-    std::app_settings::AppSettings app_settings{};
+    app_settings::SettingsManager settings_{
+        "rx_aprs", app_settings::Mode::RX};
 
     uint8_t console_color{0};
     std::string str_log{""};

--- a/firmware/application/apps/ui_aprs_tx.cpp
+++ b/firmware/application/apps/ui_aprs_tx.cpp
@@ -44,10 +44,6 @@ void APRSTXView::focus() {
 }
 
 APRSTXView::~APRSTXView() {
-    // save app settings
-    app_settings.tx_frequency = transmitter_model.tuning_frequency();
-    settings.save("tx_aprs", &app_settings);
-
     transmitter_model.disable();
     hackrf::cpld::load_sram_no_verify();  // to leave all RX ok, without ghost signal problem at the exit.
     baseband::shutdown();                 // better this function at the end, not load_sram() that sometimes produces hang up.
@@ -62,7 +58,6 @@ void APRSTXView::start_tx() {
     // uint8_t * bb_data_ptr = shared_memory.bb_data.data;
     // text_payload.set(to_string_hex_array(bb_data_ptr + 56, 15));
 
-    transmitter_model.set_tuning_frequency(persistent_memory::tuned_frequency());
     transmitter_model.set_sampling_rate(AFSK_TX_SAMPLERATE);
     transmitter_model.set_baseband_bandwidth(1750000);
     transmitter_model.enable();
@@ -97,14 +92,6 @@ APRSTXView::APRSTXView(NavigationView& nav) {
                   &button_set,
                   &tx_view});
 
-    // load app settings
-    auto rc = settings.load("tx_aprs", &app_settings);
-    if (rc == SETTINGS_OK) {
-        transmitter_model.set_rf_amp(app_settings.tx_amp);
-        transmitter_model.set_tuning_frequency(app_settings.tx_frequency);
-        transmitter_model.set_tx_gain(app_settings.tx_gain);
-    }
-
     button_set.on_select = [this, &nav](Button&) {
         text_prompt(
             nav,
@@ -116,9 +103,9 @@ APRSTXView::APRSTXView(NavigationView& nav) {
     };
 
     tx_view.on_edit_frequency = [this, &nav]() {
-        auto new_view = nav.push<FrequencyKeypadView>(receiver_model.tuning_frequency());
+        auto new_view = nav.push<FrequencyKeypadView>(transmitter_model.target_frequency());
         new_view->on_changed = [this](rf::Frequency f) {
-            receiver_model.set_tuning_frequency(f);
+            transmitter_model.set_target_frequency(f);
         };
     };
 

--- a/firmware/application/apps/ui_aprs_tx.hpp
+++ b/firmware/application/apps/ui_aprs_tx.hpp
@@ -43,9 +43,8 @@ class APRSTXView : public View {
     std::string title() const override { return "APRS TX"; };
 
    private:
-    // app save settings
-    std::app_settings settings{};
-    std::app_settings::AppSettings app_settings{};
+    app_settings::SettingsManager settings_{
+        "tx_aprs", app_settings::Mode::TX};
 
     std::string payload{""};
 

--- a/firmware/application/apps/ui_bht_tx.cpp
+++ b/firmware/application/apps/ui_bht_tx.cpp
@@ -137,10 +137,6 @@ void BHTView::on_tx_progress(const uint32_t progress, const bool done) {
 }
 
 BHTView::~BHTView() {
-    // save app settings
-    app_settings.tx_frequency = transmitter_model.tuning_frequency();
-    settings.save("tx_bht", &app_settings);
-
     transmitter_model.disable();
     hackrf::cpld::load_sram_no_verify();  // to leave all RX ok, without ghost signal problem at the exit .
     baseband::shutdown();                 // better this function at the end, not load_sram() that sometimes produces hang up.
@@ -157,21 +153,12 @@ BHTView::BHTView(NavigationView& nav) {
                   &progressbar,
                   &tx_view});
 
-    // load app settings
-    auto rc = settings.load("tx_bht", &app_settings);
-    if (rc == SETTINGS_OK) {
-        transmitter_model.set_rf_amp(app_settings.tx_amp);
-        transmitter_model.set_channel_bandwidth(app_settings.channel_bandwidth);
-        transmitter_model.set_tuning_frequency(app_settings.tx_frequency);
-        transmitter_model.set_tx_gain(app_settings.tx_gain);
-    }
-
     field_speed.set_value(1);
 
     tx_view.on_edit_frequency = [this, &nav]() {
-        auto new_view = nav.push<FrequencyKeypadView>(receiver_model.tuning_frequency());
+        auto new_view = nav.push<FrequencyKeypadView>(transmitter_model.target_frequency());
         new_view->on_changed = [this](rf::Frequency f) {
-            transmitter_model.set_tuning_frequency(f);
+            transmitter_model.set_target_frequency(f);
         };
     };
 

--- a/firmware/application/apps/ui_bht_tx.hpp
+++ b/firmware/application/apps/ui_bht_tx.hpp
@@ -165,9 +165,8 @@ class BHTView : public View {
     std::string title() const override { return "BHT TX"; };
 
    private:
-    // app save settings
-    std::app_settings settings{};
-    std::app_settings::AppSettings app_settings{};
+    app_settings::SettingsManager settings_{
+        "tx_bht", app_settings::Mode::TX};
 
     void on_tx_progress(const uint32_t progress, const bool done);
     void start_tx();

--- a/firmware/application/apps/ui_btle_rx.cpp
+++ b/firmware/application/apps/ui_btle_rx.cpp
@@ -41,7 +41,7 @@ void BTLERxView::focus() {
 }
 
 void BTLERxView::update_freq(rf::Frequency f) {
-    receiver_model.set_tuning_frequency(f);
+    receiver_model.set_target_frequency(f);
 }
 
 BTLERxView::BTLERxView(NavigationView& nav) {
@@ -56,14 +56,6 @@ BTLERxView::BTLERxView(NavigationView& nav) {
                   &button_modem_setup,
                   &console});
 
-    // load app settings
-    auto rc = settings.load("rx_btle", &app_settings);
-    if (rc == SETTINGS_OK) {
-        field_lna.set_value(app_settings.lna);
-        field_vga.set_value(app_settings.vga);
-        field_rf_amp.set_value(app_settings.rx_amp);
-    }
-
     // Auto-configure modem for LCR RX (will be removed later)
     update_freq(2426000000);
     auto def_bell202 = &modem_defs[0];
@@ -75,15 +67,14 @@ BTLERxView::BTLERxView(NavigationView& nav) {
     serial_format.bit_order = LSB_FIRST;
     persistent_memory::set_serial_format(serial_format);
 
-    field_frequency.set_value(receiver_model.tuning_frequency());
+    field_frequency.set_value(receiver_model.target_frequency());
     field_frequency.set_step(100);
     field_frequency.on_change = [this](rf::Frequency f) {
         update_freq(f);
     };
     field_frequency.on_edit = [this, &nav]() {
-        auto new_view = nav.push<FrequencyKeypadView>(receiver_model.tuning_frequency());
+        auto new_view = nav.push<FrequencyKeypadView>(receiver_model.target_frequency());
         new_view->on_changed = [this](rf::Frequency f) {
-            update_freq(f);
             field_frequency.set_value(f);
         };
     };
@@ -148,10 +139,6 @@ void BTLERxView::on_data(uint32_t value, bool is_data) {
 }
 
 BTLERxView::~BTLERxView() {
-    // save app settings
-    app_settings.rx_frequency = field_frequency.value();
-    settings.save("rx_btle", &app_settings);
-
     audio::output::stop();
     receiver_model.disable();
     baseband::shutdown();

--- a/firmware/application/apps/ui_btle_rx.hpp
+++ b/firmware/application/apps/ui_btle_rx.hpp
@@ -46,9 +46,8 @@ class BTLERxView : public View {
    private:
     void on_data(uint32_t value, bool is_data);
 
-    // app save settings
-    std::app_settings settings{};
-    std::app_settings::AppSettings app_settings{};
+    app_settings::SettingsManager settings_{
+        "rx_btle", app_settings::Mode::RX};
 
     uint8_t console_color{0};
     uint32_t prev_value{0};

--- a/firmware/application/apps/ui_coasterp.cpp
+++ b/firmware/application/apps/ui_coasterp.cpp
@@ -38,10 +38,6 @@ void CoasterPagerView::focus() {
 }
 
 CoasterPagerView::~CoasterPagerView() {
-    // save app settings
-    app_settings.tx_frequency = transmitter_model.tuning_frequency();
-    settings.save("tx_coaster", &app_settings);
-
     transmitter_model.disable();
     hackrf::cpld::load_sram_no_verify();  // to leave all RX ok, without ghost signal problem at the exit .
     baseband::shutdown();                 // better this function at the end, not load_sram() that sometimes produces hang up.
@@ -123,15 +119,6 @@ CoasterPagerView::CoasterPagerView(NavigationView& nav) {
                   &text_message,
                   &tx_view});
 
-    // load app settings
-    auto rc = settings.load("tx_coaster", &app_settings);
-    if (rc == SETTINGS_OK) {
-        transmitter_model.set_rf_amp(app_settings.tx_amp);
-        transmitter_model.set_channel_bandwidth(app_settings.channel_bandwidth);
-        transmitter_model.set_tuning_frequency(app_settings.tx_frequency);
-        transmitter_model.set_tx_gain(app_settings.tx_gain);
-    }
-
     // Bytes to nibbles
     for (c = 0; c < 16; c++)
         sym_data.set_sym(c, (data_init[c >> 1] >> ((c & 1) ? 0 : 4)) & 0x0F);
@@ -141,9 +128,9 @@ CoasterPagerView::CoasterPagerView(NavigationView& nav) {
     generate_frame();
 
     tx_view.on_edit_frequency = [this, &nav]() {
-        auto new_view = nav.push<FrequencyKeypadView>(receiver_model.tuning_frequency());
+        auto new_view = nav.push<FrequencyKeypadView>(transmitter_model.target_frequency());
         new_view->on_changed = [this](rf::Frequency f) {
-            receiver_model.set_tuning_frequency(f);
+            transmitter_model.set_target_frequency(f);
         };
     };
 

--- a/firmware/application/apps/ui_coasterp.hpp
+++ b/firmware/application/apps/ui_coasterp.hpp
@@ -51,8 +51,8 @@ class CoasterPagerView : public View {
     tx_modes tx_mode = IDLE;
 
     // app save settings
-    std::app_settings settings{};
-    std::app_settings::AppSettings app_settings{};
+    app_settings::SettingsManager settings_{
+        "tx_coaster", app_settings::Mode::TX};
 
     void start_tx();
     void generate_frame();

--- a/firmware/application/apps/ui_encoders.cpp
+++ b/firmware/application/apps/ui_encoders.cpp
@@ -200,10 +200,6 @@ void EncodersView::focus() {
 }
 
 EncodersView::~EncodersView() {
-    // save app settings
-    app_settings.tx_frequency = transmitter_model.tuning_frequency();
-    settings.save("tx_ook", &app_settings);
-
     transmitter_model.disable();
     hackrf::cpld::load_sram_no_verify();  // ghost signal c/m to the problem at the exit .
     baseband::shutdown();                 // better this function after load_sram()
@@ -290,19 +286,10 @@ EncodersView::EncodersView(
                   &progressbar,
                   &tx_view});
 
-    // load app settings
-    auto rc = settings.load("tx_ook", &app_settings);
-    if (rc == SETTINGS_OK) {
-        transmitter_model.set_rf_amp(app_settings.tx_amp);
-        transmitter_model.set_channel_bandwidth(app_settings.channel_bandwidth);
-        transmitter_model.set_tuning_frequency(app_settings.tx_frequency);
-        transmitter_model.set_tx_gain(app_settings.tx_gain);
-    }
-
     tx_view.on_edit_frequency = [this, &nav]() {
-        auto new_view = nav.push<FrequencyKeypadView>(transmitter_model.tuning_frequency());
+        auto new_view = nav.push<FrequencyKeypadView>(transmitter_model.target_frequency());
         new_view->on_changed = [this](rf::Frequency f) {
-            transmitter_model.set_tuning_frequency(f);
+            transmitter_model.set_target_frequency(f);
         };
     };
 

--- a/firmware/application/apps/ui_encoders.hpp
+++ b/firmware/application/apps/ui_encoders.hpp
@@ -184,8 +184,8 @@ class EncodersView : public View {
     };
 
     // app save settings
-    std::app_settings settings{};
-    std::app_settings::AppSettings app_settings{};
+    app_settings::SettingsManager settings_{
+        "tx_ook", app_settings::Mode::TX};
 
     tx_modes tx_mode = IDLE;
     uint32_t repeat_index{0};

--- a/firmware/application/apps/ui_jammer.cpp
+++ b/firmware/application/apps/ui_jammer.cpp
@@ -186,7 +186,7 @@ JammerView::~JammerView() {
 
 void JammerView::on_retune(const rf::Frequency freq, const uint32_t range) {
     if (freq) {
-        transmitter_model.set_tuning_frequency(freq);
+        transmitter_model.set_target_frequency(freq);
         text_range_number.set(to_string_dec_uint(range, 2));
     }
 }

--- a/firmware/application/apps/ui_keyfob.cpp
+++ b/firmware/application/apps/ui_keyfob.cpp
@@ -236,12 +236,12 @@ KeyfobView::KeyfobView(
 
     options_make.set_selected_index(0);
 
-    transmitter_model.set_tuning_frequency(433920000);  // Fixed 433.92MHz
+    transmitter_model.set_target_frequency(433920000);  // Fixed 433.92MHz
 
     tx_view.on_edit_frequency = [this, &nav]() {
-        auto new_view = nav.push<FrequencyKeypadView>(transmitter_model.tuning_frequency());
+        auto new_view = nav.push<FrequencyKeypadView>(transmitter_model.target_frequency());
         new_view->on_changed = [this](rf::Frequency f) {
-            transmitter_model.set_tuning_frequency(f);
+            transmitter_model.set_target_frequency(f);
         };
     };
 

--- a/firmware/application/apps/ui_keyfob.hpp
+++ b/firmware/application/apps/ui_keyfob.hpp
@@ -43,8 +43,8 @@ class KeyfobView : public View {
     NavigationView& nav_;
 
     // app save settings
-    std::app_settings settings{};
-    std::app_settings::AppSettings app_settings{};
+    app_settings::SettingsManager settings_{
+        "tx_keyfob", , app_settings::Mode::TX};
 
     // 1013210ns / bit
     static constexpr uint32_t subaru_samples_per_bit = (OOK_SAMPLERATE * 0.00101321);

--- a/firmware/application/apps/ui_lcr.hpp
+++ b/firmware/application/apps/ui_lcr.hpp
@@ -79,9 +79,8 @@ class LCRView : public View {
         SCAN
     };
 
-    // app save settings
-    std::app_settings settings{};
-    std::app_settings::AppSettings app_settings{};
+    app_settings::SettingsManager settings_{
+        "tx_lcr", app_settings::Mode::TX};
 
     tx_modes tx_mode = IDLE;
     uint8_t scan_count{0}, scan_index{0};

--- a/firmware/application/apps/ui_level.hpp
+++ b/firmware/application/apps/ui_level.hpp
@@ -53,6 +53,9 @@ class LevelView : public View {
    private:
     NavigationView& nav_;
 
+    app_settings::SettingsManager settings_{
+        "rx_level", app_settings::Mode::RX};
+
     size_t change_mode(freqman_index_t mod_type);
     void on_statistics_update(const ChannelStatistics& statistics);
     void set_display_freq(int64_t freq);
@@ -168,9 +171,6 @@ class LevelView : public View {
         [this](const Message* const p) {
             this->on_statistics_update(static_cast<const ChannelStatisticsMessage*>(p)->statistics);
         }};
-    // app save settings
-    std::app_settings settings{};
-    std::app_settings::AppSettings app_settings{};
 };
 
 } /* namespace ui */

--- a/firmware/application/apps/ui_level.hpp
+++ b/firmware/application/apps/ui_level.hpp
@@ -60,9 +60,10 @@ class LevelView : public View {
     void on_statistics_update(const ChannelStatistics& statistics);
     void set_display_freq(int64_t freq);
 
+    // TODO: needed?
     int32_t db{0};
     long long int MAX_UFREQ = {7200000000};  // maximum usable freq
-    rf::Frequency freq = {0};
+    rf::Frequency freq_ = {0};
 
     Labels labels{
         {{0 * 8, 0 * 16}, "LNA:   VGA:   AMP:  VOL:     ", Color::light_grey()},
@@ -107,7 +108,7 @@ class LevelView : public View {
             {"audio off", 0},
             {"audio on", 1}
             //{"tone on", 2},
-            //{"tone off", 2},
+            //{"tone off", 3},
         }};
 
     Text text_ctcss{

--- a/firmware/application/apps/ui_looking_glass_app.cpp
+++ b/firmware/application/apps/ui_looking_glass_app.cpp
@@ -271,7 +271,7 @@ void GlassView::on_range_changed() {
     receiver_model.set_squelch_level(0);
     f_center = f_center_ini;  // Reset sweep into first slice
     baseband::set_spectrum(looking_glass_bandwidth, field_trigger.value());
-    receiver_model.set_tuning_frequency(f_center);  // tune rx for this slice
+    receiver_model.set_target_frequency(f_center);  // tune rx for this slice
 }
 
 void GlassView::PlotMarker(uint8_t pos) {
@@ -467,7 +467,7 @@ GlassView::GlassView(
     };
 
     button_marker.on_select = [this](ButtonWithEncoder&) {
-        receiver_model.set_tuning_frequency(marker);  // Center tune rx in marker freq.
+        receiver_model.set_target_frequency(marker);  // Center tune rx in marker freq.
         receiver_model.set_frequency_step(MHZ_DIV);   // Preset a 1 MHz frequency step into RX -> AUDIO
         nav_.pop();
         nav_.push<AnalogAudioView>();  // Jump into audio view
@@ -491,7 +491,7 @@ GlassView::GlassView(
     };
 
     button_jump.on_select = [this](Button&) {
-        receiver_model.set_tuning_frequency(max_freq_hold);  // Center tune rx in marker freq.
+        receiver_model.set_target_frequency(max_freq_hold);  // Center tune rx in marker freq.
         receiver_model.set_frequency_step(MHZ_DIV);          // Preset a 1 MHz frequency step into RX -> AUDIO
         nav_.pop();
         nav_.push<AnalogAudioView>();  // Jump into audio view

--- a/firmware/application/apps/ui_mictx.hpp
+++ b/firmware/application/apps/ui_mictx.hpp
@@ -26,6 +26,7 @@
 #define SHORT_UI true
 #define NORMAL_UI false
 
+#include "app_settings.hpp"
 #include "ui.hpp"
 #include "ui_widget.hpp"
 #include "ui_navigation.hpp"
@@ -71,13 +72,16 @@ class MicTXView : public View {
     void update_vumeter();
     void do_timing();
     void set_tx(bool enable);
-    //	void on_tuning_frequency_changed(rf::Frequency f);
+    //	void on_target_frequency_changed(rf::Frequency f);
     void on_tx_progress(const bool done);
     void configure_baseband();
 
     void rxaudio(bool is_on);
 
     void set_ptt_visibility(bool v);
+
+    app_settings::SettingsManager settings_{
+        "tx_mic", app_settings::Mode::RX_TX};
 
     bool transmitting{false};
     bool va_enabled{false};

--- a/firmware/application/apps/ui_morse.cpp
+++ b/firmware/application/apps/ui_morse.cpp
@@ -98,10 +98,6 @@ void MorseView::focus() {
 }
 
 MorseView::~MorseView() {
-    // save app settings
-    app_settings.tx_frequency = transmitter_model.tuning_frequency();
-    settings.save("tx_morse", &app_settings);
-
     transmitter_model.disable();
     hackrf::cpld::load_sram_no_verify();  // to leave all RX ok, without ghost signal problem at the exit .
     baseband::shutdown();                 // better this function at the end, not load_sram() that sometimes produces hang up.
@@ -206,15 +202,6 @@ MorseView::MorseView(
                   &progressbar,
                   &tx_view});
 
-    // load app settings
-    auto rc = settings.load("tx_morse", &app_settings);
-    if (rc == SETTINGS_OK) {
-        transmitter_model.set_rf_amp(app_settings.tx_amp);
-        transmitter_model.set_channel_bandwidth(app_settings.channel_bandwidth);
-        transmitter_model.set_tuning_frequency(app_settings.tx_frequency);
-        transmitter_model.set_tx_gain(app_settings.tx_gain);
-    }
-
     // Default settings
     field_speed.set_value(15);                 // 15wps
     field_tone.set_value(700);                 // 700Hz FM tone
@@ -251,9 +238,9 @@ MorseView::MorseView(
     };
 
     tx_view.on_edit_frequency = [this, &nav]() {
-        auto new_view = nav.push<FrequencyKeypadView>(receiver_model.tuning_frequency());
+        auto new_view = nav.push<FrequencyKeypadView>(transmitter_model.target_frequency());
         new_view->on_changed = [this](rf::Frequency f) {
-            receiver_model.set_tuning_frequency(f);
+            transmitter_model.set_target_frequency(f);
         };
     };
 

--- a/firmware/application/apps/ui_morse.hpp
+++ b/firmware/application/apps/ui_morse.hpp
@@ -68,9 +68,8 @@ class MorseView : public View {
     std::string message{};
     uint32_t time_units{0};
 
-    // app save settings
-    std::app_settings settings{};
-    std::app_settings::AppSettings app_settings{};
+    app_settings::SettingsManager settings_{
+        "tx_morse", app_settings::Mode::TX};
 
     enum modulation_t {
         CW = 0,

--- a/firmware/application/apps/ui_nrf_rx.hpp
+++ b/firmware/application/apps/ui_nrf_rx.hpp
@@ -46,9 +46,8 @@ class NRFRxView : public View {
    private:
     void on_data(uint32_t value, bool is_data);
 
-    // app save settings
-    std::app_settings settings{};
-    std::app_settings::AppSettings app_settings{};
+    app_settings::SettingsManager settings_{
+        "rx_nrf", app_settings::Mode::RX};
 
     uint8_t console_color{0};
     uint32_t prev_value{0};

--- a/firmware/application/apps/ui_nuoptix.cpp
+++ b/firmware/application/apps/ui_nuoptix.cpp
@@ -156,9 +156,9 @@ NuoptixView::NuoptixView(
     number_timecode.set_value(1);
 
     tx_view.on_edit_frequency = [this, &nav]() {
-        auto new_view = nav.push<FrequencyKeypadView>(receiver_model.tuning_frequency());
+        auto new_view = nav.push<FrequencyKeypadView>(transmitter_model.target_frequency());
         new_view->on_changed = [this](rf::Frequency f) {
-            receiver_model.set_tuning_frequency(f);
+            transmitter_model.target_frequency(f);
         };
     };
 

--- a/firmware/application/apps/ui_nuoptix.hpp
+++ b/firmware/application/apps/ui_nuoptix.hpp
@@ -56,7 +56,6 @@ class NuoptixView : public View {
 
     tx_modes tx_mode{IDLE};
 
-    void on_tuning_frequency_changed(rf::Frequency f);
     void transmit(bool setup);
     void on_tx_progress(const uint32_t progress, const bool done);
 

--- a/firmware/application/apps/ui_playlist.cpp
+++ b/firmware/application/apps/ui_playlist.cpp
@@ -184,7 +184,7 @@ void PlaylistView::start() {
     playlist_entry item = playlist_db.front();
     playlist_db.pop_front();
     on_file_changed(item.replay_file, item.replay_frequency, item.sample_rate, item.next_delay);
-    on_target_frequency_changed(item.replay_frequency);
+    transmitter_model.set_target_frequency(item.replay_frequency);
 
     std::unique_ptr<stream::Reader> reader;
 
@@ -293,16 +293,15 @@ PlaylistView::PlaylistView(
         &waterfall,
     });
 
-    field_frequency.set_value(target_frequency());
+    field_frequency.set_value(transmitter_model.target_frequency());
     field_frequency.set_step(receiver_model.frequency_step());
     field_frequency.on_change = [this](rf::Frequency f) {
-        this->on_target_frequency_changed(f);
+        transmitter_model.set_target_frequency(f);
     };
     field_frequency.on_edit = [this, &nav]() {
         // TODO: Provide separate modal method/scheme?
-        auto new_view = nav.push<FrequencyKeypadView>(this->target_frequency());
+        auto new_view = nav.push<FrequencyKeypadView>(transmitter_model.target_frequency());
         new_view->on_changed = [this](rf::Frequency f) {
-            this->on_target_frequency_changed(f);
             this->field_frequency.set_value(f);
         };
     };
@@ -342,18 +341,6 @@ void PlaylistView::set_parent_rect(const Rect new_parent_rect) {
     const ui::Rect waterfall_rect{0, header_height, new_parent_rect.width(),
                                   new_parent_rect.height() - header_height};
     waterfall.set_parent_rect(waterfall_rect);
-}
-
-void PlaylistView::on_target_frequency_changed(rf::Frequency f) {
-    set_target_frequency(f);
-}
-
-void PlaylistView::set_target_frequency(const rf::Frequency new_value) {
-    persistent_memory::set_tuned_frequency(new_value);
-}
-
-rf::Frequency PlaylistView::target_frequency() const {
-    return persistent_memory::tuned_frequency();
 }
 
 } /* namespace ui */

--- a/firmware/application/apps/ui_playlist.hpp
+++ b/firmware/application/apps/ui_playlist.hpp
@@ -23,16 +23,17 @@
 #define SHORT_UI true
 #define NORMAL_UI false
 
+#include "app_settings.hpp"
 #include "ui_widget.hpp"
 #include "ui_navigation.hpp"
 #include "ui_receiver.hpp"
 #include "replay_thread.hpp"
 #include "ui_spectrum.hpp"
+#include "ui_transmitter.hpp"
 
 #include <string>
 #include <memory>
 #include <deque>
-#include "ui_transmitter.hpp"
 
 namespace ui {
 
@@ -52,6 +53,8 @@ class PlaylistView : public View {
 
    private:
     NavigationView& nav_;
+    app_settings::SettingsManager settings_{
+        "tx_playlist", app_settings::Mode::TX};
 
     static constexpr ui::Dim header_height = 3 * 16;
 

--- a/firmware/application/apps/ui_playlist.hpp
+++ b/firmware/application/apps/ui_playlist.hpp
@@ -76,7 +76,6 @@ class PlaylistView : public View {
     void load_file(std::filesystem::path playlist_path);
     void txtline_process(std::string&);
     void on_file_changed(std::filesystem::path new_file_path, rf::Frequency replay_frequency, uint32_t replay_sample_rate, uint32_t next_delay);
-    void on_target_frequency_changed(rf::Frequency f);
     void on_tx_progress(const uint32_t progress);
     void set_target_frequency(const rf::Frequency new_value);
     rf::Frequency target_frequency() const;

--- a/firmware/application/apps/ui_pocsag_tx.cpp
+++ b/firmware/application/apps/ui_pocsag_tx.cpp
@@ -39,10 +39,6 @@ void POCSAGTXView::focus() {
 }
 
 POCSAGTXView::~POCSAGTXView() {
-    // save app settings
-    app_settings.tx_frequency = transmitter_model.tuning_frequency();
-    settings.save("tx_pocsag", &app_settings);
-
     transmitter_model.disable();
     hackrf::cpld::load_sram_no_verify();  // to leave all RX ok, without ghost signal problem at the exit
     baseband::shutdown();                 // better this function at the end, not load_sram() that sometimes produces hang up.
@@ -143,15 +139,6 @@ POCSAGTXView::POCSAGTXView(
                   &progressbar,
                   &tx_view});
 
-    // load app settings
-    auto rc = settings.load("tx_pocsag", &app_settings);
-    if (rc == SETTINGS_OK) {
-        transmitter_model.set_rf_amp(app_settings.tx_amp);
-        transmitter_model.set_channel_bandwidth(app_settings.channel_bandwidth);
-        transmitter_model.set_tuning_frequency(app_settings.tx_frequency);
-        transmitter_model.set_tx_gain(app_settings.tx_gain);
-    }
-
     options_bitrate.set_selected_index(1);  // 1200bps
     options_type.set_selected_index(0);     // Address only
 
@@ -172,9 +159,9 @@ POCSAGTXView::POCSAGTXView(
     };
 
     tx_view.on_edit_frequency = [this, &nav]() {
-        auto new_view = nav.push<FrequencyKeypadView>(transmitter_model.tuning_frequency());
+        auto new_view = nav.push<FrequencyKeypadView>(transmitter_model.target_frequency());
         new_view->on_changed = [this](rf::Frequency f) {
-            transmitter_model.set_tuning_frequency(f);
+            transmitter_model.set_target_frequency(f);
         };
     };
 

--- a/firmware/application/apps/ui_pocsag_tx.hpp
+++ b/firmware/application/apps/ui_pocsag_tx.hpp
@@ -58,16 +58,15 @@ class POCSAGTXView : public View {
     std::string message{};
     NavigationView& nav_;
 
+    app_settings::SettingsManager settings_{
+        "tx_pocsag", app_settings::Mode::TX};
+
     BCHCode BCH_code{
         {1, 0, 1, 0, 0, 1},
         5,
         31,
         21,
         2};
-
-    // app save settings
-    std::app_settings settings{};
-    std::app_settings::AppSettings app_settings{};
 
     void on_set_text(NavigationView& nav);
     void on_tx_progress(const uint32_t progress, const bool done);

--- a/firmware/application/apps/ui_rds.cpp
+++ b/firmware/application/apps/ui_rds.cpp
@@ -160,10 +160,6 @@ void RDSView::focus() {
 }
 
 RDSView::~RDSView() {
-    // save app settings
-    app_settings.tx_frequency = transmitter_model.tuning_frequency();
-    settings.save("tx_rds", &app_settings);
-
     transmitter_model.disable();
     hackrf::cpld::load_sram_no_verify();  // to leave all RX ok, without ghost signal problem at the exit.
     baseband::shutdown();                 // better this function at the end, not load_sram() that sometimes produces hang up.
@@ -218,14 +214,6 @@ RDSView::RDSView(
         &tx_view,
     });
 
-    // load app settings
-    auto rc = settings.load("tx_rds", &app_settings);
-    if (rc == SETTINGS_OK) {
-        transmitter_model.set_rf_amp(app_settings.tx_amp);
-        transmitter_model.set_channel_bandwidth(app_settings.channel_bandwidth);
-        transmitter_model.set_tuning_frequency(app_settings.tx_frequency);
-        transmitter_model.set_tx_gain(app_settings.tx_gain);
-    }
     check_TP.set_value(true);
 
     sym_pi_code.set_sym(0, 0xF);
@@ -239,9 +227,9 @@ RDSView::RDSView(
     options_pty.set_selected_index(0);  // None
 
     tx_view.on_edit_frequency = [this, &nav]() {
-        auto new_view = nav.push<FrequencyKeypadView>(receiver_model.tuning_frequency());
+        auto new_view = nav.push<FrequencyKeypadView>(transmitter_model.target_frequency());
         new_view->on_changed = [this](rf::Frequency f) {
-            receiver_model.set_tuning_frequency(f);
+            transmitter_model.set_target_frequency(f);
         };
     };
 

--- a/firmware/application/apps/ui_rds.hpp
+++ b/firmware/application/apps/ui_rds.hpp
@@ -140,9 +140,8 @@ class RDSView : public View {
     NavigationView& nav_;
     RDS_flags rds_flags{};
 
-    // app save settings
-    std::app_settings settings{};
-    std::app_settings::AppSettings app_settings{};
+    app_settings::SettingsManager settings_{
+        "tx_rds", app_settings::Mode::TX};
 
     std::vector<RDSGroup> frame_psn{};
     std::vector<RDSGroup> frame_radiotext{};

--- a/firmware/application/apps/ui_recon.cpp
+++ b/firmware/application/apps/ui_recon.cpp
@@ -879,8 +879,8 @@ ReconView::ReconView(NavigationView& nav)
     freqman_set_step_option(step_mode);
 
     // set radio
-    change_mode(AM_MODULATION);                                                            // start on AM.
-    field_mode.set_by_value(AM_MODULATION);                                                // reflect the mode into the manual selector
+    change_mode(AM_MODULATION);              // start on AM.
+    field_mode.set_by_value(AM_MODULATION);  // reflect the mode into the manual selector
 
     if (filedelete) {
         delete_file(freq_file_path);

--- a/firmware/application/apps/ui_recon.cpp
+++ b/firmware/application/apps/ui_recon.cpp
@@ -291,7 +291,7 @@ void ReconView::recon_redraw() {
 void ReconView::handle_retune() {
     if (last_freq != freq) {
         last_freq = freq;
-        receiver_model.set_tuning_frequency(freq);  // Retune
+        receiver_model.set_target_frequency(freq);  // Retune
     }
     if (frequency_list.size() > 0) {
         if (last_entry.modulation != frequency_list[current_index].modulation && frequency_list[current_index].modulation >= 0) {
@@ -361,10 +361,8 @@ void ReconView::focus() {
 }
 
 ReconView::~ReconView() {
-    // save app config
+    // Save recon config.
     recon_save_config_to_sd();
-    // save app common settings
-    settings.save("recon", &app_settings);
 
     audio::output::stop();
     receiver_model.disable();
@@ -412,8 +410,7 @@ ReconView::ReconView(NavigationView& nav)
 
     def_step = 0;
     // HELPER: Pre-setting a manual range, based on stored frequency
-    rf::Frequency stored_freq = persistent_memory::tuned_frequency();
-    receiver_model.set_tuning_frequency(stored_freq);
+    rf::Frequency stored_freq = receiver_model.target_frequency();
     if (stored_freq - OneMHz > 0)
         frequency_range.min = stored_freq - OneMHz;
     else
@@ -424,6 +421,7 @@ ReconView::ReconView(NavigationView& nav)
     else
         frequency_range.max = MAX_UFREQ;
     button_manual_end.set_text(to_string_short_freq(frequency_range.max));
+
     // Loading settings
     autostart = persistent_memory::recon_autostart_recon();
     autosave = persistent_memory::recon_autosave_freqs();
@@ -433,16 +431,6 @@ ReconView::ReconView(NavigationView& nav)
     load_ranges = persistent_memory::recon_load_ranges();
     load_hamradios = persistent_memory::recon_load_hamradios();
     update_ranges = persistent_memory::recon_update_ranges_when_recon();
-    if (sd_card_mounted) {
-        // load auto common app settings
-        auto rc = settings.load("recon", &app_settings);
-        if (rc == SETTINGS_OK) {
-            field_lna.set_value(app_settings.lna);
-            field_vga.set_value(app_settings.vga);
-            field_rf_amp.set_value(app_settings.rx_amp);
-            receiver_model.set_rf_amp(app_settings.rx_amp);
-        }
-    }
 
     button_manual_start.on_select = [this, &nav](ButtonWithEncoder& button) {
         clear_freqlist_for_ui_action();
@@ -563,17 +551,18 @@ ReconView::ReconView(NavigationView& nav)
         nav_.push<LevelView>();
     };
 
+    // TODO: *BUG* Both transmitter_model and receiver_model share the same pmem setting for target_frequency.
     button_mic_app.on_select = [this](Button&) {
         if (frequency_list.size() > 0 && current_index >= 0 && (unsigned)current_index < frequency_list.size()) {
             if (frequency_list[current_index].type == HAMRADIO) {
                 // if it's a HAMRADIO entry, then frequency_a is the freq at which the repeater reveive, so we have to set it in transmit in mic app
-                transmitter_model.set_tuning_frequency(frequency_list[current_index].frequency_a);
+                transmitter_model.set_target_frequency(frequency_list[current_index].frequency_a);
                 // if it's a HAMRADIO entry, then frequency_b is the freq at which the repeater transmit, so we have to set it in receive in mic app
-                receiver_model.set_tuning_frequency(frequency_list[current_index].frequency_b);
+                receiver_model.set_target_frequency(frequency_list[current_index].frequency_b);
             } else {
                 // it's single or range so we us actual tuned frequency
-                transmitter_model.set_tuning_frequency(freq);
-                receiver_model.set_tuning_frequency(freq);
+                transmitter_model.set_target_frequency(freq);
+                receiver_model.set_target_frequency(freq);
             }
         }
         // there is no way yet to set modulation and bandwidth from Recon to MicApp
@@ -672,7 +661,7 @@ ReconView::ReconView(NavigationView& nav)
                     }
                 }
             }
-            receiver_model.set_tuning_frequency(frequency_list[current_index].frequency_a);  // retune
+            receiver_model.set_target_frequency(frequency_list[current_index].frequency_a);  // retune
         }
         if (frequency_list.size() == 0) {
             text_cycle.set_text(" ");
@@ -892,7 +881,6 @@ ReconView::ReconView(NavigationView& nav)
     // set radio
     change_mode(AM_MODULATION);                                                            // start on AM.
     field_mode.set_by_value(AM_MODULATION);                                                // reflect the mode into the manual selector
-    receiver_model.set_tuning_frequency(portapack::persistent_memory::tuned_frequency());  // first tune
 
     if (filedelete) {
         delete_file(freq_file_path);

--- a/firmware/application/apps/ui_recon.hpp
+++ b/firmware/application/apps/ui_recon.hpp
@@ -60,6 +60,9 @@ class ReconView : public View {
    private:
     NavigationView& nav_;
 
+    app_settings::SettingsManager settings_{
+        "rx_recon", app_settings::Mode::RX};
+
     void clear_freqlist_for_ui_action();
     void reset_indexes();
     void audio_output_start();
@@ -322,9 +325,6 @@ class ReconView : public View {
         [this](const Message* const p) {
             this->on_statistics_update(static_cast<const ChannelStatisticsMessage*>(p)->statistics);
         }};
-    // app save settings
-    std::app_settings settings{};
-    std::app_settings::AppSettings app_settings{};
 };
 
 } /* namespace ui */

--- a/firmware/application/apps/ui_recon.hpp
+++ b/firmware/application/apps/ui_recon.hpp
@@ -61,7 +61,7 @@ class ReconView : public View {
     NavigationView& nav_;
 
     app_settings::SettingsManager settings_{
-        "rx_recon", app_settings::Mode::RX};
+        "rx_recon", app_settings::Mode::RX_TX};
 
     void clear_freqlist_for_ui_action();
     void reset_indexes();

--- a/firmware/application/apps/ui_recon.hpp
+++ b/firmware/application/apps/ui_recon.hpp
@@ -61,7 +61,7 @@ class ReconView : public View {
     NavigationView& nav_;
 
     app_settings::SettingsManager settings_{
-        "rx_recon", app_settings::Mode::RX_TX};
+        "rx_recon", app_settings::Mode::RX};
 
     void clear_freqlist_for_ui_action();
     void reset_indexes();

--- a/firmware/application/apps/ui_scanner.cpp
+++ b/firmware/application/apps/ui_scanner.cpp
@@ -122,7 +122,7 @@ void ScannerThread::run() {
                     if (force_one_step)
                         _index_stepper = 0;
 
-                    receiver_model.set_tuning_frequency(frequency_list_[frequency_index]);  // Retune
+                    receiver_model.set_target_frequency(frequency_list_[frequency_index]);  // Retune
                 }
                 message.freq = frequency_list_[frequency_index];
                 message.range = frequency_index;  // Inform freq (for coloring purposes also!)
@@ -160,7 +160,7 @@ void ScannerThread::run() {
                     if (force_one_step)
                         _index_stepper = 0;
 
-                    receiver_model.set_tuning_frequency(frequency_range_.min + frequency_index * def_step_hz_);  // Retune
+                    receiver_model.set_target_frequency(frequency_range_.min + frequency_index * def_step_hz_);  // Retune
                 }
                 message.freq = frequency_range_.min + frequency_index * def_step_hz_;
                 message.range = 0;  // Inform freq (for coloring purposes also!)
@@ -305,8 +305,7 @@ ScannerView::ScannerView(
     field_step.set_by_value(9000);           // Default step interval (Hz)
 
     // FUTURE: perhaps additional settings should be stored in persistent memory vs using defaults
-    // HELPER: Pre-setting a manual range, based on stored frequency
-    rf::Frequency stored_freq = persistent_memory::tuned_frequency();
+    rf::Frequency stored_freq = receiver_model.target_frequency();
     frequency_range.min = stored_freq - 1000000;
     button_manual_start.set_text(to_string_short_freq(frequency_range.min));
     frequency_range.max = stored_freq + 1000000;

--- a/firmware/application/apps/ui_search.cpp
+++ b/firmware/application/apps/ui_search.cpp
@@ -221,7 +221,7 @@ void SearchView::on_channel_spectrum(const ChannelSpectrum& spectrum) {
             slice_counter = 0;
         } else
             slice_counter++;
-        receiver_model.set_tuning_frequency(slices[slice_counter].center_frequency);
+        receiver_model.set_target_frequency(slices[slice_counter].center_frequency);
         baseband::set_spectrum(SEARCH_SLICE_WIDTH, 31);  // Clear
     } else {
         // Unique slice
@@ -271,7 +271,7 @@ void SearchView::on_range_changed() {
         }
     } else {
         slices[0].center_frequency = (f_max + f_min) / 2;
-        receiver_model.set_tuning_frequency(slices[0].center_frequency);
+        receiver_model.set_target_frequency(slices[0].center_frequency);
 
         slices_nb = 1;
         text_slices.set(" 1");
@@ -376,25 +376,25 @@ SearchView::SearchView(
         power_threshold = value;
     };
 
-    field_frequency_min.set_value(receiver_model.tuning_frequency() - 1000000);
+    field_frequency_min.set_value(receiver_model.target_frequency() - 1000000);
     field_frequency_min.set_step(100000);
     field_frequency_min.on_change = [this](rf::Frequency) {
         this->on_range_changed();
     };
     field_frequency_min.on_edit = [this, &nav]() {
-        auto new_view = nav.push<FrequencyKeypadView>(receiver_model.tuning_frequency());
+        auto new_view = nav.push<FrequencyKeypadView>(receiver_model.target_frequency());
         new_view->on_changed = [this](rf::Frequency f) {
             this->field_frequency_min.set_value(f);
         };
     };
 
-    field_frequency_max.set_value(receiver_model.tuning_frequency() + 1000000);
+    field_frequency_max.set_value(receiver_model.target_frequency() + 1000000);
     field_frequency_max.set_step(100000);
     field_frequency_max.on_change = [this](rf::Frequency) {
         this->on_range_changed();
     };
     field_frequency_max.on_edit = [this, &nav]() {
-        auto new_view = nav.push<FrequencyKeypadView>(receiver_model.tuning_frequency());
+        auto new_view = nav.push<FrequencyKeypadView>(receiver_model.target_frequency());
         new_view->on_changed = [this](rf::Frequency f) {
             this->field_frequency_max.set_value(f);
         };

--- a/firmware/application/apps/ui_settings.cpp
+++ b/firmware/application/apps/ui_settings.cpp
@@ -334,8 +334,8 @@ SetConverterSettingsView::SetConverterSettingsView(NavigationView& nav) {
         if (!v) {
             check_converter.set_value(false);
         }
-        // Retune to take converter change in account
-        receiver_model.set_tuning_frequency(portapack::persistent_memory::tuned_frequency());
+        // Retune to take converter change in account.
+        receiver_model.set_target_frequency(receiver_model.target_frequency());
         // Refresh status bar with/out converter
         StatusRefreshMessage message{};
         EventDispatcher::send_message(message);
@@ -349,7 +349,7 @@ SetConverterSettingsView::SetConverterSettingsView(NavigationView& nav) {
         }
         portapack::persistent_memory::set_config_converter(v);
         // Retune to take converter change in account
-        receiver_model.set_tuning_frequency(portapack::persistent_memory::tuned_frequency());
+        receiver_model.set_target_frequency(receiver_model.target_frequency());
         // Refresh status bar with/out converter
         StatusRefreshMessage message{};
         EventDispatcher::send_message(message);
@@ -369,7 +369,7 @@ SetConverterSettingsView::SetConverterSettingsView(NavigationView& nav) {
         new_view->on_changed = [this, &button](rf::Frequency f) {
             portapack::persistent_memory::set_config_converter_freq(f);
             // Retune to take converter change in account
-            receiver_model.set_tuning_frequency(portapack::persistent_memory::tuned_frequency());
+            receiver_model.set_target_frequency(receiver_model.target_frequency());
             button_converter_freq.set_text("<" + to_string_short_freq(f) + " MHz>");
         };
     };
@@ -412,7 +412,7 @@ SetFrequencyCorrectionView::SetFrequencyCorrectionView(NavigationView& nav) {
                 f = MAX_FREQ_CORRECTION;
             portapack::persistent_memory::set_config_freq_rx_correction(f);
             // Retune to take converter change in account
-            receiver_model.set_tuning_frequency(portapack::persistent_memory::tuned_frequency());
+            receiver_model.set_target_frequency(receiver_model.target_frequency());
             button_freq_rx_correction.set_text("<" + to_string_short_freq(f) + " MHz>");
         };
     };
@@ -425,7 +425,7 @@ SetFrequencyCorrectionView::SetFrequencyCorrectionView(NavigationView& nav) {
                 f = MAX_FREQ_CORRECTION;
             portapack::persistent_memory::set_config_freq_tx_correction(f);
             // Retune to take converter change in account
-            receiver_model.set_tuning_frequency(portapack::persistent_memory::tuned_frequency());
+            receiver_model.set_target_frequency(receiver_model.target_frequency());
             button_freq_tx_correction.set_text("<" + to_string_short_freq(f) + " MHz>");
         };
     };

--- a/firmware/application/apps/ui_sigfrx.cpp
+++ b/firmware/application/apps/ui_sigfrx.cpp
@@ -119,9 +119,9 @@ SIGFRXView::SIGFRXView(
         .sampling_rate = 3072000,
         .decimation_factor = 4,
     });
+    // TODO: use settings.
     receiver_model.set_baseband_bandwidth(1750000);
-
-    receiver_model.set_tuning_frequency(868110000);
+    receiver_model.set_target_frequency(868110000);
 
     receiver_model.set_lna(0);
     receiver_model.set_vga(0);

--- a/firmware/application/apps/ui_siggen.cpp
+++ b/firmware/application/apps/ui_siggen.cpp
@@ -55,7 +55,6 @@ void SigGenView::update_tone() {
 
 void SigGenView::start_tx() {
     transmitter_model.set_sampling_rate(1536000);
-    //	transmitter_model.set_rf_amp(true);
     transmitter_model.set_baseband_bandwidth(1750000);
     transmitter_model.enable();
 
@@ -116,9 +115,9 @@ SigGenView::SigGenView(
     };
 
     tx_view.on_edit_frequency = [this, &nav]() {
-        auto new_view = nav.push<FrequencyKeypadView>(receiver_model.tuning_frequency());
+        auto new_view = nav.push<FrequencyKeypadView>(transmitter_model.target_frequency());
         new_view->on_changed = [this](rf::Frequency f) {
-            receiver_model.set_tuning_frequency(f);
+            transmitter_model.set_target_frequency(f);
         };
     };
 

--- a/firmware/application/apps/ui_siggen.hpp
+++ b/firmware/application/apps/ui_siggen.hpp
@@ -23,6 +23,7 @@
 #ifndef __SIGGEN_H__
 #define __SIGGEN_H__
 
+#include "app_settings.hpp"
 #include "ui.hpp"
 #include "ui_widget.hpp"
 #include "ui_navigation.hpp"
@@ -47,6 +48,9 @@ class SigGenView : public View {
     void update_config();
     void update_tone();
     void on_tx_progress(const uint32_t progress, const bool done);
+
+    app_settings::SettingsManager settings_{
+        "tx_siggen", app_settings::Mode::TX};
 
     const std::string shape_strings[7] = {
         "CW-just carrier",

--- a/firmware/application/apps/ui_sonde.cpp
+++ b/firmware/application/apps/ui_sonde.cpp
@@ -93,7 +93,7 @@ SondeView::SondeView(NavigationView& nav) {
     };
 
     // TODO: Actually necessary?
-    //receiver_model.update_sampling_rate(sampling_rate);
+    // receiver_model.update_sampling_rate(sampling_rate);
     receiver_model.enable();
 
     // QR code with geo URI

--- a/firmware/application/apps/ui_sonde.cpp
+++ b/firmware/application/apps/ui_sonde.cpp
@@ -65,27 +65,15 @@ SondeView::SondeView(NavigationView& nav) {
                   &button_see_qr,
                   &button_see_map});
 
-    // load app settings
-    auto rc = settings.load("rx_sonde", &app_settings);
-    if (rc == SETTINGS_OK) {
-        field_lna.set_value(app_settings.lna);
-        field_vga.set_value(app_settings.vga);
-        field_rf_amp.set_value(app_settings.rx_amp);
-        target_frequency_ = app_settings.rx_frequency;
-    } else
-        target_frequency_ = receiver_model.tuning_frequency();
-
-    field_frequency.set_value(target_frequency_);
+    field_frequency.set_value(receiver_model.target_frequency());
     field_frequency.set_step(500);  // euquiq: was 10000, but we are using this for fine-tunning
     field_frequency.on_change = [this](rf::Frequency f) {
-        set_target_frequency(f);
-        field_frequency.set_value(f);
+        receiver_model.set_target_frequency(f);
     };
     field_frequency.on_edit = [this, &nav]() {
         // TODO: Provide separate modal method/scheme?
-        auto new_view = nav.push<FrequencyKeypadView>(receiver_model.tuning_frequency());
+        auto new_view = nav.push<FrequencyKeypadView>(receiver_model.target_frequency());
         new_view->on_changed = [this](rf::Frequency f) {
-            set_target_frequency(f);
             field_frequency.set_value(f);
         };
     };
@@ -104,9 +92,8 @@ SondeView::SondeView(NavigationView& nav) {
         use_crc = v;
     };
 
-    receiver_model.set_tuning_frequency(tuning_frequency());
-    receiver_model.set_sampling_rate(sampling_rate);
-    receiver_model.set_baseband_bandwidth(baseband_bandwidth);
+    // TODO: Actually necessary?
+    //receiver_model.update_sampling_rate(sampling_rate);
     receiver_model.enable();
 
     // QR code with geo URI
@@ -142,10 +129,6 @@ SondeView::SondeView(NavigationView& nav) {
 }
 
 SondeView::~SondeView() {
-    // save app settings
-    app_settings.rx_frequency = target_frequency_;
-    settings.save("rx_sonde", &app_settings);
-
     baseband::set_pitch_rssi(0, false);
 
     receiver_model.disable();
@@ -216,15 +199,11 @@ void SondeView::on_packet(const sonde::Packet& packet) {
         temp_humid_info = packet.get_temp_humid();
         if (temp_humid_info.humid != 0) {
             double decimals = abs(get_decimals(temp_humid_info.humid, 10, true));
-            // if (decimals < 0)
-            //	decimals = -decimals;
             text_humid.set(to_string_dec_int((int)temp_humid_info.humid) + "." + to_string_dec_uint(decimals, 1) + "%");
         }
 
         if (temp_humid_info.temp != 0) {
             double decimals = abs(get_decimals(temp_humid_info.temp, 10, true));
-            // if (decimals < 0)
-            // 	decimals = -decimals;
             text_temp.set(to_string_dec_int((int)temp_humid_info.temp) + "." + to_string_dec_uint(decimals, 1) + "C");
         }
 
@@ -242,15 +221,6 @@ void SondeView::on_packet(const sonde::Packet& packet) {
             baseband::request_beep();
         }
     }
-}
-
-void SondeView::set_target_frequency(const uint32_t new_value) {
-    target_frequency_ = new_value;
-    receiver_model.set_tuning_frequency(target_frequency_);
-}
-
-uint32_t SondeView::tuning_frequency() const {
-    return target_frequency_ - (sampling_rate / 4);
 }
 
 } /* namespace ui */

--- a/firmware/application/apps/ui_sonde.cpp
+++ b/firmware/application/apps/ui_sonde.cpp
@@ -92,8 +92,8 @@ SondeView::SondeView(NavigationView& nav) {
         use_crc = v;
     };
 
-    // TODO: Actually necessary?
-    // receiver_model.update_sampling_rate(sampling_rate);
+    receiver_model.set_sampling_rate(sampling_rate);
+    receiver_model.set_baseband_bandwidth(baseband_bandwidth);
     receiver_model.enable();
 
     // QR code with geo URI

--- a/firmware/application/apps/ui_sonde.hpp
+++ b/firmware/application/apps/ui_sonde.hpp
@@ -55,7 +55,6 @@ namespace ui {
 class SondeView : public View {
    public:
     static constexpr uint32_t sampling_rate = 2457600;
-    static constexpr uint32_t baseband_bandwidth = 1750000;
 
     SondeView(NavigationView& nav);
     ~SondeView();
@@ -177,9 +176,6 @@ class SondeView : public View {
 
     void on_packet(const sonde::Packet& packet);
     char* float_to_char(float x, char* p);
-    void set_target_frequency(const uint32_t new_value);
-
-    uint32_t tuning_frequency() const;
 };
 
 } /* namespace ui */

--- a/firmware/application/apps/ui_sonde.hpp
+++ b/firmware/application/apps/ui_sonde.hpp
@@ -55,6 +55,7 @@ namespace ui {
 class SondeView : public View {
    public:
     static constexpr uint32_t sampling_rate = 2457600;
+    static constexpr uint32_t baseband_bandwidth = 1750000;
 
     SondeView(NavigationView& nav);
     ~SondeView();

--- a/firmware/application/apps/ui_sonde.hpp
+++ b/firmware/application/apps/ui_sonde.hpp
@@ -65,6 +65,9 @@ class SondeView : public View {
     std::string title() const override { return "Radiosnd RX"; };
 
    private:
+    app_settings::SettingsManager settings_{
+        "rx_sonde", app_settings::Mode::RX};
+
     std::unique_ptr<SondeLogger> logger{};
     uint32_t target_frequency_{402700000};
     bool logging{false};
@@ -72,9 +75,6 @@ class SondeView : public View {
     bool beep{false};
 
     char geo_uri[32] = {};
-    // app save settings
-    std::app_settings settings{};
-    std::app_settings::AppSettings app_settings{};
 
     sonde::GPS_data gps_info{};
     sonde::temp_humid temp_humid_info{};

--- a/firmware/application/apps/ui_spectrum_painter.hpp
+++ b/firmware/application/apps/ui_spectrum_painter.hpp
@@ -29,6 +29,7 @@
 #include "capture_app.hpp"
 #include "baseband_api.hpp"
 
+#include "app_settings.hpp"
 #include "portapack.hpp"
 #include "message.hpp"
 
@@ -53,11 +54,10 @@ class SpectrumPainterView : public View {
     std::string title() const override { return "Spec.Painter"; };
 
    private:
-    void on_target_frequency_changed(rf::Frequency f);
-    void set_target_frequency(const rf::Frequency new_value);
-    rf::Frequency target_frequency() const;
-
     NavigationView& nav_;
+    app_settings::SettingsManager settings_{
+        "tx_painter", app_settings::Mode::TX};
+
     bool image_input_avaliable{false};
     bool tx_active{false};
     uint32_t tx_mode{0};

--- a/firmware/application/apps/ui_sstvtx.hpp
+++ b/firmware/application/apps/ui_sstvtx.hpp
@@ -56,11 +56,10 @@ class SSTVTXView : public View {
 
    private:
     NavigationView& nav_;
+    app_settings::SettingsManager settings_{
+        "tx_sstv", app_settings::Mode::TX};
 
     sstv_scanline scanline_buffer{};
-    // app save settings
-    std::app_settings settings{};
-    std::app_settings::AppSettings app_settings{};
 
     bool file_error{false};
     File bmp_file{};

--- a/firmware/application/apps/ui_sstvtx.hpp
+++ b/firmware/application/apps/ui_sstvtx.hpp
@@ -74,7 +74,6 @@ class SSTVTXView : public View {
     void read_boundary(uint8_t* buffer, uint32_t position, uint32_t length);
     void on_bitmap_changed(const size_t index);
     void on_mode_changed(const size_t index);
-    void on_tuning_frequency_changed(rf::Frequency f);
     void start_tx();
     void prepare_scanline();
 

--- a/firmware/application/apps/ui_test.cpp
+++ b/firmware/application/apps/ui_test.cpp
@@ -79,6 +79,8 @@ TestView::TestView(NavigationView& nav) {
     if (logger)
         logger->append("saucepan.txt");
 
+    receiver_model.set_sampling_rate(sampling_rate);
+    receiver_model.set_baseband_bandwidth(baseband_bandwidth);
     receiver_model.enable();
 }
 

--- a/firmware/application/apps/ui_test.cpp
+++ b/firmware/application/apps/ui_test.cpp
@@ -54,17 +54,15 @@ TestView::TestView(NavigationView& nav) {
                   &button_cal,
                   &check_log});
 
-    field_frequency.set_value(target_frequency_);
+    field_frequency.set_value(receiver_model.target_frequency());
     field_frequency.set_step(10000);
     field_frequency.on_change = [this](rf::Frequency f) {
-        set_target_frequency(f);
-        field_frequency.set_value(f);
+        receiver_model.set_target_frequency(f);
     };
     field_frequency.on_edit = [this, &nav]() {
         // TODO: Provide separate modal method/scheme?
-        auto new_view = nav.push<FrequencyKeypadView>(receiver_model.tuning_frequency());
+        auto new_view = nav.push<FrequencyKeypadView>(receiver_model.target_frequency());
         new_view->on_changed = [this](rf::Frequency f) {
-            set_target_frequency(f);
             field_frequency.set_value(f);
         };
     };
@@ -81,9 +79,6 @@ TestView::TestView(NavigationView& nav) {
     if (logger)
         logger->append("saucepan.txt");
 
-    receiver_model.set_tuning_frequency(tuning_frequency());
-    receiver_model.set_sampling_rate(sampling_rate);
-    receiver_model.set_baseband_bandwidth(baseband_bandwidth);
     receiver_model.enable();
 }
 
@@ -128,15 +123,6 @@ void TestView::on_packet(const testapp::Packet& packet) {
         altitude = packet.GPS_altitude();
         latitude = packet.GPS_latitude();
         longitude = packet.GPS_longitude();*/
-}
-
-void TestView::set_target_frequency(const uint32_t new_value) {
-    target_frequency_ = new_value;
-    receiver_model.set_tuning_frequency(tuning_frequency());
-}
-
-uint32_t TestView::tuning_frequency() const {
-    return target_frequency_ - (sampling_rate / 4);
 }
 
 } /* namespace ui */

--- a/firmware/application/apps/ui_test.hpp
+++ b/firmware/application/apps/ui_test.hpp
@@ -51,9 +51,6 @@ namespace ui {
 
 class TestView : public View {
    public:
-    static constexpr uint32_t sampling_rate = 2457600 * 2;
-    static constexpr uint32_t baseband_bandwidth = 1750000;
-
     TestView(NavigationView& nav);
     ~TestView();
 
@@ -62,7 +59,6 @@ class TestView : public View {
     std::string title() const override { return "Test app"; };
 
    private:
-    uint32_t target_frequency_{439206000};
     Coord cur_x{0};
     uint32_t packet_count{0};
     uint32_t packets_lost{0};
@@ -112,12 +108,10 @@ class TestView : public View {
         [this](Message* const p) {
             const auto message = static_cast<const TestAppPacketMessage*>(p);
             const testapp::Packet packet{message->packet};
-            this->on_packet(packet);
+            on_packet(packet);
         }};
 
     void on_packet(const testapp::Packet& packet);
-    void set_target_frequency(const uint32_t new_value);
-    uint32_t tuning_frequency() const;
 };
 
 } /* namespace ui */

--- a/firmware/application/apps/ui_test.hpp
+++ b/firmware/application/apps/ui_test.hpp
@@ -51,8 +51,8 @@ namespace ui {
 
 class TestView : public View {
    public:
-   static constexpr uint32_t sampling_rate = 2457600 * 2;
-   static constexpr uint32_t baseband_bandwidth = 1750000;
+    static constexpr uint32_t sampling_rate = 2457600 * 2;
+    static constexpr uint32_t baseband_bandwidth = 1750000;
 
     TestView(NavigationView& nav);
     ~TestView();

--- a/firmware/application/apps/ui_test.hpp
+++ b/firmware/application/apps/ui_test.hpp
@@ -51,6 +51,9 @@ namespace ui {
 
 class TestView : public View {
    public:
+   static constexpr uint32_t sampling_rate = 2457600 * 2;
+   static constexpr uint32_t baseband_bandwidth = 1750000;
+
     TestView(NavigationView& nav);
     ~TestView();
 

--- a/firmware/application/apps/ui_touchtunes.cpp
+++ b/firmware/application/apps/ui_touchtunes.cpp
@@ -87,7 +87,7 @@ void TouchTunesView::on_tx_progress(const uint32_t progress, const bool done) {
 // transmission events.
 void TouchTunesView::start_ew() {
     // Radio
-    transmitter_model.set_tuning_frequency(433920000);
+    transmitter_model.set_target_frequency(433920000);
     transmitter_model.set_sampling_rate(3072000U);
     transmitter_model.set_rf_amp(true);
     transmitter_model.set_baseband_bandwidth(3500000U);
@@ -155,7 +155,7 @@ void TouchTunesView::start_tx(const uint32_t button_index) {
 
     size_t bitstream_length = make_bitstream(fragments);
 
-    transmitter_model.set_tuning_frequency(433920000);
+    transmitter_model.set_target_frequency(433920000);
     transmitter_model.set_sampling_rate(OOK_SAMPLERATE);
     transmitter_model.set_rf_amp(true);
     transmitter_model.set_baseband_bandwidth(1750000);

--- a/firmware/application/apps/ui_whipcalc.cpp
+++ b/firmware/application/apps/ui_whipcalc.cpp
@@ -147,7 +147,7 @@ WhipCalcView::WhipCalcView(NavigationView& nav) {
     };
     field_frequency.on_edit = [this, &nav]() {
         // TODO: Provide separate modal method/scheme?
-        auto new_view = nav.push<FrequencyKeypadView>(transmitter_model.tuning_frequency());
+        auto new_view = nav.push<FrequencyKeypadView>(transmitter_model.target_frequency());
         new_view->on_changed = [this](rf::Frequency f) {
             this->field_frequency.set_value(f);
             this->update_result();
@@ -158,7 +158,7 @@ WhipCalcView::WhipCalcView(NavigationView& nav) {
         nav.pop();
     };
 
-    field_frequency.set_value(transmitter_model.tuning_frequency());
+    field_frequency.set_value(transmitter_model.target_frequency());
 }
 
 void ui::WhipCalcView::txtline_process(std::string& line) {

--- a/firmware/application/receiver_model.cpp
+++ b/firmware/application/receiver_model.cpp
@@ -62,12 +62,12 @@ static constexpr std::array<baseband::WFMConfig, 3> wfm_configs{{
 
 } /* namespace */
 
-rf::Frequency ReceiverModel::tuning_frequency() const {
-    return persistent_memory::tuned_frequency();
+rf::Frequency ReceiverModel::target_frequency() const {
+    return persistent_memory::target_frequency();
 }
 
-void ReceiverModel::set_tuning_frequency(rf::Frequency f) {
-    persistent_memory::set_tuned_frequency(f);
+void ReceiverModel::set_target_frequency(rf::Frequency f) {
+    persistent_memory::set_target_frequency(f);
     update_tuning_frequency();
 }
 
@@ -190,10 +190,6 @@ void ReceiverModel::disable() {
     // TODO: Responsibility for enabling/disabling the radio is muddy.
     // Some happens in ReceiverModel, some inside radio namespace.
     radio::disable();
-
-    // TODO: we are doing this repeatedly in different levels of the
-    // call stack. Keeping it for now, but there seem to be too many
-    // redundant calls:
     led_rx.off();
 }
 
@@ -206,7 +202,8 @@ int32_t ReceiverModel::tuning_offset() {
 }
 
 void ReceiverModel::update_tuning_frequency() {
-    radio::set_tuning_frequency(persistent_memory::tuned_frequency() + tuning_offset());
+    // TODO: use positive offset if freq < offset.
+    radio::set_tuning_frequency(target_frequency() + tuning_offset());
 }
 
 void ReceiverModel::update_antenna_bias() {

--- a/firmware/application/receiver_model.hpp
+++ b/firmware/application/receiver_model.hpp
@@ -31,6 +31,7 @@
 #include "volume.hpp"
 
 // TODO: consider a base class for ReceiverModel & TransmitterModel.
+// There are multiple values that are actually shared by both.
 class ReceiverModel {
    public:
     enum class Mode {
@@ -41,8 +42,9 @@ class ReceiverModel {
         Capture = 4
     };
 
-    rf::Frequency tuning_frequency() const;
-    void set_tuning_frequency(rf::Frequency f);
+    /* The frequency to receive (no offset). */
+    rf::Frequency target_frequency() const;
+    void set_target_frequency(rf::Frequency f);
 
     rf::Frequency frequency_step() const;
     void set_frequency_step(rf::Frequency f);
@@ -119,7 +121,6 @@ class ReceiverModel {
     void update_lna();
     void update_baseband_bandwidth();
     void update_vga();
-    // void update_tx_gain();
     void update_sampling_rate();
     void update_headphone_volume();
 

--- a/firmware/application/receiver_model.hpp
+++ b/firmware/application/receiver_model.hpp
@@ -25,6 +25,7 @@
 #include <cstdint>
 #include <cstddef>
 
+#include "app_settings.hpp"
 #include "message.hpp"
 #include "rf_path.hpp"
 #include "max283x.hpp"
@@ -73,8 +74,8 @@ class ReceiverModel {
     void set_headphone_volume(volume_t v);
 
     /* Volume range 0-99, normalized for audio HW. */
-    int32_t normalized_headphone_volume() const;
-    void set_normalized_headphone_volume(int32_t v);
+    uint8_t normalized_headphone_volume() const;
+    void set_normalized_headphone_volume(uint8_t v);
 
     uint8_t squelch_level() const;
     void set_squelch_level(uint8_t v);
@@ -98,6 +99,8 @@ class ReceiverModel {
         const size_t new_nbfm_config_index,
         const size_t new_wfm_config_index,
         uint8_t new_squelch_level);
+
+    void configure_from_app_settings(const app_settings::AppSettings& settings);
 
    private:
     rf::Frequency frequency_step_{25000};

--- a/firmware/application/transmitter_model.cpp
+++ b/firmware/application/transmitter_model.cpp
@@ -84,13 +84,13 @@ void TransmitterModel::set_vga(int32_t v_db) {
     update_vga();
 }
 
-uint32_t TransmitterModel::channel_bandwidth() const {
+/*uint32_t TransmitterModel::channel_bandwidth() const {
     return channel_bandwidth_;
 }
 
 void TransmitterModel::set_channel_bandwidth(uint32_t v) {
     channel_bandwidth_ = v;
-}
+}*/
 
 uint32_t TransmitterModel::sampling_rate() const {
     return sampling_rate_;
@@ -131,6 +131,7 @@ void TransmitterModel::enable() {
     signal_token_tick_second = rtc_time::signal_tick_second += [this]() {
         this->on_tick_second();
     };
+
     if (portapack::persistent_memory::stealth_mode()) {
         DisplaySleepMessage message;
         EventDispatcher::send_message(message);

--- a/firmware/application/transmitter_model.cpp
+++ b/firmware/application/transmitter_model.cpp
@@ -27,13 +27,13 @@
 #include "portapack_persistent_memory.hpp"
 #include "hackrf_gpio.hpp"
 #include "portapack.hpp"
-using namespace hackrf::one;
-using namespace portapack;
-
 #include "rtc_time.hpp"
 #include "event_m0.hpp"
 #include "radio.hpp"
 #include "audio.hpp"
+
+using namespace hackrf::one;
+using namespace portapack;
 
 rf::Frequency TransmitterModel::target_frequency() const {
     return persistent_memory::target_frequency();
@@ -145,6 +145,21 @@ void TransmitterModel::disable() {
 
     rtc_time::signal_tick_second -= signal_token_tick_second;
     led_tx.off();
+}
+
+void TransmitterModel::configure_from_app_settings(
+    const app_settings::AppSettings& settings) {
+    set_target_frequency(settings.tx_frequency);
+
+    baseband_bandwidth_ = settings.baseband_bandwidth;
+    channel_bandwidth_ = settings.channel_bandwidth;
+    tx_gain_db_ = settings.tx_gain;
+    rf_amp_ = settings.tx_amp;
+
+    // TODO: Do these make sense for TX?
+    lna_gain_db_ = settings.lna;
+    vga_gain_db_ = settings.vga;
+    sampling_rate_ = settings.sampling_rate;
 }
 
 void TransmitterModel::update_tuning_frequency() {

--- a/firmware/application/transmitter_model.cpp
+++ b/firmware/application/transmitter_model.cpp
@@ -35,12 +35,12 @@ using namespace portapack;
 #include "radio.hpp"
 #include "audio.hpp"
 
-rf::Frequency TransmitterModel::tuning_frequency() const {
-    return persistent_memory::tuned_frequency();
+rf::Frequency TransmitterModel::target_frequency() const {
+    return persistent_memory::target_frequency();
 }
 
-void TransmitterModel::set_tuning_frequency(rf::Frequency f) {
-    persistent_memory::set_tuned_frequency(f);
+void TransmitterModel::set_target_frequency(rf::Frequency f) {
+    persistent_memory::set_target_frequency(f);
     update_tuning_frequency();
 }
 
@@ -84,13 +84,13 @@ void TransmitterModel::set_vga(int32_t v_db) {
     update_vga();
 }
 
-/*uint32_t TransmitterModel::channel_bandwidth() const {
+uint32_t TransmitterModel::channel_bandwidth() const {
     return channel_bandwidth_;
 }
 
 void TransmitterModel::set_channel_bandwidth(uint32_t v) {
     channel_bandwidth_ = v;
-}*/
+}
 
 uint32_t TransmitterModel::sampling_rate() const {
     return sampling_rate_;
@@ -141,8 +141,6 @@ void TransmitterModel::enable() {
 void TransmitterModel::disable() {
     enabled_ = false;
 
-    // TODO: Responsibility for enabling/disabling the radio is muddy.
-    // Some happens in ReceiverModel, some inside radio namespace.
     radio::disable();
 
     rtc_time::signal_tick_second -= signal_token_tick_second;
@@ -150,7 +148,7 @@ void TransmitterModel::disable() {
 }
 
 void TransmitterModel::update_tuning_frequency() {
-    radio::set_tuning_frequency(persistent_memory::tuned_frequency());
+    radio::set_tuning_frequency(persistent_memory::target_frequency());
 }
 
 void TransmitterModel::update_antenna_bias() {

--- a/firmware/application/transmitter_model.hpp
+++ b/firmware/application/transmitter_model.hpp
@@ -35,8 +35,9 @@
 
 class TransmitterModel {
    public:
-    rf::Frequency tuning_frequency() const;
-    void set_tuning_frequency(rf::Frequency f);
+    /* The frequency to transmit on. */
+    rf::Frequency target_frequency() const;
+    void set_target_frequency(rf::Frequency f);
 
     void set_antenna_bias();
 
@@ -57,9 +58,9 @@ class TransmitterModel {
     int32_t tx_gain() const;
     void set_tx_gain(int32_t v_db);
 
-    // Unused
-    /*uint32_t channel_bandwidth() const;
-    void set_channel_bandwidth(uint32_t v);*/
+    // TODO: Doesn't actually affect radio.
+    uint32_t channel_bandwidth() const;
+    void set_channel_bandwidth(uint32_t v);
 
     // TODO: does this make sense on TX?
     uint32_t sampling_rate() const;
@@ -72,7 +73,7 @@ class TransmitterModel {
     bool enabled_{false};
     bool rf_amp_{false};
     int32_t lna_gain_db_{0};
-    //uint32_t channel_bandwidth_{1};
+    uint32_t channel_bandwidth_{1};
     uint32_t baseband_bandwidth_{max2837::filter::bandwidth_minimum};
     int32_t vga_gain_db_{8};
     /* 35 should give approx 1m transmission range. */

--- a/firmware/application/transmitter_model.hpp
+++ b/firmware/application/transmitter_model.hpp
@@ -27,6 +27,7 @@
 #include <cstddef>
 
 #include "receiver_model.hpp"
+#include "app_settings.hpp"
 #include "message.hpp"
 #include "rf_path.hpp"
 #include "max2837.hpp"
@@ -68,6 +69,8 @@ class TransmitterModel {
 
     void enable();
     void disable();
+
+    void configure_from_app_settings(const app_settings::AppSettings& settings);
 
    private:
     bool enabled_{false};

--- a/firmware/application/transmitter_model.hpp
+++ b/firmware/application/transmitter_model.hpp
@@ -43,21 +43,25 @@ class TransmitterModel {
     bool rf_amp() const;
     void set_rf_amp(bool enabled);
 
+    // TODO: does this make sense on TX?
     int32_t lna() const;
     void set_lna(int32_t v_db);
 
     uint32_t baseband_bandwidth() const;
     void set_baseband_bandwidth(uint32_t v);
 
+    // TODO: does this make sense on TX?
     int32_t vga() const;
     void set_vga(int32_t v_db);
 
     int32_t tx_gain() const;
     void set_tx_gain(int32_t v_db);
 
-    uint32_t channel_bandwidth() const;
-    void set_channel_bandwidth(uint32_t v);
+    // Unused
+    /*uint32_t channel_bandwidth() const;
+    void set_channel_bandwidth(uint32_t v);*/
 
+    // TODO: does this make sense on TX?
     uint32_t sampling_rate() const;
     void set_sampling_rate(uint32_t v);
 
@@ -68,7 +72,7 @@ class TransmitterModel {
     bool enabled_{false};
     bool rf_amp_{false};
     int32_t lna_gain_db_{0};
-    uint32_t channel_bandwidth_{1};
+    //uint32_t channel_bandwidth_{1};
     uint32_t baseband_bandwidth_{max2837::filter::bandwidth_minimum};
     int32_t vga_gain_db_{8};
     /* 35 should give approx 1m transmission range. */

--- a/firmware/application/ui/ui_receiver.cpp
+++ b/firmware/application/ui/ui_receiver.cpp
@@ -350,7 +350,6 @@ LNAGainField::LNAGainField(
 }
 
 void LNAGainField::on_focus() {
-    // Widget::on_focus();
     if (on_show_options) {
         on_show_options();
     }
@@ -375,7 +374,6 @@ VGAGainField::VGAGainField(
 }
 
 void VGAGainField::on_focus() {
-    // Widget::on_focus();
     if (on_show_options) {
         on_show_options();
     }

--- a/firmware/application/ui/ui_receiver.hpp
+++ b/firmware/application/ui/ui_receiver.hpp
@@ -36,6 +36,7 @@
 
 namespace ui {
 
+// TODO: build in support for editing.
 class FrequencyField : public Widget {
    public:
     std::function<void(rf::Frequency)> on_change{};

--- a/firmware/application/ui/ui_transmitter.cpp
+++ b/firmware/application/ui/ui_transmitter.cpp
@@ -53,11 +53,12 @@ void TransmitterView::paint(Painter& painter) {
     }
 }
 
-void TransmitterView::on_tuning_frequency_changed(rf::Frequency f) {
-    transmitter_model.set_tuning_frequency(f);
+void TransmitterView::on_target_frequency_changed(rf::Frequency f) {
+    transmitter_model.set_target_frequency(f);
 }
 
 void TransmitterView::on_channel_bandwidth_changed(uint32_t channel_bandwidth) {
+    // TODO: this doesn't actually affect the radio through the model.
     transmitter_model.set_channel_bandwidth(channel_bandwidth);
 }
 
@@ -102,7 +103,7 @@ void TransmitterView::set_transmitting(const bool transmitting) {
 }
 
 void TransmitterView::on_show() {
-    field_frequency.set_value(transmitter_model.tuning_frequency());
+    field_frequency.set_value(transmitter_model.target_frequency());
     field_frequency_step.set_by_value(receiver_model.frequency_step());
 
     field_gain.set_value(transmitter_model.tx_gain());
@@ -139,6 +140,7 @@ TransmitterView::TransmitterView(
         field_frequency.set_focusable(false);
         field_frequency.set_style(&style_locked);
     } else {
+        // TODO: Make a widget.
         if (channel_bandwidth) {
             add_children({&text_bw,
                           &field_bw});
@@ -150,10 +152,9 @@ TransmitterView::TransmitterView(
         }
     }
 
-    // field_frequency.set_value(transmitter_model.tuning_frequency());
     field_frequency.set_step(frequency_step);
     field_frequency.on_change = [this](rf::Frequency f) {
-        on_tuning_frequency_changed(f);
+        on_target_frequency_changed(f);
     };
     field_frequency.on_edit = [this]() {
         if (on_edit_frequency)

--- a/firmware/application/ui/ui_transmitter.cpp
+++ b/firmware/application/ui/ui_transmitter.cpp
@@ -20,16 +20,17 @@
  * Boston, MA 02110-1301, USA.
  */
 
+// TODO: Consolidate and make TX Widgets instead like ui_receiver.
+
 #include "ui_transmitter.hpp"
 
 #include "audio.hpp"
 #include "baseband_api.hpp"
 #include "portapack.hpp"
-using namespace portapack;
-
 #include "string_format.hpp"
-
 #include "max2837.hpp"
+
+using namespace portapack;
 
 namespace ui {
 
@@ -189,14 +190,10 @@ TransmitterView::~TransmitterView() {
 }
 
 /* TransmitterView2 *******************************************************/
-// Derivative from TransmitterView (that handles many param. freq, fre_step, start_button, gain, amp, used in the majority of the TX App's.
-// This one ,is a simple version ,  it is only handling 2 x param  (TX GAIN and AMP ) in one line .
-// We use normal character lines , in Mic App,  called (x pos, y pos,  NORMAL_UI)
-// We use short compact char lines , in Replay / GPS Simul / Playlist App , called (x pos , y pos,SHORT_UI )
-
-void TransmitterView2::paint(Painter& painter) {
-    //	Not using TransmitterView2, but if we delete it,we got , top line 1 a blanking rect.
-    (void)painter;  // Avoid  warning: unused parameter .
+/* Simpler transmitter view that only renders TX Gain and Amp.
+ * There are two modes, NORMAL_UI and SHORT_UI. SHORT_UI abbreviates control labels. */
+void TransmitterView2::paint(Painter&) {
+    // All widgets paint themselves. Don't let base paint.
 }
 
 void TransmitterView2::on_tx_gain_changed(int32_t tx_gain) {
@@ -241,7 +238,7 @@ void TransmitterView2::on_show() {
 }
 
 TransmitterView2::TransmitterView2(const Coord x, const Coord y, bool short_UI) {
-    set_parent_rect({x, y, 20 * 8, 1 * 8});  // set_parent_rect({ 0, y, 30 * 8, 6 * 8 });
+    set_parent_rect({x, y, 20 * 8, 1 * 8});
 
     add_children({
         &(short_UI ? text_gain_amp_short_UI : text_gain_amp),

--- a/firmware/application/ui/ui_transmitter.hpp
+++ b/firmware/application/ui/ui_transmitter.hpp
@@ -126,7 +126,7 @@ class TransmitterView : public View {
         {10 * 8 - 4, 1 * 8},
     };
 
-    void on_tuning_frequency_changed(rf::Frequency f);
+    void on_target_frequency_changed(rf::Frequency f);
     void on_channel_bandwidth_changed(uint32_t channel_bandwidth);
     void on_tx_gain_changed(int32_t tx_gain);
     void on_tx_amp_changed(bool rf_amp);

--- a/firmware/application/ui_navigation.cpp
+++ b/firmware/application/ui_navigation.cpp
@@ -217,9 +217,9 @@ void SystemStatusView::refresh() {
             button_converter.set_foreground(Color::light_grey());
         }
     }
-    // Retune to take converter change in account
-    receiver_model.set_tuning_frequency(portapack::persistent_memory::tuned_frequency());
-    transmitter_model.set_tuning_frequency(portapack::persistent_memory::tuned_frequency());
+    // Poke tunings to take converter change in account.
+    receiver_model.set_target_frequency(receiver_model.target_frequency());
+    transmitter_model.set_target_frequency(transmitter_model.target_frequency());
 
     if (!portapack::persistent_memory::config_speaker()) {
         button_speaker.set_foreground(Color::light_grey());
@@ -284,7 +284,9 @@ void SystemStatusView::on_converter() {
         portapack::persistent_memory::set_config_converter(false);
         button_converter.set_foreground(Color::light_grey());
     }
-    receiver_model.set_tuning_frequency(portapack::persistent_memory::tuned_frequency());  // Retune
+
+    // Poke to update tuning.
+    receiver_model.set_target_frequency(receiver_model.target_frequency());
 }
 
 void SystemStatusView::on_speaker() {

--- a/firmware/application/ui_record_view.cpp
+++ b/firmware/application/ui_record_view.cpp
@@ -168,7 +168,7 @@ void RecordView::start() {
                                 to_string_dec_uint(datetime.second());
 
         base_path = filename_stem_pattern.string() + "_" + date_time + "_" +
-                    trim(to_string_freq(receiver_model.tuning_frequency())) + "Hz";
+                    trim(to_string_freq(receiver_model.target_frequency())) + "Hz";
         base_path = folder / base_path;
     } else {
         base_path = next_filename_matching_pattern(folder / filename_stem_pattern);
@@ -185,7 +185,7 @@ void RecordView::start() {
             auto create_error = p->create(
                 base_path.replace_extension(u".WAV"),
                 sampling_rate,
-                to_string_dec_uint(receiver_model.tuning_frequency()) + "Hz");
+                to_string_dec_uint(receiver_model.target_frequency()) + "Hz");
             if (create_error.is_valid()) {
                 handle_error(create_error.value());
             } else {
@@ -256,7 +256,7 @@ Optional<File::Error> RecordView::write_metadata_file(const std::filesystem::pat
         if (error_line1.is_valid()) {
             return error_line1;
         }
-        const auto error_line2 = file.write_line("center_frequency=" + to_string_dec_uint(receiver_model.tuning_frequency()));
+        const auto error_line2 = file.write_line("center_frequency=" + to_string_dec_uint(receiver_model.target_frequency()));
         if (error_line2.is_valid()) {
             return error_line2;
         }

--- a/firmware/common/portapack_persistent_memory.cpp
+++ b/firmware/common/portapack_persistent_memory.cpp
@@ -46,7 +46,7 @@ using namespace std;
 namespace portapack {
 namespace persistent_memory {
 
-constexpr rf::Frequency tuned_frequency_reset_value{100000000};
+constexpr rf::Frequency target_frequency_reset_value{100000000};
 
 using ppb_range_t = range_t<ppb_t>;
 constexpr ppb_range_t ppb_range{-99000, 99000};
@@ -257,7 +257,7 @@ struct ui_config_t {
 /* struct must pack the same way on M4 and M0 cores. */
 struct data_t {
     data_structure_version_enum structure_version;
-    int64_t tuned_frequency;
+    int64_t target_frequency;
     int32_t correction_ppb;
     uint32_t touch_calibration_magic;
     touch::Calibration touch_calibration;
@@ -313,7 +313,7 @@ struct data_t {
 
     constexpr data_t()
         : structure_version(data_structure_version_enum::VERSION_CURRENT),
-          tuned_frequency(tuned_frequency_reset_value),
+          target_frequency(target_frequency_reset_value),
           correction_ppb(ppb_reset_value),
           touch_calibration_magic(TOUCH_CALIBRATION_MAGIC),
           touch_calibration(touch::Calibration()),
@@ -471,13 +471,13 @@ void persist() {
 
 } /* namespace cache */
 
-rf::Frequency tuned_frequency() {
-    rf::tuning_range.reset_if_outside(data->tuned_frequency, tuned_frequency_reset_value);
-    return data->tuned_frequency;
+rf::Frequency target_frequency() {
+    rf::tuning_range.reset_if_outside(data->target_frequency, target_frequency_reset_value);
+    return data->target_frequency;
 }
 
-void set_tuned_frequency(const rf::Frequency new_value) {
-    data->tuned_frequency = rf::tuning_range.clip(new_value);
+void set_target_frequency(const rf::Frequency new_value) {
+    data->target_frequency = rf::tuning_range.clip(new_value);
 }
 
 volume_t headphone_volume() {

--- a/firmware/common/portapack_persistent_memory.hpp
+++ b/firmware/common/portapack_persistent_memory.hpp
@@ -130,8 +130,8 @@ void persist();
 
 using ppb_t = int32_t;
 
-rf::Frequency tuned_frequency();
-void set_tuned_frequency(const rf::Frequency new_value);
+rf::Frequency target_frequency();
+void set_target_frequency(const rf::Frequency new_value);
 
 volume_t headphone_volume();
 void set_headphone_volume(volume_t new_value);

--- a/firmware/common/result.hpp
+++ b/firmware/common/result.hpp
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2023 Kyle Reed
+ * Copyright (C) 2015 Jared Boone, ShareBrained Technology, Inc.
+ * Copyright (C) 2016 Furrtek
+ *
+ * This file is part of PortaPack.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#include <utility>
+
+template <typename TValue, typename TError>
+struct Result {
+    enum class Type {
+        Success,
+        Error,
+    } type;
+
+    union {
+        TValue value_;
+        TError error_;
+    };
+
+    bool is_ok() const {
+        return type == Type::Success;
+    }
+
+    operator bool() const {
+        return is_ok();
+    }
+
+    bool is_error() const {
+        return type == Type::Error;
+    }
+
+    const TValue& value() const& {
+        return value_;
+    }
+
+    const TValue& operator*() const& {
+        return value_;
+    }
+
+    TValue&& operator*() && {
+        return std::move(value_);
+    }
+
+    // TODO: should this require lvalue?
+    const TError& error() const& {
+        return error_;
+    }
+
+    Result() = delete;
+
+    constexpr Result(TValue&& value)
+        : type{Type::Success},
+          value_{std::forward<TValue>(value)} {
+    }
+
+    constexpr Result(TError error)
+        : type{Type::Error},
+          error_{error} {
+    }
+
+    ~Result() {
+        if (is_ok())
+            value_.~TValue();
+        else
+            error_.~TError();
+    }
+};

--- a/firmware/common/result.hpp
+++ b/firmware/common/result.hpp
@@ -59,7 +59,6 @@ struct Result {
         return std::move(value_);
     }
 
-    // TODO: should this require lvalue?
     const TError& error() const& {
         return error_;
     }

--- a/firmware/common/ui_widget.cpp
+++ b/firmware/common/ui_widget.cpp
@@ -1362,14 +1362,21 @@ void ImageOptionsField::set_by_value(value_t v) {
     for (const auto& option : options) {
         if (option.second == v) {
             set_selected_index(new_index);
-            break;
+            return;
         }
+
         new_index++;
     }
+
+    // No exact match was found, default to 0.
+    set_selected_index(0);
 }
 
 void ImageOptionsField::set_options(options_t new_options) {
     options = new_options;
+
+    // Set an invalid index to force on_change.
+    selected_index_ = (size_t)-1;
     set_by_value(0);
     set_dirty();
 }
@@ -1440,19 +1447,25 @@ void OptionsField::set_selected_index(const size_t new_index, bool trigger_chang
 }
 
 void OptionsField::set_by_value(value_t v) {
-    size_t new_index{0};
+    size_t new_index = 0;
     for (const auto& option : options) {
         if (option.second == v) {
             set_selected_index(new_index);
-            break;
+            return;
         }
         new_index++;
     }
+
+    // No exact match was found, default to 0.
+    set_selected_index(0);
 }
 
 void OptionsField::set_options(options_t new_options) {
     options = new_options;
-    set_by_value(0);
+
+    // Set an invalid index to force on_change.
+    selected_index_ = (size_t)-1;
+    set_selected_index(0);
     set_dirty();
 }
 

--- a/firmware/common/utility.hpp
+++ b/firmware/common/utility.hpp
@@ -94,6 +94,14 @@ int fast_int_magnitude(int y, int x);
 int int_atan2(int y, int x);
 int32_t int16_sin_s4(int32_t x);
 
+template <typename TEnum>
+bool flags_enabled(TEnum value, TEnum flags) {
+    auto i_value = static_cast<std::underlying_type_t<TEnum>>(value);
+    auto i_flags = static_cast<std::underlying_type_t<TEnum>>(flags);
+
+    return (i_value & i_flags) == i_flags;
+}
+
 /* Returns value constrained to min and max. */
 template <class T>
 constexpr const T& clip(const T& value, const T& minimum, const T& maximum) {

--- a/firmware/test/application/CMakeLists.txt
+++ b/firmware/test/application/CMakeLists.txt
@@ -38,6 +38,7 @@ add_executable(application_test EXCLUDE_FROM_ALL
 	${PROJECT_SOURCE_DIR}/test_circular_buffer.cpp
 	${PROJECT_SOURCE_DIR}/test_file_wrapper.cpp
 	${PROJECT_SOURCE_DIR}/test_optional.cpp
+	${PROJECT_SOURCE_DIR}/test_utility.cpp
 )
 
 target_include_directories(application_test PRIVATE

--- a/firmware/test/application/test_utility.cpp
+++ b/firmware/test/application/test_utility.cpp
@@ -22,7 +22,7 @@
 #include "doctest.h"
 #include "utility.hpp"
 
-TEST_SUITE_BEGIN("optional");
+TEST_SUITE_BEGIN("flags_enabled");
 
 enum class Flags : uint8_t {
     A = 0x1,

--- a/firmware/test/application/test_utility.cpp
+++ b/firmware/test/application/test_utility.cpp
@@ -24,8 +24,7 @@
 
 TEST_SUITE_BEGIN("optional");
 
-enum class Flags : uint8_t
-{
+enum class Flags : uint8_t {
     A = 0x1,
     B = 0x2,
     C = 0x4,

--- a/firmware/test/application/test_utility.cpp
+++ b/firmware/test/application/test_utility.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Jared Boone, ShareBrained Technology, Inc.
+ * Copyright (C) 2023
  *
  * This file is part of PortaPack.
  *
@@ -19,22 +19,26 @@
  * Boston, MA 02110-1301, USA.
  */
 
-#include "log_file.hpp"
-#include "string_format.hpp"
+#include "doctest.h"
+#include "utility.hpp"
 
-Optional<File::Error> LogFile::write_entry(const std::string& entry) {
-    return write_entry(rtc_time::now(), entry);
+TEST_SUITE_BEGIN("optional");
+
+enum class Flags : uint8_t
+{
+    A = 0x1,
+    B = 0x2,
+    C = 0x4,
+};
+
+TEST_CASE("When flag set, flags_enabled should be true.") {
+    Flags f = Flags::A;
+    CHECK(flags_enabled(f, Flags::A));
 }
 
-Optional<File::Error> LogFile::write_entry(const rtc::RTC& datetime, const std::string& entry) {
-    std::string timestamp = to_string_timestamp(datetime);
-    return write_line(timestamp + " " + entry);
+TEST_CASE("When flag not set, flags_enabled should be false.") {
+    Flags f = Flags::B;
+    CHECK(flags_enabled(f, Flags::A) == false);
 }
 
-Optional<File::Error> LogFile::write_line(const std::string& message) {
-    auto error = file.write_line(message);
-    if (!error) {
-        file.sync();
-    }
-    return error;
-}
+TEST_SUITE_END();


### PR DESCRIPTION
Consolidation and cleanup of app settings.
This is the first round and making app settings "just work" while also reducing code size.
App settings will automatically be loaded/saved when an app start/closes. Also, because most of the settings were driving the TX/RX models, all the code that was needed to initialize controls can also be deleted.

*This change reduced the size of the bin file by 8,144 bytes!*

As part of this (and after a small discussion) this also renames "tuned_frequency" to "target_frequency" so that it's more clear that it's meant to be the frequency without an offset. The offset is applied automatically in by the TX/RX model classes.

While doing that refactor, I took the time to clean up the TX/RX model usage in all of the apps.

It's smaller that it looks, it just touched a lot of files. I'm hoping you'll notice a pattern in the changes during the review.