### PR TITLE
Support showing invalid entries in Freqman and allow minor edits

### DIFF
--- a/firmware/application/apps/ui_freqman.cpp
+++ b/firmware/application/apps/ui_freqman.cpp
@@ -140,7 +140,7 @@ FrequencySaveView::FrequencySaveView(
 
     button_edit.on_select = [this, &nav](Button&) {
         temp_buffer_ = entry_.description;
-        text_prompt(nav_, temp_buffer_, 30, [this](std::string& new_desc) {
+        text_prompt(nav_, temp_buffer_, desc_edit_max, [this](std::string& new_desc) {
             entry_.description = new_desc;
             refresh_ui();
         });
@@ -189,7 +189,7 @@ FrequencyLoadView::FrequencyLoadView(
 /* FrequencyManagerView **********************************/
 
 void FrequencyManagerView::on_edit_freq() {
-    // TODO: range edit support?
+    // TODO: range edit support.
     auto freq_edit_view = nav_.push<FrequencyKeypadView>(current_entry().frequency_a);
     freq_edit_view->on_changed = [this](rf::Frequency f) {
         auto entry = current_entry();
@@ -201,7 +201,7 @@ void FrequencyManagerView::on_edit_freq() {
 
 void FrequencyManagerView::on_edit_desc() {
     temp_buffer_ = current_entry().description;
-    text_prompt(nav_, temp_buffer_, 28, [this](std::string& new_desc) {
+    text_prompt(nav_, temp_buffer_, desc_edit_max, [this](std::string& new_desc) {
         auto entry = current_entry();
         entry.description = std::move(new_desc);
         db_.replace_entry(current_index(), entry);
@@ -211,7 +211,7 @@ void FrequencyManagerView::on_edit_desc() {
 
 void FrequencyManagerView::on_add_category() {
     temp_buffer_.clear();
-    text_prompt(nav_, temp_buffer_, 12, [this](std::string& new_name) {
+    text_prompt(nav_, temp_buffer_, 20, [this](std::string& new_name) {
         if (!new_name.empty()) {
             create_freqman_file(new_name);
             refresh_categories();

--- a/firmware/application/apps/ui_freqman.cpp
+++ b/firmware/application/apps/ui_freqman.cpp
@@ -249,7 +249,7 @@ void FrequencyManagerView::on_del_entry() {
         return;
 
     nav_.push<ModalMessageView>(
-        "Delete", "Delete '" + pretty_string(current_entry(), 23) + "'\nAre you sure?", YESNO,
+        "Delete", "Delete " + trim(pretty_string(current_entry(), 23)) + "\nAre you sure?", YESNO,
         [this](bool choice) {
             if (choice) {
                 db_.delete_entry(current_index());

--- a/firmware/application/apps/ui_freqman.cpp
+++ b/firmware/application/apps/ui_freqman.cpp
@@ -249,7 +249,7 @@ void FrequencyManagerView::on_del_entry() {
         return;
 
     nav_.push<ModalMessageView>(
-        "Delete", "Delete" + pretty_string(current_entry(), 23) + "\nAre you sure?", YESNO,
+        "Delete", "Delete '" + pretty_string(current_entry(), 23) + "'\nAre you sure?", YESNO,
         [this](bool choice) {
             if (choice) {
                 db_.delete_entry(current_index());

--- a/firmware/application/apps/ui_freqman.hpp
+++ b/firmware/application/apps/ui_freqman.hpp
@@ -79,6 +79,7 @@ class FreqManBaseView : public View {
    protected:
     /* Static so selected category is persisted across UI instances. */
     static size_t current_category_index;
+    static constexpr size_t desc_edit_max = 0x80;
 };
 
 // TODO: support for new category.

--- a/firmware/application/freqman_db.hpp
+++ b/firmware/application/freqman_db.hpp
@@ -59,6 +59,7 @@ enum class freqman_type : uint8_t {
     Single,    // f=
     Range,     // a=,b=
     HamRadio,  // r=,t=
+    Raw,       // line content in description
     Unknown,
 };
 

--- a/firmware/application/freqman_db.hpp
+++ b/firmware/application/freqman_db.hpp
@@ -141,9 +141,9 @@ enum class freqman_type : uint8_t {
 
 /* Freqman Entry *******************************/
 struct freqman_entry {
-    int64_t frequency_a{0};      // 'f=freq' or 'a=freq_start' or 'r=recv_freq'
-    int64_t frequency_b{0};      // 'b=freq_end' or 't=tx_freq'
-    std::string description{0};  // 'd=desc'
+    int64_t frequency_a{0};     // 'f=freq' or 'a=freq_start' or 'r=recv_freq'
+    int64_t frequency_b{0};     // 'b=freq_end' or 't=tx_freq'
+    std::string description{};  // 'd=desc'
     freqman_type type{freqman_type::Unknown};
     freqman_index_t modulation{freqman_invalid_index};
     freqman_index_t bandwidth{freqman_invalid_index};

--- a/firmware/application/ui/ui_freqlist.cpp
+++ b/firmware/application/ui/ui_freqlist.cpp
@@ -62,10 +62,11 @@ void FreqManUIList::paint(Painter& painter) {
         if (index < db_->entry_count()) {
             auto entry = (*db_)[index];
             // db_ is directly backed by a file, so invalid lines cannot be
-            // pre-filtered. Just show an empty 'slot' in this case.
+            // pre-filtered. Show an empty entry if 'Unknown'.
             if (entry.type != freqman_type::Unknown)
                 text = pretty_string(entry, line_max_length);
 
+            // Otherwise, if 'Raw' indicate an invalid entry by color.
             if (entry.type == freqman_type::Raw)
                 style = &Styles::light_grey;
         }

--- a/firmware/application/ui/ui_freqlist.cpp
+++ b/firmware/application/ui/ui_freqlist.cpp
@@ -67,7 +67,7 @@ void FreqManUIList::paint(Painter& painter) {
                 text = pretty_string(entry, line_max_length);
 
             if (entry.type == freqman_type::Raw)
-                style = &Styles::grey;
+                style = &Styles::light_grey;
         }
 
         // Pad right with ' ' so trailing chars are cleaned up.

--- a/firmware/application/ui/ui_freqlist.cpp
+++ b/firmware/application/ui/ui_freqlist.cpp
@@ -56,9 +56,8 @@ void FreqManUIList::paint(Painter& painter) {
         auto text = std::string{};
         auto index = start_index_ + offset;
         auto line_position = rect.location() + Point{4, 1 + (int)offset * char_height};
-
-        // Highlight the selected item.
-        auto style = (offset == selected_index_) ? &Styles::bg_white : base_style;
+        auto is_selected = offset == selected_index_;
+        auto style = base_style;
 
         if (index < db_->entry_count()) {
             auto entry = (*db_)[index];
@@ -66,6 +65,9 @@ void FreqManUIList::paint(Painter& painter) {
             // pre-filtered. Just show an empty 'slot' in this case.
             if (entry.type != freqman_type::Unknown)
                 text = pretty_string(entry, line_max_length);
+
+            if (entry.type == freqman_type::Raw)
+                style = &Styles::grey;
         }
 
         // Pad right with ' ' so trailing chars are cleaned up.
@@ -73,7 +75,8 @@ void FreqManUIList::paint(Painter& painter) {
         if (text.length() < line_max_length)
             text.resize(line_max_length, ' ');
 
-        painter.draw_string(line_position, *style, text);
+        painter.draw_string(
+            line_position, (is_selected ? style->invert() : *style), text);
     }
 
     // Draw a bounding rectangle when focused.

--- a/firmware/test/application/test_string_format.cpp
+++ b/firmware/test/application/test_string_format.cpp
@@ -47,3 +47,7 @@ TEST_CASE("trim removes whitespace.") {
 TEST_CASE("trim returns empty for only whitespace.") {
     CHECK(trim("  \n").empty());
 }
+
+TEST_CASE("trim empty returns empty.") {
+    CHECK(trim("").empty());
+}


### PR DESCRIPTION
Introduces a concept of a "Raw" freqman entry that is only persisted as a string.
This allows Freqman to show comments, invalid entries and empty lines in grey.
String data is stashed in the entry description which allows the item to be edited in Freqman's description edit mode.