### PR TITLE
Set modulation type in AIS, Sonde, TPMS, and ERT

### DIFF
--- a/firmware/application/apps/ais_app.cpp
+++ b/firmware/application/apps/ais_app.cpp
@@ -385,6 +385,7 @@ AISAppView::AISAppView(NavigationView& nav)
     if (!settings_.loaded())
         receiver_model.set_target_frequency(initial_target_frequency);
 
+    receiver_model.set_modulation(ReceiverModel::Mode::NarrowbandFMAudio);
     receiver_model.enable();
 
     options_channel.on_change = [this](size_t, OptionsField::value_t v) {

--- a/firmware/application/apps/ert_app.cpp
+++ b/firmware/application/apps/ert_app.cpp
@@ -113,6 +113,7 @@ ERTAppView::ERTAppView(NavigationView&) {
     if (!settings_.loaded())
         receiver_model.set_target_frequency(initial_target_frequency);
 
+    receiver_model.set_modulation(ReceiverModel::Mode::AMAudio);
     receiver_model.enable();
 
     logger = std::make_unique<ERTLogger>();

--- a/firmware/application/apps/ert_app.cpp
+++ b/firmware/application/apps/ert_app.cpp
@@ -113,6 +113,7 @@ ERTAppView::ERTAppView(NavigationView&) {
     if (!settings_.loaded())
         receiver_model.set_target_frequency(initial_target_frequency);
 
+    receiver_model.set_modulation(ReceiverModel::Mode::NarrowbandFMAudio);
     receiver_model.enable();
 
     logger = std::make_unique<ERTLogger>();

--- a/firmware/application/apps/ert_app.cpp
+++ b/firmware/application/apps/ert_app.cpp
@@ -113,7 +113,6 @@ ERTAppView::ERTAppView(NavigationView&) {
     if (!settings_.loaded())
         receiver_model.set_target_frequency(initial_target_frequency);
 
-    receiver_model.set_modulation(ReceiverModel::Mode::NarrowbandFMAudio);
     receiver_model.enable();
 
     logger = std::make_unique<ERTLogger>();

--- a/firmware/application/apps/tpms_app.cpp
+++ b/firmware/application/apps/tpms_app.cpp
@@ -160,7 +160,6 @@ TPMSAppView::TPMSAppView(NavigationView&) {
     if (!settings_.loaded())
         receiver_model.set_target_frequency(initial_target_frequency);
 
-    receiver_model.set_modulation(ReceiverModel::Mode::NarrowbandFMAudio);
     receiver_model.enable();
 
     options_band.on_change = [this](size_t, OptionsField::value_t v) {

--- a/firmware/application/apps/tpms_app.cpp
+++ b/firmware/application/apps/tpms_app.cpp
@@ -160,6 +160,7 @@ TPMSAppView::TPMSAppView(NavigationView&) {
     if (!settings_.loaded())
         receiver_model.set_target_frequency(initial_target_frequency);
 
+    receiver_model.set_modulation(ReceiverModel::Mode::NarrowbandFMAudio);
     receiver_model.enable();
 
     options_band.on_change = [this](size_t, OptionsField::value_t v) {

--- a/firmware/application/apps/tpms_app.cpp
+++ b/firmware/application/apps/tpms_app.cpp
@@ -160,6 +160,7 @@ TPMSAppView::TPMSAppView(NavigationView&) {
     if (!settings_.loaded())
         receiver_model.set_target_frequency(initial_target_frequency);
 
+    receiver_model.set_modulation(ReceiverModel::Mode::AMAudio);
     receiver_model.enable();
 
     options_band.on_change = [this](size_t, OptionsField::value_t v) {

--- a/firmware/application/apps/ui_sonde.cpp
+++ b/firmware/application/apps/ui_sonde.cpp
@@ -85,6 +85,7 @@ SondeView::SondeView(NavigationView& nav)
         use_crc = v;
     };
 
+    receiver_model.set_modulation(ReceiverModel::Mode::NarrowbandFMAudio);
     receiver_model.enable();
 
     // QR code with geo URI


### PR DESCRIPTION
Quick workaround proposal for issue #1233.  Force modulation to something other than Spec for a few apps that weren't setting it.  Currently RadioState does not include a modulation setting, and we can't rely on the modulation to be set correctly from the previous app.  We can't rely on Load App Settings either since the .ini file might not exist or may contain the wrong modulation value (e.g. if the .ini file was saved by older firmware).

Note that the baseband code for these apps is hard-coded to receive a specific modulation, so baseband doesn't care what the modulation is set to for these apps; HOWEVER the Spec modulation setting disables the "tuning_offset" value.  So if we still want the receiver tuning_offset then we need to set the modulation to anything other than Spec.

Modifying RadioState would probably be better, but this can solve the issue #1233 in the mean time.