### PR TITLE
trying to fix replay app smashing the radio at exit, looks like the c…

### DIFF
--- a/firmware/application/apps/gps_sim_app.cpp
+++ b/firmware/application/apps/gps_sim_app.cpp
@@ -214,8 +214,7 @@ GpsSimAppView::GpsSimAppView(
 
 GpsSimAppView::~GpsSimAppView() {
     transmitter_model.disable();
-    hackrf::cpld::load_sram_no_verify();  // to leave all RX ok, without ghost signal problem at the exit .
-    baseband::shutdown();                 // better this function at the end, not load_sram() that sometimes produces hang up.
+    baseband::shutdown();
 }
 
 void GpsSimAppView::on_hide() {

--- a/firmware/application/apps/lge_app.cpp
+++ b/firmware/application/apps/lge_app.cpp
@@ -45,8 +45,7 @@ void LGEView::focus() {
 
 LGEView::~LGEView() {
     transmitter_model.disable();
-    hackrf::cpld::load_sram_no_verify();  // to leave all RX ok, without ghost signal problem at the exit .
-    baseband::shutdown();                 // better this function at the end, not load_sram() that sometimes produces hang up.
+    baseband::shutdown();
 }
 
 void LGEView::generate_lge_frame(const uint8_t command, const uint16_t address_a, const uint16_t address_b, std::vector<uint8_t>& data) {

--- a/firmware/application/apps/replay_app.cpp
+++ b/firmware/application/apps/replay_app.cpp
@@ -223,12 +223,9 @@ ReplayAppView::ReplayAppView(
 
 ReplayAppView::~ReplayAppView() {
     transmitter_model.disable();
-
-    display.fill_rectangle({0, 0, 240, 320}, Color::black());  // Solving sometimes visible bottom waterfall artifacts, clearing all LCD  pixels.
+    baseband::shutdown();                                      // better this function at the end, after load_sram(). If not , sometimes produced hang up (now not , it is ok).
     chThdSleepMilliseconds(40);                                // (that happened sometimes if we interrupt the waterfall play at the beggining of the play  around 25% and exit )
-    hackrf::cpld::load_sram_no_verify();                       // to leave all  RX reception ok, without "ghost interference signal problem" at the exit .
-
-    baseband::shutdown();  // better this function at the end, after load_sram(). If not , sometimes produced hang up (now not , it is ok).
+    display.fill_rectangle({0, 0, 240, 320}, Color::black());  // Solving sometimes visible bottom waterfall artifacts, clearing all LCD  pixels.
 }
 
 void ReplayAppView::on_hide() {

--- a/firmware/application/apps/soundboard_app.cpp
+++ b/firmware/application/apps/soundboard_app.cpp
@@ -275,8 +275,7 @@ SoundBoardView::SoundBoardView(
 SoundBoardView::~SoundBoardView() {
     stop();
     transmitter_model.disable();
-    hackrf::cpld::load_sram_no_verify();  // to leave all RX ok, without ghost signal problem at the exit.
-    baseband::shutdown();                 // better this function at the end, not load_sram() that sometimes produces hang up.
+    baseband::shutdown();
 }
 
 }  // namespace ui

--- a/firmware/application/apps/ui_adsb_tx.cpp
+++ b/firmware/application/apps/ui_adsb_tx.cpp
@@ -274,8 +274,7 @@ void ADSBTxView::focus() {
 
 ADSBTxView::~ADSBTxView() {
     transmitter_model.disable();
-    hackrf::cpld::load_sram_no_verify();  // to leave all RX ok, withouth ghost signal problem at the exit.
-    baseband::shutdown();                 // better this function at the end, not load_sram() that sometimes produces hang up.
+    baseband::shutdown();
 }
 
 void ADSBTxView::generate_frames() {

--- a/firmware/application/apps/ui_aprs_tx.cpp
+++ b/firmware/application/apps/ui_aprs_tx.cpp
@@ -45,8 +45,7 @@ void APRSTXView::focus() {
 
 APRSTXView::~APRSTXView() {
     transmitter_model.disable();
-    hackrf::cpld::load_sram_no_verify();  // to leave all RX ok, without ghost signal problem at the exit.
-    baseband::shutdown();                 // better this function at the end, not load_sram() that sometimes produces hang up.
+    baseband::shutdown();
 }
 
 void APRSTXView::start_tx() {

--- a/firmware/application/apps/ui_bht_tx.cpp
+++ b/firmware/application/apps/ui_bht_tx.cpp
@@ -138,8 +138,7 @@ void BHTView::on_tx_progress(const uint32_t progress, const bool done) {
 
 BHTView::~BHTView() {
     transmitter_model.disable();
-    hackrf::cpld::load_sram_no_verify();  // to leave all RX ok, without ghost signal problem at the exit .
-    baseband::shutdown();                 // better this function at the end, not load_sram() that sometimes produces hang up.
+    baseband::shutdown();
 }
 
 BHTView::BHTView(NavigationView& nav) {

--- a/firmware/application/apps/ui_coasterp.cpp
+++ b/firmware/application/apps/ui_coasterp.cpp
@@ -39,8 +39,7 @@ void CoasterPagerView::focus() {
 
 CoasterPagerView::~CoasterPagerView() {
     transmitter_model.disable();
-    hackrf::cpld::load_sram_no_verify();  // to leave all RX ok, without ghost signal problem at the exit .
-    baseband::shutdown();                 // better this function at the end, not load_sram() that sometimes produces hang up.
+    baseband::shutdown();
 }
 
 void CoasterPagerView::generate_frame() {

--- a/firmware/application/apps/ui_encoders.cpp
+++ b/firmware/application/apps/ui_encoders.cpp
@@ -201,8 +201,7 @@ void EncodersView::focus() {
 
 EncodersView::~EncodersView() {
     transmitter_model.disable();
-    hackrf::cpld::load_sram_no_verify();  // ghost signal c/m to the problem at the exit .
-    baseband::shutdown();                 // better this function after load_sram()
+    baseband::shutdown();
 }
 
 void EncodersView::update_progress() {

--- a/firmware/application/apps/ui_jammer.cpp
+++ b/firmware/application/apps/ui_jammer.cpp
@@ -180,8 +180,7 @@ void JammerView::focus() {
 
 JammerView::~JammerView() {
     transmitter_model.disable();
-    hackrf::cpld::load_sram_no_verify();  // to leave all RX ok, without ghost signal problem at the exit .
-    baseband::shutdown();                 // better this function at the end, not load_sram() that sometimes produces hang up.
+    baseband::shutdown();
 }
 
 void JammerView::on_retune(const rf::Frequency freq, const uint32_t range) {

--- a/firmware/application/apps/ui_keyfob.cpp
+++ b/firmware/application/apps/ui_keyfob.cpp
@@ -141,8 +141,7 @@ KeyfobView::~KeyfobView() {
     settings.save("tx_keyfob", &app_settings);
 
     transmitter_model.disable();
-    hackrf::cpld::load_sram_no_verify();  // to leave all RX ok, without ghost signal problem at the exit .
-    baseband::shutdown();                 // better this function at the end, not load_sram() that sometimes produces hang up.
+    baseband::shutdown();
 }
 
 void KeyfobView::update_progress(const uint32_t progress) {

--- a/firmware/application/apps/ui_lcr.cpp
+++ b/firmware/application/apps/ui_lcr.cpp
@@ -40,8 +40,7 @@ void LCRView::focus() {
 
 LCRView::~LCRView() {
     transmitter_model.disable();
-    hackrf::cpld::load_sram_no_verify();  // to leave all RX ok, without ghost signal problem at the exit.
-    baseband::shutdown();                 // better this function at the end, not load_sram() that sometimes produces hang up.
+    baseband::shutdown();
 }
 
 /*

--- a/firmware/application/apps/ui_mictx.cpp
+++ b/firmware/application/apps/ui_mictx.cpp
@@ -172,7 +172,7 @@ void MicTXView::rxaudio(bool is_on) {
         receiver_model.set_vga(rx_vga);
         receiver_model.set_rf_amp(rx_amp);
         receiver_model.enable();
-        hackrf::cpld::load_sram_no_verify();  // to have a good RX without any ghost inside Mic App
+        // hackrf::cpld::load_sram_no_verify();  // to have a good RX without any ghost inside Mic App
         audio::output::start();
     } else {                                                                    // These incredibly convoluted steps are required for the vumeter to reappear when stopping RX.
         receiver_model.set_modulation(ReceiverModel::Mode::NarrowbandFMAudio);  // This fixes something with AM RX...
@@ -609,8 +609,7 @@ MicTXView::~MicTXView() {
     transmitter_model.disable();
     if (rx_enabled)  // Also turn off audio rx if enabled
         rxaudio(false);
-    hackrf::cpld::load_sram_no_verify();  // to leave all RX ok, without ghost signal problem at the exit .
-    baseband::shutdown();                 // better this function at the end, not load_sram() that sometimes produces hang up.
+    baseband::shutdown();
 }
 
 }  // namespace ui

--- a/firmware/application/apps/ui_morse.cpp
+++ b/firmware/application/apps/ui_morse.cpp
@@ -99,8 +99,7 @@ void MorseView::focus() {
 
 MorseView::~MorseView() {
     transmitter_model.disable();
-    hackrf::cpld::load_sram_no_verify();  // to leave all RX ok, without ghost signal problem at the exit .
-    baseband::shutdown();                 // better this function at the end, not load_sram() that sometimes produces hang up.
+    baseband::shutdown();
 }
 
 void MorseView::paint(Painter&) {

--- a/firmware/application/apps/ui_pocsag_tx.cpp
+++ b/firmware/application/apps/ui_pocsag_tx.cpp
@@ -40,8 +40,7 @@ void POCSAGTXView::focus() {
 
 POCSAGTXView::~POCSAGTXView() {
     transmitter_model.disable();
-    hackrf::cpld::load_sram_no_verify();  // to leave all RX ok, without ghost signal problem at the exit
-    baseband::shutdown();                 // better this function at the end, not load_sram() that sometimes produces hang up.
+    baseband::shutdown();
 }
 
 void POCSAGTXView::on_tx_progress(const uint32_t progress, const bool done) {

--- a/firmware/application/apps/ui_rds.cpp
+++ b/firmware/application/apps/ui_rds.cpp
@@ -161,8 +161,7 @@ void RDSView::focus() {
 
 RDSView::~RDSView() {
     transmitter_model.disable();
-    hackrf::cpld::load_sram_no_verify();  // to leave all RX ok, without ghost signal problem at the exit.
-    baseband::shutdown();                 // better this function at the end, not load_sram() that sometimes produces hang up.
+    baseband::shutdown();
 }
 
 void RDSView::start_tx() {

--- a/firmware/application/apps/ui_spectrum_painter.cpp
+++ b/firmware/application/apps/ui_spectrum_painter.cpp
@@ -176,7 +176,6 @@ void SpectrumPainterView::frame_sync() {
 
 SpectrumPainterView::~SpectrumPainterView() {
     transmitter_model.disable();
-    hackrf::cpld::load_sram_no_verify();
     baseband::shutdown();
 }
 

--- a/firmware/application/apps/ui_sstvtx.cpp
+++ b/firmware/application/apps/ui_sstvtx.cpp
@@ -89,8 +89,7 @@ void SSTVTXView::paint(Painter&) {
 
 SSTVTXView::~SSTVTXView() {
     transmitter_model.disable();
-    hackrf::cpld::load_sram_no_verify();  // to leave all RX ok, without ghost signal problem at the exit.
-    baseband::shutdown();                 // better this function at the end, not load_sram() that sometimes produces hang up.
+    baseband::shutdown();
 }
 
 void SSTVTXView::prepare_scanline() {

--- a/firmware/application/apps/ui_touchtunes.cpp
+++ b/firmware/application/apps/ui_touchtunes.cpp
@@ -39,8 +39,7 @@ void TouchTunesView::focus() {
 
 TouchTunesView::~TouchTunesView() {
     transmitter_model.disable();
-    hackrf::cpld::load_sram_no_verify();  // to leave all RX ok, without ghost signal problem at the exit.
-    baseband::shutdown();                 // better this function at the end, not load_sram() that sometimes produces hang up.
+    baseband::shutdown();
 }
 
 void TouchTunesView::stop_tx() {


### PR DESCRIPTION
Trying to fix replay app smashing the radio at exit. See [discord question from user](https://discord.com/channels/719669764804444213/737376558754300081/1119114065839665233).
Problem is that replaying signals is at best smashing the reception, at worse freezing the device at app exit.
Looks like the cpld reload was the culprit. It may not even be needed anymore because of the recent radio interface changes.
Historically it was here to kill a bug with radio interface not being reset properly and producing ghost artifacts.
I could not see them with the PR change.