### PR TITLE
Stash radio settings per app

### DIFF
--- a/firmware/application/app_settings.cpp
+++ b/firmware/application/app_settings.cpp
@@ -197,7 +197,7 @@ void copy_to_radio_model(const AppSettings& settings) {
             settings.squelch);
     }
 
-    receiver_model.set_frequency_step(settings.volume);
+    receiver_model.set_frequency_step(settings.step);
     receiver_model.set_normalized_headphone_volume(settings.volume);
 }
 

--- a/firmware/application/apps/acars_app.cpp
+++ b/firmware/application/apps/acars_app.cpp
@@ -67,8 +67,6 @@ ACARSAppView::ACARSAppView(NavigationView& nav) {
                   &check_log,
                   &console});
 
-    receiver_model.set_sampling_rate(2457600);
-    receiver_model.set_baseband_bandwidth(1750000);
     receiver_model.enable();
 
     field_frequency.set_value(receiver_model.target_frequency());

--- a/firmware/application/apps/acars_app.hpp
+++ b/firmware/application/apps/acars_app.hpp
@@ -24,6 +24,7 @@
 #define __ACARS_APP_H__
 
 #include "app_settings.hpp"
+#include "radio_state.hpp"
 #include "ui_widget.hpp"
 #include "ui_receiver.hpp"
 #include "ui_rssi.hpp"
