### PR TITLE
App Settings (TPMS & step fixes) & support in SCANNER app (modulation, bandwidth, and step)

### DIFF
--- a/firmware/application/app_settings.cpp
+++ b/firmware/application/app_settings.cpp
@@ -197,7 +197,7 @@ void copy_to_radio_model(const AppSettings& settings) {
             settings.squelch);
     }
 
-    receiver_model.set_frequency_step(settings.volume);
+    receiver_model.set_frequency_step(settings.step);
     receiver_model.set_normalized_headphone_volume(settings.volume);
 }
 

--- a/firmware/application/apps/pocsag_app.cpp
+++ b/firmware/application/apps/pocsag_app.cpp
@@ -69,6 +69,9 @@ POCSAGAppView::POCSAGAppView(NavigationView& nav) {
                   &sym_ignore,
                   &console});
 
+    if (!settings_.loaded())
+        receiver_model.set_target_frequency(initial_target_frequency);
+
     receiver_model.set_modulation(ReceiverModel::Mode::NarrowbandFMAudio);
     receiver_model.set_sampling_rate(3072000);
     receiver_model.set_baseband_bandwidth(1750000);

--- a/firmware/application/apps/pocsag_app.hpp
+++ b/firmware/application/apps/pocsag_app.hpp
@@ -56,6 +56,7 @@ class POCSAGAppView : public View {
     void focus() override;
 
    private:
+    static constexpr uint32_t initial_target_frequency = 466175000;
     bool logging() const { return check_log.value(); };
     bool ignore() const { return check_ignore.value(); };
 

--- a/firmware/application/apps/tpms_app.cpp
+++ b/firmware/application/apps/tpms_app.cpp
@@ -158,7 +158,7 @@ TPMSAppView::TPMSAppView(NavigationView&) {
                   &recent_entries_view});
 
     if (!settings_.loaded())
-        receiver_model.set_sampling_rate(initial_target_frequency);
+        receiver_model.set_target_frequency(initial_target_frequency);
 
     receiver_model.set_sampling_rate(sampling_rate);
     receiver_model.set_baseband_bandwidth(baseband_bandwidth);

