### PR TITLE
Update playlist file parsing, reduce allocs

### DIFF
--- a/firmware/application/CMakeLists.txt
+++ b/firmware/application/CMakeLists.txt
@@ -175,6 +175,7 @@ set(CPPSRC
 	#emu_cc1101.cpp
 	rfm69.cpp
 	event_m0.cpp
+	file_reader.cpp
 	file.cpp
 	freqman.cpp
 	io_file.cpp

--- a/firmware/application/apps/ui_looking_glass_app.cpp
+++ b/firmware/application/apps/ui_looking_glass_app.cpp
@@ -535,18 +535,15 @@ void GlassView::load_Presets() {
             if (cols.size() != 3)
                 continue;
 
-            uint32_t min_freq = 0;
-            uint32_t max_freq = 0;
-            parse_int(cols[0], min_freq);
-            parse_int(cols[1], max_freq);
+            preset_entry entry{};
+            parse_int(cols[0], entry.min);
+            parse_int(cols[1], entry.max);
+            entry.label = trimr(cols[2]);
 
-            if (min_freq == 0 || max_freq == 0 || min_freq >= max_freq)
-                continue;
+            if (entry.min == 0 || entry.max == 0 || entry.min >= entry.max)
+                continue;  // Invalid line.
 
-            presets_db.emplace_back(preset_entry{
-                min_freq,
-                max_freq,
-                trimr(cols[2])});
+            presets_db.emplace_back(std::move(entry));
         }
     }
 

--- a/firmware/application/apps/ui_looking_glass_app.cpp
+++ b/firmware/application/apps/ui_looking_glass_app.cpp
@@ -22,6 +22,7 @@
  */
 
 #include "ui_looking_glass_app.hpp"
+#include "convert.hpp"
 #include "file_reader.hpp"
 #include "string_format.hpp"
 
@@ -534,11 +535,18 @@ void GlassView::load_Presets() {
             if (cols.size() != 3)
                 continue;
 
-            // TODO: add some conversion helpers that take string_view.
+            uint32_t min_freq = 0;
+            uint32_t max_freq = 0;
+            parse_int(cols[0], min_freq);
+            parse_int(cols[1], max_freq);
+
+            if (min_freq == 0 || max_freq == 0 || min_freq >= max_freq)
+                continue;
+
             presets_db.emplace_back(preset_entry{
-                std::stoi(std::string{cols[0]}),
-                std::stoi(std::string{cols[1]}),
-                trimr(std::string{cols[2]})});
+                min_freq,
+                max_freq,
+                trimr(cols[2])});
         }
     }
 

