### PR TITLE
Support save prompt on back arrow

### DIFF
--- a/firmware/application/apps/ui_text_editor.cpp
+++ b/firmware/application/apps/ui_text_editor.cpp
@@ -432,6 +432,9 @@ TextEditorView::TextEditorView(NavigationView& nav, const fs::path& path)
 }
 
 TextEditorView::~TextEditorView() {
+    // NB: Be careful here. The UI will render after this instance
+    // has been destroyed. Everything needed to render the UI
+    // and perform the save actions must be value captured.
     if (file_dirty_) {
         ui::show_save_prompt(
             nav_,

--- a/firmware/application/apps/ui_text_editor.hpp
+++ b/firmware/application/apps/ui_text_editor.hpp
@@ -229,10 +229,7 @@ class TextEditorView : public View {
     void show_save_prompt(std::function<void()> continuation);
 
     void prepare_for_write();
-    void create_temp_file() const;
-    void delete_temp_file() const;
     void save_temp_file();
-    std::filesystem::path get_temp_path() const;
 
     NavigationView& nav_;
     std::unique_ptr<FileWrapper> file_{};


### PR DESCRIPTION
Asks to save modified files when exiting via back arrow in Notepad.
This kind of removes the need for the Exit button, so we could reuse it for something else if we want.