### PR TITLE
Use unicode standard 0xA0-0xFF for Latin 1 characters

### DIFF
--- a/firmware/application/ui/ui_geomap.hpp
+++ b/firmware/application/ui/ui_geomap.hpp
@@ -84,8 +84,8 @@ class GeoPos : public View {
 
     Labels labels_position{
         {{1 * 8, 0 * 16}, "Alt:", Color::light_grey()},
-        {{1 * 8, 1 * 16}, "Lat:    \x90  '  \"", Color::light_grey()},  // 0x90 is degree ° symbol in our 8x16 font
-        {{1 * 8, 2 * 16}, "Lon:    \x90  '  \"", Color::light_grey()},
+        {{1 * 8, 1 * 16}, "Lat:    \xB0  '  \"", Color::light_grey()},  // 0xB0 is degree ° symbol in our 8x16 font
+        {{1 * 8, 2 * 16}, "Lon:    \xB0  '  \"", Color::light_grey()},
     };
 
     NumberField field_altitude{

--- a/firmware/common/ui_text.cpp
+++ b/firmware/common/ui_text.cpp
@@ -24,11 +24,26 @@
 namespace ui {
 
 Glyph Font::glyph(const char c) const {
+    size_t index;
+    
     if (c < c_start) {
+        // Non-display C0 Control characters - map to blank (index 0)
         return {w, h, data};
     }
-    const size_t index = c - c_start;
-    if (index >= c_count) {
+
+    // Handle gap in glyphs table for C1 Control characters 0x80-0x9F
+    if (c < C1_CONTROL_CHARS_START) {
+        // ASCII chars <0x80:
+        index = c - c_start;
+    } else if (c >= C1_CONTROL_CHARS_START + C1_CONTROL_CHARS_COUNT) {
+        // Latin 1 chars 0xA0-0xFF
+        index = c - c_start - C1_CONTROL_CHARS_COUNT;
+    } else {
+        // C1 Control characters - map to blank
+        return {w, h, data};
+    }
+
+    if (index >= c_count) {  // Latin Extended characters > 0xFF - not supported
         return {w, h, data};
     } else {
         return {w, h, &data[index * data_stride]};

--- a/firmware/common/ui_text.cpp
+++ b/firmware/common/ui_text.cpp
@@ -25,7 +25,7 @@ namespace ui {
 
 Glyph Font::glyph(const char c) const {
     size_t index;
-    
+
     if (c < c_start) {
         // Non-display C0 Control characters - map to blank (index 0)
         return {w, h, data};

--- a/firmware/common/ui_text.hpp
+++ b/firmware/common/ui_text.hpp
@@ -28,6 +28,10 @@
 
 #include "ui.hpp"
 
+// C1 Control Characters are an unprintable range of glyphs missing from the font files
+#define C1_CONTROL_CHARS_START 0x80
+#define C1_CONTROL_CHARS_COUNT 32
+
 namespace ui {
 
 class Glyph {


### PR DESCRIPTION
Per discussion on Discord, this changes the character codes for 8x16 font glyphs for Latin 1 characters from the non-standard range 0x80-0xDF to the unicode-standard range 0xA0-0xFF, just in case someone opens a file with such characters in the Notepad app or perhaps one of these characters is used in a file name in File Manager.  It also means that we can use unicode-standard values in print strings to print characters such as the degree symbol (unicode 0xB0).

Note that there are still many unused characters in the 8x16 glyph table that could be commented out to save code space (since they're not currently printable using single-byte character codes), but it seems that my editors all want to remove the special characters, so I purposely did not modify the ui_font_fixed_8x16.cpp file.

The updated font table is shown below (this should now match the Latin 1 unicode table on Wikipedia)
https://en.wikipedia.org/wiki/Latin-1_Supplement

![SCR_0055](https://github.com/eried/portapack-mayhem/assets/129641948/45588b53-8fa2-4016-9bd9-f734072c3d65)
