### PR TITLE
Smaller SD card ZIP

### DIFF
--- a/.github/workflows/create_nightly_release.yml
+++ b/.github/workflows/create_nightly_release.yml
@@ -47,6 +47,9 @@ jobs:
         run: mkdir ${{ github.workspace }}/build
       - name: Run the Docker image
         run: docker run -e VERSION_STRING=${{ steps.version_date.outputs.date }} -i -v ${{ github.workspace }}:/havoc portapack-dev
+      - name: Create Small SD Card ZIP - No World Map
+        run: |
+          mkdir -p sdcard/FIRMWARE && cp build/firmware/portapack-h1_h2-mayhem.bin sdcard/FIRMWARE/portapack-mayhem_${{ steps.version_date.outputs.date }}.bin && zip -r sdcard-no-map.zip sdcard
       - name: Download world map
         run: |
           wget https://github.com/eried/portapack-mayhem/releases/download/world_map/world_map.zip
@@ -102,4 +105,14 @@ jobs:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: ./sdcard.zip
           asset_name: mayhem_nightly_${{ steps.version_date.outputs.date }}_COPY_TO_SDCARD.zip
+          asset_content_type: application/zip
+      - name: Upload SD Card Assets - No Map
+        id: upload-sd-card-asset-no-map 
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./sdcard-no-map.zip
+          asset_name: mayhem_nightly_${{ steps.version_date.outputs.date }}_COPY_TO_SDCARD-no-world-map.zip
           asset_content_type: application/zip

--- a/.github/workflows/create_stable_release.yml
+++ b/.github/workflows/create_stable_release.yml
@@ -31,6 +31,9 @@ jobs:
         run: mkdir ${{ github.workspace }}/build
       - name: Run the Docker image
         run: docker run -e VERSION_STRING=${{ steps.version.outputs.version }} -i -v ${{ github.workspace }}:/havoc portapack-dev
+      - name: Create Small SD Card ZIP - No World Map
+        run: |
+          mkdir -p sdcard/FIRMWARE && cp build/firmware/portapack-h1_h2-mayhem.bin sdcard/FIRMWARE/portapack-mayhem_${{ steps.version.outputs.version }}.bin && zip -r sdcard-no-map.zip sdcard
       - name: Download world map
         run: |
           wget https://github.com/eried/portapack-mayhem/releases/download/world_map/world_map.zip
@@ -95,5 +98,15 @@ jobs:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: ./sdcard.zip
           asset_name: mayhem_${{ steps.version.outputs.version }}_COPY_TO_SDCARD.zip
+          asset_content_type: application/zip
+      - name: Upload SD Card Assets - No Map
+        id: upload-sd-card-asset-no-map 
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./sdcard-no-map.zip
+          asset_name: mayhem_${{ steps.version.outputs.version }}_COPY_TO_SDCARD-no-world-map.zip
           asset_content_type: application/zip
      


### PR DESCRIPTION
Based on https://github.com/eried/portapack-mayhem/issues/1248 some users want an SD card zip file that does not include the world map for faster downloads. This PR gives them that option as now it has both the normal one with the world map bin and now a smaller one which just does not contain the world map bin

![image](https://github.com/eried/portapack-mayhem/assets/4393979/f52978f5-3594-4666-9da1-08339d627d0b)
