### PR TITLE
Revert color of "SD over USB" icon back to yellow

### DIFF
--- a/firmware/application/ui_navigation.cpp
+++ b/firmware/application/ui_navigation.cpp
@@ -608,7 +608,7 @@ UtilitiesMenuView::UtilitiesMenuView(NavigationView& nav) {
 
         {"Wipe SD card", Color::red(), &bitmap_icon_tools_wipesd, [&nav]() { nav.push<WipeSDView>(); }},
         {"Flash Utility", Color::red(), &bitmap_icon_temperature, [&nav]() { nav.push<FlashUtilityView>(); }},
-        {"SD over USB", Color::green(), &bitmap_icon_hackrf, [&nav]() { nav.push<SdOverUsbView>(); }},
+        {"SD over USB", Color::yellow(), &bitmap_icon_hackrf, [&nav]() { nav.push<SdOverUsbView>(); }},
     });
     set_max_rows(2);  // allow wider buttons
 }


### PR DESCRIPTION
I changed its development status it to green the other day but I propose to revert that change pending further testing