--- a/firmware/application/apps/ui_playlist.hpp
+++ b/firmware/application/apps/ui_playlist.hpp
@@ -77,7 +77,6 @@ class PlaylistView : public View {
     const size_t buffer_count{3};
 
     void load_file(std::filesystem::path playlist_path);
-    void txtline_process(std::string&);
     void on_file_changed(std::filesystem::path new_file_path, rf::Frequency replay_frequency, uint32_t replay_sample_rate, uint32_t next_delay);
     void on_tx_progress(const uint32_t progress);
     void set_target_frequency(const rf::Frequency new_value);

--- a/firmware/application/file_reader.hpp
+++ b/firmware/application/file_reader.hpp
@@ -131,25 +131,6 @@ using FileLineReader = BufferLineReader<File>;
  * a vector of string_views. NB: the lifetime of the
  * string to split must be maintained while the views
  * are used or they will dangle. */
-inline std::vector<std::string_view> split_string(std::string_view str, char c) {
-    std::vector<std::string_view> cols;
-    size_t start = 0;
-
-    while (start < str.length()) {
-        auto it = str.find(c, start);
-
-        if (it == str.npos)
-            break;
-
-        // TODO: allow empty?
-        cols.emplace_back(&str[start], it - start);
-        start = it + 1;
-    }
-
-    if (start <= str.length() && !str.empty())
-        cols.emplace_back(&str[start], str.length() - start);
-
-    return cols;
-}
+std::vector<std::string_view> split_string(std::string_view str, char c);
 
 #endif

--- a/firmware/application/file_reader.hpp
+++ b/firmware/application/file_reader.hpp
@@ -131,7 +131,7 @@ using FileLineReader = BufferLineReader<File>;
  * a vector of string_views. NB: the lifetime of the
  * string to split must be maintained while the views
  * are used or they will dangle. */
-std::vector<std::string_view> split_string(std::string_view str, char c) {
+inline std::vector<std::string_view> split_string(std::string_view str, char c) {
     std::vector<std::string_view> cols;
     size_t start = 0;
 

--- a/firmware/application/string_format.cpp
+++ b/firmware/application/string_format.cpp
@@ -283,17 +283,17 @@ double get_decimals(double num, int16_t mult, bool round) {
 
 static const char* whitespace_str = " \t\r\n";
 
-std::string trim(const std::string& str) {
+std::string trim(std::string_view str) {
     auto first = str.find_first_not_of(whitespace_str);
     auto last = str.find_last_not_of(whitespace_str);
-    return str.substr(first, last - first);
+    return std::string{str.substr(first, last - first)};
 }
 
-std::string trimr(const std::string& str) {
+std::string trimr(std::string_view str) {
     size_t last = str.find_last_not_of(whitespace_str);
-    return (last != std::string::npos) ? str.substr(0, last + 1) : "";  // Remove the trailing spaces
+    return std::string{last != std::string::npos ? str.substr(0, last + 1) : ""};
 }
 
-std::string truncate(const std::string& str, size_t length) {
-    return str.length() <= length ? str : str.substr(0, length);
+std::string truncate(std::string_view str, size_t length) {
+    return std::string{str.length() <= length ? str : str.substr(0, length)};
 }

--- a/firmware/application/string_format.hpp
+++ b/firmware/application/string_format.hpp
@@ -25,6 +25,7 @@
 #include <cstdint>
 #include <array>
 #include <string>
+#include <string_view>
 
 #include "file.hpp"
 
@@ -66,10 +67,10 @@ std::string to_string_FAT_timestamp(const FATTimestamp& timestamp);
 std::string to_string_file_size(uint32_t file_size);
 
 std::string unit_auto_scale(double n, const uint32_t base_nano, uint32_t precision);
-double get_decimals(double num, int16_t mult, bool round = false);  // euquiq added
+double get_decimals(double num, int16_t mult, bool round = false);
 
-std::string trim(const std::string& str);   // Remove whitespace at ends.
-std::string trimr(const std::string& str);  // Remove trailing spaces
-std::string truncate(const std::string& str, size_t length);
+std::string trim(std::string_view str);   // Remove whitespace at ends.
+std::string trimr(std::string_view str);  // Remove trailing spaces
+std::string truncate(std::string_view, size_t length);
 
 #endif /*__STRING_FORMAT_H__*/

--- a/firmware/common/convert.hpp
+++ b/firmware/common/convert.hpp
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2023 Kyle Reed
+ *
+ * This file is part of PortaPack.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#ifndef __CONVERT_H__
+#define __CONVERT_H__
+
+#include <charconv>
+#include <cstdlib>
+#include <string>
+#include <string_view>
+#include <type_traits>
+
+/* Zero-allocation conversion helper. */
+/* Notes:
+ * - T must be an integer type.
+ * - For base 16, input _must not_ contain a '0x' or '0X' prefix.
+ * - For base 8 a leading 0 on the literal is allowed.
+ * - Leading whitespce will cause the parse to fail.
+ */
+
+template <typename T>
+std::enable_if_t<std::is_integral_v<T>, bool> parse_int(std::string_view str, T& out_val, int base = 10) {
+    auto result = std::from_chars(str.data(), str.data() + str.length(), out_val, base);
+    return static_cast<int>(result.ec) == 0;
+}
+
+#endif /*__CONVERT_H__*/

--- a/firmware/test/application/CMakeLists.txt
+++ b/firmware/test/application/CMakeLists.txt
@@ -36,6 +36,7 @@ add_executable(application_test EXCLUDE_FROM_ALL
 	${PROJECT_SOURCE_DIR}/main.cpp
 	${PROJECT_SOURCE_DIR}/test_basics.cpp
 	${PROJECT_SOURCE_DIR}/test_circular_buffer.cpp
+	${PROJECT_SOURCE_DIR}/test_convert.cpp
 	${PROJECT_SOURCE_DIR}/test_file_reader.cpp
 	${PROJECT_SOURCE_DIR}/test_file_wrapper.cpp
 	${PROJECT_SOURCE_DIR}/test_mock_file.cpp

--- a/firmware/test/application/CMakeLists.txt
+++ b/firmware/test/application/CMakeLists.txt
@@ -42,6 +42,8 @@ add_executable(application_test EXCLUDE_FROM_ALL
 	${PROJECT_SOURCE_DIR}/test_mock_file.cpp
 	${PROJECT_SOURCE_DIR}/test_optional.cpp
 	${PROJECT_SOURCE_DIR}/test_utility.cpp
+
+	${PROJECT_SOURCE_DIR}/../../application/file_reader.cpp
 )
 
 target_include_directories(application_test PRIVATE

--- a/firmware/test/application/test_convert.cpp
+++ b/firmware/test/application/test_convert.cpp
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2023
+ *
+ * This file is part of PortaPack.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#include "doctest.h"
+#include "convert.hpp"
+#include <string>
+#include <string_view>
+
+TEST_SUITE_BEGIN("parse_int");
+
+TEST_CASE("It should convert literals.") {
+    int val = 0;
+    REQUIRE(parse_int("12345", val));
+    CHECK_EQ(val, 12345);
+}
+
+TEST_CASE("It should convert strings.") {
+    int val = 0;
+    std::string s = "12345";
+    REQUIRE(parse_int(s, val));
+    CHECK_EQ(val, 12345);
+}
+
+TEST_CASE("It should convert string_views.") {
+    int val = 0;
+    std::string_view s{"12345"};
+    REQUIRE(parse_int(s, val));
+    CHECK_EQ(val, 12345);
+}
+
+TEST_CASE("It should return false for invalid input") {
+    int val = 0;
+    REQUIRE_FALSE(parse_int("QWERTY", val));
+}
+
+TEST_CASE("It should return false for overflow input") {
+    uint8_t val = 0;
+    REQUIRE_FALSE(parse_int("500", val));
+}
+
+TEST_CASE("It should convert base 16.") {
+    int val = 0;
+    REQUIRE(parse_int("30", val, 16));  // NB: No '0x'
+    CHECK_EQ(val, 0x30);
+}
+
+TEST_CASE("It should convert base 8.") {
+    int val = 0;
+    REQUIRE(parse_int("020", val, 8));
+    CHECK_EQ(val, 020);
+}
+
+TEST_CASE("It should convert as much of the string as it can.") {
+    int val = 0;
+    REQUIRE(parse_int("12345foobar", val));
+    CHECK_EQ(val, 12345);
+}
+
+TEST_SUITE_END();


### PR DESCRIPTION
Convert the playlist file format parsing to a (hopefully) more readable version using the FileLineReader and split_string.
Add conversion wrapper that works better with string_view so more of the conversion ops can be performed without allocations.
Use string_view in trim/trimr/truncate places to avoid temporary allocations.