### PR TITLE
Second DFU Overlay Screen with Receiver Info

### DIFF
--- a/firmware/application/apps/ui_dfu_menu.cpp
+++ b/firmware/application/apps/ui_dfu_menu.cpp
@@ -22,6 +22,7 @@
 #include "ui_dfu_menu.hpp"
 #include "portapack_shared_memory.hpp"
 #include "performance_counter.hpp"
+#include "portapack.hpp"
 
 namespace ui {
 
@@ -77,6 +78,59 @@ void DfuMenu::paint(Painter& painter) {
     painter.fill_rectangle(
         {{5 * CHARACTER_WIDTH - margin, (lines + 3) * LINE_HEIGHT + margin},
          {17 * CHARACTER_WIDTH + margin * 2, 8}},
+        ui::Color::dark_cyan());
+}
+
+DfuMenu2::DfuMenu2(NavigationView& nav)
+    : nav_(nav) {
+    add_children({&text_head,
+                  &labels,
+                  &text_info_line_1,
+                  &text_info_line_2,
+                  &text_info_line_3,
+                  &text_info_line_4,
+                  &text_info_line_5,
+                  &text_info_line_6,
+                  &text_info_line_7,
+                  &text_info_line_8});
+}
+
+void DfuMenu2::paint(Painter& painter) {
+    text_info_line_1.set(to_string_dec_uint(portapack::receiver_model.target_frequency(), 10));
+    text_info_line_2.set(to_string_dec_uint(portapack::receiver_model.baseband_bandwidth(), 10));
+    text_info_line_3.set(to_string_dec_uint(portapack::receiver_model.sampling_rate(), 10));
+    text_info_line_4.set(to_string_dec_uint((uint32_t)portapack::receiver_model.modulation(), 10));
+    text_info_line_5.set(to_string_dec_uint(portapack::receiver_model.am_configuration(), 10));
+    text_info_line_6.set(to_string_dec_uint(portapack::receiver_model.nbfm_configuration(), 10));
+    text_info_line_7.set(to_string_dec_uint(portapack::receiver_model.wfm_configuration(), 10));
+    text_info_line_8.set("");
+
+    constexpr auto margin = 5;
+    constexpr auto lines = 8 + 2;
+
+    painter.fill_rectangle(
+        {{5 * CHARACTER_WIDTH - margin, 3 * LINE_HEIGHT - margin},
+         {19 * CHARACTER_WIDTH + margin * 2, lines * LINE_HEIGHT + margin * 2}},
+        ui::Color::black());
+
+    painter.fill_rectangle(
+        {{4 * CHARACTER_WIDTH - margin, 3 * LINE_HEIGHT - margin},
+         {CHARACTER_WIDTH, lines * LINE_HEIGHT + margin * 2}},
+        ui::Color::dark_cyan());
+
+    painter.fill_rectangle(
+        {{24 * CHARACTER_WIDTH + margin, 3 * LINE_HEIGHT - margin},
+         {CHARACTER_WIDTH, lines * LINE_HEIGHT + margin * 2}},
+        ui::Color::dark_cyan());
+
+    painter.fill_rectangle(
+        {{4 * CHARACTER_WIDTH - margin, 3 * LINE_HEIGHT - margin - 8},
+         {21 * CHARACTER_WIDTH + margin * 2, 8}},
+        ui::Color::dark_cyan());
+
+    painter.fill_rectangle(
+        {{4 * CHARACTER_WIDTH - margin, (lines + 3) * LINE_HEIGHT + margin},
+         {21 * CHARACTER_WIDTH + margin * 2, 8}},
         ui::Color::dark_cyan());
 }
 

--- a/firmware/application/apps/ui_dfu_menu.hpp
+++ b/firmware/application/apps/ui_dfu_menu.hpp
@@ -67,6 +67,39 @@ class DfuMenu : public View {
     Text text_info_line_8{{15 * CHARACTER_WIDTH, 12 * LINE_HEIGHT, 5 * CHARACTER_WIDTH, 1 * LINE_HEIGHT}, ""};
 };
 
+class DfuMenu2 : public View {
+   public:
+    DfuMenu2(NavigationView& nav);
+    ~DfuMenu2() = default;
+
+    void paint(Painter& painter) override;
+
+   private:
+    NavigationView& nav_;
+
+    Text text_head{{6 * CHARACTER_WIDTH, 3 * LINE_HEIGHT, 8 * CHARACTER_WIDTH, 1 * LINE_HEIGHT}, "Receiver"};
+
+    Labels labels{
+        {{5 * CHARACTER_WIDTH, 5 * LINE_HEIGHT}, "Tgt freq:", Color::dark_cyan()},
+        {{5 * CHARACTER_WIDTH, 6 * LINE_HEIGHT}, "Bandwidt:", Color::dark_cyan()},
+        {{5 * CHARACTER_WIDTH, 7 * LINE_HEIGHT}, "Sampl Rt:", Color::dark_cyan()},
+        {{5 * CHARACTER_WIDTH, 8 * LINE_HEIGHT}, "Modulatn:", Color::dark_cyan()},
+        {{5 * CHARACTER_WIDTH, 9 * LINE_HEIGHT}, "AM cfg:" , Color::dark_cyan()},
+        {{5 * CHARACTER_WIDTH, 10 * LINE_HEIGHT}, "NBFM cfg:", Color::dark_cyan()},
+        {{5 * CHARACTER_WIDTH, 11 * LINE_HEIGHT}, "WFM cfg: ", Color::dark_cyan()},
+        {{5 * CHARACTER_WIDTH, 12 * LINE_HEIGHT}, "", Color::dark_cyan()}};
+
+    Text text_info_line_1{{14 * CHARACTER_WIDTH, 5 * LINE_HEIGHT, 10 * CHARACTER_WIDTH, 1 * LINE_HEIGHT}, ""};
+    Text text_info_line_2{{14 * CHARACTER_WIDTH, 6 * LINE_HEIGHT, 10 * CHARACTER_WIDTH, 1 * LINE_HEIGHT}, ""};
+    Text text_info_line_3{{14 * CHARACTER_WIDTH, 7 * LINE_HEIGHT, 10 * CHARACTER_WIDTH, 1 * LINE_HEIGHT}, ""};
+    Text text_info_line_4{{14 * CHARACTER_WIDTH, 8 * LINE_HEIGHT, 10 * CHARACTER_WIDTH, 1 * LINE_HEIGHT}, ""};
+    Text text_info_line_5{{14 * CHARACTER_WIDTH, 9 * LINE_HEIGHT, 10 * CHARACTER_WIDTH, 1 * LINE_HEIGHT}, ""};
+    Text text_info_line_6{{14 * CHARACTER_WIDTH, 10 * LINE_HEIGHT, 10 * CHARACTER_WIDTH, 1 * LINE_HEIGHT}, ""};
+    Text text_info_line_7{{14 * CHARACTER_WIDTH, 11 * LINE_HEIGHT, 10 * CHARACTER_WIDTH, 1 * LINE_HEIGHT}, ""};
+    Text text_info_line_8{{14 * CHARACTER_WIDTH, 12 * LINE_HEIGHT, 10 * CHARACTER_WIDTH, 1 * LINE_HEIGHT}, ""};
+};
+
+
 } /* namespace ui */
 
 #endif /*__UI_DFU_MENU_H__*/

