### PR TITLE
Recon revamp

### DIFF
--- a/firmware/application/apps/ui_recon.cpp
+++ b/firmware/application/apps/ui_recon.cpp
@@ -530,8 +530,10 @@ ReconView::ReconView(NavigationView& nav)
             } else {
                 if (!recon) {
                     recon_resume();
+                    user_pause = false;
                 } else {
                     recon_pause();
+                    user_pause = true;
                 }
             }
         }
@@ -1010,7 +1012,7 @@ void ReconView::on_statistics_update(const ChannelStatistics& statistics) {
         if (!manual_mode) {
             frequency_file_load(false);
         }
-        if (autostart) {
+        if (autostart && !user_pause) {
             recon_resume();
         } else {
             recon_pause();

--- a/firmware/application/apps/ui_recon.cpp
+++ b/firmware/application/apps/ui_recon.cpp
@@ -855,6 +855,8 @@ ReconView::ReconView(NavigationView& nav)
 
     field_nblocks.on_change = [this](int32_t v) {
         recon_lock_nb_match = v;
+        if ((unsigned)v < freq_lock)
+            freq_lock = v;
         colorize_waits();
     };
 
@@ -876,6 +878,7 @@ ReconView::ReconView(NavigationView& nav)
     recon_load_config_from_sd();
     freq_file_path = "/FREQMAN/" + output_file + ".TXT";
 
+    field_recon_match_mode.set_selected_index(recon_match_mode);
     field_squelch.set_value(squelch);
     field_wait.set_value(wait);
     field_lock_wait.set_value(recon_lock_duration);

--- a/firmware/application/apps/ui_recon.hpp
+++ b/firmware/application/apps/ui_recon.hpp
@@ -101,6 +101,7 @@ class ReconView : public View {
     bool update_ranges = {true};
     bool fwd = {true};
     bool recon = true;
+    bool user_pause = false;
     uint32_t recon_lock_nb_match = {3};
     uint32_t recon_lock_duration = {RECON_MIN_LOCK_DURATION};
     uint32_t recon_match_mode = {RECON_MATCH_CONTINUOUS};

--- a/firmware/application/apps/ui_recon.hpp
+++ b/firmware/application/apps/ui_recon.hpp
@@ -138,11 +138,10 @@ class ReconView : public View {
 
     Labels labels{
         {{0 * 8, 0 * 16}, "LNA:   VGA:   AMP:  VOL:     ", Color::light_grey()},
-        {{0 * 8, 1 * 16}, "BW:      SQ:    W,L:     ,     ", Color::light_grey()},
-        {{3 * 8, 10 * 16}, "START       END     MANUAL", Color::light_grey()},
-        {{0 * 8, (26 * 8) + 4}, "MODE:", Color::light_grey()},
-        {{11 * 8, (26 * 8) + 4}, "STEP:", Color::light_grey()},
-    };
+        {{3 * 8, 8 * 16}, "START       END", Color::light_grey()},
+        {{0 * 8, (22 * 8)}, "                S:          ", Color::light_grey()},
+        {{0 * 8, (24 * 8) + 4}, "NBLCK: x      W,L:      ,     ", Color::light_grey()},
+        {{0 * 8, (26 * 8) + 4}, "MODE:    ,       SQUELCH:    ", Color::light_grey()}};
 
     LNAGainField field_lna{
         {4 * 8, 0 * 16}};
@@ -156,37 +155,8 @@ class ReconView : public View {
     AudioVolumeField field_volume{
         {24 * 8, 0 * 16}};
 
-    OptionsField field_bw{
-        {3 * 8, 1 * 16},
-        6,
-        {}};
-
-    NumberField field_squelch{
-        {12 * 8, 1 * 16},
-        3,
-        {-90, 20},
-        1,
-        ' ',
-    };
-
-    NumberField field_wait{
-        {20 * 8, 1 * 16},
-        5,
-        {-RECON_MAX_LOCK_DURATION, RECON_MAX_LOCK_DURATION},
-        STATS_UPDATE_INTERVAL,
-        ' ',
-    };
-
-    NumberField field_lock_wait{
-        {26 * 8, 1 * 16},
-        4,
-        {RECON_MIN_LOCK_DURATION, RECON_MAX_LOCK_DURATION},
-        STATS_UPDATE_INTERVAL,
-        ' ',
-    };
-
     RSSI rssi{
-        {0 * 16, 2 * 16, SCREEN_W - 8 * 8 + 4, 14},
+        {0 * 16, 2 * 16 + 2, SCREEN_W - 8 * 8 + 4, 12},
     };
 
     ButtonWithEncoder text_cycle{
@@ -209,12 +179,12 @@ class ReconView : public View {
 
     Text big_display{
         // Show frequency in text mode
-        {0, 5 * 16, 23 * 8, 16},
+        {0, 5 * 16, 21 * 8, 16},
     };
 
     Text freq_stats{
         // Show frequency stats in text mode
-        {0, 6 * 16, 23 * 8, 16},
+        {0, 6 * 16, 21 * 8, 16},
     };
 
     // TIMER: 9999
@@ -225,7 +195,7 @@ class ReconView : public View {
 
     // T: Senn. 32.000k
     Text text_ctcss{
-        {12 * 8 + 4, 7 * 16, 14 * 8, 1 * 8},
+        {14 * 8, 7 * 16, 8 * 8, 1 * 8},
         ""};
 
     Button button_config{
@@ -238,35 +208,79 @@ class ReconView : public View {
 
     // Button can be RECON or SCANNER
     Button button_scanner_mode{
-        {SCREEN_W - 7 * 8, 8 * 16, 7 * 8, 28},
+        {SCREEN_W - 7 * 8, 7 * 16, 7 * 8, 28},
         "RECON"};
 
     Text file_name{
         // show file used
-        {0, 8 * 16 + 6, SCREEN_W - 7 * 8, 16},
+        {0, 1 * 16, SCREEN_W, 16},
     };
 
     ButtonWithEncoder button_manual_start{
-        {0 * 8, 11 * 16, 11 * 8, 28},
+        {0 * 8, 9 * 16, 11 * 8, 28},
         ""};
 
     ButtonWithEncoder button_manual_end{
-        {12 * 8 - 6, 11 * 16, 11 * 8, 28},
+        {12 * 8 - 6, 9 * 16, 11 * 8, 28},
         ""};
 
+    OptionsField field_recon_match_mode{
+        {0 * 8, 11 * 16},
+        16,  // CONTINUOUS MATCH MODE / SPARSE TIMED MATCH MODE
+        {
+            {"MATCH:CONTINOUS", 0},
+            {"MATCH:SPARSE", 1}}};
+
+    OptionsField step_mode{
+        {18 * 8, 11 * 16},
+        12,
+        {}};
+
     Button button_manual_recon{
-        {23 * 8 - 3, 11 * 16, 7 * 8, 28},
+        {23 * 8, 9 * 16, 7 * 8, 28},
         "SEARCH"};
 
+    NumberField field_nblocks{
+        {8 * 8, 24 * 8 + 4},
+        2,
+        {1, 99},
+        1,
+        ' ',
+    };
+
+    NumberField field_wait{
+        {19 * 8, 24 * 8 + 4},
+        5,
+        {-RECON_MAX_LOCK_DURATION, RECON_MAX_LOCK_DURATION},
+        STATS_UPDATE_INTERVAL,
+        ' ',
+    };
+
+    NumberField field_lock_wait{
+        {25 * 8, 24 * 8 + 4},
+        4,
+        {RECON_MIN_LOCK_DURATION, RECON_MAX_LOCK_DURATION},
+        STATS_UPDATE_INTERVAL,
+        ' ',
+    };
+
     OptionsField field_mode{
-        {5 * 8, (26 * 8) + 4},
+        {6 * 8, (26 * 8) + 4},
+        3,
+        {}};
+
+    OptionsField field_bw{
+        {10 * 8, (26 * 8) + 4},
         6,
         {}};
 
-    OptionsField step_mode{
-        {17 * 8, (26 * 8) + 4},
-        12,
-        {}};
+    NumberField field_squelch{
+        {26 * 8, (26 * 8) + 4},
+        3,
+        {-90, 20},
+        1,
+        ' ',
+    };
 
     ButtonWithEncoder button_pause{
         {0, (15 * 16) - 4, 72, 28},

--- a/firmware/application/apps/ui_recon_settings.cpp
+++ b/firmware/application/apps/ui_recon_settings.cpp
@@ -101,44 +101,31 @@ void ReconSetupViewMain::save(std::string& input_file, std::string& output_file)
     input_file = _input_file;
     output_file = _output_file;
 };
-void ReconSetupViewMore::save(uint32_t& recon_lock_duration, uint32_t& recon_lock_nb_match, uint32_t& recon_match_mode) {
+void ReconSetupViewMore::save() {
     persistent_memory::set_recon_load_freqs(checkbox_load_freqs.value());
     persistent_memory::set_recon_load_ranges(checkbox_load_ranges.value());
     persistent_memory::set_recon_load_hamradios(checkbox_load_hamradios.value());
     persistent_memory::set_recon_update_ranges_when_recon(checkbox_update_ranges_when_recon.value());
-    recon_lock_duration = field_recon_lock_duration.value();
-    recon_lock_nb_match = field_recon_lock_nb_match.value();
-    recon_match_mode = field_recon_match_mode.selected_index_value();
 };
 
 void ReconSetupViewMain::focus() {
     button_load_freqs.focus();
 }
 
-ReconSetupViewMore::ReconSetupViewMore(NavigationView& nav, Rect parent_rect, uint32_t recon_lock_duration, uint32_t recon_lock_nb_match, uint32_t recon_match_mode)
-    : View(parent_rect), _recon_lock_duration{recon_lock_duration}, _recon_lock_nb_match{recon_lock_nb_match}, _recon_match_mode{recon_match_mode} {
+ReconSetupViewMore::ReconSetupViewMore(NavigationView& nav, Rect parent_rect)
+    : View(parent_rect) {
     (void)nav;
     hidden(true);
 
-    add_children({
-        &checkbox_load_freqs,
-        &checkbox_load_ranges,
-        &checkbox_load_hamradios,
-        &checkbox_update_ranges_when_recon,
-        &text_recon_lock_duration,
-        &field_recon_lock_duration,
-        &text_recon_lock_nb,
-        &field_recon_lock_nb_match,
-        &field_recon_match_mode,
-    });
+    add_children({&checkbox_load_freqs,
+                  &checkbox_load_ranges,
+                  &checkbox_load_hamradios,
+                  &checkbox_update_ranges_when_recon});
 
     checkbox_load_freqs.set_value(persistent_memory::recon_load_freqs());
     checkbox_load_ranges.set_value(persistent_memory::recon_load_ranges());
     checkbox_load_hamradios.set_value(persistent_memory::recon_load_hamradios());
     checkbox_update_ranges_when_recon.set_value(persistent_memory::recon_update_ranges_when_recon());
-    field_recon_lock_duration.set_value(_recon_lock_duration);
-    field_recon_lock_nb_match.set_value(_recon_lock_nb_match);
-    field_recon_match_mode.set_by_value(_recon_match_mode);
 };
 
 void ReconSetupViewMore::focus() {
@@ -149,14 +136,8 @@ void ReconSetupView::focus() {
     viewMain.focus();
 }
 
-ReconSetupView::ReconSetupView(
-    NavigationView& nav,
-    std::string _input_file,
-    std::string _output_file,
-    uint32_t _recon_lock_duration,
-    uint32_t _recon_lock_nb_match,
-    uint32_t _recon_match_mode)
-    : nav_{nav}, input_file{_input_file}, output_file{_output_file}, recon_lock_duration{_recon_lock_duration}, recon_lock_nb_match{_recon_lock_nb_match}, recon_match_mode{_recon_match_mode} {
+ReconSetupView::ReconSetupView(NavigationView& nav, std::string _input_file, std::string _output_file)
+    : nav_{nav}, input_file{_input_file}, output_file{_output_file} {
     add_children({&tab_view,
                   &viewMain,
                   &viewMore,
@@ -164,13 +145,10 @@ ReconSetupView::ReconSetupView(
 
     button_save.on_select = [this, &nav](Button&) {
         viewMain.save(input_file, output_file);
-        viewMore.save(recon_lock_duration, recon_lock_nb_match, recon_match_mode);
+        viewMore.save();
         std::vector<std::string> messages;
         messages.push_back(input_file);
         messages.push_back(output_file);
-        messages.push_back(to_string_dec_uint(recon_lock_duration));
-        messages.push_back(to_string_dec_uint(recon_lock_nb_match));
-        messages.push_back(to_string_dec_uint(recon_match_mode));
         on_changed(messages);
         nav.pop();
     };

--- a/firmware/application/apps/ui_recon_settings.hpp
+++ b/firmware/application/apps/ui_recon_settings.hpp
@@ -110,17 +110,13 @@ class ReconSetupViewMain : public View {
 
 class ReconSetupViewMore : public View {
    public:
-    ReconSetupViewMore(NavigationView& nav, Rect parent_rect, uint32_t _recon_lock_duration, uint32_t _recon_lock_nb_match, uint32_t _recon_match_mode);
+    ReconSetupViewMore(NavigationView& nav, Rect parent_rect);
 
-    void save(uint32_t& recon_lock_duration, uint32_t& recon_lock_nb_match, uint32_t& recon_match_mode);
+    void save();
 
     void focus() override;
 
    private:
-    uint32_t _recon_lock_duration = STATS_UPDATE_INTERVAL;
-    uint32_t _recon_lock_nb_match = RECON_DEF_NB_MATCH;
-    uint32_t _recon_match_mode = RECON_MATCH_CONTINUOUS;
-
     Checkbox checkbox_load_freqs{
         {1 * 8, 12},
         3,
@@ -140,43 +136,11 @@ class ReconSetupViewMore : public View {
         {1 * 8, 102},
         3,
         "auto update m-ranges"};
-
-    NumberField field_recon_lock_duration{
-        {1 * 8, 132},                                      // position X , Y
-        4,                                                 // number of displayed digits (even empty)
-        {STATS_UPDATE_INTERVAL, RECON_MAX_LOCK_DURATION},  // range of number
-        STATS_UPDATE_INTERVAL,                             // rotary encoder increment
-        ' ',                                               // filling character
-        false                                              // can loop
-    };
-
-    Text text_recon_lock_duration{
-        {1 * 8, 132, 22 * 8, 22},
-        "    ms (lock duration)"};
-
-    NumberField field_recon_lock_nb_match{
-        {1 * 8, 162},
-        4,
-        {1, 99},
-        1,
-        ' ',
-        false};
-
-    Text text_recon_lock_nb{
-        {1 * 8, 162, 25 * 8, 22},
-        "    x (nb lock to match freq)"};
-
-    OptionsField field_recon_match_mode{
-        {1 * 8, 192},
-        20,  // CONTINUOUS MATCH MODE / SPARSE TIMED MATCH MODE
-        {
-            {"SQL MATCH: CONTINOUS", 0},
-            {"SQL MATCH: SPARSE", 1}}};
 };
 
 class ReconSetupView : public View {
    public:
-    ReconSetupView(NavigationView& nav, std::string _input_file, std::string _output_file, uint32_t _recon_lock_duration, uint32_t _recon_lock_nb_match, uint32_t _recon_match_mode);
+    ReconSetupView(NavigationView& nav, std::string _input_file, std::string _output_file);
 
     std::function<void(std::vector<std::string> messages)> on_changed{};
 
@@ -189,14 +153,11 @@ class ReconSetupView : public View {
 
     std::string input_file = {"RECON"};
     std::string output_file = {"RECON_RESULTS"};
-    uint32_t recon_lock_duration = STATS_UPDATE_INTERVAL;
-    uint32_t recon_lock_nb_match = RECON_DEF_NB_MATCH;
-    uint32_t recon_match_mode = RECON_MATCH_CONTINUOUS;
 
     Rect view_rect = {0, 3 * 8, SCREEN_W, 230};
 
     ReconSetupViewMain viewMain{nav_, view_rect, input_file, output_file};
-    ReconSetupViewMore viewMore{nav_, view_rect, recon_lock_duration, recon_lock_nb_match, recon_match_mode};
+    ReconSetupViewMore viewMore{nav_, view_rect};
 
     TabView tab_view{
         {"Main", Color::cyan(), &viewMain},


### PR DESCRIPTION
Revamped GUI to display on main page:
-Match Mode (continuous/sparse)
-Nb locks
-Wait on locked
-Locking wait
-Modulation on same line as bandwidth
-Mod,BW,Squelch near the other buttons
-Fixed bug that was restarting the Recon/Scan after editing a manual start /end frequency
-Moved input file to top of app, changed to 'input' => 'output' display

|Before|After|
|:-:|:-:|
|![Before](https://github.com/eried/portapack-mayhem/assets/3157857/f0cf1b12-1126-414d-af84-8f860d0893ef) |![After](https://github.com/eried/portapack-mayhem/assets/3157857/c7933928-714b-4468-ad73-799a81a25e62)|
