### PR TITLE
Improve visibility of green icons on white background

### DIFF
--- a/firmware/common/ui_painter.cpp
+++ b/firmware/common/ui_painter.cpp
@@ -80,7 +80,7 @@ int Painter::draw_string(
 
 void Painter::draw_bitmap(Point p, const Bitmap& bitmap, Color foreground, Color background) {
     // If bright foreground colors on white background, darken the foreground color to improve visibility
-    if ((background.v == ui::Color::white().v) && (foreground.to_greyscale() > 175))
+    if ((background.v == ui::Color::white().v) && (foreground.to_greyscale() > 146))
         foreground = foreground.dark();
 
     display.draw_bitmap(p, bitmap.size, bitmap.data, foreground, background);


### PR DESCRIPTION
Lowered the threshold for darkening icons on a white background to include the green icons also to make them more visible when selected.