### PR TITLE
Support for viewing BMP files in File Manager and setting as Splash screen

### DIFF
--- a/firmware/application/apps/ui_fileman.cpp
+++ b/firmware/application/apps/ui_fileman.cpp
@@ -41,6 +41,7 @@ static const fs::path txt_ext{u".TXT"};
 static const fs::path ppl_ext{u".PPL"};
 static const fs::path c16_ext{u".C16"};
 static const fs::path png_ext{u".PNG"};
+static const fs::path bmp_ext{u".BMP"};
 }  // namespace ui
 
 namespace {
@@ -502,6 +503,10 @@ bool FileManagerView::handle_file_open() {
         return true;
     } else if (path_iequal(png_ext, ext)) {
         nav_.push<ScreenshotViewer>(path);
+        return true;
+    } else if (path_iequal(bmp_ext, ext)) {
+        nav_.push<SplashViewer>(path);
+        reload_current();
         return true;
     }
 

--- a/firmware/application/apps/ui_ss_viewer.cpp
+++ b/firmware/application/apps/ui_ss_viewer.cpp
@@ -26,6 +26,8 @@ namespace fs = std::filesystem;
 
 namespace ui {
 
+const std::filesystem::path splash_dot_bmp{u"/splash.bmp"};
+
 ScreenshotViewer::ScreenshotViewer(
     NavigationView& nav,
     const std::filesystem::path& path)
@@ -40,11 +42,9 @@ bool ScreenshotViewer::on_key(KeyEvent) {
 }
 
 void ScreenshotViewer::paint(Painter& painter) {
-    constexpr size_t pixel_width = 240;
-    constexpr size_t pixel_height = 320;
     File file{};
 
-    painter.fill_rectangle({0, 0, pixel_width, pixel_height}, Color::black());
+    painter.fill_rectangle({0, 0, screen_width, screen_height}, Color::black());
 
     auto show_invalid = [&]() {
         painter.draw_string({10, 160}, Styles::white, "Not a valid screenshot.");
@@ -65,19 +65,19 @@ void ScreenshotViewer::paint(Painter& painter) {
     constexpr size_t read_chunk = 80;  // NB: must be a factor of pixel_width.
     constexpr size_t buffer_size = sizeof(ColorRGB888) * read_chunk;
     uint8_t buffer[buffer_size];
-    std::array<Color, pixel_width> pixel_data;
+    std::array<Color, screen_width> pixel_data;
 
     // Seek past all the headers.
     file.seek(43);
 
-    for (auto line = 0u; line < pixel_height; ++line) {
+    for (auto line = 0u; line < screen_height; ++line) {
         // Seek past the per-line header.
         file.seek(file.tell() + 6);
 
         // Per comment in PNGWriter, read in chunks of 80.
         // NB: Reading in one large chunk caused corruption so there's
         // likely a bug lurking in the SD Card/FatFs layer.
-        for (auto offset = 0u; offset < pixel_width; offset += read_chunk) {
+        for (auto offset = 0u; offset < screen_width; offset += read_chunk) {
             auto read = file.read(buffer, buffer_size);
 
             if (!read || *read != buffer_size) {
@@ -92,7 +92,7 @@ void ScreenshotViewer::paint(Painter& painter) {
             }
         }
 
-        display.draw_pixels({0, (int)line, pixel_width, 1}, pixel_data);
+        display.draw_pixels({0, (int)line, screen_width, 1}, pixel_data);
     }
 }
 
@@ -116,10 +116,7 @@ bool SplashViewer::on_key(const KeyEvent key) {
 }
 
 void SplashViewer::paint(Painter& painter) {
-    constexpr size_t pixel_width = 240;
-    constexpr size_t pixel_height = 320;
-
-    painter.fill_rectangle({0, 0, pixel_width, pixel_height}, Color::black());
+    painter.fill_rectangle({0, 0, screen_width, screen_height}, Color::black());
 
     if (!portapack::display.drawBMP2({0, 0}, path_)) {
         painter.draw_string({10, 160}, Styles::white, "Not a valid splash image.");

--- a/firmware/application/apps/ui_ss_viewer.cpp
+++ b/firmware/application/apps/ui_ss_viewer.cpp
@@ -96,4 +96,41 @@ void ScreenshotViewer::paint(Painter& painter) {
     }
 }
 
+SplashViewer::SplashViewer(
+    NavigationView& nav,
+    const std::filesystem::path& path)
+    : nav_{nav},
+      path_{path} {
+    valid_image = false;
+    set_focusable(true);
+}
+
+bool SplashViewer::on_key(const KeyEvent key) {
+    if (valid_image && key == KeyEvent::Right) {
+        delete_file(splash_dot_bmp);
+        copy_file(path_, splash_dot_bmp);
+    }
+
+    nav_.pop();
+    return true;
+}
+
+void SplashViewer::paint(Painter& painter) {
+    constexpr size_t pixel_width = 240;
+    constexpr size_t pixel_height = 320;
+
+    painter.fill_rectangle({0, 0, pixel_width, pixel_height}, Color::black());
+
+    if (!portapack::display.drawBMP2({0, 0}, path_)) {
+        painter.draw_string({10, 160}, Styles::white, "Not a valid splash image.");
+        return;
+    }
+
+    // Show option to set splash screen if it's not already the splash screen
+    if (!path_iequal(path_, splash_dot_bmp)) {
+        painter.draw_string({0, 0}, Styles::white, "*RIGHT BUTTON UPDATES SPLASH*");
+        valid_image = true;
+    }
+}
+
 }  // namespace ui

--- a/firmware/application/apps/ui_ss_viewer.hpp
+++ b/firmware/application/apps/ui_ss_viewer.hpp
@@ -31,7 +31,7 @@
 
 namespace ui {
 
-static const std::filesystem::path splash_dot_bmp{u"/splash.bmp"};
+extern const std::filesystem::path splash_dot_bmp;
 
 class ScreenshotViewer : public View {
    public:

--- a/firmware/application/apps/ui_ss_viewer.hpp
+++ b/firmware/application/apps/ui_ss_viewer.hpp
@@ -31,6 +31,8 @@
 
 namespace ui {
 
+static const std::filesystem::path splash_dot_bmp{u"/splash.bmp"};
+
 class ScreenshotViewer : public View {
    public:
     ScreenshotViewer(NavigationView& nav, const std::filesystem::path& path);
@@ -40,6 +42,19 @@ class ScreenshotViewer : public View {
    private:
     NavigationView& nav_;
     std::filesystem::path path_{};
+};
+
+class SplashViewer : public View {
+   public:
+    SplashViewer(NavigationView& nav, const std::filesystem::path& path);
+    bool on_key(KeyEvent key) override;
+    void paint(Painter& painter) override;
+    void update_ss(void);
+
+   private:
+    NavigationView& nav_;
+    std::filesystem::path path_{};
+    bool valid_image{};
 };
 
 }  // namespace ui

--- a/firmware/application/ui_navigation.cpp
+++ b/firmware/application/ui_navigation.cpp
@@ -77,6 +77,7 @@
 #include "ui_flash_utility.hpp"
 #include "ui_sd_over_usb.hpp"
 #include "ui_spectrum_painter.hpp"
+#include "ui_ss_viewer.hpp"
 
 // #include "acars_app.hpp"
 #include "ais_app.hpp"
@@ -734,7 +735,7 @@ BMPView::BMPView(NavigationView& nav) {
 }
 
 void BMPView::paint(Painter&) {
-    if (!portapack::display.drawBMP2({0, 0}, "splash.bmp"))
+    if (!portapack::display.drawBMP2({0, 0}, splash_dot_bmp))
         portapack::display.drawBMP({(240 - 230) / 2, (320 - 50) / 2 - 10}, splash_bmp, false);
 }
 

--- a/firmware/common/lcd_ili9341.cpp
+++ b/firmware/common/lcd_ili9341.cpp
@@ -412,7 +412,7 @@ void ILI9341::drawBMP(const ui::Point p, const uint8_t* bitmap, const bool trans
                 24bpp RGB
                 32bpp ARGB
 */
-bool ILI9341::drawBMP2(const ui::Point p, const std::string file) {
+bool ILI9341::drawBMP2(const ui::Point p, const std::filesystem::path& file) {
     File bmpimage;
     size_t file_pos = 0;
     uint16_t pointer = 0;

--- a/firmware/common/lcd_ili9341.hpp
+++ b/firmware/common/lcd_ili9341.hpp
@@ -25,6 +25,7 @@
 
 #include "ui.hpp"
 #include "ui_text.hpp"
+#include "file.hpp"
 
 #include <cstdint>
 #include <array>
@@ -58,7 +59,7 @@ class ILI9341 {
 
     void draw_pixel(const ui::Point p, const ui::Color color);
     void drawBMP(const ui::Point p, const uint8_t* bitmap, const bool transparency);
-    bool drawBMP2(const ui::Point p, const std::string file);
+    bool drawBMP2(const ui::Point p, const std::filesystem::path& file);
     void render_line(const ui::Point p, const uint8_t count, const ui::Color* line_buffer);
     void render_box(const ui::Point p, const ui::Size s, const ui::Color* line_buffer);
 


### PR DESCRIPTION
This PR is meant to address enhancement #1238.

Previously, clicking on BMP files in File Manager did nothing.  Now, the BMP file is displayed, and pressing the Right button will cause the displayed image file to be set as the new splash screen (copied over the existing "/splash.bmp").

Only BMP files matching the specific splash screen dimensions are supported (similar to the restrictions on viewing PNG screen-shot files).

A test version of firmware is available on Discord:
https://discord.com/channels/719669764804444213/722101917135798312/1126222765515616387