--- a/firmware/application/ui_navigation.cpp
+++ b/firmware/application/ui_navigation.cpp
@@ -714,20 +714,27 @@ Context& SystemView::context() const {
 }
 
 void SystemView::toggle_overlay() {
-    if (overlay_active) {
-        this->remove_child(&this->overlay);
-        this->set_dirty();
-        shared_memory.request_m4_performance_counter = 0;
-    } else {
-        this->add_child(&this->overlay);
-        this->set_dirty();
-        shared_memory.request_m4_performance_counter = 1;
-        shared_memory.m4_cpu_usage = 0;
-        shared_memory.m4_heap_usage = 0;
-        shared_memory.m4_stack_usage = 0;
+    switch (++overlay_active) {
+        case 1:
+            this->add_child(&this->overlay);
+            this->set_dirty();
+            shared_memory.request_m4_performance_counter = 1;
+            shared_memory.m4_cpu_usage = 0;
+            shared_memory.m4_heap_usage = 0;
+            shared_memory.m4_stack_usage = 0;
+            break;
+        case 2:
+            this->remove_child(&this->overlay);
+            this->add_child(&this->overlay2);
+            this->set_dirty();
+            shared_memory.request_m4_performance_counter = 0;
+            break;
+        case 3:
+            this->remove_child(&this->overlay2);
+            this->set_dirty();
+            overlay_active = 0;
+            break;
     }
-
-    overlay_active = !overlay_active;
 }
 
 void SystemView::paint_overlay() {
@@ -738,7 +745,10 @@ void SystemView::paint_overlay() {
             return;
 
         last_paint_state = !last_paint_state;
-        this->overlay.set_dirty();
+        if (overlay_active == 1)
+            this->overlay.set_dirty();
+        else
+            this->overlay2.set_dirty();
     }
 }
 

--- a/firmware/application/ui_navigation.hpp
+++ b/firmware/application/ui_navigation.hpp
@@ -328,11 +328,12 @@ class SystemView : public View {
     void paint_overlay();
 
    private:
-    bool overlay_active{false};
+    uint8_t overlay_active{0};
 
     SystemStatusView status_view{navigation_view};
     InformationView info_view{navigation_view};
     DfuMenu overlay{navigation_view};
+    DfuMenu2 overlay2{navigation_view};
     NavigationView navigation_view{};
     Context& context_;
 };


### PR DESCRIPTION
I'm proposing this second DFU overlay screen for debugging receiver settings.

To view it, press the DFU button a second time.

(I thought it would help to debug the open ERT RX issue, but alas that one is still unresolved.)

![SCR_0039](https://github.com/eried/portapack-mayhem/assets/129641948/f1839c2e-c6ca-4830-a2f7-9f7123025a63)
