### PR TITLE
Changelog fix 3rd way

### DIFF
--- a/.github/workflows/changelog.py
+++ b/.github/workflows/changelog.py
@@ -2,6 +2,7 @@ import os
 import re
 import sys
 import json
+from urllib.error import HTTPError
 
 main_repo_url = "https://github.com/eried/portapack-mayhem.git"
 main_repo_identifier = "eried/portapack-mayhem"
@@ -9,7 +10,7 @@ main_repo_identifier = "eried/portapack-mayhem"
 
 os.system('gh repo set-default ' + main_repo_url)
 
-raw_git = os.popen('git log next --since="24 hours" --pretty=format:"- ^%h^ - {USERNAME}*_%al_%an*: %s"').read()
+raw_git = os.popen('git log next --since="1200 hours" --pretty=format:"- ^%h^ - {USERNAME}*_%al_%an*: %s"').read()
 
 
 # ^ as github's rule, a real username can contains "-" but not "_" and "*", so use these two to seperate things.
@@ -57,16 +58,22 @@ def compile_line(line):
 
 
 def extract_first_login(json_data):
-    data = json.loads(json_data)
+    if not json_data:  # if returned null
+        return None
 
-    # if json is 403, return False
-    if isinstance(data, dict) and any("API rate limit exceeded for user ID" in value for value in data.values()):
-        return False
+    try:
+        data = json.loads(json_data)
 
-    if isinstance(data, list) and len(data) > 0:
-        first_object = data[0]
-        if 'author' in first_object and 'login' in first_object['author']:
-            return first_object['author']['login']
+        if isinstance(data, list) and len(data) > 0:
+            first_object = data[0]
+            if 'author' in first_object and 'login' in first_object['author']:
+                return first_object['author']['login']
+
+    except HTTPError as e:
+        if e.code == 403 and "API rate limit exceeded" in str(e):
+            return False
+    except json.decoder.JSONDecodeError:
+        return None
 
     return None
 

--- a/.github/workflows/create_nightly_release.yml
+++ b/.github/workflows/create_nightly_release.yml
@@ -63,6 +63,8 @@ jobs:
         run: |
           mkdir -p sdcard/FIRMWARE && cp build/firmware/portapack-h1_h2-mayhem.bin sdcard/FIRMWARE/portapack-mayhem_${{ steps.version_date.outputs.date }}.bin && zip -r sdcard.zip sdcard
       - name: Create changelog
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
         run: |
           CHANGELOG=$(python3 .github/workflows/changelog.py)
           CHANGELOG="${CHANGELOG//'%'/'%25'}"

--- a/.github/workflows/create_stable_release.yml
+++ b/.github/workflows/create_stable_release.yml
@@ -47,6 +47,8 @@ jobs:
         run: |
           mkdir -p sdcard/FIRMWARE && cp build/firmware/portapack-h1_h2-mayhem.bin sdcard/FIRMWARE/portapack-mayhem_${{ steps.version.outputs.version }}.bin && zip -r sdcard.zip sdcard
       - name: Create changelog
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
         run: |
           CHANGELOG=$(python3 .github/workflows/stable_changelog.py ${{ steps.past_version.outputs.past_version }})
           CHANGELOG="${CHANGELOG//'%'/'%25'}"

--- a/.github/workflows/stable_changelog.py
+++ b/.github/workflows/stable_changelog.py
@@ -5,6 +5,7 @@ import sys
 past_version = sys.argv[1]
 
 raw_git = os.popen('git log ' + past_version + '..next --pretty=format:"- %h - {USERNAME}*+%al-%an*: %s"').read()
+raw_merge_log = os.popen('git log ' + past_version + '..next --merges --pretty=format:"%s"').read()
 
 
 def compute_username(line):
@@ -26,5 +27,30 @@ def compile_line(line):
     return line
 
 
+def merge_log_line_to_author_username(line):
+    if re.search(r'Merge pull request #\d+ from ([A-Za-z\d-]+)', line) is None:
+        return None
+    return "@" + re.search(r'Merge pull request #\d+ from ([A-Za-z\d-]+)/([A-Za-z\d-]+)', line).group(1)
+
+
+def rank_authors():
+    authors = {}
+    for name_item in raw_merge_log.splitlines():
+        author = merge_log_line_to_author_username(name_item)
+        if author is None:
+            continue
+        if author in authors:
+            authors[author] += 1
+        else:
+            authors[author] = 1
+    return authors
+
+
 for row in raw_git.splitlines():
     print(compile_line(row))
+
+print("\n\ncontributors:")
+
+authors = rank_authors()
+for author in authors:
+    print(author + " : " + str(authors[author]) + " PRs")

--- a/.github/workflows/stable_changelog.py
+++ b/.github/workflows/stable_changelog.py
@@ -4,7 +4,7 @@ import sys
 
 past_version = sys.argv[1]
 
-raw_git = os.popen('git log ' + past_version + '..next --pretty=format:"- %h - {USERNAME}*+%al-%an*: %s"').read()
+raw_git = os.popen('git log ' + past_version + '..next --pretty=format:"- %h - *+%al-%an*: %s"').read()
 raw_merge_log = os.popen('git log ' + past_version + '..next --merges --pretty=format:"%s"').read()
 
 
