### PR TITLE
Fix Capture app hang when it's the first app executed (intermittent)

### DIFF
--- a/firmware/application/apps/capture_app.cpp
+++ b/firmware/application/apps/capture_app.cpp
@@ -102,7 +102,8 @@ CaptureAppView::CaptureAppView(NavigationView& nav)
         waterfall.on_show();
     };
 
-    receiver_model.set_sampling_rate(8*500000);  // Set to any valid rate before waterfall.on_hide() code triggered by line below
+    // Set sampling rate to any valid rate before waterfall code is triggered by line below
+    receiver_model.set_sampling_rate(4000000);
     option_bandwidth.set_selected_index(7);  // Preselected default option 500kHz.
 
     receiver_model.set_modulation(ReceiverModel::Mode::Capture);

--- a/firmware/application/apps/capture_app.cpp
+++ b/firmware/application/apps/capture_app.cpp
@@ -102,6 +102,7 @@ CaptureAppView::CaptureAppView(NavigationView& nav)
         waterfall.on_show();
     };
 
+    receiver_model.set_sampling_rate(8*500000);  // Set to any valid rate before waterfall.on_hide() code triggered by line below
     option_bandwidth.set_selected_index(7);  // Preselected default option 500kHz.
 
     receiver_model.set_modulation(ReceiverModel::Mode::Capture);


### PR DESCRIPTION
At power-up, sampling rate field in receiver model is apparently uninitialized and must be set to a valid value in receiver_model before the waterfall functions is called.  Setting the bandwidth on the line below triggers the option_bandwidth.on_change() code above which called waterfall functions.  This one-line change seems to resolve the issue, and is otherwise harmless.

(Feel free to move this initialization code elsewhere if you feel it's more appropriate.)