### PR TITLE
Don't update radio directly when saving/restoring tx/rx model settings.

### DIFF
--- a/firmware/application/app_settings.cpp
+++ b/firmware/application/app_settings.cpp
@@ -94,8 +94,6 @@ constexpr std::string_view volume = "volume="sv;
 // TODO: Maybe just use a dictionary which would allow for custom settings.
 // TODO: Create a control value binding which will allow controls to
 //       be declaratively bound to a setting and persistence will be magic.
-// TODO: radio settings should be pushed and popped to prevent cross-app
-//       radio bugs caused by sharing a global model.
 
 ResultCode load_settings(const std::string& app_name, AppSettings& settings) {
     if (!portapack::persistent_memory::load_app_settings())
@@ -178,17 +176,17 @@ void copy_to_radio_model(const AppSettings& settings) {
 
     if (flags_enabled(settings.mode, Mode::TX)) {
         if (!flags_enabled(settings.options, Options::UseGlobalTargetFrequency))
-            transmitter_model.set_target_frequency(settings.tx_frequency);
+            persistent_memory::set_target_frequency(settings.tx_frequency);
 
         transmitter_model.configure_from_app_settings(settings);
     }
 
     if (flags_enabled(settings.mode, Mode::RX)) {
         if (!flags_enabled(settings.options, Options::UseGlobalTargetFrequency))
-            transmitter_model.set_target_frequency(settings.rx_frequency);
+            persistent_memory::set_target_frequency(settings.rx_frequency);
 
         receiver_model.configure_from_app_settings(settings);
-        receiver_model.set_configuration_without_init(
+        receiver_model.set_configuration_without_update(
             static_cast<ReceiverModel::Mode>(settings.modulation),
             settings.step,
             settings.am_config_index,

--- a/firmware/application/apps/capture_app.hpp
+++ b/firmware/application/apps/capture_app.hpp
@@ -28,24 +28,25 @@
 #include "ui_receiver.hpp"
 #include "ui_record_view.hpp"
 #include "ui_spectrum.hpp"
+#include "app_settings.hpp"
 #include "radio_state.hpp"
 
-#define BW_OPTIONS                                                                                                                 \
-    {"  8k5", 8500},                                                                                                               \
-        {"  11k", 11000},                                                                                                          \
-        {"  16k", 16000},                                                                                                          \
-        {"  25k", 25000},                                                                                                          \
-        {"  50k", 50000},                                                                                                          \
-        {" 100k", 100000},                                                                                                         \
-        {" 250k", 250000},                                                                                                         \
-        {" 500k", 500000}, /* Previous Limit bandwith Option with perfect micro SD write .C16 format operaton.*/                   \
-        {" 600k", 600000}, /* That extended option is still possible to record with FW version Mayhem v1.41 (< 2,5MB/sec)  */      \
-        {" 750k", 750000}, /* From that BW onwards, the LCD is ok, but the recorded file is auto decimated,(not real file size) */ \
-        {"1100k", 1100000},                                                                                                        \
-        {"1750k", 1750000},                                                                                                        \
-        {"2000k", 2000000},                                                                                                        \
-        {"2500k", 2500000},                                                                                                        \
-        {"2750k", 2750000},  // That is our max Capture option , to keep using later / 8 decimation (22Mhz sampling  ADC)
+#define BW_OPTIONS                                                                                                             \
+    {"  8k5", 8500},                                                                                                           \
+        {"  11k", 11000},                                                                                                      \
+        {"  16k", 16000},                                                                                                      \
+        {"  25k", 25000},                                                                                                      \
+        {"  50k", 50000},                                                                                                      \
+        {" 100k", 100000},                                                                                                     \
+        {" 250k", 250000},                                                                                                     \
+        {" 500k", 500000}, /* Previous Limit bandwith Option with perfect micro SD write .C16 format operaton.*/               \
+        {" 600k", 600000}, /* That extended option is still possible to record with FW version Mayhem v1.41 (< 2,5MB/sec) */   \
+        {" 750k", 750000}, /* From this BW onwards, the LCD is ok, but the recorded file is decimated, (not real file size) */ \
+        {"1100k", 1100000},                                                                                                    \
+        {"1750k", 1750000},                                                                                                    \
+        {"2000k", 2000000},                                                                                                    \
+        {"2500k", 2500000},                                                                                                    \
+        {"2750k", 2750000},  // That is our max Capture option, to keep using later / 8 decimation (22Mhz sampling  ADC)
 
 namespace ui {
 
@@ -55,10 +56,8 @@ class CaptureAppView : public View {
     ~CaptureAppView();
 
     void on_hide() override;
-
-    void set_parent_rect(const Rect new_parent_rect) override;
-
     void focus() override;
+    void set_parent_rect(const Rect new_parent_rect) override;
 
     std::string title() const override { return "Capture"; };
 
@@ -66,9 +65,12 @@ class CaptureAppView : public View {
     static constexpr ui::Dim header_height = 3 * 16;
 
     RxRadioState radio_state_{};
+    app_settings::SettingsManager settings_{
+        "rx_capture", app_settings::Mode::RX,
+        app_settings::Options::UseGlobalTargetFrequency};
 
     uint32_t sampling_rate = 0;
-    uint32_t anti_alias_baseband_bandwidth_filter = 2500000;  // we rename the previous var , and change type static constexpr to normal var.
+    uint32_t anti_alias_baseband_bandwidth_filter = 2500000;
 
     void on_target_frequency_changed(rf::Frequency f);
 

--- a/firmware/application/apps/gps_sim_app.cpp
+++ b/firmware/application/apps/gps_sim_app.cpp
@@ -29,7 +29,6 @@
 
 #include "baseband_api.hpp"
 #include "portapack.hpp"
-#include "cpld_update.hpp"
 #include "portapack_persistent_memory.hpp"
 
 using namespace portapack;
@@ -214,8 +213,7 @@ GpsSimAppView::GpsSimAppView(
 
 GpsSimAppView::~GpsSimAppView() {
     transmitter_model.disable();
-    hackrf::cpld::load_sram_no_verify();  // to leave all RX ok, without ghost signal problem at the exit .
-    baseband::shutdown();                 // better this function at the end, not load_sram() that sometimes produces hang up.
+    baseband::shutdown();
 }
 
 void GpsSimAppView::on_hide() {

--- a/firmware/application/apps/lge_app.cpp
+++ b/firmware/application/apps/lge_app.cpp
@@ -27,7 +27,6 @@
 #include "lge_app.hpp"
 
 #include "baseband_api.hpp"
-#include "cpld_update.hpp"
 #include "ui_textentry.hpp"
 
 #include "string_format.hpp"
@@ -45,8 +44,7 @@ void LGEView::focus() {
 
 LGEView::~LGEView() {
     transmitter_model.disable();
-    hackrf::cpld::load_sram_no_verify();  // to leave all RX ok, without ghost signal problem at the exit .
-    baseband::shutdown();                 // better this function at the end, not load_sram() that sometimes produces hang up.
+    baseband::shutdown();
 }
 
 void LGEView::generate_lge_frame(const uint8_t command, const uint16_t address_a, const uint16_t address_b, std::vector<uint8_t>& data) {

--- a/firmware/application/apps/replay_app.cpp
+++ b/firmware/application/apps/replay_app.cpp
@@ -26,7 +26,6 @@
 
 #include "ui_fileman.hpp"
 #include "io_file.hpp"
-#include "cpld_update.hpp"
 #include "baseband_api.hpp"
 #include "portapack.hpp"
 #include "portapack_persistent_memory.hpp"
@@ -226,9 +225,7 @@ ReplayAppView::~ReplayAppView() {
 
     display.fill_rectangle({0, 0, 240, 320}, Color::black());  // Solving sometimes visible bottom waterfall artifacts, clearing all LCD  pixels.
     chThdSleepMilliseconds(40);                                // (that happened sometimes if we interrupt the waterfall play at the beggining of the play  around 25% and exit )
-    hackrf::cpld::load_sram_no_verify();                       // to leave all  RX reception ok, without "ghost interference signal problem" at the exit .
-
-    baseband::shutdown();  // better this function at the end, after load_sram(). If not , sometimes produced hang up (now not , it is ok).
+    baseband::shutdown();
 }
 
 void ReplayAppView::on_hide() {

--- a/firmware/application/apps/soundboard_app.cpp
+++ b/firmware/application/apps/soundboard_app.cpp
@@ -25,7 +25,6 @@
 #include "soundboard_app.hpp"
 #include "string_format.hpp"
 #include "tonesets.hpp"
-#include "cpld_update.hpp"
 
 using namespace tonekey;
 using namespace portapack;
@@ -275,8 +274,7 @@ SoundBoardView::SoundBoardView(
 SoundBoardView::~SoundBoardView() {
     stop();
     transmitter_model.disable();
-    hackrf::cpld::load_sram_no_verify();  // to leave all RX ok, without ghost signal problem at the exit.
-    baseband::shutdown();                 // better this function at the end, not load_sram() that sometimes produces hang up.
+    baseband::shutdown();
 }
 
 }  // namespace ui

--- a/firmware/application/apps/ui_adsb_tx.cpp
+++ b/firmware/application/apps/ui_adsb_tx.cpp
@@ -26,7 +26,6 @@
 #include "manchester.hpp"
 #include "string_format.hpp"
 #include "portapack.hpp"
-#include "cpld_update.hpp"
 #include "baseband_api.hpp"
 
 #include <cstring>
@@ -274,8 +273,7 @@ void ADSBTxView::focus() {
 
 ADSBTxView::~ADSBTxView() {
     transmitter_model.disable();
-    hackrf::cpld::load_sram_no_verify();  // to leave all RX ok, withouth ghost signal problem at the exit.
-    baseband::shutdown();                 // better this function at the end, not load_sram() that sometimes produces hang up.
+    baseband::shutdown();
 }
 
 void ADSBTxView::generate_frames() {

--- a/firmware/application/apps/ui_aprs_tx.cpp
+++ b/firmware/application/apps/ui_aprs_tx.cpp
@@ -26,7 +26,6 @@
 #include "aprs.hpp"
 #include "string_format.hpp"
 #include "portapack.hpp"
-#include "cpld_update.hpp"
 #include "baseband_api.hpp"
 #include "portapack_shared_memory.hpp"
 #include "portapack_persistent_memory.hpp"
@@ -45,8 +44,7 @@ void APRSTXView::focus() {
 
 APRSTXView::~APRSTXView() {
     transmitter_model.disable();
-    hackrf::cpld::load_sram_no_verify();  // to leave all RX ok, without ghost signal problem at the exit.
-    baseband::shutdown();                 // better this function at the end, not load_sram() that sometimes produces hang up.
+    baseband::shutdown();
 }
 
 void APRSTXView::start_tx() {

--- a/firmware/application/apps/ui_bht_tx.cpp
+++ b/firmware/application/apps/ui_bht_tx.cpp
@@ -24,7 +24,6 @@
 #include "string_format.hpp"
 
 #include "baseband_api.hpp"
-#include "cpld_update.hpp"
 #include "portapack_persistent_memory.hpp"
 
 using namespace portapack;
@@ -138,8 +137,7 @@ void BHTView::on_tx_progress(const uint32_t progress, const bool done) {
 
 BHTView::~BHTView() {
     transmitter_model.disable();
-    hackrf::cpld::load_sram_no_verify();  // to leave all RX ok, without ghost signal problem at the exit .
-    baseband::shutdown();                 // better this function at the end, not load_sram() that sometimes produces hang up.
+    baseband::shutdown();
 }
 
 BHTView::BHTView(NavigationView& nav) {

--- a/firmware/application/apps/ui_coasterp.cpp
+++ b/firmware/application/apps/ui_coasterp.cpp
@@ -23,7 +23,6 @@
 #include "ui_coasterp.hpp"
 
 #include "baseband_api.hpp"
-#include "cpld_update.hpp"
 #include "portapack_persistent_memory.hpp"
 
 #include <cstring>
@@ -39,8 +38,7 @@ void CoasterPagerView::focus() {
 
 CoasterPagerView::~CoasterPagerView() {
     transmitter_model.disable();
-    hackrf::cpld::load_sram_no_verify();  // to leave all RX ok, without ghost signal problem at the exit .
-    baseband::shutdown();                 // better this function at the end, not load_sram() that sometimes produces hang up.
+    baseband::shutdown();
 }
 
 void CoasterPagerView::generate_frame() {

--- a/firmware/application/apps/ui_encoders.cpp
+++ b/firmware/application/apps/ui_encoders.cpp
@@ -24,7 +24,6 @@
 
 #include "baseband_api.hpp"
 #include "string_format.hpp"
-#include "cpld_update.hpp"
 
 using namespace portapack;
 
@@ -201,8 +200,7 @@ void EncodersView::focus() {
 
 EncodersView::~EncodersView() {
     transmitter_model.disable();
-    hackrf::cpld::load_sram_no_verify();  // ghost signal c/m to the problem at the exit .
-    baseband::shutdown();                 // better this function after load_sram()
+    baseband::shutdown();
 }
 
 void EncodersView::update_progress() {

--- a/firmware/application/apps/ui_jammer.cpp
+++ b/firmware/application/apps/ui_jammer.cpp
@@ -25,7 +25,6 @@
 #include "ui_freqman.hpp"
 
 #include "baseband_api.hpp"
-#include "cpld_update.hpp"
 #include "string_format.hpp"
 
 using namespace portapack;
@@ -180,8 +179,7 @@ void JammerView::focus() {
 
 JammerView::~JammerView() {
     transmitter_model.disable();
-    hackrf::cpld::load_sram_no_verify();  // to leave all RX ok, without ghost signal problem at the exit .
-    baseband::shutdown();                 // better this function at the end, not load_sram() that sometimes produces hang up.
+    baseband::shutdown();
 }
 
 void JammerView::on_retune(const rf::Frequency freq, const uint32_t range) {

--- a/firmware/application/apps/ui_keyfob.cpp
+++ b/firmware/application/apps/ui_keyfob.cpp
@@ -23,7 +23,6 @@
 #include "ui_keyfob.hpp"
 
 #include "baseband_api.hpp"
-#include "cpld_update.hpp"
 #include "string_format.hpp"
 
 using namespace portapack;
@@ -141,8 +140,7 @@ KeyfobView::~KeyfobView() {
     settings.save("tx_keyfob", &app_settings);
 
     transmitter_model.disable();
-    hackrf::cpld::load_sram_no_verify();  // to leave all RX ok, without ghost signal problem at the exit .
-    baseband::shutdown();                 // better this function at the end, not load_sram() that sometimes produces hang up.
+    baseband::shutdown();
 }
 
 void KeyfobView::update_progress(const uint32_t progress) {

--- a/firmware/application/apps/ui_lcr.cpp
+++ b/firmware/application/apps/ui_lcr.cpp
@@ -26,7 +26,6 @@
 #include "lcr.hpp"
 #include "baseband_api.hpp"
 #include "string_format.hpp"
-#include "cpld_update.hpp"
 
 #include "serializer.hpp"
 
@@ -40,8 +39,7 @@ void LCRView::focus() {
 
 LCRView::~LCRView() {
     transmitter_model.disable();
-    hackrf::cpld::load_sram_no_verify();  // to leave all RX ok, without ghost signal problem at the exit.
-    baseband::shutdown();                 // better this function at the end, not load_sram() that sometimes produces hang up.
+    baseband::shutdown();
 }
 
 /*

--- a/firmware/application/apps/ui_mictx.cpp
+++ b/firmware/application/apps/ui_mictx.cpp
@@ -30,7 +30,6 @@ using wolfson::wm8731::WM8731;
 
 #include "tonesets.hpp"
 #include "portapack_hal.hpp"
-#include "cpld_update.hpp"
 #include "string_format.hpp"
 #include "irq_controls.hpp"
 
@@ -172,7 +171,6 @@ void MicTXView::rxaudio(bool is_on) {
         receiver_model.set_vga(rx_vga);
         receiver_model.set_rf_amp(rx_amp);
         receiver_model.enable();
-        hackrf::cpld::load_sram_no_verify();  // to have a good RX without any ghost inside Mic App
         audio::output::start();
     } else {                                                                    // These incredibly convoluted steps are required for the vumeter to reappear when stopping RX.
         receiver_model.set_modulation(ReceiverModel::Mode::NarrowbandFMAudio);  // This fixes something with AM RX...
@@ -609,8 +607,7 @@ MicTXView::~MicTXView() {
     transmitter_model.disable();
     if (rx_enabled)  // Also turn off audio rx if enabled
         rxaudio(false);
-    hackrf::cpld::load_sram_no_verify();  // to leave all RX ok, without ghost signal problem at the exit .
-    baseband::shutdown();                 // better this function at the end, not load_sram() that sometimes produces hang up.
+    baseband::shutdown();
 }
 
 }  // namespace ui

--- a/firmware/application/apps/ui_morse.cpp
+++ b/firmware/application/apps/ui_morse.cpp
@@ -26,7 +26,6 @@
 #include "baseband_api.hpp"
 #include "hackrf_gpio.hpp"
 #include "portapack_shared_memory.hpp"
-#include "cpld_update.hpp"
 #include "ui_textentry.hpp"
 #include "string_format.hpp"
 
@@ -99,8 +98,7 @@ void MorseView::focus() {
 
 MorseView::~MorseView() {
     transmitter_model.disable();
-    hackrf::cpld::load_sram_no_verify();  // to leave all RX ok, without ghost signal problem at the exit .
-    baseband::shutdown();                 // better this function at the end, not load_sram() that sometimes produces hang up.
+    baseband::shutdown();
 }
 
 void MorseView::paint(Painter&) {

--- a/firmware/application/apps/ui_pocsag_tx.cpp
+++ b/firmware/application/apps/ui_pocsag_tx.cpp
@@ -23,7 +23,6 @@
 #include "ui_pocsag_tx.hpp"
 
 #include "baseband_api.hpp"
-#include "cpld_update.hpp"
 #include "string_format.hpp"
 #include "ui_textentry.hpp"
 
@@ -40,8 +39,7 @@ void POCSAGTXView::focus() {
 
 POCSAGTXView::~POCSAGTXView() {
     transmitter_model.disable();
-    hackrf::cpld::load_sram_no_verify();  // to leave all RX ok, without ghost signal problem at the exit
-    baseband::shutdown();                 // better this function at the end, not load_sram() that sometimes produces hang up.
+    baseband::shutdown();
 }
 
 void POCSAGTXView::on_tx_progress(const uint32_t progress, const bool done) {

--- a/firmware/application/apps/ui_rds.cpp
+++ b/firmware/application/apps/ui_rds.cpp
@@ -24,7 +24,6 @@
 
 #include "portapack.hpp"
 #include "baseband_api.hpp"
-#include "cpld_update.hpp"
 #include "portapack_shared_memory.hpp"
 
 #include <cstring>
@@ -161,8 +160,7 @@ void RDSView::focus() {
 
 RDSView::~RDSView() {
     transmitter_model.disable();
-    hackrf::cpld::load_sram_no_verify();  // to leave all RX ok, without ghost signal problem at the exit.
-    baseband::shutdown();                 // better this function at the end, not load_sram() that sometimes produces hang up.
+    baseband::shutdown();
 }
 
 void RDSView::start_tx() {

--- a/firmware/application/apps/ui_spectrum_painter.cpp
+++ b/firmware/application/apps/ui_spectrum_painter.cpp
@@ -20,7 +20,6 @@
  */
 
 #include "ui_spectrum_painter.hpp"
-#include "cpld_update.hpp"
 #include "bmp.hpp"
 #include "baseband_api.hpp"
 
@@ -176,7 +175,6 @@ void SpectrumPainterView::frame_sync() {
 
 SpectrumPainterView::~SpectrumPainterView() {
     transmitter_model.disable();
-    hackrf::cpld::load_sram_no_verify();
     baseband::shutdown();
 }
 

--- a/firmware/application/apps/ui_sstvtx.cpp
+++ b/firmware/application/apps/ui_sstvtx.cpp
@@ -25,7 +25,6 @@
 
 #include "portapack.hpp"
 #include "hackrf_hal.hpp"
-#include "cpld_update.hpp"
 
 #include <cstring>
 #include <stdio.h>
@@ -89,8 +88,7 @@ void SSTVTXView::paint(Painter&) {
 
 SSTVTXView::~SSTVTXView() {
     transmitter_model.disable();
-    hackrf::cpld::load_sram_no_verify();  // to leave all RX ok, without ghost signal problem at the exit.
-    baseband::shutdown();                 // better this function at the end, not load_sram() that sometimes produces hang up.
+    baseband::shutdown();
 }
 
 void SSTVTXView::prepare_scanline() {

--- a/firmware/application/apps/ui_touchtunes.cpp
+++ b/firmware/application/apps/ui_touchtunes.cpp
@@ -26,7 +26,6 @@
 
 #include "baseband_api.hpp"
 #include "string_format.hpp"
-#include "cpld_update.hpp"
 
 using namespace portapack;
 using namespace encoders;
@@ -39,8 +38,7 @@ void TouchTunesView::focus() {
 
 TouchTunesView::~TouchTunesView() {
     transmitter_model.disable();
-    hackrf::cpld::load_sram_no_verify();  // to leave all RX ok, without ghost signal problem at the exit.
-    baseband::shutdown();                 // better this function at the end, not load_sram() that sometimes produces hang up.
+    baseband::shutdown();
 }
 
 void TouchTunesView::stop_tx() {

--- a/firmware/application/radio.cpp
+++ b/firmware/application/radio.cpp
@@ -92,7 +92,8 @@ max2839::MAX2839 second_if_max2839{ssp1_target_max283x};
 static max5864::MAX5864 baseband_codec{ssp1_target_max5864};
 static baseband::CPLD baseband_cpld;
 
-static rf::Direction direction{rf::Direction::Receive};
+// Set invalid to force the set_direction CPLD workaround to run.
+static rf::Direction direction{-1};
 static bool baseband_invert = false;
 static bool mixer_invert = false;
 
@@ -115,13 +116,9 @@ void set_direction(const rf::Direction new_direction) {
     /* TODO: Refactor all the various "Direction" enumerations into one. */
     /* TODO: Only make changes if direction changes, but beware of clock enabling. */
 
-    // Hack to fix the CPLD (clocking ?) bug: toggle CPLD SRAM overlay depending on new direction
+    // Hack to fix the CPLD (clocking ?) bug: toggle CPLD SRAM overlay depending on new direction.
     // Use CPLD's EEPROM config when transmitting
     // Use the SRAM overlay when receiving
-
-    // teixeluis: undone "Hack to fix the CPLD (clocking ?) bug".
-    // Apparently with current CPLD code from the hackrf repo,
-    // toggling CPLD overlay should no longer be necessary:
     if (direction != new_direction) {
         if (new_direction == rf::Direction::Transmit)
             hackrf::cpld::init_from_eeprom();

--- a/firmware/application/radio.cpp
+++ b/firmware/application/radio.cpp
@@ -122,8 +122,12 @@ void set_direction(const rf::Direction new_direction) {
     // teixeluis: undone "Hack to fix the CPLD (clocking ?) bug".
     // Apparently with current CPLD code from the hackrf repo,
     // toggling CPLD overlay should no longer be necessary:
-    if (direction != new_direction && new_direction == rf::Direction::Transmit) {
-        hackrf::cpld::init_from_eeprom();
+    if (direction != new_direction) {
+        if (new_direction == rf::Direction::Transmit)
+            hackrf::cpld::init_from_eeprom();
+        else
+            // Prevents ghosting when switching back to RX from TX mode.
+            hackrf::cpld::load_sram_no_verify();
     }
 
     direction = new_direction;

--- a/firmware/application/radio_state.hpp
+++ b/firmware/application/radio_state.hpp
@@ -41,14 +41,13 @@ class RadioState {
     RadioState(uint32_t new_bandwidth, uint32_t new_sampling_rate)
         : prev_bandwidth_{model->baseband_bandwidth()},
           prev_sampling_rate_{model->sampling_rate()} {
-        model->set_rf_direction();
-        model->set_baseband_bandwidth(new_bandwidth);
-        model->set_sampling_rate(new_sampling_rate);
+        model->set_configuration_without_update(
+            new_bandwidth, new_sampling_rate);
     }
 
     ~RadioState() {
-        model->set_baseband_bandwidth(prev_bandwidth_);
-        model->set_sampling_rate(prev_sampling_rate_);
+        model->set_configuration_without_update(
+            prev_bandwidth_, prev_sampling_rate_);
     }
 
    private:

--- a/firmware/application/radio_state.hpp
+++ b/firmware/application/radio_state.hpp
@@ -41,6 +41,7 @@ class RadioState {
     RadioState(uint32_t new_bandwidth, uint32_t new_sampling_rate)
         : prev_bandwidth_{model->baseband_bandwidth()},
           prev_sampling_rate_{model->sampling_rate()} {
+        model->set_rf_direction();
         model->set_baseband_bandwidth(new_bandwidth);
         model->set_sampling_rate(new_sampling_rate);
     }

--- a/firmware/application/receiver_model.cpp
+++ b/firmware/application/receiver_model.cpp
@@ -61,10 +61,6 @@ static constexpr std::array<baseband::WFMConfig, 3> wfm_configs{{
 
 } /* namespace */
 
-void ReceiverModel::set_rf_direction() {
-    radio::set_direction(rf::Direction::Receive);
-}
-
 rf::Frequency ReceiverModel::target_frequency() const {
     return persistent_memory::target_frequency();
 }
@@ -172,7 +168,7 @@ void ReceiverModel::set_squelch_level(uint8_t v) {
 
 void ReceiverModel::enable() {
     enabled_ = true;
-    set_rf_direction();
+    radio::set_direction(rf::Direction::Receive);
     update_tuning_frequency();
     update_antenna_bias();
     update_rf_amp();
@@ -252,12 +248,19 @@ void ReceiverModel::set_wfm_configuration(const size_t n) {
     }
 }
 
-void ReceiverModel::set_configuration_without_init(
-    const Mode new_mode,
-    const rf::Frequency new_frequency_step,
-    const size_t new_am_config_index,
-    const size_t new_nbfm_config_index,
-    const size_t new_wfm_config_index,
+void ReceiverModel::set_configuration_without_update(
+    uint32_t baseband_bandwidth,
+    uint32_t sampling_rate) {
+    baseband_bandwidth_ = baseband_bandwidth;
+    sampling_rate_ = sampling_rate;
+}
+
+void ReceiverModel::set_configuration_without_update(
+    Mode new_mode,
+    rf::Frequency new_frequency_step,
+    size_t new_am_config_index,
+    size_t new_nbfm_config_index,
+    size_t new_wfm_config_index,
     uint8_t new_squelch_level) {
     mode_ = new_mode;
     frequency_step_ = new_frequency_step;

--- a/firmware/application/receiver_model.cpp
+++ b/firmware/application/receiver_model.cpp
@@ -61,6 +61,10 @@ static constexpr std::array<baseband::WFMConfig, 3> wfm_configs{{
 
 } /* namespace */
 
+void ReceiverModel::set_rf_direction() {
+    radio::set_direction(rf::Direction::Receive);
+}
+
 rf::Frequency ReceiverModel::target_frequency() const {
     return persistent_memory::target_frequency();
 }
@@ -168,7 +172,7 @@ void ReceiverModel::set_squelch_level(uint8_t v) {
 
 void ReceiverModel::enable() {
     enabled_ = true;
-    radio::set_direction(rf::Direction::Receive);
+    set_rf_direction();
     update_tuning_frequency();
     update_antenna_bias();
     update_rf_amp();

--- a/firmware/application/receiver_model.hpp
+++ b/firmware/application/receiver_model.hpp
@@ -43,6 +43,8 @@ class ReceiverModel {
         Capture = 4
     };
 
+    void set_rf_direction();
+
     /* The frequency to receive (no offset). */
     rf::Frequency target_frequency() const;
     void set_target_frequency(rf::Frequency f);

--- a/firmware/application/receiver_model.hpp
+++ b/firmware/application/receiver_model.hpp
@@ -43,8 +43,6 @@ class ReceiverModel {
         Capture = 4
     };
 
-    void set_rf_direction();
-
     /* The frequency to receive (no offset). */
     rf::Frequency target_frequency() const;
     void set_target_frequency(rf::Frequency f);
@@ -94,12 +92,17 @@ class ReceiverModel {
     size_t wfm_configuration() const;
     void set_wfm_configuration(const size_t n);
 
-    void set_configuration_without_init(
-        const Mode new_mode,
-        const rf::Frequency new_frequency_step,
-        const size_t new_am_config_index,
-        const size_t new_nbfm_config_index,
-        const size_t new_wfm_config_index,
+    /* Sets the model values without updating the radio. */
+    void set_configuration_without_update(
+        uint32_t baseband_bandwidth,
+        uint32_t sampling_rate);
+
+    void set_configuration_without_update(
+        Mode new_mode,
+        rf::Frequency new_frequency_step,
+        size_t new_am_config_index,
+        size_t new_nbfm_config_index,
+        size_t new_wfm_config_index,
         uint8_t new_squelch_level);
 
     void configure_from_app_settings(const app_settings::AppSettings& settings);

--- a/firmware/application/transmitter_model.cpp
+++ b/firmware/application/transmitter_model.cpp
@@ -35,6 +35,10 @@
 using namespace hackrf::one;
 using namespace portapack;
 
+void TransmitterModel::set_rf_direction() {
+    radio::set_direction(rf::Direction::Transmit);
+}
+
 rf::Frequency TransmitterModel::target_frequency() const {
     return persistent_memory::target_frequency();
 }
@@ -117,7 +121,7 @@ void TransmitterModel::on_tick_second() {
 
 void TransmitterModel::enable() {
     enabled_ = true;
-    radio::set_direction(rf::Direction::Transmit);
+    set_rf_direction();
     update_tuning_frequency();
     update_antenna_bias();
     update_rf_amp();

--- a/firmware/application/transmitter_model.cpp
+++ b/firmware/application/transmitter_model.cpp
@@ -35,10 +35,6 @@
 using namespace hackrf::one;
 using namespace portapack;
 
-void TransmitterModel::set_rf_direction() {
-    radio::set_direction(rf::Direction::Transmit);
-}
-
 rf::Frequency TransmitterModel::target_frequency() const {
     return persistent_memory::target_frequency();
 }
@@ -121,7 +117,7 @@ void TransmitterModel::on_tick_second() {
 
 void TransmitterModel::enable() {
     enabled_ = true;
-    set_rf_direction();
+    radio::set_direction(rf::Direction::Transmit);
     update_tuning_frequency();
     update_antenna_bias();
     update_rf_amp();
@@ -149,6 +145,13 @@ void TransmitterModel::disable() {
 
     rtc_time::signal_tick_second -= signal_token_tick_second;
     led_tx.off();
+}
+
+void TransmitterModel::set_configuration_without_update(
+    uint32_t baseband_bandwidth,
+    uint32_t sampling_rate) {
+    baseband_bandwidth_ = baseband_bandwidth;
+    sampling_rate_ = sampling_rate;
 }
 
 void TransmitterModel::configure_from_app_settings(

--- a/firmware/application/transmitter_model.hpp
+++ b/firmware/application/transmitter_model.hpp
@@ -36,8 +36,6 @@
 
 class TransmitterModel {
    public:
-    void set_rf_direction();
-
     /* The frequency to transmit on. */
     rf::Frequency target_frequency() const;
     void set_target_frequency(rf::Frequency f);
@@ -71,6 +69,11 @@ class TransmitterModel {
 
     void enable();
     void disable();
+
+    /* Sets the model values without updating the radio. */
+    void set_configuration_without_update(
+        uint32_t baseband_bandwidth,
+        uint32_t sampling_rate);
 
     void configure_from_app_settings(const app_settings::AppSettings& settings);
 

--- a/firmware/application/transmitter_model.hpp
+++ b/firmware/application/transmitter_model.hpp
@@ -36,6 +36,8 @@
 
 class TransmitterModel {
    public:
+    void set_rf_direction();
+
     /* The frequency to transmit on. */
     rf::Frequency target_frequency() const;
     void set_target_frequency(rf::Frequency f);

--- a/firmware/common/cpld_update.cpp
+++ b/firmware/common/cpld_update.cpp
@@ -113,10 +113,10 @@ bool load_sram() {
 }
 
 void load_sram_no_verify() {
-    // CoolRunner II family has Hybrid memory CPLD arquitecture (SRAM+NVM)
-    // It seems that after using TX App somehow , I do not why , the CPLD_SRAM part needs to be re_loaded to solve #637 ghost beat
-    // load_sram() it is already called at each boot in portapack.cpp ,including verify CPLD part.
-    // Here we skipped CPLD verify part,just to be quicker (in case any CPLD problem it will be detected in the boot process).
+    // CoolRunner II family has Hybrid memory CPLD architecture (SRAM+NVM)
+    // It seems that after using a TX App the CPLD_SRAM part needs to be re_loaded to solve #637 ghost beat.
+    // load_sram() it is already called at each boot in portapack.cpp, including verify CPLD part.
+    // Here we skipped CPLD verify part, just to be quicker (in case any CPLD problem it will be detected in the boot process).
 
     auto jtag_target_hackrf_cpld = jtag_target_hackrf();
     hackrf::one::cpld::CPLD hackrf_cpld{jtag_target_hackrf_cpld};

--- a/firmware/common/cpld_update.hpp
+++ b/firmware/common/cpld_update.hpp
@@ -44,7 +44,7 @@ namespace hackrf {
 namespace cpld {
 
 bool load_sram();
-void load_sram_no_verify();  // added to solve issue #637 , "ghost" signal at RX , after using any TX App
+void load_sram_no_verify();  // Added to solve issue #637, "ghost" signal at RX, after using any TX App.
 bool verify_eeprom();
 void init_from_eeprom();
 


### PR DESCRIPTION
- This re-adds the CPLD workaround that was previously removed to use EEPROM for TX and SRAM for RX
- Consolidate the workaround for RX ghost after TX (same as above) into set_direction
- All settings (radio state and app settings) are only written to the models without updating the radio. This should hopefully prevent strange app behavior (like TX in RDS or Mic).
- Minor comment fixup as I was reading through.