### PR TITLE
Recon capture mod

### DIFF
--- a/firmware/application/apps/capture_app.cpp
+++ b/firmware/application/apps/capture_app.cpp
@@ -30,8 +30,7 @@ namespace ui {
 
 CaptureAppView::CaptureAppView(NavigationView& nav)
     : nav_{nav} {
-        
-    freqman_set_bandwidth_option( SPEC_MODULATION, option_bandwidth);
+    freqman_set_bandwidth_option(SPEC_MODULATION, option_bandwidth);
     baseband::run_image(portapack::spi_flash::image_tag_capture);
 
     add_children({

--- a/firmware/application/apps/capture_app.cpp
+++ b/firmware/application/apps/capture_app.cpp
@@ -30,6 +30,8 @@ namespace ui {
 
 CaptureAppView::CaptureAppView(NavigationView& nav)
     : nav_{nav} {
+        
+    freqman_set_bandwidth_option( SPEC_MODULATION, option_bandwidth);
     baseband::run_image(portapack::spi_flash::image_tag_capture);
 
     add_children({

--- a/firmware/application/apps/capture_app.hpp
+++ b/firmware/application/apps/capture_app.hpp
@@ -31,23 +31,7 @@
 #include "ui_spectrum.hpp"
 #include "app_settings.hpp"
 #include "radio_state.hpp"
-
-#define BW_OPTIONS                                                                                                             \
-    {"  8k5", 8500},                                                                                                           \
-        {"  11k", 11000},                                                                                                      \
-        {"  16k", 16000},                                                                                                      \
-        {"  25k", 25000},                                                                                                      \
-        {"  50k", 50000},                                                                                                      \
-        {" 100k", 100000},                                                                                                     \
-        {" 250k", 250000},                                                                                                     \
-        {" 500k", 500000}, /* Previous Limit bandwith Option with perfect micro SD write .C16 format operaton.*/               \
-        {" 600k", 600000}, /* That extended option is still possible to record with FW version Mayhem v1.41 (< 2,5MB/sec) */   \
-        {" 750k", 750000}, /* From this BW onwards, the LCD is ok, but the recorded file is decimated, (not real file size) */ \
-        {"1100k", 1100000},                                                                                                    \
-        {"1750k", 1750000},                                                                                                    \
-        {"2000k", 2000000},                                                                                                    \
-        {"2500k", 2500000},                                                                                                    \
-        {"2750k", 2750000},  // That is our max Capture option, to keep using later / 8 decimation (22Mhz sampling  ADC)
+#include "freqman.hpp"
 
 namespace ui {
 
@@ -103,7 +87,7 @@ class CaptureAppView : public View {
     OptionsField option_bandwidth{
         {5 * 8, 1 * 16},
         5,
-        {BW_OPTIONS}};
+        {}};
 
     RecordView record_view{
         {0 * 8, 2 * 16, 30 * 8, 1 * 16},

--- a/firmware/application/apps/ui_recon.cpp
+++ b/firmware/application/apps/ui_recon.cpp
@@ -42,6 +42,7 @@ void ReconView::recon_stop_recording() {
     if (is_recording) {
         button_audio_app.set_style(&Styles::white);
         record_view->stop();
+        button_config.set_style(&Styles::white);  // disable config while recording as it's causing an IO error pop up at exit
         is_recording = false;
     }
 }
@@ -820,6 +821,8 @@ ReconView::ReconView(NavigationView& nav)
     };
 
     button_config.on_select = [this, &nav](Button&) {
+        if (is_recording)  // disabling config while recording
+            return;
         clear_freqlist_for_ui_action();
         freq_lock = 0;
         timer = 0;
@@ -1090,6 +1093,7 @@ void ReconView::on_statistics_update(const ChannelStatistics& statistics) {
                     if (auto_record_locked && !is_recording) {
                         button_audio_app.set_style(&Styles::red);
                         record_view->start();
+                        button_config.set_style(&Styles::grey);  // disable config while recording as it's causing an IO error pop up at exit
                         is_recording = true;
                     }
                     // FREQ IS STRONG: GREEN and recon will pause when on_statistics_update()

--- a/firmware/application/apps/ui_recon.cpp
+++ b/firmware/application/apps/ui_recon.cpp
@@ -1093,7 +1093,7 @@ void ReconView::on_statistics_update(const ChannelStatistics& statistics) {
                     if (auto_record_locked && !is_recording) {
                         button_audio_app.set_style(&Styles::red);
                         record_view->start();
-                        button_config.set_style(&Styles::grey);  // disable config while recording as it's causing an IO error pop up at exit
+                        button_config.set_style(&Styles::light_grey);  // disable config while recording as it's causing an IO error pop up at exit
                         is_recording = true;
                     }
                     // FREQ IS STRONG: GREEN and recon will pause when on_statistics_update()

--- a/firmware/application/apps/ui_spectrum_painter.cpp
+++ b/firmware/application/apps/ui_spectrum_painter.cpp
@@ -57,6 +57,8 @@ SpectrumPainterView::SpectrumPainterView(
     input_image.set_parent_rect(view_rect);
     input_text.set_parent_rect(view_rect);
 
+    freqman_set_bandwidth_option(SPEC_MODULATION, option_bandwidth);
+
     field_frequency.set_step(5000);
 
     tx_gain = transmitter_model.tx_gain();

--- a/firmware/application/apps/ui_spectrum_painter.hpp
+++ b/firmware/application/apps/ui_spectrum_painter.hpp
@@ -127,7 +127,7 @@ class SpectrumPainterView : public View {
     OptionsField option_bandwidth{
         {4 * 8, footer_location + 2 * 16},
         5,
-        {BW_OPTIONS}};
+        {}};
 
     NumberField field_duration{
         {13 * 8, footer_location + 2 * 16},


### PR DESCRIPTION
Fixed a bug by disabling config button during recordings in Recon
Used freqman_set_bandwidth instead of static define in capture, spectrum painter