### PR TITLE
Fix hang in Audio when switching from Capture app, & bug fixes.

### DIFF
--- a/firmware/application/apps/analog_audio_app.hpp
+++ b/firmware/application/apps/analog_audio_app.hpp
@@ -38,7 +38,7 @@ namespace ui {
 
 class AMOptionsView : public View {
    public:
-    AMOptionsView(const Rect parent_rect, const Style* const style);
+    AMOptionsView(Rect parent_rect, const Style* style);
 
    private:
     Text label_config{
@@ -56,7 +56,7 @@ class AMOptionsView : public View {
 
 class NBFMOptionsView : public View {
    public:
-    NBFMOptionsView(const Rect parent_rect, const Style* const style);
+    NBFMOptionsView(Rect parent_rect, const Style* style);
 
    private:
     Text label_config{
@@ -84,7 +84,7 @@ class NBFMOptionsView : public View {
 
 class WFMOptionsView : public View {
    public:
-    WFMOptionsView(const Rect parent_rect, const Style* const style);
+    WFMOptionsView(Rect parent_rect, const Style* style);
 
    private:
     Text label_config{
@@ -103,7 +103,7 @@ class AnalogAudioView;
 
 class SPECOptionsView : public View {
    public:
-    SPECOptionsView(AnalogAudioView* view, const Rect parent_rect, const Style* const style);
+    SPECOptionsView(AnalogAudioView* view, Rect parent_rect, const Style* style);
 
    private:
     Text label_config{
@@ -140,10 +140,7 @@ class AnalogAudioView : public View {
     AnalogAudioView(NavigationView& nav);
     ~AnalogAudioView();
 
-    void on_hide() override;
-
-    void set_parent_rect(const Rect new_parent_rect) override;
-
+    void set_parent_rect(Rect new_parent_rect) override;
     void focus() override;
 
     std::string title() const override { return "Audio RX"; };
@@ -169,8 +166,6 @@ class AnalogAudioView : public View {
     size_t spec_bw_index = 0;
     uint32_t spec_bw = 20000000;
     uint16_t spec_trigger = 63;
-
-    // bool exit_on_squelch { false };
 
     RSSI rssi{
         {21 * 8, 0, 6 * 8, 4}};
@@ -221,7 +216,7 @@ class AnalogAudioView : public View {
     spectrum::WaterfallWidget waterfall{true};
 
     void on_baseband_bandwidth_changed(uint32_t bandwidth_hz);
-    void on_modulation_changed(const ReceiverModel::Mode modulation);
+    void on_modulation_changed(ReceiverModel::Mode modulation);
     void on_show_options_frequency();
     void on_show_options_rf_gain();
     void on_show_options_modulation();
@@ -231,22 +226,13 @@ class AnalogAudioView : public View {
     void remove_options_widget();
     void set_options_widget(std::unique_ptr<Widget> new_widget);
 
-    void update_modulation(const ReceiverModel::Mode modulation);
+    void update_modulation(ReceiverModel::Mode modulation);
 
-    // void squelched();
-    void handle_coded_squelch(const uint32_t value);
-
-    /*MessageHandlerRegistration message_handler_squelch_signal {
-                Message::ID::RequestSignal,
-                [this](const Message* const p) {
-                        (void)p;
-                        this->squelched();
-                }
-        };*/
+    void handle_coded_squelch(uint32_t value);
 
     MessageHandlerRegistration message_handler_coded_squelch{
         Message::ID::CodedSquelch,
-        [this](const Message* const p) {
+        [this](const Message* p) {
             const auto message = *reinterpret_cast<const CodedSquelchMessage*>(p);
             this->handle_coded_squelch(message.value);
         }};

--- a/firmware/application/apps/capture_app.cpp
+++ b/firmware/application/apps/capture_app.cpp
@@ -113,6 +113,8 @@ CaptureAppView::CaptureAppView(NavigationView& nav)
 }
 
 CaptureAppView::~CaptureAppView() {
+    // Most other apps can't handle "Capture" mode, set to something standard.
+    receiver_model.set_modulation(ReceiverModel::Mode::WidebandFMAudio);
     receiver_model.disable();
     baseband::shutdown();
 }

--- a/firmware/application/apps/ui_looking_glass_app.hpp
+++ b/firmware/application/apps/ui_looking_glass_app.hpp
@@ -26,6 +26,7 @@
 
 #include "ui.hpp"
 #include "portapack.hpp"
+#include "app_settings.hpp"
 #include "baseband_api.hpp"
 #include "radio_state.hpp"
 #include "receiver_model.hpp"
@@ -71,6 +72,8 @@ class GlassView : public View {
    private:
     NavigationView& nav_;
     RxRadioState radio_state_{};
+    app_settings::SettingsManager settings_{
+        "rx_glass", app_settings::Mode::RX};
 
     struct preset_entry {
         rf::Frequency min{};

--- a/firmware/application/apps/ui_mictx.cpp
+++ b/firmware/application/apps/ui_mictx.cpp
@@ -595,12 +595,6 @@ MicTXView::MicTXView(
         }
     };
 
-    // These shouldn't be necessary, but because
-    // this app uses both transmitter_model and directly
-    // configures the baseband, these end up being required.
-    transmitter_model.set_sampling_rate(sampling_rate);
-    transmitter_model.set_baseband_bandwidth(1750000);
-
     set_tx(false);
 
     audio::set_rate(audio::Rate::Hz_24000);

--- a/firmware/application/apps/ui_playlist.cpp
+++ b/firmware/application/apps/ui_playlist.cpp
@@ -142,7 +142,9 @@ bool PlaylistView::next_track() {
 
 /* Transmits the current_entry_ */
 void PlaylistView::send_current_track() {
+    // Prepare to send a file.
     replay_thread_.reset();
+    transmitter_model.disable();
     ready_signal_ = false;
 
     if (!current_entry_)
@@ -171,6 +173,10 @@ void PlaylistView::send_current_track() {
     transmitter_model.set_sampling_rate(current_entry_->sample_rate * 8);
     transmitter_model.set_baseband_bandwidth(baseband_bandwidth);
     transmitter_model.enable();
+
+    // Set baseband sample rate too for waterfall to be correct.
+    // TODO: Why doesn't the transmitter_model just handle this?
+    baseband::set_sample_rate(transmitter_model.sampling_rate());
 
     // Use the ReplayThread class to send the data.
     replay_thread_ = std::make_unique<ReplayThread>(

--- a/firmware/application/apps/ui_scanner.hpp
+++ b/firmware/application/apps/ui_scanner.hpp
@@ -96,7 +96,7 @@ class ScannerView : public View {
 
    private:
     app_settings::SettingsManager settings_{
-        "scanner", app_settings::Mode::RX};
+        "rx_scanner", app_settings::Mode::RX};
 
     NavigationView& nav_;
     RxRadioState radio_state_{};

--- a/firmware/application/radio_state.hpp
+++ b/firmware/application/radio_state.hpp
@@ -30,6 +30,12 @@
 
 /* Stashes current radio bandwidth and sampling rate.
  * Inits to defaults, and restores previous when destroyed.
+ * The idea here is that an app will eventually call enable
+ * on the model which will sync all of the model state into
+ * the radio. We tried lazily setting these using the
+ * set_configuration_without_update function, but there are
+ * still various UI components (mainly Waterfall) that need
+ * the radio set in order to load properly.
  * NB: This member must be added before SettingsManager. */
 template <typename TModel, TModel* model>
 class RadioState {
@@ -41,8 +47,9 @@ class RadioState {
     RadioState(uint32_t new_bandwidth, uint32_t new_sampling_rate)
         : prev_bandwidth_{model->baseband_bandwidth()},
           prev_sampling_rate_{model->sampling_rate()} {
-        model->set_configuration_without_update(
-            new_bandwidth, new_sampling_rate);
+        // Update the new settings in the radio.
+        model->set_sampling_rate(new_sampling_rate);
+        model->set_baseband_bandwidth(new_bandwidth);
     }
 
     ~RadioState() {

--- a/firmware/application/ui/ui_spectrum.cpp
+++ b/firmware/application/ui/ui_spectrum.cpp
@@ -311,10 +311,12 @@ WaterfallWidget::WaterfallWidget(const bool cursor) {
 }
 
 void WaterfallWidget::on_show() {
+    // TODO: Assert that baseband is not shutdown.
     baseband::spectrum_streaming_start();
 }
 
 void WaterfallWidget::on_hide() {
+    // TODO: Assert that baseband is not shutdown.
     baseband::spectrum_streaming_stop();
 }
 

--- a/firmware/application/ui/ui_spectrum.hpp
+++ b/firmware/application/ui/ui_spectrum.hpp
@@ -104,6 +104,10 @@ class FrequencyScale : public Widget {
     void draw_filter_ranges(Painter& painter, const Rect r);
 };
 
+/* NB: These visualizations rely on having a baseband image running.
+ * If the baseband is shutdown or otherwise not running when interacting
+ * with these, they will almost certainly hang the device. */
+
 class WaterfallView : public Widget {
    public:
     void on_show() override;


### PR DESCRIPTION
The underlying problem here was that capture would leave the receiver_model in Capture modulation.
The Audio app didn't know what to do with that mode and would fail. -- Separately the app would hang in this state because a baseband image was not loaded and running before interacting with the Waterfall (show/hide). Showing and hiding interacts with the baseband with is expected to be running. If the baseband is shutdown, the app will hang.
I introduced this bug in #1151 by deleting a line from capture.cpp that reset the Mode back to WFM from Capture.

Second, we made a change the other day while trying to get to the bottom of a few bugs, to make radio_state not actually set the radio in #1160. This ended up causing some regressions in apps that use show a waterfall if they didn't call model.enable before interacting with the waterfall view. Re-enabling updating the radio in radio_state should prevent the waterfall bug.

There were a few bugs introduced in playlist. The most surprising one was that the waterfall view seemed "too fast". This was because baseband::set_sample_rate needed to be called and that was removed in #1151. This is very surprising because the baseband isn't getting set by the tx/rx models. That seems like something that needs to be investigated more.



