### PR TITLE
Fix up Waterfall control names

### DIFF
--- a/firmware/application/apps/analog_audio_app.hpp
+++ b/firmware/application/apps/analog_audio_app.hpp
@@ -213,7 +213,7 @@ class AnalogAudioView : public View {
         4096,
         4};
 
-    spectrum::WaterfallWidget waterfall{true};
+    spectrum::WaterfallView waterfall{true};
 
     void on_baseband_bandwidth_changed(uint32_t bandwidth_hz);
     void on_modulation_changed(ReceiverModel::Mode modulation);

--- a/firmware/application/apps/capture_app.hpp
+++ b/firmware/application/apps/capture_app.hpp
@@ -97,7 +97,7 @@ class CaptureAppView : public View {
         16384,
         3};
 
-    spectrum::WaterfallWidget waterfall{};
+    spectrum::WaterfallView waterfall{};
 };
 
 } /* namespace ui */

--- a/firmware/application/apps/gps_sim_app.hpp
+++ b/firmware/application/apps/gps_sim_app.hpp
@@ -124,7 +124,7 @@ class GpsSimAppView : public View {
         Color::green(),
         Color::black()};
 
-    spectrum::WaterfallWidget waterfall{};
+    spectrum::WaterfallView waterfall{};
 
     MessageHandlerRegistration message_handler_replay_thread_error{
         Message::ID::ReplayThreadDone,

--- a/firmware/application/apps/replay_app.hpp
+++ b/firmware/application/apps/replay_app.hpp
@@ -121,7 +121,7 @@ class ReplayAppView : public View {
         Color::green(),
         Color::black()};
 
-    spectrum::WaterfallWidget waterfall{};
+    spectrum::WaterfallView waterfall{};
 
     MessageHandlerRegistration message_handler_replay_thread_error{
         Message::ID::ReplayThreadDone,

--- a/firmware/application/apps/spectrum_analysis_app.hpp
+++ b/firmware/application/apps/spectrum_analysis_app.hpp
@@ -32,7 +32,7 @@ class SpectrumAnalysisModel {
 
 namespace ui {
 
-class SpectrumAnalysisView : public spectrum::WaterfallWidget {
+class SpectrumAnalysisView : public spectrum::WaterfallView {
    public:
    private:
     SpectrumAnalysisModel model;

--- a/firmware/application/apps/ui_playlist.hpp
+++ b/firmware/application/apps/ui_playlist.hpp
@@ -188,7 +188,7 @@ class PlaylistView : public View {
         &bitmap_icon_save,
         Color::dark_blue()};
 
-    spectrum::WaterfallWidget waterfall{};
+    spectrum::WaterfallView waterfall{};
 
     MessageHandlerRegistration message_handler_replay_thread_error{
         Message::ID::ReplayThreadDone,

--- a/firmware/application/ui/ui_spectrum.cpp
+++ b/firmware/application/ui/ui_spectrum.cpp
@@ -36,7 +36,7 @@ using namespace portapack;
 namespace ui {
 namespace spectrum {
 
-/* AudioSpectrumView******************************************************/
+/* AudioSpectrumView ******************************************************/
 
 AudioSpectrumView::AudioSpectrumView(
     const Rect parent_rect)
@@ -247,28 +247,25 @@ void FrequencyScale::on_tick_second() {
     _blink = !_blink;
 }
 
-/* WaterfallView *********************************************************/
+/* WaterfallWidget *********************************************************/
+// TODO: buffer and use "paint" instead of immediate drawing would help with
+// preventing flicker from drawing. Would use more RAM however.
 
-void WaterfallView::on_show() {
+void WaterfallWidget::on_show() {
     clear();
 
     const auto screen_r = screen_rect();
     display.scroll_set_area(screen_r.top(), screen_r.bottom());
 }
 
-void WaterfallView::on_hide() {
+void WaterfallWidget::on_hide() {
     /* TODO: Clear region to eliminate brief flash of content at un-shifted
      * position?
      */
     display.scroll_disable();
 }
 
-void WaterfallView::paint(Painter& painter) {
-    // Do nothing.
-    (void)painter;
-}
-
-void WaterfallView::on_channel_spectrum(
+void WaterfallWidget::on_channel_spectrum(
     const ChannelSpectrum& spectrum) {
     /* TODO: static_assert that message.spectrum.db.size() >= pixel_row.size() */
 
@@ -290,16 +287,16 @@ void WaterfallView::on_channel_spectrum(
         pixel_row);
 }
 
-void WaterfallView::clear() {
+void WaterfallWidget::clear() {
     display.fill_rectangle(
         screen_rect(),
         Color::black());
 }
 
-/* WaterfallWidget *******************************************************/
+/* WaterfallView *******************************************************/
 
-WaterfallWidget::WaterfallWidget(const bool cursor) {
-    add_children({&waterfall_view,
+WaterfallView::WaterfallView(const bool cursor) {
+    add_children({&waterfall_widget,
                   &frequency_scale});
 
     frequency_scale.set_focusable(cursor);
@@ -310,17 +307,17 @@ WaterfallWidget::WaterfallWidget(const bool cursor) {
     };
 }
 
-void WaterfallWidget::on_show() {
+void WaterfallView::on_show() {
     // TODO: Assert that baseband is not shutdown.
     baseband::spectrum_streaming_start();
 }
 
-void WaterfallWidget::on_hide() {
+void WaterfallView::on_hide() {
     // TODO: Assert that baseband is not shutdown.
     baseband::spectrum_streaming_stop();
 }
 
-void WaterfallWidget::show_audio_spectrum_view(const bool show) {
+void WaterfallView::show_audio_spectrum_view(const bool show) {
     if ((audio_spectrum_view && show) || (!audio_spectrum_view && !show)) return;
 
     if (show) {
@@ -335,18 +332,18 @@ void WaterfallWidget::show_audio_spectrum_view(const bool show) {
     }
 }
 
-void WaterfallWidget::update_widgets_rect() {
+void WaterfallView::update_widgets_rect() {
     if (audio_spectrum_view) {
         frequency_scale.set_parent_rect({0, audio_spectrum_height, screen_rect().width(), scale_height});
-        waterfall_view.set_parent_rect(waterfall_reduced_rect);
+        waterfall_widget.set_parent_rect(waterfall_reduced_rect);
     } else {
         frequency_scale.set_parent_rect({0, 0, screen_rect().width(), scale_height});
-        waterfall_view.set_parent_rect(waterfall_normal_rect);
+        waterfall_widget.set_parent_rect(waterfall_normal_rect);
     }
-    waterfall_view.on_show();
+    waterfall_widget.on_show();
 }
 
-void WaterfallWidget::set_parent_rect(const Rect new_parent_rect) {
+void WaterfallView::set_parent_rect(const Rect new_parent_rect) {
     View::set_parent_rect(new_parent_rect);
 
     waterfall_normal_rect = {0, scale_height, new_parent_rect.width(), new_parent_rect.height() - scale_height};
@@ -355,13 +352,8 @@ void WaterfallWidget::set_parent_rect(const Rect new_parent_rect) {
     update_widgets_rect();
 }
 
-void WaterfallWidget::paint(Painter& painter) {
-    // TODO:
-    (void)painter;
-}
-
-void WaterfallWidget::on_channel_spectrum(const ChannelSpectrum& spectrum) {
-    waterfall_view.on_channel_spectrum(spectrum);
+void WaterfallView::on_channel_spectrum(const ChannelSpectrum& spectrum) {
+    waterfall_widget.on_channel_spectrum(spectrum);
     sampling_rate = spectrum.sampling_rate;
     frequency_scale.set_spectrum_sampling_rate(sampling_rate);
     frequency_scale.set_channel_filter(
@@ -370,7 +362,7 @@ void WaterfallWidget::on_channel_spectrum(const ChannelSpectrum& spectrum) {
         spectrum.channel_filter_transition);
 }
 
-void WaterfallWidget::on_audio_spectrum() {
+void WaterfallView::on_audio_spectrum() {
     audio_spectrum_view->on_audio_spectrum(audio_spectrum_data);
 }
 

--- a/firmware/application/ui/ui_spectrum.hpp
+++ b/firmware/application/ui/ui_spectrum.hpp
@@ -108,12 +108,11 @@ class FrequencyScale : public Widget {
  * If the baseband is shutdown or otherwise not running when interacting
  * with these, they will almost certainly hang the device. */
 
-class WaterfallView : public Widget {
+class WaterfallWidget : public Widget {
    public:
     void on_show() override;
     void on_hide() override;
-
-    void paint(Painter& painter) override;
+    void paint(Painter&) override {}
 
     void on_channel_spectrum(const ChannelSpectrum& spectrum);
 
@@ -121,16 +120,16 @@ class WaterfallView : public Widget {
     void clear();
 };
 
-class WaterfallWidget : public View {
+class WaterfallView : public View {
    public:
     std::function<void(int32_t offset)> on_select{};
 
-    WaterfallWidget(const bool cursor = false);
+    WaterfallView(const bool cursor = false);
 
-    WaterfallWidget(const WaterfallWidget&) = delete;
-    WaterfallWidget(WaterfallWidget&&) = delete;
-    WaterfallWidget& operator=(const WaterfallWidget&) = delete;
-    WaterfallWidget& operator=(WaterfallWidget&&) = delete;
+    WaterfallView(const WaterfallView&) = delete;
+    WaterfallView(WaterfallView&&) = delete;
+    WaterfallView& operator=(const WaterfallView&) = delete;
+    WaterfallView& operator=(WaterfallView&&) = delete;
 
     void on_show() override;
     void on_hide() override;
@@ -139,8 +138,6 @@ class WaterfallWidget : public View {
 
     void show_audio_spectrum_view(const bool show);
 
-    void paint(Painter& painter) override;
-
    private:
     void update_widgets_rect();
 
@@ -148,7 +145,7 @@ class WaterfallWidget : public View {
     static constexpr Dim audio_spectrum_height = 16 * 2 + 20;
     static constexpr Dim scale_height = 20;
 
-    WaterfallView waterfall_view{};
+    WaterfallWidget waterfall_widget{};
     FrequencyScale frequency_scale{};
 
     ChannelSpectrumFIFO* channel_fifo{nullptr};


### PR DESCRIPTION
It bugged me that the WaterfallWidget was a View and the WaterfallView was a Widget. This just fixes up the names.