@@ -56,6 +57,10 @@ class ACARSAppView : public View {
     std::string title() const override { return "ACARS (WIP)"; };
 
    private:
+    RxRadioState radio_state_{
+        1750000 /* bandwidth */,
+        2457600 /* sampling rate */
+    };
     app_settings::SettingsManager settings_{
         "rx_acars.hpp", app_settings::Mode::RX};
 

--- a/firmware/application/apps/ais_app.cpp
+++ b/firmware/application/apps/ais_app.cpp
@@ -385,8 +385,6 @@ AISAppView::AISAppView(NavigationView& nav)
     if (!settings_.loaded())
         receiver_model.set_target_frequency(initial_target_frequency);
 
-    receiver_model.set_sampling_rate(sampling_rate);
-    receiver_model.set_baseband_bandwidth(baseband_bandwidth);
     receiver_model.enable();
 
     options_channel.on_change = [this](size_t, OptionsField::value_t v) {

--- a/firmware/application/apps/ais_app.hpp
+++ b/firmware/application/apps/ais_app.hpp
@@ -34,6 +34,7 @@
 
 #include "log_file.hpp"
 #include "app_settings.hpp"
+#include "radio_state.hpp"
 #include "ais_packet.hpp"
 
 #include "lpc43xx_cpp.hpp"
@@ -162,9 +163,11 @@ class AISAppView : public View {
 
    private:
     static constexpr uint32_t initial_target_frequency = 162025000;
-    static constexpr uint32_t sampling_rate = 2457600;
-    static constexpr uint32_t baseband_bandwidth = 1750000;
 
+    RxRadioState radio_state_{
+        1750000 /* bandwidth */,
+        2457600 /* sampling rate */
+    };
     app_settings::SettingsManager settings_{
         "rx_ais", app_settings::Mode::RX};
 

--- a/firmware/application/apps/analog_audio_app.hpp
+++ b/firmware/application/apps/analog_audio_app.hpp
@@ -30,6 +30,7 @@
 #include "ui_record_view.hpp"
 #include "ui_styles.hpp"
 #include "app_settings.hpp"
+#include "radio_state.hpp"
 #include "tone_key.hpp"
 
 namespace ui {
@@ -155,6 +156,7 @@ class AnalogAudioView : public View {
    private:
     static constexpr ui::Dim header_height = 3 * 16;
 
+    RxRadioState radio_state_{};
     app_settings::SettingsManager settings_{
         "rx_audio", app_settings::Mode::RX,
         app_settings::Options::UseGlobalTargetFrequency};

--- a/firmware/application/apps/analog_tv_app.hpp
+++ b/firmware/application/apps/analog_tv_app.hpp
@@ -31,6 +31,7 @@
 #include "ui_record_view.hpp"
 #include "ui_styles.hpp"
 #include "app_settings.hpp"
+#include "radio_state.hpp"
 
 #include "tone_key.hpp"
 
@@ -52,6 +53,7 @@ class AnalogTvView : public View {
    private:
     static constexpr ui::Dim header_height = 3 * 16;
 
+    RxRadioState radio_state_{};
     app_settings::SettingsManager settings_{
         "rx_tv", app_settings::Mode::RX};
 

--- a/firmware/application/apps/capture_app.cpp
+++ b/firmware/application/apps/capture_app.cpp
@@ -46,12 +46,6 @@ CaptureAppView::CaptureAppView(NavigationView& nav) {
         &waterfall,
     });
 
-    // Hack for initialization
-    // TODO: This should be included in a more global section so apps dont need to do it
-    receiver_model.set_sampling_rate(3072000);
-    receiver_model.set_baseband_bandwidth(1750000);
-    //-------------------
-
     field_frequency.set_value(receiver_model.target_frequency());
     field_frequency.set_step(receiver_model.frequency_step());
     field_frequency.on_change = [this](rf::Frequency f) {
@@ -133,13 +127,6 @@ CaptureAppView::CaptureAppView(NavigationView& nav) {
 }
 
 CaptureAppView::~CaptureAppView() {
-    // Hack for preventing halting other apps
-    // TODO: This should be also part of something global
-    receiver_model.set_sampling_rate(3072000);
-    receiver_model.set_baseband_bandwidth(1750000);
-    receiver_model.set_modulation(ReceiverModel::Mode::WidebandFMAudio);
-    // ----------------------------
-
     receiver_model.disable();
     baseband::shutdown();
 }

--- a/firmware/application/apps/capture_app.hpp
+++ b/firmware/application/apps/capture_app.hpp
@@ -28,6 +28,7 @@
 #include "ui_receiver.hpp"
 #include "ui_record_view.hpp"
 #include "ui_spectrum.hpp"
+#include "radio_state.hpp"
 
 #define BW_OPTIONS                                                                                                                 \
     {"  8k5", 8500},                                                                                                               \
@@ -63,6 +64,8 @@ class CaptureAppView : public View {
 
    private:
     static constexpr ui::Dim header_height = 3 * 16;
+
+    RxRadioState radio_state_{};
 
     uint32_t sampling_rate = 0;
     uint32_t anti_alias_baseband_bandwidth_filter = 2500000;  // we rename the previous var , and change type static constexpr to normal var.

--- a/firmware/application/apps/ert_app.cpp
+++ b/firmware/application/apps/ert_app.cpp
@@ -112,7 +112,7 @@ ERTAppView::ERTAppView(NavigationView&) {
 
     if (!settings_.loaded())
         receiver_model.set_target_frequency(initial_target_frequency);
-    
+
     receiver_model.enable();
 
     logger = std::make_unique<ERTLogger>();

--- a/firmware/application/apps/ert_app.cpp
+++ b/firmware/application/apps/ert_app.cpp
@@ -110,9 +110,9 @@ ERTAppView::ERTAppView(NavigationView&) {
         &recent_entries_view,
     });
 
-    receiver_model.set_target_frequency(initial_target_frequency);
-    receiver_model.set_sampling_rate(sampling_rate);
-    receiver_model.set_baseband_bandwidth(baseband_bandwidth);
+    if (!settings_.loaded())
+        receiver_model.set_target_frequency(initial_target_frequency);
+    
     receiver_model.enable();
 
     logger = std::make_unique<ERTLogger>();

--- a/firmware/application/apps/ert_app.hpp
+++ b/firmware/application/apps/ert_app.hpp
@@ -29,6 +29,7 @@
 
 #include "event_m0.hpp"
 #include "app_settings.hpp"
+#include "radio_state.hpp"
 #include "log_file.hpp"
 
 #include "ert_packet.hpp"
@@ -108,10 +109,6 @@ using ERTRecentEntriesView = RecentEntriesView<ERTRecentEntries>;
 
 class ERTAppView : public View {
    public:
-    static constexpr uint32_t initial_target_frequency = 911600000;
-    static constexpr uint32_t sampling_rate = 4194304;
-    static constexpr uint32_t baseband_bandwidth = 2500000;
-
     ERTAppView(NavigationView& nav);
     ~ERTAppView();
 
@@ -126,9 +123,15 @@ class ERTAppView : public View {
     std::string title() const override { return "ERT RX"; };
 
    private:
+    static constexpr uint32_t initial_target_frequency = 911600000;
+
     ERTRecentEntries recent{};
     std::unique_ptr<ERTLogger> logger{};
 
+    RxRadioState radio_state_{
+        2500000 /* bandwidth */,
+        4194304 /* sampling rate */
+    };
     app_settings::SettingsManager settings_{
         "rx_ert", app_settings::Mode::RX};
 

--- a/firmware/application/apps/gps_sim_app.cpp
+++ b/firmware/application/apps/gps_sim_app.cpp
@@ -129,7 +129,6 @@ void GpsSimAppView::start() {
 
     if (reader) {
         button_play.set_bitmap(&bitmap_stop);
-        baseband::set_sample_rate(sample_rate);
 
         replay_thread = std::make_unique<ReplayThread>(
             std::move(reader),
@@ -142,7 +141,6 @@ void GpsSimAppView::start() {
     }
 
     transmitter_model.set_sampling_rate(sample_rate);
-    transmitter_model.set_baseband_bandwidth(baseband_bandwidth);
     transmitter_model.enable();
 }
 

--- a/firmware/application/apps/gps_sim_app.hpp
+++ b/firmware/application/apps/gps_sim_app.hpp
@@ -28,6 +28,7 @@
 #define NORMAL_UI false
 
 #include "app_settings.hpp"
+#include "radio_state.hpp"
 #include "ui_widget.hpp"
 #include "ui_navigation.hpp"
 #include "ui_receiver.hpp"
@@ -53,6 +54,7 @@ class GpsSimAppView : public View {
 
    private:
     NavigationView& nav_;
+    TxRadioSettings radio_settings_;
     app_settings::SettingsManager settings_{
         "tx_gps", app_settings::Mode::TX};
 

--- a/firmware/application/apps/gps_sim_app.hpp
+++ b/firmware/application/apps/gps_sim_app.hpp
@@ -54,7 +54,10 @@ class GpsSimAppView : public View {
 
    private:
     NavigationView& nav_;
-    TxRadioSettings radio_settings_;
+    RxRadioState radio_state_{
+        3000000 /* bandwidth */,
+        500000 /* sampling rate */
+    };
     app_settings::SettingsManager settings_{
         "tx_gps", app_settings::Mode::TX};
 

--- a/firmware/application/apps/lge_app.cpp
+++ b/firmware/application/apps/lge_app.cpp
@@ -243,8 +243,7 @@ void LGEView::start_tx() {
         tx_view.on_show();  // Refresh tuning frequency display
         tx_view.set_dirty();
     }
-    transmitter_model.set_sampling_rate(2280000);
-    transmitter_model.set_baseband_bandwidth(1750000);
+
     transmitter_model.enable();
 
     chThdSleep(100);

--- a/firmware/application/apps/lge_app.hpp
+++ b/firmware/application/apps/lge_app.hpp
@@ -30,6 +30,7 @@
 #include "transmitter_model.hpp"
 #include "portapack.hpp"
 #include "app_settings.hpp"
+#include "radio_settings.hpp"
 
 namespace ui {
 
@@ -49,6 +50,10 @@ class LGEView : public View {
         ALL
     };
 
+    TxRadioState radio_state_{
+        1750000 /* bandwidth */,
+        2280000 /* sampling rate */
+    };
     app_settings::SettingsManager settings_{
         "tx_lge", app_settings::Mode::TX};
 

--- a/firmware/application/apps/lge_app.hpp
+++ b/firmware/application/apps/lge_app.hpp
@@ -30,7 +30,7 @@
 #include "transmitter_model.hpp"
 #include "portapack.hpp"
 #include "app_settings.hpp"
-#include "radio_settings.hpp"
+#include "radio_state.hpp"
 
 namespace ui {
 

--- a/firmware/application/apps/pocsag_app.cpp
+++ b/firmware/application/apps/pocsag_app.cpp
@@ -70,8 +70,6 @@ POCSAGAppView::POCSAGAppView(NavigationView& nav) {
                   &console});
 
     receiver_model.set_modulation(ReceiverModel::Mode::NarrowbandFMAudio);
-    receiver_model.set_sampling_rate(3072000);
-    receiver_model.set_baseband_bandwidth(1750000);
     receiver_model.enable();
 
     field_frequency.set_value(receiver_model.target_frequency());

--- a/firmware/application/apps/pocsag_app.hpp
+++ b/firmware/application/apps/pocsag_app.hpp
@@ -29,6 +29,7 @@
 
 #include "log_file.hpp"
 #include "app_settings.hpp"
+#include "radio_settings.hpp"
 #include "pocsag.hpp"
 #include "pocsag_packet.hpp"
 
@@ -59,6 +60,7 @@ class POCSAGAppView : public View {
     bool logging() const { return check_log.value(); };
     bool ignore() const { return check_ignore.value(); };
 
+    RxRadioState radio_state_;
     app_settings::SettingsManager settings_{
         "rx_pocsag", app_settings::Mode::RX};
 

--- a/firmware/application/apps/pocsag_app.hpp
+++ b/firmware/application/apps/pocsag_app.hpp
@@ -29,7 +29,7 @@
 
 #include "log_file.hpp"
 #include "app_settings.hpp"
-#include "radio_settings.hpp"
+#include "radio_state.hpp"
 #include "pocsag.hpp"
 #include "pocsag_packet.hpp"
 
@@ -60,7 +60,7 @@ class POCSAGAppView : public View {
     bool logging() const { return check_log.value(); };
     bool ignore() const { return check_ignore.value(); };
 
-    RxRadioState radio_state_;
+    RxRadioState radio_state_{};
     app_settings::SettingsManager settings_{
         "rx_pocsag", app_settings::Mode::RX};
 

--- a/firmware/application/apps/replay_app.hpp
+++ b/firmware/application/apps/replay_app.hpp
@@ -27,6 +27,7 @@
 #define NORMAL_UI false
 
 #include "app_settings.hpp"
+#include "radio_state.hpp"
 #include "ui_widget.hpp"
 #include "ui_navigation.hpp"
 #include "ui_receiver.hpp"
@@ -52,6 +53,7 @@ class ReplayAppView : public View {
 
    private:
     NavigationView& nav_;
+    TxRadioState radio_state_;
     app_settings::SettingsManager settings_{
         "tx_replay", app_settings::Mode::TX};
 

--- a/firmware/application/apps/replay_app.hpp
+++ b/firmware/application/apps/replay_app.hpp
@@ -53,7 +53,7 @@ class ReplayAppView : public View {
 
    private:
     NavigationView& nav_;
-    TxRadioState radio_state_;
+    TxRadioState radio_state_{};
     app_settings::SettingsManager settings_{
         "tx_replay", app_settings::Mode::TX};
 

--- a/firmware/application/apps/soundboard_app.cpp
+++ b/firmware/application/apps/soundboard_app.cpp
@@ -106,6 +106,7 @@ void SoundBoardView::start_tx(const uint32_t id) {
             EventDispatcher::send_message(message);
         });
 
+    // TODO: Delete all this and use tx model.
     baseband::set_audiotx_config(
         1536000 / 20,  // Update vu-meter at 20Hz
         transmitter_model.channel_bandwidth(),
@@ -119,8 +120,6 @@ void SoundBoardView::start_tx(const uint32_t id) {
     );
     baseband::set_sample_rate(sample_rate);
 
-    transmitter_model.set_sampling_rate(1536000);
-    transmitter_model.set_baseband_bandwidth(1750000);
     transmitter_model.enable();
 
     tx_view.set_transmitting(true);

--- a/firmware/application/apps/soundboard_app.hpp
+++ b/firmware/application/apps/soundboard_app.hpp
@@ -31,6 +31,7 @@
 #include "io_wave.hpp"
 #include "tone_key.hpp"
 #include "app_settings.hpp"
+#include "radio_state.hpp"
 
 namespace ui {
 
@@ -49,6 +50,10 @@ class SoundBoardView : public View {
     std::string title() const override { return "Soundbrd TX"; };
 
    private:
+    TxRadioState radio_state_{
+        1750000 /* bandwidth */,
+        1536000 /* sampling rate */
+    };
     app_settings::SettingsManager settings_{
         "tx_soundboard", app_settings::Mode::TX};
 

--- a/firmware/application/apps/tpms_app.cpp
+++ b/firmware/application/apps/tpms_app.cpp
@@ -160,8 +160,6 @@ TPMSAppView::TPMSAppView(NavigationView&) {
     if (!settings_.loaded())
         receiver_model.set_sampling_rate(initial_target_frequency);
 
-    receiver_model.set_sampling_rate(sampling_rate);
-    receiver_model.set_baseband_bandwidth(baseband_bandwidth);
     receiver_model.enable();
 
     options_band.on_change = [this](size_t, OptionsField::value_t v) {

--- a/firmware/application/apps/tpms_app.hpp
+++ b/firmware/application/apps/tpms_app.hpp
@@ -28,6 +28,7 @@
 #include "ui_rssi.hpp"
 #include "ui_channel.hpp"
 #include "app_settings.hpp"
+#include "radio_state.hpp"
 #include "event_m0.hpp"
 
 #include "log_file.hpp"
@@ -102,9 +103,11 @@ class TPMSAppView : public View {
 
    private:
     static constexpr uint32_t initial_target_frequency = 315000000;
-    static constexpr uint32_t sampling_rate = 2457600;
-    static constexpr uint32_t baseband_bandwidth = 1750000;
 
+    RxRadioState radio_state_{
+        1750000 /* bandwidth */,
+        2457600 /* sampling rate */
+    };
     app_settings::SettingsManager settings_{
         "rx_tpms", app_settings::Mode::RX};
 

--- a/firmware/application/apps/ui_about_demo.cpp
+++ b/firmware/application/apps/ui_about_demo.cpp
@@ -56,7 +56,6 @@ void AboutView::on_show() {
     transmitter_model.set_rf_amp(true);
     transmitter_model.set_lna(40);
     transmitter_model.set_vga(40);
-    transmitter_model.set_baseband_bandwidth(1750000);
     transmitter_model.enable();
 
     baseband::set_audiotx_data(32, 50, false, 0);

--- a/firmware/application/apps/ui_adsb_rx.cpp
+++ b/firmware/application/apps/ui_adsb_rx.cpp
@@ -514,8 +514,6 @@ ADSBRxView::ADSBRxView(NavigationView& nav) {
 
     receiver_model.set_target_frequency(1090000000);
     receiver_model.set_modulation(ReceiverModel::Mode::SpectrumAnalysis);
-    receiver_model.set_sampling_rate(2000000);
-    receiver_model.set_baseband_bandwidth(2500000);
     receiver_model.enable();
 }
 

--- a/firmware/application/apps/ui_adsb_rx.hpp
+++ b/firmware/application/apps/ui_adsb_rx.hpp
@@ -33,6 +33,7 @@
 #include "adsb.hpp"
 #include "message.hpp"
 #include "app_settings.hpp"
+#include "radio_state.hpp"
 #include "crc.hpp"
 
 using namespace adsb;
@@ -340,6 +341,10 @@ class ADSBRxView : public View {
     void sort_entries_by_state();
 
    private:
+    RxRadioState radio_state_{
+        2500000 /* bandwidth */,
+        2000000 /* sampling rate */
+    };
     app_settings::SettingsManager settings_{
         "rx_adsb", app_settings::Mode::RX};
 

--- a/firmware/application/apps/ui_adsb_tx.cpp
+++ b/firmware/application/apps/ui_adsb_tx.cpp
@@ -299,8 +299,6 @@ void ADSBTxView::generate_frames() {
 void ADSBTxView::start_tx() {
     generate_frames();
 
-    transmitter_model.set_sampling_rate(4000000U);
-    transmitter_model.set_baseband_bandwidth(10000000);
     transmitter_model.enable();
 
     baseband::set_adsb();

--- a/firmware/application/apps/ui_adsb_tx.hpp
+++ b/firmware/application/apps/ui_adsb_tx.hpp
@@ -29,6 +29,7 @@
 #include "message.hpp"
 #include "transmitter_model.hpp"
 #include "app_settings.hpp"
+#include "radio_state.hpp"
 #include "portapack.hpp"
 
 using namespace adsb;
@@ -201,6 +202,10 @@ class ADSBTxView : public View {
                 -1
         };*/
 
+    TxRadioState radio_state_{
+        10000000 /* bandwidth */,
+        4000000 /* sampling rate */
+    };
     app_settings::SettingsManager settings_{
         "tx_adsb", app_settings::Mode::TX};
 

--- a/firmware/application/apps/ui_afsk_rx.cpp
+++ b/firmware/application/apps/ui_afsk_rx.cpp
@@ -104,8 +104,6 @@ AFSKRxView::AFSKRxView(NavigationView& nav) {
     audio::set_rate(audio::Rate::Hz_24000);
     audio::output::start();
 
-    receiver_model.set_sampling_rate(3072000);
-    receiver_model.set_baseband_bandwidth(1750000);
     receiver_model.set_modulation(ReceiverModel::Mode::NarrowbandFMAudio);
     receiver_model.enable();
 }

--- a/firmware/application/apps/ui_afsk_rx.hpp
+++ b/firmware/application/apps/ui_afsk_rx.hpp
@@ -58,7 +58,7 @@ class AFSKRxView : public View {
    private:
     void on_data(uint32_t value, bool is_data);
 
-    RxRadioState radio_state_;
+    RxRadioState radio_state_{};
     app_settings::SettingsManager settings_{
         "rx_afsk", app_settings::Mode::RX};
 

--- a/firmware/application/apps/ui_afsk_rx.hpp
+++ b/firmware/application/apps/ui_afsk_rx.hpp
@@ -28,6 +28,7 @@
 #include "ui_receiver.hpp"
 #include "ui_record_view.hpp"  // DEBUG
 #include "app_settings.hpp"
+#include "radio_state.hpp"
 #include "log_file.hpp"
 #include "utility.hpp"
 
@@ -57,6 +58,7 @@ class AFSKRxView : public View {
    private:
     void on_data(uint32_t value, bool is_data);
 
+    RxRadioState radio_state_;
     app_settings::SettingsManager settings_{
         "rx_afsk", app_settings::Mode::RX};
 

--- a/firmware/application/apps/ui_aprs_rx.cpp
+++ b/firmware/application/apps/ui_aprs_rx.cpp
@@ -134,8 +134,6 @@ APRSRxView::APRSRxView(NavigationView& nav, Rect parent_rect)
     audio::set_rate(audio::Rate::Hz_24000);
     audio::output::start();
 
-    receiver_model.set_sampling_rate(3072000);
-    receiver_model.set_baseband_bandwidth(1750000);
     receiver_model.set_modulation(ReceiverModel::Mode::NarrowbandFMAudio);
     receiver_model.enable();
 }

--- a/firmware/application/apps/ui_aprs_rx.hpp
+++ b/firmware/application/apps/ui_aprs_rx.hpp
@@ -188,7 +188,7 @@ class APRSRxView : public View {
     void on_data(uint32_t value, bool is_data);
     bool reset_console = false;
 
-    RxRadioState radio_state_;
+    RxRadioState radio_state_{};
     app_settings::SettingsManager settings_{
         "rx_aprs", app_settings::Mode::RX};
 

--- a/firmware/application/apps/ui_aprs_rx.hpp
+++ b/firmware/application/apps/ui_aprs_rx.hpp
@@ -29,6 +29,7 @@
 #include "ui_record_view.hpp"  // DEBUG
 #include "ui_geomap.hpp"
 #include "app_settings.hpp"
+#include "radio_state.hpp"
 #include "recent_entries.hpp"
 #include "ui_tabview.hpp"
 
@@ -187,6 +188,7 @@ class APRSRxView : public View {
     void on_data(uint32_t value, bool is_data);
     bool reset_console = false;
 
+    RxRadioState radio_state_;
     app_settings::SettingsManager settings_{
         "rx_aprs", app_settings::Mode::RX};
 

--- a/firmware/application/apps/ui_aprs_tx.cpp
+++ b/firmware/application/apps/ui_aprs_tx.cpp
@@ -57,9 +57,7 @@ void APRSTXView::start_tx() {
 
     // uint8_t * bb_data_ptr = shared_memory.bb_data.data;
     // text_payload.set(to_string_hex_array(bb_data_ptr + 56, 15));
-
-    transmitter_model.set_sampling_rate(AFSK_TX_SAMPLERATE);
-    transmitter_model.set_baseband_bandwidth(1750000);
+    
     transmitter_model.enable();
 
     baseband::set_afsk_data(

--- a/firmware/application/apps/ui_aprs_tx.cpp
+++ b/firmware/application/apps/ui_aprs_tx.cpp
@@ -57,7 +57,7 @@ void APRSTXView::start_tx() {
 
     // uint8_t * bb_data_ptr = shared_memory.bb_data.data;
     // text_payload.set(to_string_hex_array(bb_data_ptr + 56, 15));
-    
+
     transmitter_model.enable();
 
     baseband::set_afsk_data(

--- a/firmware/application/apps/ui_aprs_tx.hpp
+++ b/firmware/application/apps/ui_aprs_tx.hpp
@@ -27,6 +27,7 @@
 #include "ui_transmitter.hpp"
 
 #include "message.hpp"
+#include "modems.hpp"
 #include "transmitter_model.hpp"
 #include "app_settings.hpp"
 #include "radio_state.hpp"

--- a/firmware/application/apps/ui_aprs_tx.hpp
+++ b/firmware/application/apps/ui_aprs_tx.hpp
@@ -29,6 +29,7 @@
 #include "message.hpp"
 #include "transmitter_model.hpp"
 #include "app_settings.hpp"
+#include "radio_state.hpp"
 #include "portapack.hpp"
 
 namespace ui {
@@ -43,6 +44,10 @@ class APRSTXView : public View {
     std::string title() const override { return "APRS TX"; };
 
    private:
+    TxRadioState radio_state_{
+        1750000 /* bandwidth */,
+        AFSK_TX_SAMPLERATE /* sampling rate */
+    };
     app_settings::SettingsManager settings_{
         "tx_aprs", app_settings::Mode::TX};
 

--- a/firmware/application/apps/ui_bht_tx.hpp
+++ b/firmware/application/apps/ui_bht_tx.hpp
@@ -166,7 +166,7 @@ class BHTView : public View {
     std::string title() const override { return "BHT TX"; };
 
    private:
-    TxRadioState radio_state_;
+    TxRadioState radio_state_{};
     app_settings::SettingsManager settings_{
         "tx_bht", app_settings::Mode::TX};
 

--- a/firmware/application/apps/ui_bht_tx.hpp
+++ b/firmware/application/apps/ui_bht_tx.hpp
@@ -32,6 +32,7 @@
 #include "transmitter_model.hpp"
 #include "encoders.hpp"
 #include "app_settings.hpp"
+#include "radio_state.hpp"
 #include "portapack.hpp"
 
 namespace ui {
@@ -165,6 +166,7 @@ class BHTView : public View {
     std::string title() const override { return "BHT TX"; };
 
    private:
+    TxRadioState radio_state_;
     app_settings::SettingsManager settings_{
         "tx_bht", app_settings::Mode::TX};
 

--- a/firmware/application/apps/ui_btle_rx.cpp
+++ b/firmware/application/apps/ui_btle_rx.cpp
@@ -89,8 +89,6 @@ BTLERxView::BTLERxView(NavigationView& nav) {
     audio::set_rate(audio::Rate::Hz_24000);
     audio::output::start();
 
-    receiver_model.set_sampling_rate(4000000);
-    receiver_model.set_baseband_bandwidth(4000000);
     receiver_model.set_modulation(ReceiverModel::Mode::WidebandFMAudio);
     receiver_model.enable();
 }

--- a/firmware/application/apps/ui_btle_rx.hpp
+++ b/firmware/application/apps/ui_btle_rx.hpp
@@ -28,6 +28,7 @@
 #include "ui_navigation.hpp"
 #include "ui_receiver.hpp"
 #include "app_settings.hpp"
+#include "radio_state.hpp"
 #include "ui_record_view.hpp"  // DEBUG
 
 #include "utility.hpp"
@@ -46,6 +47,10 @@ class BTLERxView : public View {
    private:
     void on_data(uint32_t value, bool is_data);
 
+    RxRadioState radio_state_{
+        4000000 /* bandwidth */,
+        4000000 /* sampling rate */
+    };
     app_settings::SettingsManager settings_{
         "rx_btle", app_settings::Mode::RX};
 

--- a/firmware/application/apps/ui_coasterp.cpp
+++ b/firmware/application/apps/ui_coasterp.cpp
@@ -69,8 +69,6 @@ void CoasterPagerView::generate_frame() {
 void CoasterPagerView::start_tx() {
     generate_frame();
 
-    transmitter_model.set_sampling_rate(2280000);
-    transmitter_model.set_baseband_bandwidth(1750000);
     transmitter_model.enable();
 
     baseband::set_fsk_data(19 * 8, 2280000 / 1000, 5000, 32);

--- a/firmware/application/apps/ui_coasterp.hpp
+++ b/firmware/application/apps/ui_coasterp.hpp
@@ -28,6 +28,7 @@
 #include "message.hpp"
 #include "transmitter_model.hpp"
 #include "app_settings.hpp"
+#include "radio_state.hpp"
 #include "portapack.hpp"
 
 namespace ui {
@@ -50,7 +51,10 @@ class CoasterPagerView : public View {
 
     tx_modes tx_mode = IDLE;
 
-    // app save settings
+    TxRadioState radio_state_{
+        1750000 /* bandwidth */,
+        2280000 /* sampling rate */
+    };
     app_settings::SettingsManager settings_{
         "tx_coaster", app_settings::Mode::TX};
 

--- a/firmware/application/apps/ui_encoders.cpp
+++ b/firmware/application/apps/ui_encoders.cpp
@@ -262,8 +262,6 @@ void EncodersView::start_tx(const bool scan) {
     repeat_index = 1;
     update_progress();
 
-    transmitter_model.set_sampling_rate(OOK_SAMPLERATE);
-    transmitter_model.set_baseband_bandwidth(1750000);
     transmitter_model.enable();
 
     baseband::set_ook_data(

--- a/firmware/application/apps/ui_encoders.hpp
+++ b/firmware/application/apps/ui_encoders.hpp
@@ -27,6 +27,7 @@
 #include "encoders.hpp"
 #include "de_bruijn.hpp"
 #include "app_settings.hpp"
+#include "radio_state.hpp"
 
 using namespace encoders;
 
@@ -183,7 +184,10 @@ class EncodersView : public View {
         SCAN
     };
 
-    // app save settings
+    TxRadioState radio_state_{
+        1750000 /* bandwidth */,
+        OOK_SAMPLERATE /* sampling rate */
+    };
     app_settings::SettingsManager settings_{
         "tx_ook", app_settings::Mode::TX};
 

--- a/firmware/application/apps/ui_jammer.cpp
+++ b/firmware/application/apps/ui_jammer.cpp
@@ -261,9 +261,7 @@ void JammerView::start_tx() {
         button_transmit.set_style(&style_cancel);
         button_transmit.set_text("STOP");
 
-        transmitter_model.set_sampling_rate(3072000U);
         transmitter_model.set_rf_amp(field_amp.value());
-        transmitter_model.set_baseband_bandwidth(3500000U);
         transmitter_model.set_tx_gain(field_gain.value());
         transmitter_model.enable();
 

--- a/firmware/application/apps/ui_jammer.hpp
+++ b/firmware/application/apps/ui_jammer.hpp
@@ -29,6 +29,7 @@
 #include "message.hpp"
 #include "jammer.hpp"
 #include "lfsr_random.hpp"
+#include "radio_state.hpp"
 
 using namespace jammer;
 
@@ -99,6 +100,10 @@ class JammerView : public View {
 
    private:
     NavigationView& nav_;
+    TxRadioState radio_state_{
+        3500000 /* bandwidth */,
+        3072000 /* sampling rate */
+    };
 
     void start_tx();
     void on_timer();

--- a/firmware/application/apps/ui_keyfob.cpp
+++ b/firmware/application/apps/ui_keyfob.cpp
@@ -190,8 +190,6 @@ void KeyfobView::start_tx() {
 
     size_t bitstream_length = generate_frame();
 
-    transmitter_model.set_sampling_rate(OOK_SAMPLERATE);
-    transmitter_model.set_baseband_bandwidth(1750000);
     transmitter_model.enable();
 
     baseband::set_ook_data(

--- a/firmware/application/apps/ui_keyfob.hpp
+++ b/firmware/application/apps/ui_keyfob.hpp
@@ -24,6 +24,7 @@
 #include "ui_transmitter.hpp"
 #include "transmitter_model.hpp"
 #include "app_settings.hpp"
+#include "radio_state.hpp"
 #include "encoders.hpp"
 
 using namespace encoders;
@@ -42,7 +43,10 @@ class KeyfobView : public View {
    private:
     NavigationView& nav_;
 
-    // app save settings
+    TxRadioState radio_state_{
+        1750000 /* bandwidth */,
+        OOK_SAMPLERATE /* sampling rate */
+    };
     app_settings::SettingsManager settings_{
         "tx_keyfob", , app_settings::Mode::TX};
 

--- a/firmware/application/apps/ui_lcr.cpp
+++ b/firmware/application/apps/ui_lcr.cpp
@@ -24,7 +24,6 @@
 #include "ui_modemsetup.hpp"
 
 #include "lcr.hpp"
-#include "modems.hpp"
 #include "baseband_api.hpp"
 #include "string_format.hpp"
 #include "cpld_update.hpp"
@@ -130,8 +129,6 @@ void LCRView::start_tx(const bool scan) {
 
     modems::generate_data(lcr::generate_message(rgsb, litterals_list, options_ec.selected_index()), lcr_message_data);
 
-    transmitter_model.set_sampling_rate(AFSK_TX_SAMPLERATE);
-    transmitter_model.set_baseband_bandwidth(1750000);
     transmitter_model.enable();
 
     memcpy(shared_memory.bb_data.data, lcr_message_data, sizeof(lcr_message_data));

--- a/firmware/application/apps/ui_lcr.hpp
+++ b/firmware/application/apps/ui_lcr.hpp
@@ -26,8 +26,10 @@
 #include "ui_transmitter.hpp"
 
 #include "message.hpp"
+#include "modems.hpp"
 #include "transmitter_model.hpp"
 #include "app_settings.hpp"
+#include "radio_state.hpp"
 
 namespace ui {
 
@@ -79,6 +81,10 @@ class LCRView : public View {
         SCAN
     };
 
+    TxRadioState radio_state_{
+        1750000 /* bandwidth */,
+        AFSK_TX_SAMPLERATE /* sampling rate */
+    };
     app_settings::SettingsManager settings_{
         "tx_lcr", app_settings::Mode::TX};
 

--- a/firmware/application/apps/ui_level.cpp
+++ b/firmware/application/apps/ui_level.cpp
@@ -178,8 +178,6 @@ size_t LevelView::change_mode(freqman_index_t new_mod) {
             receiver_model.set_modulation(ReceiverModel::Mode::AMAudio);
             receiver_model.set_am_configuration(field_bw.selected_index_value());
             field_bw.on_change = [this](size_t, OptionsField::value_t n) { receiver_model.set_am_configuration(n); };
-            receiver_model.set_sampling_rate(3072000);
-            receiver_model.set_baseband_bandwidth(1750000);
             text_ctcss.set("             ");
             break;
         case NFM_MODULATION:
@@ -190,8 +188,6 @@ size_t LevelView::change_mode(freqman_index_t new_mod) {
             receiver_model.set_modulation(ReceiverModel::Mode::NarrowbandFMAudio);
             receiver_model.set_nbfm_configuration(field_bw.selected_index_value());
             field_bw.on_change = [this](size_t, OptionsField::value_t n) { receiver_model.set_nbfm_configuration(n); };
-            receiver_model.set_sampling_rate(3072000);
-            receiver_model.set_baseband_bandwidth(1750000);
             break;
         case WFM_MODULATION:
             freqman_set_bandwidth_option(new_mod, field_bw);
@@ -201,8 +197,6 @@ size_t LevelView::change_mode(freqman_index_t new_mod) {
             receiver_model.set_modulation(ReceiverModel::Mode::WidebandFMAudio);
             receiver_model.set_wfm_configuration(field_bw.selected_index_value());
             field_bw.on_change = [this](size_t, OptionsField::value_t n) { receiver_model.set_wfm_configuration(n); };
-            receiver_model.set_sampling_rate(3072000);
-            receiver_model.set_baseband_bandwidth(1750000);
             text_ctcss.set("             ");
             break;
         default:

--- a/firmware/application/apps/ui_level.hpp
+++ b/firmware/application/apps/ui_level.hpp
@@ -38,6 +38,7 @@
 #include "string_format.hpp"
 #include "file.hpp"
 #include "app_settings.hpp"
+#include "radio_state.hpp"
 
 namespace ui {
 
@@ -53,6 +54,7 @@ class LevelView : public View {
    private:
     NavigationView& nav_;
 
+    RxRadioState radio_state_{};
     app_settings::SettingsManager settings_{
         "rx_level", app_settings::Mode::RX};
 

--- a/firmware/application/apps/ui_looking_glass_app.cpp
+++ b/firmware/application/apps/ui_looking_glass_app.cpp
@@ -518,7 +518,7 @@ GlassView::GlassView(
 }
 
 void GlassView::load_Presets() {
-    File presets_file;  // LOAD /WHIPCALC/ANTENNAS.TXT from microSD
+    File presets_file;
     auto result = presets_file.open("LOOKINGGLASS/PRESETS.TXT");
     presets_db.clear();  // Start with fresh db
     if (result.is_valid()) {

--- a/firmware/application/apps/ui_looking_glass_app.hpp
+++ b/firmware/application/apps/ui_looking_glass_app.hpp
@@ -27,6 +27,7 @@
 #include "ui.hpp"
 #include "portapack.hpp"
 #include "baseband_api.hpp"
+#include "radio_state.hpp"
 #include "receiver_model.hpp"
 #include "ui_widget.hpp"
 #include "ui_navigation.hpp"
@@ -69,6 +70,7 @@ class GlassView : public View {
 
    private:
     NavigationView& nav_;
+    RxRadioState radio_state_{};
 
     struct preset_entry {
         rf::Frequency min{};

--- a/firmware/application/apps/ui_mictx.cpp
+++ b/firmware/application/apps/ui_mictx.cpp
@@ -163,8 +163,6 @@ void MicTXView::rxaudio(bool is_on) {
                                                                                         // receiver_model.set_nbfm_configuration(n); is called above  , depending user's selection (8k5, 11k, 16k).
             }
         }
-        receiver_model.set_sampling_rate(3072000);
-        receiver_model.set_baseband_bandwidth(1750000);
         //		receiver_model.set_target_frequency(field_frequency.value()); //probably this too can be commented out.
         if (bool_same_F_tx_rx_enabled)                          // when stop TX ,define to which freq RX we return
             receiver_model.set_target_frequency(tx_frequency);  // Update freq also for RX = TX
@@ -598,9 +596,6 @@ MicTXView::MicTXView(
             button_touch = true;
         }
     };
-
-    transmitter_model.set_sampling_rate(sampling_rate);
-    transmitter_model.set_baseband_bandwidth(1750000);
 
     set_tx(false);
 

--- a/firmware/application/apps/ui_mictx.hpp
+++ b/firmware/application/apps/ui_mictx.hpp
@@ -27,6 +27,7 @@
 #define NORMAL_UI false
 
 #include "app_settings.hpp"
+#include "radio_state.hpp"
 #include "ui.hpp"
 #include "ui_widget.hpp"
 #include "ui_navigation.hpp"
@@ -80,6 +81,11 @@ class MicTXView : public View {
 
     void set_ptt_visibility(bool v);
 
+    RxRadioState rx_radio_state_{};
+    TxRadioState tx_radio_state_{
+        1750000 /* bandwidth */,
+        sampling_rate /* sampling rate */
+    };
     app_settings::SettingsManager settings_{
         "tx_mic", app_settings::Mode::RX_TX,
         app_settings::Options::UseGlobalTargetFrequency};

--- a/firmware/application/apps/ui_morse.cpp
+++ b/firmware/application/apps/ui_morse.cpp
@@ -119,9 +119,6 @@ bool MorseView::start_tx() {
     }
 
     progressbar.set_max(symbol_count);
-
-    transmitter_model.set_sampling_rate(1536000U);
-    transmitter_model.set_baseband_bandwidth(1750000);
     transmitter_model.enable();
 
     if (modulation == CW) {

--- a/firmware/application/apps/ui_morse.hpp
+++ b/firmware/application/apps/ui_morse.hpp
@@ -28,6 +28,7 @@
 #include "ui_navigation.hpp"
 #include "ui_transmitter.hpp"
 #include "app_settings.hpp"
+#include "radio_state.hpp"
 #include "portapack.hpp"
 #include "message.hpp"
 #include "volume.hpp"
@@ -68,6 +69,10 @@ class MorseView : public View {
     std::string message{};
     uint32_t time_units{0};
 
+    TxRadioState radio_state_{
+        1750000 /* bandwidth */,
+        1536000 /* sampling rate */
+    };
     app_settings::SettingsManager settings_{
         "tx_morse", app_settings::Mode::TX};
 

--- a/firmware/application/apps/ui_nrf_rx.cpp
+++ b/firmware/application/apps/ui_nrf_rx.cpp
@@ -89,8 +89,6 @@ NRFRxView::NRFRxView(NavigationView& nav) {
     audio::set_rate(audio::Rate::Hz_24000);
     audio::output::start();
 
-    receiver_model.set_sampling_rate(4000000);
-    receiver_model.set_baseband_bandwidth(4000000);
     receiver_model.set_modulation(ReceiverModel::Mode::WidebandFMAudio);
     receiver_model.enable();
 }

--- a/firmware/application/apps/ui_nrf_rx.hpp
+++ b/firmware/application/apps/ui_nrf_rx.hpp
@@ -28,6 +28,7 @@
 #include "ui_navigation.hpp"
 #include "ui_receiver.hpp"
 #include "app_settings.hpp"
+#include "radio_state.hpp"
 #include "ui_record_view.hpp"  // DEBUG
 
 #include "utility.hpp"
@@ -46,6 +47,10 @@ class NRFRxView : public View {
    private:
     void on_data(uint32_t value, bool is_data);
 
+    RxRadioState radio_state_{
+        4000000 /* bandwidth */,
+        4000000 /* sampling rate */
+    };
     app_settings::SettingsManager settings_{
         "rx_nrf", app_settings::Mode::RX};
 

--- a/firmware/application/apps/ui_numbers.cpp
+++ b/firmware/application/apps/ui_numbers.cpp
@@ -129,9 +129,7 @@ void NumbersStationView::start_tx() {
 
     prepare_audio();
 
-    transmitter_model.set_sampling_rate(1536000U);
     transmitter_model.set_rf_amp(true);
-    transmitter_model.set_baseband_bandwidth(1750000);
     transmitter_model.enable();
 
     baseband::set_audiotx_data(

--- a/firmware/application/apps/ui_numbers.hpp
+++ b/firmware/application/apps/ui_numbers.hpp
@@ -34,6 +34,7 @@
 #include "message.hpp"
 #include "file.hpp"
 #include "io_wave.hpp"
+#include "radio_state.hpp"
 
 namespace ui {
 
@@ -53,6 +54,11 @@ class NumbersStationView : public View {
 
    private:
     NavigationView& nav_;
+
+    TxRadioState radio_state_{
+        1750000 /* bandwidth */,
+        1536000 /* sampling rate */
+    };
 
     // Sequencing state machine
     enum segments {

--- a/firmware/application/apps/ui_nuoptix.cpp
+++ b/firmware/application/apps/ui_nuoptix.cpp
@@ -77,11 +77,9 @@ void NuoptixView::transmit(bool setup) {
             timecode = number_timecode.value();
         }
 
-        transmitter_model.set_sampling_rate(1536000U);
         transmitter_model.set_rf_amp(true);
         transmitter_model.set_lna(40);
         transmitter_model.set_vga(40);
-        transmitter_model.set_baseband_bandwidth(1750000);
         transmitter_model.enable();
 
         dtmf_message[0] = '*';  // "Pre-tone for restart" method #1

--- a/firmware/application/apps/ui_nuoptix.hpp
+++ b/firmware/application/apps/ui_nuoptix.hpp
@@ -33,6 +33,7 @@
 #include "message.hpp"
 #include "volume.hpp"
 #include "audio.hpp"
+#include "radio_state.hpp"
 
 #define NUOPTIX_TONE_LENGTH ((TONES_SAMPLERATE * 0.049) - 1)  // 49ms
 
@@ -52,6 +53,11 @@ class NuoptixView : public View {
         IDLE = 0,
         NORMAL,
         IMPROVISE
+    };
+
+    TxRadioState radio_state_{
+        1750000 /* bandwidth */,
+        1536000 /* sampling rate */
     };
 
     tx_modes tx_mode{IDLE};

--- a/firmware/application/apps/ui_playlist.cpp
+++ b/firmware/application/apps/ui_playlist.cpp
@@ -202,9 +202,6 @@ void PlaylistView::start() {
 
     if (reader) {
         button_play.set_bitmap(&bitmap_stop);
-
-        baseband::set_sample_rate(sample_rate * 8);
-
         if (now_delay) {  // this `if` is because, if the delay is 0, it will sleep forever
             chThdSleepMilliseconds(now_delay);
         }

--- a/firmware/application/apps/ui_playlist.hpp
+++ b/firmware/application/apps/ui_playlist.hpp
@@ -24,6 +24,7 @@
 #define NORMAL_UI false
 
 #include "app_settings.hpp"
+#include "radio_state.hpp"
 #include "ui_widget.hpp"
 #include "ui_navigation.hpp"
 #include "ui_receiver.hpp"
@@ -53,6 +54,7 @@ class PlaylistView : public View {
 
    private:
     NavigationView& nav_;
+    TxRadioState radio_state_{};
     app_settings::SettingsManager settings_{
         "tx_playlist", app_settings::Mode::TX};
 

--- a/firmware/application/apps/ui_pocsag_tx.cpp
+++ b/firmware/application/apps/ui_pocsag_tx.cpp
@@ -81,11 +81,9 @@ bool POCSAGTXView::start_tx() {
 
     progressbar.set_max(total_frames);
 
-    transmitter_model.set_sampling_rate(2280000);
     transmitter_model.set_rf_amp(true);
     transmitter_model.set_lna(40);
     transmitter_model.set_vga(40);
-    transmitter_model.set_baseband_bandwidth(1750000);
     transmitter_model.enable();
 
     uint8_t* data_ptr = shared_memory.bb_data.data;

--- a/firmware/application/apps/ui_pocsag_tx.hpp
+++ b/firmware/application/apps/ui_pocsag_tx.hpp
@@ -32,6 +32,7 @@
 #include "message.hpp"
 #include "transmitter_model.hpp"
 #include "app_settings.hpp"
+#include "radio_state.hpp"
 #include "pocsag.hpp"
 
 using namespace pocsag;
@@ -58,6 +59,10 @@ class POCSAGTXView : public View {
     std::string message{};
     NavigationView& nav_;
 
+    TxRadioState radio_state_{
+        1750000 /* bandwidth */,
+        2280000 /* sampling rate */
+    };
     app_settings::SettingsManager settings_{
         "tx_pocsag", app_settings::Mode::TX};
 

--- a/firmware/application/apps/ui_rds.cpp
+++ b/firmware/application/apps/ui_rds.cpp
@@ -189,8 +189,6 @@ void RDSView::start_tx() {
     else
         frame_datetime.clear();
 
-    transmitter_model.set_sampling_rate(2280000U);
-    transmitter_model.set_baseband_bandwidth(1750000);
     transmitter_model.enable();
 
     tx_thread = std::make_unique<RDSThread>(frames);

--- a/firmware/application/apps/ui_rds.hpp
+++ b/firmware/application/apps/ui_rds.hpp
@@ -25,6 +25,7 @@
 #include "ui_textentry.hpp"
 #include "ui_tabview.hpp"
 #include "app_settings.hpp"
+#include "radio_state.hpp"
 #include "rds.hpp"
 
 using namespace rds;
@@ -140,6 +141,10 @@ class RDSView : public View {
     NavigationView& nav_;
     RDS_flags rds_flags{};
 
+    TxRadioState radio_state_{
+        1750000 /* bandwidth */,
+        2280000 /* sampling rate */
+    };
     app_settings::SettingsManager settings_{
         "tx_rds", app_settings::Mode::TX};
 

--- a/firmware/application/apps/ui_recon.cpp
+++ b/firmware/application/apps/ui_recon.cpp
@@ -1302,8 +1302,6 @@ size_t ReconView::change_mode(freqman_index_t new_mod) {
             receiver_model.set_modulation(ReceiverModel::Mode::AMAudio);
             receiver_model.set_am_configuration(field_bw.selected_index_value());
             field_bw.on_change = [this](size_t, OptionsField::value_t n) { receiver_model.set_am_configuration(n); };
-            receiver_model.set_sampling_rate(3072000);
-            receiver_model.set_baseband_bandwidth(1750000);
             text_ctcss.set("        ");
             break;
         case NFM_MODULATION:
@@ -1314,8 +1312,6 @@ size_t ReconView::change_mode(freqman_index_t new_mod) {
             receiver_model.set_modulation(ReceiverModel::Mode::NarrowbandFMAudio);
             receiver_model.set_nbfm_configuration(field_bw.selected_index_value());
             field_bw.on_change = [this](size_t, OptionsField::value_t n) { receiver_model.set_nbfm_configuration(n); };
-            receiver_model.set_sampling_rate(3072000);
-            receiver_model.set_baseband_bandwidth(1750000);
             break;
         case WFM_MODULATION:
             freqman_set_bandwidth_option(new_mod, field_bw);
@@ -1325,8 +1321,6 @@ size_t ReconView::change_mode(freqman_index_t new_mod) {
             receiver_model.set_modulation(ReceiverModel::Mode::WidebandFMAudio);
             receiver_model.set_wfm_configuration(field_bw.selected_index_value());
             field_bw.on_change = [this](size_t, OptionsField::value_t n) { receiver_model.set_wfm_configuration(n); };
-            receiver_model.set_sampling_rate(3072000);
-            receiver_model.set_baseband_bandwidth(1750000);
             text_ctcss.set("        ");
             break;
         default:

--- a/firmware/application/apps/ui_recon.hpp
+++ b/firmware/application/apps/ui_recon.hpp
@@ -39,6 +39,7 @@
 #include "string_format.hpp"
 #include "file.hpp"
 #include "app_settings.hpp"
+#include "radio_state.hpp"
 #include "ui_recon_settings.hpp"
 
 namespace ui {
@@ -60,6 +61,7 @@ class ReconView : public View {
    private:
     NavigationView& nav_;
 
+    RxRadioState radio_state_{};
     app_settings::SettingsManager settings_{
         "rx_recon", app_settings::Mode::RX};
 

--- a/firmware/application/apps/ui_scanner.cpp
+++ b/firmware/application/apps/ui_scanner.cpp
@@ -761,8 +761,6 @@ void ScannerView::change_mode(freqman_index_t new_mod) {  // Before this, do a s
             field_bw.set_by_value(0);
             receiver_model.set_am_configuration(field_bw.selected_index_value());
             field_bw.on_change = [this](size_t, OptionsField::value_t n) { receiver_model.set_am_configuration(n); };
-            receiver_model.set_sampling_rate(3072000);
-            receiver_model.set_baseband_bandwidth(1750000);
             break;
         case NFM_MODULATION:  // bw 16k (2) default
             freqman_set_bandwidth_option(new_mod, field_bw);
@@ -771,8 +769,6 @@ void ScannerView::change_mode(freqman_index_t new_mod) {  // Before this, do a s
             field_bw.set_by_value(2);
             receiver_model.set_nbfm_configuration(field_bw.selected_index_value());
             field_bw.on_change = [this](size_t, OptionsField::value_t n) { receiver_model.set_nbfm_configuration(n); };
-            receiver_model.set_sampling_rate(3072000);
-            receiver_model.set_baseband_bandwidth(1750000);
             break;
         case WFM_MODULATION:
             freqman_set_bandwidth_option(new_mod, field_bw);
@@ -781,8 +777,6 @@ void ScannerView::change_mode(freqman_index_t new_mod) {  // Before this, do a s
             field_bw.set_by_value(0);
             receiver_model.set_wfm_configuration(field_bw.selected_index_value());
             field_bw.on_change = [this](size_t, OptionsField::value_t n) { receiver_model.set_wfm_configuration(n); };
-            receiver_model.set_sampling_rate(3072000);
-            receiver_model.set_baseband_bandwidth(2000000);
             break;
         default:
             break;

--- a/firmware/application/apps/ui_scanner.hpp
+++ b/firmware/application/apps/ui_scanner.hpp
@@ -22,6 +22,7 @@
 
 #include "ui.hpp"
 #include "receiver_model.hpp"
+#include "radio_state.hpp"
 #include "ui_receiver.hpp"
 #include "ui_styles.hpp"
 #include "freqman.hpp"
@@ -95,6 +96,7 @@ class ScannerView : public View {
 
    private:
     NavigationView& nav_;
+    RxRadioState radio_state_{};
 
     void start_scan_thread();
     void change_mode(freqman_index_t mod_type);

--- a/firmware/application/apps/ui_search.cpp
+++ b/firmware/application/apps/ui_search.cpp
@@ -415,8 +415,6 @@ SearchView::SearchView(
     on_range_changed();
 
     receiver_model.set_modulation(ReceiverModel::Mode::SpectrumAnalysis);
-    receiver_model.set_sampling_rate(SEARCH_SLICE_WIDTH);
-    receiver_model.set_baseband_bandwidth(2500000);
     receiver_model.enable();
 }
 

--- a/firmware/application/apps/ui_search.hpp
+++ b/firmware/application/apps/ui_search.hpp
@@ -21,6 +21,7 @@
  */
 
 #include "receiver_model.hpp"
+#include "radio_state.hpp"
 
 #include "spectrum_color_lut.hpp"
 
@@ -89,6 +90,10 @@ class SearchView : public View {
 
    private:
     NavigationView& nav_;
+    RxRadioState radio_state_{
+        2500000 /* bandwidth */,
+        SEARCH_SLICE_WIDTH /* sampling rate */
+    };
 
     struct slice_t {
         rf::Frequency center_frequency;

--- a/firmware/application/apps/ui_sigfrx.cpp
+++ b/firmware/application/apps/ui_sigfrx.cpp
@@ -120,9 +120,6 @@ SIGFRXView::SIGFRXView(
         .decimation_factor = 4,
     });
     // TODO: use settings.
-    receiver_model.set_baseband_bandwidth(1750000);
-    receiver_model.set_target_frequency(868110000);
-
     receiver_model.set_lna(0);
     receiver_model.set_vga(0);
 

--- a/firmware/application/apps/ui_sigfrx.cpp
+++ b/firmware/application/apps/ui_sigfrx.cpp
@@ -122,6 +122,7 @@ SIGFRXView::SIGFRXView(
     // TODO: use settings.
     receiver_model.set_lna(0);
     receiver_model.set_vga(0);
+    receiver_model.set_target_frequency(868110000);
 
     add_children({&text_type,
                   &text_channel,

--- a/firmware/application/apps/ui_sigfrx.hpp
+++ b/firmware/application/apps/ui_sigfrx.hpp
@@ -53,7 +53,7 @@ class SIGFRXView : public View {
 
     RxRadioState radio_state_{
         1750000 /* bandwidth */,
-        868110000 /* sampling rate */
+        3072000 /* sampling rate */
     };
 
     const uint16_t sigfrx_marks[18] = {

--- a/firmware/application/apps/ui_sigfrx.hpp
+++ b/firmware/application/apps/ui_sigfrx.hpp
@@ -32,6 +32,7 @@
 #include "max2837.hpp"
 #include "volume.hpp"
 #include "receiver_model.hpp"
+#include "radio_state.hpp"
 
 namespace ui {
 
@@ -49,6 +50,11 @@ class SIGFRXView : public View {
    private:
     uint8_t last_channel;
     uint8_t detect_counter = 0;
+
+    RxRadioState radio_state_{
+        1750000 /* bandwidth */,
+        868110000 /* sampling rate */
+    };
 
     const uint16_t sigfrx_marks[18] = {
         10, 8, 0,

--- a/firmware/application/apps/ui_siggen.cpp
+++ b/firmware/application/apps/ui_siggen.cpp
@@ -54,8 +54,6 @@ void SigGenView::update_tone() {
 }
 
 void SigGenView::start_tx() {
-    transmitter_model.set_sampling_rate(1536000);
-    transmitter_model.set_baseband_bandwidth(1750000);
     transmitter_model.enable();
 
     update_tone();

--- a/firmware/application/apps/ui_siggen.hpp
+++ b/firmware/application/apps/ui_siggen.hpp
@@ -24,6 +24,7 @@
 #define __SIGGEN_H__
 
 #include "app_settings.hpp"
+#include "radio_state.hpp"
 #include "ui.hpp"
 #include "ui_widget.hpp"
 #include "ui_navigation.hpp"
@@ -49,6 +50,10 @@ class SigGenView : public View {
     void update_tone();
     void on_tx_progress(const uint32_t progress, const bool done);
 
+    TxRadioState radio_state_{
+        1750000 /* bandwidth */,
+        1536000 /* sampling rate */
+    };
     app_settings::SettingsManager settings_{
         "tx_siggen", app_settings::Mode::TX};
 

--- a/firmware/application/apps/ui_sonde.cpp
+++ b/firmware/application/apps/ui_sonde.cpp
@@ -92,8 +92,6 @@ SondeView::SondeView(NavigationView& nav) {
         use_crc = v;
     };
 
-    receiver_model.set_sampling_rate(sampling_rate);
-    receiver_model.set_baseband_bandwidth(baseband_bandwidth);
     receiver_model.enable();
 
     // QR code with geo URI

--- a/firmware/application/apps/ui_sonde.hpp
+++ b/firmware/application/apps/ui_sonde.hpp
@@ -35,6 +35,7 @@
 
 #include "sonde_packet.hpp"
 #include "app_settings.hpp"
+#include "radio_state.hpp"
 #include <cstddef>
 #include <string>
 
@@ -54,9 +55,6 @@ namespace ui {
 
 class SondeView : public View {
    public:
-    static constexpr uint32_t sampling_rate = 2457600;
-    static constexpr uint32_t baseband_bandwidth = 1750000;
-
     SondeView(NavigationView& nav);
     ~SondeView();
 
@@ -65,6 +63,10 @@ class SondeView : public View {
     std::string title() const override { return "Radiosnd RX"; };
 
    private:
+    RxRadioState radio_state_{
+        1750000 /* bandwidth */,
+        2457600 /* sampling rate */
+    };
     app_settings::SettingsManager settings_{
         "rx_sonde", app_settings::Mode::RX};
 

--- a/firmware/application/apps/ui_spectrum_painter.cpp
+++ b/firmware/application/apps/ui_spectrum_painter.cpp
@@ -94,8 +94,6 @@ SpectrumPainterView::SpectrumPainterView(
             if (tx_mode == 0 && image_input_avaliable == false)
                 return;
 
-            transmitter_model.set_sampling_rate(3072000U);
-            transmitter_model.set_baseband_bandwidth(1750000);
             transmitter_model.enable();
 
             if (persistent_memory::stealth_mode()) {

--- a/firmware/application/apps/ui_spectrum_painter.hpp
+++ b/firmware/application/apps/ui_spectrum_painter.hpp
@@ -30,6 +30,7 @@
 #include "baseband_api.hpp"
 
 #include "app_settings.hpp"
+#include "radio_state.hpp"
 #include "portapack.hpp"
 #include "message.hpp"
 
@@ -55,6 +56,7 @@ class SpectrumPainterView : public View {
 
    private:
     NavigationView& nav_;
+    TxRadioState radio_state_{};
     app_settings::SettingsManager settings_{
         "tx_painter", app_settings::Mode::TX};
 

--- a/firmware/application/apps/ui_sstvtx.cpp
+++ b/firmware/application/apps/ui_sstvtx.cpp
@@ -162,8 +162,6 @@ void SSTVTXView::start_tx() {
     scanline_counter = 0;
     prepare_scanline();  // Preload one scanline
 
-    transmitter_model.set_sampling_rate(3072000U);
-    transmitter_model.set_baseband_bandwidth(1750000);
     transmitter_model.enable();
 
     baseband::set_sstv_data(

--- a/firmware/application/apps/ui_sstvtx.hpp
+++ b/firmware/application/apps/ui_sstvtx.hpp
@@ -34,6 +34,7 @@
 #include "file.hpp"
 #include "bmp.hpp"
 #include "app_settings.hpp"
+#include "radio_state.hpp"
 
 using namespace sstv;
 
@@ -56,6 +57,7 @@ class SSTVTXView : public View {
 
    private:
     NavigationView& nav_;
+    TxRadioState radio_state_{};
     app_settings::SettingsManager settings_{
         "tx_sstv", app_settings::Mode::TX};
 

--- a/firmware/application/apps/ui_test.cpp
+++ b/firmware/application/apps/ui_test.cpp
@@ -79,8 +79,6 @@ TestView::TestView(NavigationView& nav) {
     if (logger)
         logger->append("saucepan.txt");
 
-    receiver_model.set_sampling_rate(sampling_rate);
-    receiver_model.set_baseband_bandwidth(baseband_bandwidth);
     receiver_model.enable();
 }
 

--- a/firmware/application/apps/ui_test.hpp
+++ b/firmware/application/apps/ui_test.hpp
@@ -51,9 +51,6 @@ namespace ui {
 
 class TestView : public View {
    public:
-    static constexpr uint32_t sampling_rate = 2457600 * 2;
-    static constexpr uint32_t baseband_bandwidth = 1750000;
-
     TestView(NavigationView& nav);
     ~TestView();
 
@@ -62,6 +59,11 @@ class TestView : public View {
     std::string title() const override { return "Test app"; };
 
    private:
+    RxRadioState radio_state_{
+        1750000 /* bandwidth */,
+        2457600 * 2 /* sampling rate */
+    };
+
     Coord cur_x{0};
     uint32_t packet_count{0};
     uint32_t packets_lost{0};

--- a/firmware/application/apps/ui_touchtunes.cpp
+++ b/firmware/application/apps/ui_touchtunes.cpp
@@ -88,9 +88,7 @@ void TouchTunesView::on_tx_progress(const uint32_t progress, const bool done) {
 void TouchTunesView::start_ew() {
     // Radio
     transmitter_model.set_target_frequency(433920000);
-    transmitter_model.set_sampling_rate(3072000U);
     transmitter_model.set_rf_amp(true);
-    transmitter_model.set_baseband_bandwidth(3500000U);
     transmitter_model.set_tx_gain(47);
     transmitter_model.enable();
 

--- a/firmware/application/apps/ui_touchtunes.hpp
+++ b/firmware/application/apps/ui_touchtunes.hpp
@@ -24,6 +24,7 @@
 #include "ui.hpp"
 #include "ui_transmitter.hpp"
 #include "transmitter_model.hpp"
+#include "radio_state.hpp"
 
 // The coding in notpike's script is quite complex, using multiple LUTs to form the data sent to the YSO.
 // The format is actually very simple if it is rather seen as short and long gaps between pulses (as seen in many OOK remotes).
@@ -113,6 +114,11 @@ class TouchTunesView : public View {
     std::string title() const override { return "TouchTunes"; };
 
    private:
+    TxRadioState radio_state_{
+        3500000 /* bandwidth */,
+        3072000 /* sampling rate */
+    };
+
     uint32_t scan_button_index{};
     uint32_t pin{0};
 

--- a/firmware/application/radio_state.hpp
+++ b/firmware/application/radio_state.hpp
@@ -19,6 +19,9 @@
  * Boston, MA 02110-1301, USA.
  */
 
+ #ifndef __RADIO_STATE_H__
+ #define __RADIO_STATE_H__
+
 #include <type_traits>
 #include <utility>
 #include "portapack.hpp"
@@ -54,3 +57,5 @@ class RadioState {
 
 using RxRadioState = RadioState<ReceiverModel, &portapack::receiver_model>;
 using TxRadioState = RadioState<TransmitterModel, &portapack::transmitter_model>;
+
+#endif  // __RADIO_STATE_H__

--- a/firmware/application/radio_state.hpp
+++ b/firmware/application/radio_state.hpp
@@ -19,8 +19,8 @@
  * Boston, MA 02110-1301, USA.
  */
 
- #ifndef __RADIO_STATE_H__
- #define __RADIO_STATE_H__
+#ifndef __RADIO_STATE_H__
+#define __RADIO_STATE_H__
 
 #include <type_traits>
 #include <utility>

--- a/firmware/application/radio_state.hpp
+++ b/firmware/application/radio_state.hpp
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2023 Kyle Reed
+ *
+ * This file is part of PortaPack.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#include <type_traits>
+#include <utility>
+#include "portapack.hpp"
+#include "receiver_model.hpp"
+#include "transmitter_model.hpp"
+
+/* Stashes current radio bandwidth and sampling rate.
+ * Inits to defaults, and restores previous when destroyed.
+ * NB: This member must be added before SettingsManager. */
+template <typename TModel, TModel* model>
+class RadioState {
+   public:
+    RadioState()
+        : RadioState(max2837::filter::bandwidth_minimum, 3072000) {
+    }
+
+    RadioState(uint32_t new_bandwidth, uint32_t new_sampling_rate)
+        : prev_bandwidth_{model->baseband_bandwidth()},
+          prev_sampling_rate_{model->sampling_rate()} {
+        model->set_baseband_bandwidth(new_bandwidth);
+        model->set_sampling_rate(new_sampling_rate);
+    }
+
+    ~RadioState() {
+        model->set_baseband_bandwidth(prev_bandwidth_);
+        model->set_sampling_rate(prev_sampling_rate_);
+    }
+
+   private:
+    const uint32_t prev_bandwidth_;
+    const uint32_t prev_sampling_rate_;
+};
+
+using RxRadioState = RadioState<ReceiverModel, &portapack::receiver_model>;
+using TxRadioState = RadioState<TransmitterModel, &portapack::transmitter_model>;

--- a/firmware/common/utility.hpp
+++ b/firmware/common/utility.hpp
@@ -126,6 +126,22 @@ constexpr const T& clip(const T& value, const T& minimum, const T& maximum) {
     return std::max(std::min(value, maximum), minimum);
 }
 
+/* Saves state on construction and reverts it when destroyed. */
+template <typename T>
+struct Stash {
+    Stash(T& target)
+        : target_{target}, prev_{target} {
+    }
+
+    ~Stash() {
+        target_ = std::move(prev_);
+    }
+
+   private:
+    T& target_;
+    T prev_;
+};
+
 // TODO: need to decide if this is inclusive or exclusive.
 // The implementations are different and cause the subtle
 // bugs mentioned below.

--- a/firmware/test/application/test_utility.cpp
+++ b/firmware/test/application/test_utility.cpp
@@ -48,3 +48,15 @@ TEST_CASE("When flag not set, flags_enabled should be false.") {
 }
 
 TEST_SUITE_END();
+
+TEST_CASE("Stash should save and restore value.") {
+    int val = 10;
+
+    {
+        Stash s{val};
+        val = 20;
+        CHECK_EQ(val, 20);
+    }
+
+    CHECK_EQ(val, 10);
+}


### PR DESCRIPTION
If an app is going to modify bandwidth or sample_rate, it needs to revert its changes.
There are two approaches to this.
1) Every app has to explicitly set these values in code.
2) Use an RAII wrapper to automatically revert settings on app exit.

I'm using the second approach.