### PR TITLE
Added fonts viewer (debug) app

### DIFF
--- a/firmware/application/apps/ui_debug.cpp
+++ b/firmware/application/apps/ui_debug.cpp
@@ -496,7 +496,8 @@ void DebugFontsView::paint(Painter& painter) {
     display_font(painter, line_pos + 16, &Styles::white_small, "Fixed 5x8");
 }
 
-DebugFontsView::DebugFontsView(NavigationView& nav): nav_{nav} {
+DebugFontsView::DebugFontsView(NavigationView& nav)
+    : nav_{nav} {
     set_focusable(true);
 }
 

--- a/firmware/application/apps/ui_debug.cpp
+++ b/firmware/application/apps/ui_debug.cpp
@@ -492,20 +492,11 @@ uint16_t DebugFontsView::display_font(Painter& painter, uint16_t y_offset, const
 void DebugFontsView::paint(Painter& painter) {
     int16_t line_pos;
 
-    // 8x16 font
     line_pos = display_font(painter, 32, &Styles::white, "Fixed 8x16");
-
-    // 5x8 font
     display_font(painter, line_pos + 16, &Styles::white_small, "Fixed 5x8");
 }
 
-bool DebugFontsView::on_key(KeyEvent) {
-    nav_.pop();
-    return true;
-}
-
-DebugFontsView::DebugFontsView(NavigationView& nav)
-    : nav_{nav} {
+DebugFontsView::DebugFontsView(NavigationView& nav): nav_{nav} {
     set_focusable(true);
 }
 

--- a/firmware/application/apps/ui_debug.cpp
+++ b/firmware/application/apps/ui_debug.cpp
@@ -504,7 +504,8 @@ bool DebugFontsView::on_key(KeyEvent) {
     return true;
 }
 
-DebugFontsView::DebugFontsView(NavigationView& nav): nav_{nav} {
+DebugFontsView::DebugFontsView(NavigationView& nav)
+    : nav_{nav} {
     set_focusable(true);
 }
 

--- a/firmware/application/apps/ui_debug.cpp
+++ b/firmware/application/apps/ui_debug.cpp
@@ -30,6 +30,9 @@
 #include "audio.hpp"
 
 #include "ui_sd_card_debug.hpp"
+#include "ui_font_fixed_8x16.hpp"
+#include "ui_styles.hpp"
+#include "ui_painter.hpp"
 
 #include "portapack.hpp"
 #include "portapack_persistent_memory.hpp"
@@ -401,6 +404,7 @@ DebugMenuView::DebugMenuView(NavigationView& nav) {
         {"Temperature", ui::Color::dark_cyan(), &bitmap_icon_temperature, [&nav]() { nav.push<TemperatureView>(); }},
         {"Buttons Test", ui::Color::dark_cyan(), &bitmap_icon_controls, [&nav]() { nav.push<DebugControlsView>(); }},
         {"P.Memory", ui::Color::dark_cyan(), &bitmap_icon_memory, [&nav]() { nav.push<DebugPmemView>(); }},
+        {"Fonts Viewer", ui::Color::dark_cyan(), &bitmap_icon_notepad, [&nav]() { nav.push<DebugFontsView>(); }},
         {"Debug Dump", ui::Color::dark_cyan(), &bitmap_icon_memory, [&nav]() { portapack::persistent_memory::debug_dump(); }},
     });
     set_max_rows(2);  // allow wider buttons
@@ -461,6 +465,50 @@ uint32_t DebugPmemView::registers_widget_feed(const size_t register_number) {
     }
     return data.regfile[(page_size * page + register_number) / 4] >> (register_number % 4 * 8);
 }
+
+/* DebugFontsView *******************************************************/
+
+uint16_t DebugFontsView::display_font(Painter& painter, uint16_t y_offset, const Style* font_style, std::string_view font_name) {
+    auto char_width{font_style->font.char_width()};
+    auto char_height{font_style->font.line_height()};
+    auto cpl{((screen_width / char_width) - 6) & 0xF8};  // Display a multiple of 8 characters per line
+    uint16_t line_pos{y_offset};
+
+    painter.draw_string({0, y_offset}, *font_style, font_name);
+
+    // Displaying ASCII+extended characters from 0x20 to 0xFF
+    for (uint8_t c = 0; c <= 0xDF; c++) {
+        line_pos = y_offset + ((c / cpl) + 2) * char_height;
+
+        if ((c % cpl) == 0)
+            painter.draw_string({0, line_pos}, *font_style, "Ox" + to_string_hex(c + 0x20, 2));
+
+        painter.draw_char({((c % cpl) + 5) * char_width, line_pos}, *font_style, (char)(c + 0x20));
+    }
+
+    return line_pos + char_height;
+}
+
+void DebugFontsView::paint(Painter& painter) {
+    int16_t line_pos;
+
+    // 8x16 font
+    line_pos = display_font(painter, 32, &Styles::white, "Fixed 8x16");
+
+    // 5x8 font
+    display_font(painter, line_pos + 16, &Styles::white_small, "Fixed 5x8");
+}
+
+bool DebugFontsView::on_key(KeyEvent) {
+    nav_.pop();
+    return true;
+}
+
+DebugFontsView::DebugFontsView(NavigationView& nav): nav_{nav} {
+    set_focusable(true);
+}
+
+/* DebugLCRView *******************************************************/
 
 /*DebugLCRView::DebugLCRView(NavigationView& nav, std::string lcr_string) {
 

--- a/firmware/application/apps/ui_debug.hpp
+++ b/firmware/application/apps/ui_debug.hpp
@@ -313,7 +313,6 @@ class DebugPmemView : public View {
 class DebugFontsView : public View {
    public:
     DebugFontsView(NavigationView& nav);
-    bool on_key(KeyEvent key) override;
     void paint(Painter& painter) override;
     std::string title() const override { return "Fonts"; };
 

--- a/firmware/application/apps/ui_debug.hpp
+++ b/firmware/application/apps/ui_debug.hpp
@@ -310,6 +310,18 @@ class DebugPmemView : public View {
     uint32_t registers_widget_feed(const size_t register_number);
 };
 
+class DebugFontsView : public View {
+   public:
+    DebugFontsView(NavigationView& nav);
+    bool on_key(KeyEvent key) override;
+    void paint(Painter& painter) override;
+    std::string title() const override { return "Fonts"; };
+
+   private:
+    uint16_t display_font(Painter& painter, uint16_t y_offset, const Style* font_style, std::string_view font_name);
+    NavigationView& nav_;
+};
+
 /*class DebugLCRView : public View {
 public:
         DebugLCRView(NavigationView& nav, std::string lcrstring);

--- a/firmware/application/ui/ui_geomap.hpp
+++ b/firmware/application/ui/ui_geomap.hpp
@@ -84,8 +84,8 @@ class GeoPos : public View {
 
     Labels labels_position{
         {{1 * 8, 0 * 16}, "Alt:", Color::light_grey()},
-        {{1 * 8, 1 * 16}, "Lat:    *  '  \"", Color::light_grey()},  // No ° symbol in 8x16 font
-        {{1 * 8, 2 * 16}, "Lon:    *  '  \"", Color::light_grey()},
+        {{1 * 8, 1 * 16}, "Lat:    \x90  '  \"", Color::light_grey()},  // 0x90 is degree ° symbol in our 8x16 font
+        {{1 * 8, 2 * 16}, "Lon:    \x90  '  \"", Color::light_grey()},
     };
 
     NumberField field_altitude{


### PR DESCRIPTION
I wanted to know if the "degree" symbol is available in the 8x16 font (for latitude/longitude coordinates), but symbols such as these didn't show up in the editor when viewing the fixed_8x16_glyph_data.

To answer this question, I added a simple "Fonts Viewer" app in the Debug menu.

(This app is certainly a candidate to be disabled when we're close to running out of ROM space [this is probably true for the glyph data for many of these unused characters as well], but I found it useful so perhaps other developers will as well.)

![SCR_0054](https://github.com/eried/portapack-mayhem/assets/129641948/7a1df9b2-e5cb-4400-b4e1-c740dc4db171)