### PR TITLE
Freqman memory fix

### DIFF
--- a/firmware/application/apps/ui_freqman.cpp
+++ b/firmware/application/apps/ui_freqman.cpp
@@ -81,9 +81,7 @@ void FreqManBaseView::change_category(int32_t category_id) {
 
     if (file_list.empty()) return;
 
-    std::vector<freqman_entry>().swap(database);
-
-    if (!load_freqman_file(file_list[categories[category_id].second], database)) {
+    if (!load_freqman_file(file_list[categories[category_id].second], &database)) {
         error_ = ERROR_ACCESS;
     }
     menu_view.set_db(database);
@@ -162,6 +160,10 @@ FrequencySaveView::FrequencySaveView(
     };
 }
 
+FrequencyLoadView::~FrequencyLoadView() {
+    std::vector<freqman_entry>().swap(database);
+}
+
 void FrequencyLoadView::refresh_widgets(const bool v) {
     menu_view.hidden(v);
     text_empty.hidden(!v);
@@ -199,6 +201,9 @@ FrequencyLoadView::FrequencyLoadView(
             if (on_frequency_loaded)
                 on_frequency_loaded(entry.frequency_a);
         }
+
+        // swap with empty vector to ensure memory is immediately released
+        std::vector<freqman_entry>().swap(database);
     };
 }
 