@@ -23,7 +23,6 @@ def compute_username(line):
 def compile_line(line):
     username = compute_username(line)
     line = re.sub(r'[*].*[*]', "", line)
-    line = line.replace("{USERNAME}", username)
     return line
 
 

--- a/.github/workflows/stable_changelog.py
+++ b/.github/workflows/stable_changelog.py
@@ -1,55 +1,76 @@
 import os
 import re
 import sys
+import json
 
 past_version = sys.argv[1]
 
-raw_git = os.popen('git log ' + past_version + '..next --pretty=format:"- %h - *+%al-%an*: %s"').read()
-raw_merge_log = os.popen('git log ' + past_version + '..next --merges --pretty=format:"%s"').read()
+main_repo_url = "https://github.com/eried/portapack-mayhem.git"
+main_repo_identifier = "eried/portapack-mayhem"
+# ^^&^ change these if main repo changed
 
+os.system('gh repo set-default ' + main_repo_url)
+
+raw_git = os.popen('git log ' + past_version + '..next --pretty=format:"- ^%h^ - {USERNAME}*_%al_%an*: %s"').read()
+
+
+# ^ as github's rule, a real username can contains "-" but not "_" and "*", so use these two to seperate things
+
+# during test at 2023-07-10, %al could return 3 different types of values:
+# 123+abc <<<< abc is real username
+# def <<<< def is 3rd level domain of unhidden email, drop this, fetch info from github cli client
+# note that github will probably change in the future
 
 def compute_username(line):
-    stripped = re.search(r'(?<=\*)(.*?)(?=\*)', line).group(0)
+    line_org = line
+    stripped = re.search(r'(?<=\*)(.*?)(?=\*)', line).group(0)  # get the string between "*" and "*"
+    now_item_hash = re.search(r'(?<=\^)(.*?)(?=\^)', line).group(0)  # get the string between "*" and "*"
+    stripped_org = stripped
+    stripped = re.search(r'(?<=\_)(.*?)(?=\_)', stripped).group(0)  # get the string between "_" and "_"
+    stripped_fallback = stripped
+    # now it's like "123+abc" or "def"
 
-    pattern = re.compile("[$@+&?].*[$@+&?]")
-    if pattern.match(stripped):
-        stripped = re.sub("[$@+&?].*[$@+&?]", "", stripped)
-        stripped = re.match(r'.+?(?=-)', stripped).group(0)
-    else:
-        stripped = re.sub(r'^.*?-', "", stripped)
+    if ("+" in stripped):  # 123+abc
+        stripped = re.sub(r'^.*?\+', "", stripped)
+    elif not ("+" in stripped):  # maybe not real username, dropped, fetch from github cli client
+        fetched_now_item_json = os.popen(
+            'gh search commits repo:' + main_repo_identifier + ' --json author --hash ' + now_item_hash).read()
+        stripped = extract_first_login(fetched_now_item_json)
+        if stripped is False:  # 403
+            return "@" + stripped_fallback
+        elif stripped == "app/":
+            return "@" + stripped_fallback
+    else:  # exception and edge cases
+        return "@" + stripped_fallback
+
+    if stripped is None:  # if commit hash can't find AKA commit is only in fork
+        return "@" + stripped_fallback
+
     return "@" + stripped
 
 
 def compile_line(line):
     username = compute_username(line)
     line = re.sub(r'[*].*[*]', "", line)
+    line = line.replace("{USERNAME}", username)
+    line = re.sub(r'\^', '', line, count=2)
+
     return line
 
 
-def merge_log_line_to_author_username(line):
-    if re.search(r'Merge pull request #\d+ from ([A-Za-z\d-]+)', line) is None:
-        return None
-    return "@" + re.search(r'Merge pull request #\d+ from ([A-Za-z\d-]+)/([A-Za-z\d-]+)', line).group(1)
+def extract_first_login(json_data):
+    data = json.loads(json_data)
 
+    # if json is 403, return False
+    if isinstance(data, dict) and any("API rate limit exceeded for user ID" in value for value in data.values()):
+        return False
 
-def rank_authors():
-    authors = {}
-    for name_item in raw_merge_log.splitlines():
-        author = merge_log_line_to_author_username(name_item)
-        if author is None:
-            continue
-        if author in authors:
-            authors[author] += 1
-        else:
-            authors[author] = 1
-    return authors
+    if isinstance(data, list) and len(data) > 0:
+        first_object = data[0]
+        if 'author' in first_object and 'login' in first_object['author']:
+            return first_object['author']['login']
+    return None
 
 
 for row in raw_git.splitlines():
     print(compile_line(row))
-
-print("\n\ncontributors:")
-
-authors = rank_authors()
-for author in authors:
-    print(author + " : " + str(authors[author]) + " PRs")


### PR DESCRIPTION
use `github cli client` to correct contributor.
features:
 1. if the result from `git log` is reliable, use it first  
 2. if reach the api call limit, use fallback  
 3. if user use phone app to commit, there's currently no way to identifying by either `github cli app` or `git log`, so fallback. 

![Screenshot_20230711_112143](https://github.com/eried/portapack-mayhem/assets/24917424/8bcaa2d3-8269-4c75-9528-867940edc104)

