### PR TITLE
time counting fix for my last PR

### DIFF
--- a/.github/workflows/changelog.py
+++ b/.github/workflows/changelog.py
@@ -10,7 +10,7 @@ main_repo_identifier = "eried/portapack-mayhem"
 
 os.system('gh repo set-default ' + main_repo_url)
 
-raw_git = os.popen('git log next --since="1200 hours" --pretty=format:"- ^%h^ - {USERNAME}*_%al_%an*: %s"').read()
+raw_git = os.popen('git log next --since="24 hours" --pretty=format:"- ^%h^ - {USERNAME}*_%al_%an*: %s"').read()
 
 
 # ^ as github's rule, a real username can contains "-" but not "_" and "*", so use these two to seperate things.


### PR DESCRIPTION
sorry that when i testing the changelog, i increased the time counting to see more results, and in real PR i forgot to change it back , so now it will track 50 days of change, no deadly harm  
it's my stupid mistake, but if you guys agree, let's keep it once, to test if all the fallback works (since it will trace 50 days of change, long enough for a stressing test)  
and if all looks good in next nightly, merge this, and all returns to normal.  


**but if you guys think it's not elegant, feel free to merge it now, before the nightly released.**