### PR TITLE
Persistent audio mute support revisions

### DIFF
--- a/firmware/application/apps/ui_settings.cpp
+++ b/firmware/application/apps/ui_settings.cpp
@@ -527,6 +527,7 @@ SetAudioView::SetAudioView(NavigationView& nav) {
     button_save.on_select = [&nav, this](Button&) {
         persistent_memory::set_tone_mix(field_tone_mix.value());
         persistent_memory::set_config_speaker_disable(checkbox_speaker_disable.value());
+        audio::output::update_audio_mute();
         nav.pop();
     };
 

--- a/firmware/application/audio.cpp
+++ b/firmware/application/audio.cpp
@@ -168,7 +168,6 @@ void unmute() {
 
 void speaker_disable() {
     cfg_speaker_disable = true;
-    audio_codec->speaker_disable();
 }
 
 void speaker_enable() {
@@ -190,6 +189,19 @@ void speaker_unmute() {
         unmute();
     }
 }
+
+void update_audio_mute() {
+    if (portapack::persistent_memory::config_speaker_disable())
+        speaker_disable();
+    else
+        speaker_enable();
+
+   if (portapack::persistent_memory::config_audio_mute())
+        speaker_mute();
+    else
+        speaker_unmute();
+}
+
 
 } /* namespace output */
 

--- a/firmware/application/audio.cpp
+++ b/firmware/application/audio.cpp
@@ -166,14 +166,6 @@ void unmute() {
     }
 }
 
-void speaker_disable() {
-    cfg_speaker_disable = true;
-}
-
-void speaker_enable() {
-    cfg_speaker_disable = false;
-}
-
 // The following functions are used by the navigation-bar Speaker Mute only,
 // and override all other audio mute/unmute requests from apps
 void speaker_mute() {
@@ -191,12 +183,9 @@ void speaker_unmute() {
 }
 
 void update_audio_mute() {
-    if (portapack::persistent_memory::config_speaker_disable())
-        speaker_disable();
-    else
-        speaker_enable();
+    cfg_speaker_disable = portapack::persistent_memory::config_speaker_disable();
 
-   if (portapack::persistent_memory::config_audio_mute())
+    if (portapack::persistent_memory::config_audio_mute())
         speaker_mute();
     else
         speaker_unmute();

--- a/firmware/application/audio.cpp
+++ b/firmware/application/audio.cpp
@@ -191,7 +191,6 @@ void update_audio_mute() {
         speaker_unmute();
 }
 
-
 } /* namespace output */
 
 namespace input {

--- a/firmware/application/audio.hpp
+++ b/firmware/application/audio.hpp
@@ -69,6 +69,7 @@ void speaker_disable();
 void speaker_enable();
 void speaker_mute();
 void speaker_unmute();
+void update_audio_mute();
 
 } /* namespace output */
 

--- a/firmware/application/portapack.cpp
+++ b/firmware/application/portapack.cpp
@@ -96,20 +96,6 @@ bool get_antenna_bias() {
     return antenna_bias;
 }
 
-void set_audio_mute(const bool v) {
-    if (v)
-        audio::output::speaker_mute();
-    else
-        audio::output::speaker_unmute();
-}
-
-void set_speaker_disable(const bool v) {
-    if (v)
-        audio::output::speaker_disable();
-    else
-        audio::output::speaker_enable();
-}
-
 static constexpr uint32_t systick_count(const uint32_t clock_source_f) {
     return clock_source_f / CH_FREQUENCY;
 }

--- a/firmware/application/portapack.hpp
+++ b/firmware/application/portapack.hpp
@@ -53,9 +53,6 @@ extern ClockManager clock_manager;
 extern ReceiverModel receiver_model;
 extern TransmitterModel transmitter_model;
 
-void set_audio_mute(const bool v);
-void set_speaker_disable(const bool v);
-
 extern uint32_t bl_tick_counter;
 extern bool antenna_bias;
 

--- a/firmware/application/ui_navigation.cpp
+++ b/firmware/application/ui_navigation.cpp
@@ -194,6 +194,8 @@ SystemStatusView::SystemStatusView(
     button_clock_status.on_select = [this](ImageButton&) {
         this->on_clk();
     };
+
+    audio::output::update_audio_mute();
 }
 
 void SystemStatusView::refresh() {
@@ -212,9 +214,6 @@ void SystemStatusView::refresh() {
             button_converter.set_foreground(Color::light_grey());
         }
     }
-
-    portapack::set_speaker_disable(portapack::persistent_memory::config_speaker_disable());
-    portapack::set_audio_mute(portapack::persistent_memory::config_audio_mute());
 
     if (portapack::persistent_memory::config_audio_mute()) {
         button_speaker.set_foreground(Color::light_grey());
@@ -287,13 +286,8 @@ void SystemStatusView::on_converter() {
 }
 
 void SystemStatusView::on_speaker() {
-    if (portapack::persistent_memory::config_audio_mute()) {
-        portapack::set_audio_mute(false);
-        portapack::persistent_memory::set_config_audio_mute(false);
-    } else {
-        portapack::set_audio_mute(true);
-        portapack::persistent_memory::set_config_audio_mute(true);
-    }
+    portapack::persistent_memory::set_config_audio_mute(!portapack::persistent_memory::config_audio_mute());
+    audio::output::update_audio_mute();
     refresh();
 }
 

--- a/firmware/common/ak4951.cpp
+++ b/firmware/common/ak4951.cpp
@@ -175,7 +175,11 @@ void AK4951::headphone_enable() {
 
 void AK4951::headphone_disable() {
     set_headphone_power(false);
-    set_dac_power(false);
+
+    // Don't power off DAC unless Speaker is disabled also
+    if (map.r.power_management_2.PMSL == 0) {
+        set_dac_power(false);
+    }
 }
 
 void AK4951::speaker_enable() {
@@ -210,7 +214,11 @@ void AK4951::speaker_disable() {
     update(Register::SignalSelect1);
 
     // Power down DAC, Programmable Filter and speaker: PMDAC=PMPFIL=PMSL bits= “1”→“0”
-    set_dac_power(false);
+    // Exception: Don't power off DAC unless Headphones are disabled too
+    if (map.r.power_management_2.PMHPL == 0) {
+        set_dac_power(false);
+    }
+
     // map.r.power_management_1.PMPFIL = 0;
     // update(Register::PowerManagement1);
     set_speaker_power(false);


### PR DESCRIPTION
Fixed an issue discussed in Discord with the "Disable AK speaker amp" setting not taking effect until the navigation-bar was refreshed, such as by toggling the Speaker Mute icon on & off.

Also fixed the speaker_disable() and headphone_disable() functions in the AK4951 code to avoid disabling the DAC when the other device was still enabled.