### PR TITLE
improve keyboard

### DIFF
--- a/firmware/application/apps/ui_flash_utility.hpp
+++ b/firmware/application/apps/ui_flash_utility.hpp
@@ -40,7 +40,7 @@ class FlashUtilityView : public View {
 
     void focus() override;
 
-    std::string title() const override { return "Flash Utility"; };  // Removed the space because the title and speaker icon overlapped.
+    std::string title() const override { return "Flash Utility"; };
 
    private:
     NavigationView& nav_;

--- a/firmware/application/apps/ui_flash_utility.hpp
+++ b/firmware/application/apps/ui_flash_utility.hpp
@@ -40,7 +40,7 @@ class FlashUtilityView : public View {
 
     void focus() override;
 
-    std::string title() const override { return "FlashUtility"; };  // Removed the space because the title and speaker icon overlapped.
+    std::string title() const override { return "Flash Utility"; };  // Removed the space because the title and speaker icon overlapped.
 
    private:
     NavigationView& nav_;

--- a/firmware/application/apps/ui_looking_glass_app.hpp
+++ b/firmware/application/apps/ui_looking_glass_app.hpp
@@ -63,7 +63,7 @@ class GlassView : public View {
     GlassView& operator=(const GlassView& nav);
 
     ~GlassView();
-    std::string title() const override { return "LookingGlass"; };
+    std::string title() const override { return "Looking Glass"; };
 
     void on_show() override;
     void on_hide() override;

--- a/firmware/application/apps/ui_playlist.hpp
+++ b/firmware/application/apps/ui_playlist.hpp
@@ -119,10 +119,10 @@ class PlaylistView : public View {
         {10 * 8, 1 * 16, 7 * 8, 16}};
 
     ProgressBar progressbar_track{
-        {18 * 8, 1 * 16, 12 * 8, 8}};
+        {18 * 8, 1 * 16, 12 * 8, 8 + 1}};
 
     ProgressBar progressbar_transmit{
-        {18 * 8, 3 * 8, 12 * 8, 8}};
+        {18 * 8, 3 * 8 - 1, 12 * 8, 8}};
 
     Text text_duration{
         {0 * 8, 2 * 16, 5 * 8, 16}};

--- a/firmware/application/apps/ui_playlist.hpp
+++ b/firmware/application/apps/ui_playlist.hpp
@@ -118,6 +118,11 @@ class PlaylistView : public View {
     Text text_sample_rate{
         {10 * 8, 1 * 16, 7 * 8, 16}};
 
+    /*v making there's 1px line (instead of two) between two progress bars,
+     * by letting 1px overlapped.
+     * So, since they overlapped 1px, they are visually same, and looks better.
+     */
+
     ProgressBar progressbar_track{
         {18 * 8, 1 * 16, 12 * 8, 8 + 1}};
 

--- a/firmware/application/ui/ui_alphanum.cpp
+++ b/firmware/application/ui/ui_alphanum.cpp
@@ -70,8 +70,9 @@ AlphanumView::AlphanumView(
     field_raw.on_select = [this](NumberField&) {
         char_add(field_raw.value());
     };
+
     // make text_raw_to_char widget display the char value from field_raw
-    field_raw.on_change = [this](long int) {
+    field_raw.on_change = [this](auto) {
         text_raw_to_char.set("AKA:" + std::string{static_cast<char>(field_raw.value())});
     };
 }

--- a/firmware/application/ui/ui_alphanum.cpp
+++ b/firmware/application/ui/ui_alphanum.cpp
@@ -80,7 +80,7 @@ AlphanumView::AlphanumView(
 
     // make text_raw_to_char widget display the char value from field_raw
     field_raw.on_change = [this](auto) {
-        text_raw_to_char.set("AKA:" + std::string{static_cast<char>(field_raw.value())});
+        text_raw_to_char.set(std::string{static_cast<char>(field_raw.value())});
     };
 }
 
@@ -109,10 +109,6 @@ void AlphanumView::set_mode(const uint32_t new_mode) {
 
 void AlphanumView::on_button(Button& button) {
     const auto c = button.text()[0];
-
-    // if (c == '<')
-    //     char_delete();
-    // else
     char_add(c);
 }
 

--- a/firmware/application/ui/ui_alphanum.cpp
+++ b/firmware/application/ui/ui_alphanum.cpp
@@ -110,10 +110,10 @@ void AlphanumView::set_mode(const uint32_t new_mode) {
 void AlphanumView::on_button(Button& button) {
     const auto c = button.text()[0];
 
-//    if (c == '<')
-//        char_delete();
-//    else
-        char_add(c);
+    // if (c == '<')
+    //     char_delete();
+    // else
+    char_add(c);
 }
 
 bool AlphanumView::on_encoder(const EncoderEvent delta) {

--- a/firmware/application/ui/ui_alphanum.cpp
+++ b/firmware/application/ui/ui_alphanum.cpp
@@ -39,7 +39,8 @@ AlphanumView::AlphanumView(
 
     add_children({&button_mode,
                   &text_raw,
-                  &field_raw});
+                  &field_raw,
+                  &text_raw_to_char});
 
     const auto button_fn = [this](Button& button) {
         this->on_button(button);
@@ -68,6 +69,10 @@ AlphanumView::AlphanumView(
     field_raw.set_value('0');
     field_raw.on_select = [this](NumberField&) {
         char_add(field_raw.value());
+    };
+    // make text_raw_to_char widget display the char value from field_raw
+    field_raw.on_change = [this](long int) {
+        text_raw_to_char.set("AKA:" + std::string{static_cast<char>(field_raw.value())});
     };
 }
 

--- a/firmware/application/ui/ui_alphanum.cpp
+++ b/firmware/application/ui/ui_alphanum.cpp
@@ -38,7 +38,8 @@ AlphanumView::AlphanumView(
     size_t n;
 
     add_children({
-        &text_raw,
+        &labels_raw,
+        // &text_raw,
         &field_raw,
         &text_raw_to_char,
         &button_delete,

--- a/firmware/application/ui/ui_alphanum.cpp
+++ b/firmware/application/ui/ui_alphanum.cpp
@@ -39,7 +39,6 @@ AlphanumView::AlphanumView(
 
     add_children({
         &labels_raw,
-        // &text_raw,
         &field_raw,
         &text_raw_to_char,
         &button_delete,

--- a/firmware/application/ui/ui_alphanum.cpp
+++ b/firmware/application/ui/ui_alphanum.cpp
@@ -37,10 +37,13 @@ AlphanumView::AlphanumView(
     : TextEntryView(nav, str, max_length) {
     size_t n;
 
-    add_children({&button_mode,
-                  &text_raw,
-                  &field_raw,
-                  &text_raw_to_char});
+    add_children({
+        &text_raw,
+        &field_raw,
+        &text_raw_to_char,
+        &button_delete,
+        &button_mode,
+    });
 
     const auto button_fn = [this](Button& button) {
         this->on_button(button);
@@ -64,6 +67,10 @@ AlphanumView::AlphanumView(
 
     button_mode.on_select = [this](Button&) {
         set_mode(mode + 1);
+    };
+
+    button_delete.on_select = [this](Button&) {
+        char_delete();
     };
 
     field_raw.set_value('0');
@@ -103,9 +110,9 @@ void AlphanumView::set_mode(const uint32_t new_mode) {
 void AlphanumView::on_button(Button& button) {
     const auto c = button.text()[0];
 
-    if (c == '<')
-        char_delete();
-    else
+//    if (c == '<')
+//        char_delete();
+//    else
         char_add(c);
 }
 

--- a/firmware/application/ui/ui_alphanum.cpp
+++ b/firmware/application/ui/ui_alphanum.cpp
@@ -38,7 +38,7 @@ AlphanumView::AlphanumView(
     size_t n;
 
     add_children({
-        &labels_raw,
+        &labels,
         &field_raw,
         &text_raw_to_char,
         &button_delete,

--- a/firmware/application/ui/ui_alphanum.hpp
+++ b/firmware/application/ui/ui_alphanum.hpp
@@ -77,7 +77,7 @@ class AlphanumView : public TextEntryView {
 
     Text text_raw_to_char{
         {1 * 8, 35 * 8, 4 * 8, 16},
-        "AKA: "};
+        "AKA:0"};
 
     Button button_ok{
         {10 * 8, 33 * 8, 9 * 8, 32},

--- a/firmware/application/ui/ui_alphanum.hpp
+++ b/firmware/application/ui/ui_alphanum.hpp
@@ -60,7 +60,7 @@ class AlphanumView : public TextEntryView {
 
     std::array<Button, 30> buttons{};
 
-    Labels labels_raw{
+    Labels labels{
         {{1 * 8, 33 * 8}, "Raw:", Color::light_grey()},
         {{1 * 8, 35 * 8}, "AKA:", Color::light_grey()}};
 

--- a/firmware/application/ui/ui_alphanum.hpp
+++ b/firmware/application/ui/ui_alphanum.hpp
@@ -50,7 +50,7 @@ class AlphanumView : public TextEntryView {
     const std::pair<std::string, const char*> key_sets[3] = {
         {"ABC", keys_upper},
         {"abc", keys_lower},
-        {"123.", keys_digit}};
+        {"123", keys_digit}};
 
     int16_t focused_button = 0;
     uint32_t mode = 0;  // Uppercase
@@ -60,9 +60,9 @@ class AlphanumView : public TextEntryView {
 
     std::array<Button, 30> buttons{};
 
-    Text text_raw{
-        {1 * 8, 33 * 8, 4 * 8, 16},
-        "Raw:"};
+    Labels labels_raw{
+        {{1 * 8, 33 * 8}, "Raw:", Color::light_grey()},
+        {{1 * 8, 35 * 8}, "AKA:", Color::light_grey()}};
 
     NumberField field_raw{
         {5 * 8, 33 * 8},
@@ -72,8 +72,8 @@ class AlphanumView : public TextEntryView {
         '0'};
 
     Text text_raw_to_char{
-        {1 * 8, 35 * 8, 4 * 8, 16},
-        "AKA:0"};
+        {5 * 8, 35 * 8, 4 * 8, 16},
+        "0"};
 
     Button button_delete{
         {10 * 8 - 2, 33 * 8, 4 * 8 + 2, 32},

--- a/firmware/application/ui/ui_alphanum.hpp
+++ b/firmware/application/ui/ui_alphanum.hpp
@@ -43,14 +43,14 @@ class AlphanumView : public TextEntryView {
     bool on_encoder(const EncoderEvent delta) override;
 
    private:
-    const char* const keys_upper = "ABCDEFGHIJKLMNOPQRSTUVWXYZ, .<";
-    const char* const keys_lower = "abcdefghijklmnopqrstuvwxyz, .<";
+    const char* const keys_upper = "ABCDEFGHIJKLMNOPQRSTUVWXYZ, ._";
+    const char* const keys_lower = "abcdefghijklmnopqrstuvwxyz, ._";
     const char* const keys_digit = "0123456789!\"#'()*+-/:;=>?@[\\]<";
 
     const std::pair<std::string, const char*> key_sets[3] = {
-        {"Upper", keys_upper},
-        {"Lower", keys_lower},
-        {"Digit", keys_digit}};
+        {"ABC", keys_upper},
+        {"abc", keys_lower},
+        {"123.", keys_digit}};
 
     int16_t focused_button = 0;
     uint32_t mode = 0;  // Uppercase
@@ -59,10 +59,6 @@ class AlphanumView : public TextEntryView {
     void on_button(Button& button);
 
     std::array<Button, 30> buttons{};
-
-    Button button_mode{
-        {21 * 8, 33 * 8, 8 * 8, 32},
-        ""};
 
     Text text_raw{
         {1 * 8, 33 * 8, 4 * 8, 16},
@@ -79,9 +75,13 @@ class AlphanumView : public TextEntryView {
         {1 * 8, 35 * 8, 4 * 8, 16},
         "AKA:0"};
 
-    Button button_ok{
-        {10 * 8, 33 * 8, 9 * 8, 32},
-        "OK"};
+    Button button_delete{
+        {10 * 8, 33 * 8, 4 * 8, 32},
+        "DEL"};
+
+    Button button_mode{
+        {16 * 8 - 2, 33 * 8, 4 * 8 + 2, 32},
+        ""};
 };
 
 } /* namespace ui */

--- a/firmware/application/ui/ui_alphanum.hpp
+++ b/firmware/application/ui/ui_alphanum.hpp
@@ -45,7 +45,7 @@ class AlphanumView : public TextEntryView {
    private:
     const char* const keys_upper = "ABCDEFGHIJKLMNOPQRSTUVWXYZ, ._";
     const char* const keys_lower = "abcdefghijklmnopqrstuvwxyz, ._";
-    const char* const keys_digit = "0123456789!\"#'()*+-/:;=>?@[\\]<";
+    const char* const keys_digit = "0123456789!\"#'()*+-/:;=<>@[\\]?";
 
     const std::pair<std::string, const char*> key_sets[3] = {
         {"ABC", keys_upper},

--- a/firmware/application/ui/ui_alphanum.hpp
+++ b/firmware/application/ui/ui_alphanum.hpp
@@ -57,7 +57,6 @@ class AlphanumView : public TextEntryView {
 
     void set_mode(const uint32_t new_mode);
     void on_button(Button& button);
-    void on_tick();
 
     std::array<Button, 30> buttons{};
 

--- a/firmware/application/ui/ui_alphanum.hpp
+++ b/firmware/application/ui/ui_alphanum.hpp
@@ -76,8 +76,8 @@ class AlphanumView : public TextEntryView {
         "AKA:0"};
 
     Button button_delete{
-        {10 * 8, 33 * 8, 4 * 8, 32},
-        "DEL"};
+        {10 * 8 - 2, 33 * 8, 4 * 8 + 2, 32},
+        "<DEL"};
 
     Button button_mode{
         {16 * 8 - 2, 33 * 8, 4 * 8 + 2, 32},

--- a/firmware/application/ui/ui_alphanum.hpp
+++ b/firmware/application/ui/ui_alphanum.hpp
@@ -57,6 +57,7 @@ class AlphanumView : public TextEntryView {
 
     void set_mode(const uint32_t new_mode);
     void on_button(Button& button);
+    void on_tick();
 
     std::array<Button, 30> buttons{};
 
@@ -67,12 +68,17 @@ class AlphanumView : public TextEntryView {
     Text text_raw{
         {1 * 8, 33 * 8, 4 * 8, 16},
         "Raw:"};
+
     NumberField field_raw{
         {5 * 8, 33 * 8},
         3,
         {1, 255},
         1,
         '0'};
+
+    Text text_raw_to_char{
+        {1 * 8, 35 * 8, 4 * 8, 16},
+        "AKA: "};
 
     Button button_ok{
         {10 * 8, 33 * 8, 9 * 8, 32},

--- a/firmware/application/ui/ui_textentry.hpp
+++ b/firmware/application/ui/ui_textentry.hpp
@@ -50,7 +50,7 @@ class TextEntryView : public View {
 
     TextField text_input;
     Button button_ok{
-        {10 * 8, 33 * 8, 9 * 8, 32},
+        {22 * 8, 33 * 8, 7 * 8, 32},
         "OK"};
 };
 


### PR DESCRIPTION
1. make the add char tool visualize
2. can input `<` and `_` with keyboard now   
(Underline is necessary cuz the capture file contains underline, user should be able to type it back, if they mistakenly deleted it)  
(<is necessary too cuz there's a >)  

3. small textual or position fix / adjusting  
(brought the space in 2 apps title back, since the community had already decided how to take care of the "too long title")