--- a/firmware/application/apps/ui_freqman.cpp
+++ b/firmware/application/apps/ui_freqman.cpp
@@ -243,7 +243,6 @@ void FrequencyManagerView::refresh_widgets(const bool v) {
     button_delete.hidden(v);
     text_empty.hidden(!v);
     freqlist_view.hidden(v);
-    freqlist_view.set_dirty();
     labels.hidden(v);
     // display.fill_rectangle(freqlist_view.screen_rect(), Color::black());
     set_dirty();

--- a/firmware/application/apps/ui_freqman.cpp
+++ b/firmware/application/apps/ui_freqman.cpp
@@ -81,7 +81,7 @@ void FreqManBaseView::change_category(int32_t category_id) {
 
     if (file_list.empty()) return;
 
-    if (!load_freqman_file(file_list[categories[category_id].second], &database)) {
+    if (!load_freqman_file(file_list[categories[category_id].second], database)) {
         error_ = ERROR_ACCESS;
     }
     freqlist_view.set_db(database);

--- a/firmware/application/apps/ui_freqman.hpp
+++ b/firmware/application/apps/ui_freqman.hpp
@@ -64,7 +64,7 @@ class FreqManBaseView : public View {
         14,
         {}};
 
-    FreqManUIList menu_view{
+    FreqManUIList freqlist_view{
         {0, 3 * 8, 240, 23 * 8}};
 
     Text text_empty{

--- a/firmware/application/apps/ui_freqman.hpp
+++ b/firmware/application/apps/ui_freqman.hpp
@@ -116,6 +116,7 @@ class FrequencyLoadView : public FreqManBaseView {
     std::function<void(rf::Frequency, rf::Frequency)> on_range_loaded{};
 
     FrequencyLoadView(NavigationView& nav);
+    ~FrequencyLoadView();
 
     std::string title() const override { return "Load freq."; };
 

--- a/firmware/application/apps/ui_recon.cpp
+++ b/firmware/application/apps/ui_recon.cpp
@@ -894,10 +894,7 @@ void ReconView::frequency_file_load(bool stop_all_before) {
     audio::output::stop();
 
     def_step = step_mode.selected_index();  // use def_step from manual selector
-    // clear and shrink_to_fit are not enough to really start with a new, clean, empty vector
-    // swap is the only way to achieve a perfect memory liberation
-    std::vector<freqman_entry>().swap(frequency_list);  // clear the existing frequency list (expected behavior)
-    std::string file_input = input_file;                // default recon mode
+    std::string file_input = input_file;    // default recon mode
     if (scanner_mode) {
         file_input = output_file;
         file_name.set_style(&Styles::red);
@@ -909,7 +906,7 @@ void ReconView::frequency_file_load(bool stop_all_before) {
         button_scanner_mode.set_text("RECON");
     }
     desc_cycle.set_style(&Styles::white);
-    if (!load_freqman_file_ex(file_input, frequency_list, load_freqs, load_ranges, load_hamradios, RECON_FREQMAN_MAX_PER_FILE)) {
+    if (!load_freqman_file(file_input, &frequency_list, load_freqs, load_ranges, load_hamradios)) {
         file_name.set_style(&Styles::red);
         desc_cycle.set_style(&Styles::red);
         desc_cycle.set(" NO " + file_input + ".TXT FILE ...");
@@ -922,7 +919,7 @@ void ReconView::frequency_file_load(bool stop_all_before) {
             desc_cycle.set("/0 no entries in list");
             file_name.set("BadOrEmpty " + file_input);
         } else {
-            if (frequency_list.size() > RECON_FREQMAN_MAX_PER_FILE) {
+            if (frequency_list.size() > FREQMAN_MAX_PER_FILE) {
                 file_name.set_style(&Styles::yellow);
                 desc_cycle.set_style(&Styles::yellow);
             }

--- a/firmware/application/apps/ui_recon.cpp
+++ b/firmware/application/apps/ui_recon.cpp
@@ -39,15 +39,13 @@ void ReconView::set_loop_config(bool v) {
 void ReconView::clear_freqlist_for_ui_action() {
     audio::output::stop();
     // flag to detect and reload frequency_list
-    freqlist_cleared_for_ui_action = true;
-    // if in manual mode, there is enough memory to load freqman files, else we have to unload/reload
     if (!manual_mode) {
-        // clear and shrink_to_fit are not enough to really start with a new, clean, empty vector
-        // swap is the only way to achieve a perfect memory liberation
-        std::vector<freqman_entry>().swap(frequency_list);
-    } else {
+        frequency_list.clear();
         frequency_list.shrink_to_fit();
-    }
+        std::vector<freqman_entry>().swap(frequency_list);
+    } else
+        frequency_list.shrink_to_fit();
+    freqlist_cleared_for_ui_action = true;
 }
 
 void ReconView::reset_indexes() {
@@ -683,9 +681,10 @@ ReconView::ReconView(NavigationView& nav)
             nav_.display_modal("Error", "END freq\nis lower than START");
         } else {
             audio::output::stop();
-
             // clear and shrink_to_fit are not enough to really start with a new, clean, empty vector
             // swap is the only way to achieve a perfect memory liberation
+            std::vector<freqman_entry>().clear();
+            std::vector<freqman_entry>().shrink_to_fit();
             std::vector<freqman_entry>().swap(frequency_list);
 
             freqman_entry manual_freq_entry;
@@ -802,7 +801,6 @@ ReconView::ReconView(NavigationView& nav)
 
         auto open_view = nav.push<ReconSetupView>(input_file, output_file);
         open_view->on_changed = [this](std::vector<std::string> result) {
-            freqlist_cleared_for_ui_action = false;
             input_file = result[0];
             output_file = result[1];
             freq_file_path = "/FREQMAN/" + output_file + ".TXT";
@@ -817,6 +815,7 @@ ReconView::ReconView(NavigationView& nav)
             update_ranges = persistent_memory::recon_update_ranges_when_recon();
 
             frequency_file_load(false);
+            freqlist_cleared_for_ui_action = false;
 
             if (autostart) {
                 recon_resume();

--- a/firmware/application/apps/ui_recon.cpp
+++ b/firmware/application/apps/ui_recon.cpp
@@ -40,8 +40,8 @@ void ReconView::clear_freqlist_for_ui_action() {
     audio::output::stop();
     // flag to detect and reload frequency_list
     if (!manual_mode) {
-        frequency_list.clear();
-        frequency_list.shrink_to_fit();
+        // clear and shrink_to_fit are not enough to really start with a new, clean, empty vector
+        // swap is the only way to achieve a perfect memory liberation
         std::vector<freqman_entry>().swap(frequency_list);
     } else
         frequency_list.shrink_to_fit();
@@ -683,8 +683,6 @@ ReconView::ReconView(NavigationView& nav)
             audio::output::stop();
             // clear and shrink_to_fit are not enough to really start with a new, clean, empty vector
             // swap is the only way to achieve a perfect memory liberation
-            std::vector<freqman_entry>().clear();
-            std::vector<freqman_entry>().shrink_to_fit();
             std::vector<freqman_entry>().swap(frequency_list);
 
             freqman_entry manual_freq_entry;
@@ -905,7 +903,7 @@ void ReconView::frequency_file_load(bool stop_all_before) {
         button_scanner_mode.set_text("RECON");
     }
     desc_cycle.set_style(&Styles::white);
-    if (!load_freqman_file(file_input, &frequency_list, load_freqs, load_ranges, load_hamradios)) {
+    if (!load_freqman_file(file_input, frequency_list, load_freqs, load_ranges, load_hamradios)) {
         file_name.set_style(&Styles::red);
         desc_cycle.set_style(&Styles::red);
         desc_cycle.set(" NO " + file_input + ".TXT FILE ...");

--- a/firmware/application/apps/ui_recon.hpp
+++ b/firmware/application/apps/ui_recon.hpp
@@ -45,7 +45,6 @@
 namespace ui {
 
 #define RECON_CFG_FILE "SETTINGS/recon.cfg"
-#define RECON_FREQMAN_MAX_PER_FILE 99  // maximum tested limit for load frequency from freqman to work
 
 class ReconView : public View {
    public:

--- a/firmware/application/apps/ui_scanner.cpp
+++ b/firmware/application/apps/ui_scanner.cpp
@@ -576,7 +576,7 @@ void ScannerView::frequency_file_load(std::string file_name, bool stop_all_befor
         description_list.clear();
     }
 
-    if (load_freqman_file(file_name, database)) {
+    if (load_freqman_file(file_name, &database)) {
         loaded_file_name = file_name;                            // keep loaded filename in memory
         for (auto& entry : database) {                           // READ LINE PER LINE
             if (frequency_list.size() < FREQMAN_MAX_PER_FILE) {  // We got space!

--- a/firmware/application/apps/ui_scanner.cpp
+++ b/firmware/application/apps/ui_scanner.cpp
@@ -576,7 +576,7 @@ void ScannerView::frequency_file_load(std::string file_name, bool stop_all_befor
         description_list.clear();
     }
 
-    if (load_freqman_file(file_name, &database)) {
+    if (load_freqman_file(file_name, database)) {
         loaded_file_name = file_name;                            // keep loaded filename in memory
         for (auto& entry : database) {                           // READ LINE PER LINE
             if (frequency_list.size() < FREQMAN_MAX_PER_FILE) {  // We got space!

--- a/firmware/application/freqman.cpp
+++ b/firmware/application/freqman.cpp
@@ -98,10 +98,10 @@ bool load_freqman_file(std::string& file_stem, freqman_db* db, bool load_freqs, 
     rf::Frequency frequency_a = 0, frequency_b = 0;
     char file_data[FREQMAN_READ_BUF_SIZE + 1] = {0};
     freqman_entry_type type = NOTYPE;
-    freqman_index_t modulation = 0;
-    freqman_index_t bandwidth = 0;
-    freqman_index_t step = 0;
-    freqman_index_t tone = 0;
+    freqman_index_t modulation = -1;
+    freqman_index_t bandwidth = -1;
+    freqman_index_t step = -1;
+    freqman_index_t tone = -1;
 
     auto result = freqman_file.open("FREQMAN/" + file_stem + ".TXT");
     if (result.is_valid())
@@ -202,6 +202,7 @@ bool load_freqman_file(std::string& file_stem, freqman_db* db, bool load_freqs, 
                 pos += 2;
                 length = std::min(strcspn(pos, ",\x0A"), (size_t)FREQMAN_DESC_MAX_LEN);
                 description = string(pos, length);
+                description.shrink_to_fit();
             }
             if ((type == SINGLE && load_freqs) || (type == RANGE && load_ranges) || (type == HAMRADIO && load_hamradios)) {
                 (*db).push_back({frequency_a, frequency_b, description, type, modulation, bandwidth, step, tone});
@@ -238,6 +239,7 @@ bool load_freqman_file(std::string& file_stem, freqman_db* db, bool load_freqs, 
             }
         }
     }
+    (*db).shrink_to_fit();
     return true;
 }
 

--- a/firmware/application/freqman.cpp
+++ b/firmware/application/freqman.cpp
@@ -86,9 +86,9 @@ options_t freqman_entry_steps_short = {
     {"500kHz", 500000},
     {"1MHz", 1000000}};
 
-bool load_freqman_file(std::string& file_stem, freqman_db* db, bool load_freqs, bool load_ranges, bool load_hamradios, uint8_t max_num_freqs) {
+bool load_freqman_file(std::string& file_stem, freqman_db& db, bool load_freqs, bool load_ranges, bool load_hamradios, uint8_t max_num_freqs) {
     // swap with empty vector to ensure memory is immediately released
-    std::vector<freqman_entry>().swap((*db));
+    std::vector<freqman_entry>().swap(db);
     File freqman_file{};
     size_t length = 0, n = 0, file_position = 0;
     char* pos = NULL;
@@ -205,7 +205,7 @@ bool load_freqman_file(std::string& file_stem, freqman_db* db, bool load_freqs, 
                 description.shrink_to_fit();
             }
             if ((type == SINGLE && load_freqs) || (type == RANGE && load_ranges) || (type == HAMRADIO && load_hamradios)) {
-                (*db).push_back({frequency_a, frequency_b, description, type, modulation, bandwidth, step, tone});
+                db.push_back({frequency_a, frequency_b, description, type, modulation, bandwidth, step, tone});
                 n++;
                 if (n > max_num_freqs) return true;
             }
@@ -222,24 +222,24 @@ bool load_freqman_file(std::string& file_stem, freqman_db* db, bool load_freqs, 
     }
 
     /* populate implicitly specified modulation / bandwidth */
-    if ((*db).size() > 2) {
-        modulation = (*db)[0].modulation;
-        bandwidth = (*db)[0].bandwidth;
+    if (db.size() > 2) {
+        modulation = db[0].modulation;
+        bandwidth = db[0].bandwidth;
 
-        for (unsigned int it = 1; it < (*db).size(); it++) {
-            if ((*db)[it].modulation < 0) {
-                (*db)[it].modulation = modulation;
+        for (unsigned int it = 1; it < db.size(); it++) {
+            if (db[it].modulation < 0) {
+                db[it].modulation = modulation;
             } else {
-                modulation = (*db)[it].modulation;
+                modulation = db[it].modulation;
             }
-            if ((*db)[it].bandwidth < 0) {
-                (*db)[it].bandwidth = bandwidth;
+            if (db[it].bandwidth < 0) {
+                db[it].bandwidth = bandwidth;
             } else {
-                modulation = (*db)[it].bandwidth;
+                modulation = db[it].bandwidth;
             }
         }
     }
-    (*db).shrink_to_fit();
+    db.shrink_to_fit();
     return true;
 }
 

--- a/firmware/application/freqman.hpp
+++ b/firmware/application/freqman.hpp
@@ -91,7 +91,7 @@ struct freqman_entry {
 
 using freqman_db = std::vector<freqman_entry>;
 
-bool load_freqman_file(std::string& file_stem, freqman_db* db, bool load_freqs = true, bool load_ranges = true, bool load_hamradios = true, uint8_t max_num_freqs = FREQMAN_MAX_PER_FILE);
+bool load_freqman_file(std::string& file_stem, freqman_db& db, bool load_freqs = true, bool load_ranges = true, bool load_hamradios = true, uint8_t max_num_freqs = FREQMAN_MAX_PER_FILE);
 bool get_freq_string(freqman_entry& entry, std::string& item_string);
 bool delete_freqman_file(std::string& file_stem);
 bool save_freqman_file(std::string& file_stem, freqman_db& db);

--- a/firmware/application/freqman.hpp
+++ b/firmware/application/freqman.hpp
@@ -36,7 +36,7 @@
 #define FREQMAN_MAX_PER_FILE 90  // Maximum of entries we can read. This is a hardware limit
                                  // It was tested and lowered to leave a bit of space to the caller
 
-#define FREQMAN_READ_BUF_SIZE 128  // max freqman line size including desc is 90, + a bit of space
+#define FREQMAN_READ_BUF_SIZE 96  // max freqman line size including desc is 90, + a bit of space
 
 using namespace ui;
 using namespace std;

--- a/firmware/application/freqman.hpp
+++ b/firmware/application/freqman.hpp
@@ -32,11 +32,11 @@
 #include "string_format.hpp"
 #include "ui_widget.hpp"
 
-#define FREQMAN_DESC_MAX_LEN 24   // This is the number of characters that can be drawn in front of "R: TEXT..." before taking a full screen line
-#define FREQMAN_MAX_PER_FILE 100  // Maximum of entries we can read. This is a hardware limit
-                                  // It was tested and lowered to leave a bit of space to the caller
+#define FREQMAN_DESC_MAX_LEN 24  // This is the number of characters that can be drawn in front of "R: TEXT..." before taking a full screen line
+#define FREQMAN_MAX_PER_FILE 90  // Maximum of entries we can read. This is a hardware limit
+                                 // It was tested and lowered to leave a bit of space to the caller
 
-#define FREQMAN_READ_BUF_SIZE 96  // max freqman line size including desc is 90, +6 for a bit of space
+#define FREQMAN_READ_BUF_SIZE 128  // max freqman line size including desc is 90, + a bit of space
 
 using namespace ui;
 using namespace std;
@@ -45,58 +45,53 @@ using namespace tonekey;
 // needs to be signed as -1 means not set
 typedef int8_t freqman_index_t;
 
-enum freqman_error {
+enum freqman_error : int8_t {
     NO_ERROR = 0,
     ERROR_ACCESS,
     ERROR_NOFILES,
     ERROR_DUPLICATE
 };
 
-enum freqman_entry_type : uint8_t {
+enum freqman_entry_type : int8_t {
     SINGLE = 0,  // f=
     RANGE,       // a=,b=
     HAMRADIO,    // r=,t=
-    ERROR_TYPE
+    NOTYPE       // undetected
 };
 
-enum freqman_entry_modulation {
+enum freqman_entry_modulation : int8_t {
     AM_MODULATION = 0,
     NFM_MODULATION,
     WFM_MODULATION,
-    MODULATION_DEF,
-    ERROR_MODULATION
 };
 
 // Entry step placed for AlainD freqman version (or any other enhanced version)
-enum freqman_entry_step {
-    STEP_DEF = -1,  // default
-    AM_US,          // 10 kHz   AM/CB
-    AM_EUR,         // 9 kHz	LW/MW
-    NFM_1,          // 12,5 kHz (Analogic PMR 446)
-    NFM_2,          // 6,25 kHz  (Digital PMR 446)
-    FM_1,           // 100 kHz
-    FM_2,           // 50 kHz
-    N_1,            // 25 kHz
-    N_2,            // 250 kHz
-    AIRBAND,        // AIRBAND 8,33 kHz
-    ERROR_STEP
+enum freqman_entry_step : int8_t {
+    AM_US,    // 10 kHz   AM/CB
+    AM_EUR,   // 9 kHz	LW/MW
+    NFM_1,    // 12,5 kHz (Analogic PMR 446)
+    NFM_2,    // 6,25 kHz  (Digital PMR 446)
+    FM_1,     // 100 kHz
+    FM_2,     // 50 kHz
+    N_1,      // 25 kHz
+    N_2,      // 250 kHz
+    AIRBAND,  // AIRBAND 8,33 kHz
 };
 
 struct freqman_entry {
-    rf::Frequency frequency_a{0};  // 'f=freq' or 'a=freq_start' or 'r=recv_freq'
-    rf::Frequency frequency_b{0};  // 'b=freq_end' or 't=tx_freq'
-    std::string description{};     // 'd=desc'
-    freqman_entry_type type{};     // SINGLE,RANGE,HAMRADIO
-    freqman_index_t modulation{};  // AM,NFM,WFM
-    freqman_index_t bandwidth{};   // AM_DSB, ...
-    freqman_index_t step{};        // 5khz (SA AM,...
-    tone_index tone{};             // 0XZ, 11 1ZB,...
+    rf::Frequency frequency_a{0};               // 'f=freq' or 'a=freq_start' or 'r=recv_freq'
+    rf::Frequency frequency_b{0};               // 'b=freq_end' or 't=tx_freq'
+    std::string description{NULL};              // 'd=desc'
+    freqman_entry_type type{SINGLE};            // SINGLE,RANGE,HAMRADIO
+    freqman_index_t modulation{AM_MODULATION};  // AM,NFM,WFM
+    freqman_index_t bandwidth{0};               // AM_DSB, ...
+    freqman_index_t step{0};                    // 5khz (SA AM,...
+    tone_index tone{0};                         // 0XZ, 11 1ZB,...
 };
 
 using freqman_db = std::vector<freqman_entry>;
 
-bool load_freqman_file(std::string& file_stem, freqman_db& db);
-bool load_freqman_file_ex(std::string& file_stem, freqman_db& db, bool load_freqs, bool load_ranges, bool load_hamradios, uint8_t limit);
+bool load_freqman_file(std::string& file_stem, freqman_db* db, bool load_freqs = true, bool load_ranges = true, bool load_hamradios = true, uint8_t max_num_freqs = FREQMAN_MAX_PER_FILE);
 bool get_freq_string(freqman_entry& entry, std::string& item_string);
 bool delete_freqman_file(std::string& file_stem);
 bool save_freqman_file(std::string& file_stem, freqman_db& db);


### PR DESCRIPTION
This adresse a few fix after the recent freqman modifications:
-fixed limit for all at 90 entries, no unknown crash detected with freqlists as big as possible (hence truncated)
-cleanings in recon
-renamed main_view into freqlist_view
-took out a few unneeded set_dirty
-removed unneeded load_freqman_ex wrapper
-changed all freqman enum type to int8_t