### PR TITLE
Notepad text zoom support 5x8 to 8x16 font

### DIFF
--- a/firmware/application/apps/ui_text_editor.hpp
+++ b/firmware/application/apps/ui_text_editor.hpp
@@ -75,12 +75,20 @@ class TextViewer : public Widget {
     // Gets the length of the current line.
     uint16_t line_length();
 
-   private:
-    static constexpr int8_t char_width = 5;
-    static constexpr int8_t char_height = 8;
+    void text_zoom(Rect parent_rect) {
+        zoom = !zoom;
+        char_height = zoom ? 16 : 8;
+        char_width = zoom ? 8 : 5;
+        max_line = (uint8_t)(parent_rect.height() / char_height);
+        max_col = (uint8_t)(parent_rect.width() / char_width);
+    }
 
-    const uint8_t max_line = 32;
-    const uint8_t max_col = 48;
+   private:
+    bool zoom = 0;
+    int8_t char_width = 5;
+    int8_t char_height = 8;
+    uint8_t max_line = 32;
+    uint8_t max_col = 48;
 
     /* Returns true if the cursor was updated. */
     bool apply_scrolling_constraints(
@@ -122,7 +130,7 @@ class TextEditorMenu : public View {
 
     std::function<void()>& on_cut() { return button_cut.on_select; }
     std::function<void()>& on_paste() { return button_paste.on_select; }
-    std::function<void()>& on_copy() { return button_copy.on_select; }
+    std::function<void()>& on_zoom() { return button_zoom.on_select; }
 
     std::function<void()>& on_delete_line() { return button_delline.on_select; }
     std::function<void()>& on_edit_line() { return button_edit.on_select; }
@@ -151,11 +159,11 @@ class TextEditorMenu : public View {
         &bitmap_icon_paste,
         Color::dark_grey()};
 
-    NewButton button_copy{
+    NewButton button_zoom{
         {15 * 8, 1 * 8, 7 * 8, 7 * 8},
-        "Copy",
-        &bitmap_icon_copy,
-        Color::dark_grey()};
+        "Zoom",
+        &bitmap_icon_search,
+        Color::dark_green()};
 
     NewButton button_delline{
         {1 * 8, 8 * 8, 7 * 8, 7 * 8},


### PR DESCRIPTION
Added a Zoom option to the pop up menu (replacing the unimplemented Copy button for now) for those of us having difficulty seeing the small 5x8 font characters.

I inadvertently included another change I was fiddling with on line 175 of the .cpp file, to reposition the cursor to column 0 if the Right button is pressed when on the last character of the file.  I don't think it hurts anything but I can definitely back that one out (or make any other changes that you suggest) if you don't like it.

@kallanreed  Please review.