--- a/firmware/application/apps/ui_scanner.cpp
+++ b/firmware/application/apps/ui_scanner.cpp
@@ -300,9 +300,9 @@ ScannerView::ScannerView(
     freqman_set_step_option(field_step);
 
     // Default starting modulation (these may be overridden in SCANNER.TXT)
-    change_mode(AM_MODULATION);              // Default modulation
-    field_mode.set_by_value(AM_MODULATION);  // Reflect the mode into the manual selector
-    field_step.set_by_value(9000);           // Default step interval (Hz)
+    field_mode.set_by_value((OptionsField::value_t)receiver_model.modulation());  // Reflect the mode into the manual selector
+    field_step.set_by_value(receiver_model.frequency_step());                     // Default step interval (Hz)
+    change_mode((freqman_index_t)field_mode.selected_index_value());              // Default modulation
 
     // FUTURE: perhaps additional settings should be stored in persistent memory vs using defaults
     rf::Frequency stored_freq = receiver_model.target_frequency();
@@ -457,7 +457,7 @@ ScannerView::ScannerView(
 
     // Step field was changed (Hz) -- only affects manual Search mode
     field_step.on_change = [this](size_t, OptionsField::value_t v) {
-        (void)v;  // prevent compiler Unused warning
+        receiver_model.set_frequency_step(v);
 
         if (manual_search && scan_thread) {
             // Restart scan thread with new step value

--- a/firmware/application/apps/ui_scanner.cpp
+++ b/firmware/application/apps/ui_scanner.cpp
@@ -758,18 +758,16 @@ void ScannerView::change_mode(freqman_index_t new_mod) {  // Before this, do a s
             freqman_set_bandwidth_option(new_mod, field_bw);
             baseband::run_image(portapack::spi_flash::image_tag_am_audio);
             receiver_model.set_modulation(ReceiverModel::Mode::AMAudio);
-            field_bw.set_by_value(0);
-            receiver_model.set_am_configuration(field_bw.selected_index_value());
+            field_bw.set_by_value(receiver_model.am_configuration());
             field_bw.on_change = [this](size_t, OptionsField::value_t n) { receiver_model.set_am_configuration(n); };
             receiver_model.set_sampling_rate(3072000);
             receiver_model.set_baseband_bandwidth(1750000);
             break;
-        case NFM_MODULATION:  // bw 16k (2) default
+        case NFM_MODULATION:
             freqman_set_bandwidth_option(new_mod, field_bw);
             baseband::run_image(portapack::spi_flash::image_tag_nfm_audio);
             receiver_model.set_modulation(ReceiverModel::Mode::NarrowbandFMAudio);
-            field_bw.set_by_value(2);
-            receiver_model.set_nbfm_configuration(field_bw.selected_index_value());
+            field_bw.set_by_value(receiver_model.nbfm_configuration());
             field_bw.on_change = [this](size_t, OptionsField::value_t n) { receiver_model.set_nbfm_configuration(n); };
             receiver_model.set_sampling_rate(3072000);
             receiver_model.set_baseband_bandwidth(1750000);
@@ -778,8 +776,7 @@ void ScannerView::change_mode(freqman_index_t new_mod) {  // Before this, do a s
             freqman_set_bandwidth_option(new_mod, field_bw);
             baseband::run_image(portapack::spi_flash::image_tag_wfm_audio);
             receiver_model.set_modulation(ReceiverModel::Mode::WidebandFMAudio);
-            field_bw.set_by_value(0);
-            receiver_model.set_wfm_configuration(field_bw.selected_index_value());
+            field_bw.set_by_value(receiver_model.wfm_configuration());
             field_bw.on_change = [this](size_t, OptionsField::value_t n) { receiver_model.set_wfm_configuration(n); };
             receiver_model.set_sampling_rate(3072000);
             receiver_model.set_baseband_bandwidth(2000000);

--- a/firmware/application/apps/ui_scanner.cpp
+++ b/firmware/application/apps/ui_scanner.cpp
@@ -299,10 +299,10 @@ ScannerView::ScannerView(
     freqman_set_modulation_option(field_mode);
     freqman_set_step_option(field_step);
 
-    // Default starting modulation (these may be overridden in SCANNER.TXT)
+    // Default starting modulation (from saved App Settings if enabled, and may be overridden in SCANNER.TXT)
     field_mode.set_by_value((OptionsField::value_t)receiver_model.modulation());  // Reflect the mode into the manual selector
     field_step.set_by_value(receiver_model.frequency_step());                     // Default step interval (Hz)
-    change_mode((freqman_index_t)field_mode.selected_index_value());              // Default modulation
+    change_mode((freqman_index_t)field_mode.selected_index_value());
 
     // FUTURE: perhaps additional settings should be stored in persistent memory vs using defaults
     rf::Frequency stored_freq = receiver_model.target_frequency();

--- a/firmware/application/apps/ui_scanner.hpp
+++ b/firmware/application/apps/ui_scanner.hpp
@@ -94,6 +94,9 @@ class ScannerView : public View {
     // void set_parent_rect(const Rect new_parent_rect) override;
 
    private:
+    app_settings::SettingsManager settings_{
+        "scanner", app_settings::Mode::RX};
+
     NavigationView& nav_;
 
     void start_scan_thread();

--- a/firmware/application/apps/ui_sonde.cpp
+++ b/firmware/application/apps/ui_sonde.cpp
@@ -65,6 +65,9 @@ SondeView::SondeView(NavigationView& nav) {
                   &button_see_qr,
                   &button_see_map});
 
+    if (!settings_.loaded())
+        receiver_model.set_target_frequency(initial_target_frequency);
+
     field_frequency.set_value(receiver_model.target_frequency());
     field_frequency.set_step(500);  // euquiq: was 10000, but we are using this for fine-tunning
     field_frequency.on_change = [this](rf::Frequency f) {

--- a/firmware/application/apps/ui_sonde.hpp
+++ b/firmware/application/apps/ui_sonde.hpp
@@ -54,6 +54,7 @@ namespace ui {
 
 class SondeView : public View {
    public:
+    static constexpr uint32_t initial_target_frequency = 402700000;
     static constexpr uint32_t sampling_rate = 2457600;
     static constexpr uint32_t baseband_bandwidth = 1750000;
 
@@ -69,7 +70,6 @@ class SondeView : public View {
         "rx_sonde", app_settings::Mode::RX};
 
     std::unique_ptr<SondeLogger> logger{};
-    uint32_t target_frequency_{402700000};
     bool logging{false};
     bool use_crc{false};
     bool beep{false};


### PR DESCRIPTION
While adding support for some of the App Settings parameters to the Scanner app, I also discovered & fixed a few minor issues in the new App Settings code.  For example, I think this should fix issue #1150 (or at least it did when I tested it with 315MHz sensors).