### PR TITLE
fix pining/mentioning unrelated user in changelog

### DIFF
--- a/.github/workflows/changelog.py
+++ b/.github/workflows/changelog.py
@@ -2,18 +2,29 @@ import os
 import re
 import sys
 
-raw_git = os.popen('git log next --since="24 hours" --pretty=format:"- %h - {USERNAME}*+%al-%an*: %s"').read()
+raw_git = os.popen('git log next --since="24 hours" --pretty=format:"- %h - {USERNAME}*_%al_%an*: %s"').read()
+# ^ as github's rule, a real username can contains "-" but not "_" and "*", so use these two to seperate things
 
+# during test at 2023-07-10, %al could return 3 different types of values:
+# 123+abc
+# def@ghi.mgl+abc
+# abc
+# admin
+# ^ abc is real username, note that github will probably change in the future!!!
 
 def compute_username(line):
-    stripped = re.search(r'(?<=\*)(.*?)(?=\*)', line).group(0)
+    stripped = re.search(r'(?<=\*)(.*?)(?=\*)', line).group(0) # get the string between "*" and "*"
+    stripped_org = stripped
+    stripped = re.search(r'(?<=\_)(.*?)(?=\_)', stripped).group(0) # get the string between "_" and "_"
+    # now it's like "123+abc" or "def@ghi+mgl+abc" or "abc" or "admin"
 
-    pattern = re.compile("[$@+&?].*[$@+&?]")
-    if pattern.match(stripped):
-        stripped = re.sub("[$@+&?].*[$@+&?]", "", stripped)
-        stripped = re.match(r'.+?(?=-)', stripped).group(0)
-    else:
-        stripped = re.sub(r'^.*?-', "", stripped)
+    if ("+" in stripped): # like 123+abc or def@ghi.mgl+abc
+        stripped = re.sub(r'^.*?\+', "", stripped)
+    elif (stripped == "admin"):
+        # remove "_admin_" from stripped_org and return "@" + stripped_org
+        stripped = re.sub(r'_admin_', "", stripped_org)
+    else: # like abc or exception
+        pass
     return "@" + stripped
 
 

--- a/.github/workflows/stable_changelog.py
+++ b/.github/workflows/stable_changelog.py
@@ -4,18 +4,29 @@ import sys
 
 past_version = sys.argv[1]
 
-raw_git = os.popen('git log ' + past_version + '..next --pretty=format:"- %h - {USERNAME}*+%al-%an*: %s"').read()
+raw_git = os.popen('git log ' + past_version + '..next --pretty=format:"- %h - {USERNAME}*_%al_%an*: %s"').read()
+# ^ as github's rule, a real username can contains "-" but not "_" and "*", so use these two to seperate things
 
+# during test at 2023-07-10, %al could return 3 different types of values:
+# 123+abc
+# def@ghi.mgl+abc
+# abc
+# admin
+# ^ abc is real username, note that github will probably change in the future!!!
 
 def compute_username(line):
-    stripped = re.search(r'(?<=\*)(.*?)(?=\*)', line).group(0)
+    stripped = re.search(r'(?<=\*)(.*?)(?=\*)', line).group(0) # get the string between "*" and "*"
+    stripped_org = stripped
+    stripped = re.search(r'(?<=\_)(.*?)(?=\_)', stripped).group(0) # get the string between "_" and "_"
+    # now it's like "123+abc" or "def@ghi+mgl+abc" or "abc" or "admin"
 
-    pattern = re.compile("[$@+&?].*[$@+&?]")
-    if pattern.match(stripped):
-        stripped = re.sub("[$@+&?].*[$@+&?]", "", stripped)
-        stripped = re.match(r'.+?(?=-)', stripped).group(0)
-    else:
-        stripped = re.sub(r'^.*?-', "", stripped)
+    if ("+" in stripped): # like 123+abc or def@ghi.mgl+abc
+        stripped = re.sub(r'^.*?\+', "", stripped)
+    elif (stripped == "admin"):
+        # remove "_admin_" from stripped_org and return "@" + stripped_org
+        stripped = re.sub(r'_admin_', "", stripped_org)
+    else: # like abc or exception
+        pass
     return "@" + stripped
 
 


### PR DESCRIPTION
don't merge, waiting @jLynx to do more test before merging.  

A not solvable issue: it doesn't correctly mention @u-foka (before and after my change)
It's there before this change, and since git log returns `tamas-E.T` for doing `git log --pretty=format:"%al-%an"`   
which doesn't contains @u-foka 's username at all, so it seems can't be resolved and it's not at my side.    
moreover, i tried all placeholder below:  

`%cn` return `E******* T*****`  (i blacked out the real name here)  
`%an` return `E.T`  
`%ce` return `*******@******.hu`  (i blacked out the email here)  

there's no any placeholder can get his name. So it seems not at my side and can't be resolved. 