### PR TITLE
Increased number of encoder dial sensitivity setting levels

### DIFF
--- a/firmware/application/apps/ui_settings.cpp
+++ b/firmware/application/apps/ui_settings.cpp
@@ -605,10 +605,10 @@ SetEncoderDialView::SetEncoderDialView(NavigationView& nav) {
                   &button_save,
                   &button_cancel});
 
-    field_encoder_dial_sensitivity.set_by_value(pmem::config_encoder_dial_sensitivity());
+    field_encoder_dial_sensitivity.set_value(ENCODER_DIAL_SENSITIVITY_MAX - pmem::config_encoder_dial_sensitivity());
 
     button_save.on_select = [&nav, this](Button&) {
-        pmem::set_encoder_dial_sensitivity(field_encoder_dial_sensitivity.selected_index_value());
+        pmem::set_encoder_dial_sensitivity(ENCODER_DIAL_SENSITIVITY_MAX - field_encoder_dial_sensitivity.value());
         nav.pop();
     };
 

--- a/firmware/application/apps/ui_settings.cpp
+++ b/firmware/application/apps/ui_settings.cpp
@@ -605,10 +605,10 @@ SetEncoderDialView::SetEncoderDialView(NavigationView& nav) {
                   &button_save,
                   &button_cancel});
 
-    field_encoder_dial_sensitivity.set_value(ENCODER_DIAL_SENSITIVITY_MAX - pmem::config_encoder_dial_sensitivity());
+    field_encoder_dial_sensitivity.set_by_value(pmem::config_encoder_dial_sensitivity());
 
     button_save.on_select = [&nav, this](Button&) {
-        pmem::set_encoder_dial_sensitivity(ENCODER_DIAL_SENSITIVITY_MAX - field_encoder_dial_sensitivity.value());
+        pmem::set_encoder_dial_sensitivity(field_encoder_dial_sensitivity.selected_index_value());
         nav.pop();
     };
 

--- a/firmware/application/apps/ui_settings.hpp
+++ b/firmware/application/apps/ui_settings.hpp
@@ -478,7 +478,7 @@ class SetEncoderDialView : public View {
         {{1 * 8, 3 * 16}, "Dial sensitivity (0-4):", Color::light_grey()},
     };
 
-     NumberField field_encoder_dial_sensitivity{
+    NumberField field_encoder_dial_sensitivity{
         {25 * 8, 3 * 16},
         1,
         {0, ENCODER_DIAL_SENSITIVITY_MAX},

--- a/firmware/application/apps/ui_settings.hpp
+++ b/firmware/application/apps/ui_settings.hpp
@@ -37,8 +37,6 @@ namespace ui {
 
 #define MAX_FREQ_CORRECTION INT32_MAX
 
-#define ENCODER_DIAL_SENSITIVITY_MAX 4
-
 struct SetDateTimeModel {
     uint16_t year;
     uint8_t month;

--- a/firmware/application/apps/ui_settings.hpp
+++ b/firmware/application/apps/ui_settings.hpp
@@ -463,6 +463,8 @@ class SetQRCodeView : public View {
     };
 };
 
+using portapack::persistent_memory::encoder_dial_sensitivity;
+
 class SetEncoderDialView : public View {
    public:
     SetEncoderDialView(NavigationView& nav);
@@ -473,16 +475,17 @@ class SetEncoderDialView : public View {
 
    private:
     Labels labels{
-        {{1 * 8, 3 * 16}, "Dial sensitivity (0-4):", Color::light_grey()},
+        {{2 * 8, 3 * 16}, "Dial sensitivity:", Color::light_grey()},
     };
 
-    NumberField field_encoder_dial_sensitivity{
-        {25 * 8, 3 * 16},
-        1,
-        {0, ENCODER_DIAL_SENSITIVITY_MAX},
-        1,
-        ' ',
-        true};
+    OptionsField field_encoder_dial_sensitivity{
+        {20 * 8, 3 * 16},
+        7,
+        {{"LOWEST", encoder_dial_sensitivity::DIAL_SENSITIVITY_LOWEST},
+         {"LOW", encoder_dial_sensitivity::DIAL_SENSITIVITY_LOW},
+         {"NORMAL", encoder_dial_sensitivity::DIAL_SENSITIVITY_NORMAL},
+         {"HIGH", encoder_dial_sensitivity::DIAL_SENSITIVITY_HIGH},
+         {"HIGHEST", encoder_dial_sensitivity::DIAL_SENSITIVITY_HIGHEST}}};
 
     Button button_save{
         {2 * 8, 16 * 16, 12 * 8, 32},

--- a/firmware/application/apps/ui_settings.hpp
+++ b/firmware/application/apps/ui_settings.hpp
@@ -37,6 +37,8 @@ namespace ui {
 
 #define MAX_FREQ_CORRECTION INT32_MAX
 
+#define ENCODER_DIAL_SENSITIVITY_MAX 4
+
 struct SetDateTimeModel {
     uint16_t year;
     uint8_t month;
@@ -463,8 +465,6 @@ class SetQRCodeView : public View {
     };
 };
 
-using portapack::persistent_memory::encoder_dial_sensitivity;
-
 class SetEncoderDialView : public View {
    public:
     SetEncoderDialView(NavigationView& nav);
@@ -475,15 +475,16 @@ class SetEncoderDialView : public View {
 
    private:
     Labels labels{
-        {{2 * 8, 3 * 16}, "Dial sensitivity:", Color::light_grey()},
+        {{1 * 8, 3 * 16}, "Dial sensitivity (0-4):", Color::light_grey()},
     };
 
-    OptionsField field_encoder_dial_sensitivity{
-        {20 * 8, 3 * 16},
-        6,
-        {{"LOW", encoder_dial_sensitivity::DIAL_SENSITIVITY_LOW},
-         {"NORMAL", encoder_dial_sensitivity::DIAL_SENSITIVITY_MEDIUM},
-         {"HIGH", encoder_dial_sensitivity::DIAL_SENSITIVITY_HIGH}}};
+     NumberField field_encoder_dial_sensitivity{
+        {25 * 8, 3 * 16},
+        1,
+        {0, ENCODER_DIAL_SENSITIVITY_MAX},
+        1,
+        ' ',
+        true};
 
     Button button_save{
         {2 * 8, 16 * 16, 12 * 8, 32},

--- a/firmware/application/hw/encoder.cpp
+++ b/firmware/application/hw/encoder.cpp
@@ -40,10 +40,10 @@ static const int8_t transition_map[16] = {
     0,   // 0011: rate
     1,   // 0100: cw end
     0,   // 0101: noop
-    -1,  // 0110: (rate) worn decoder (missing 11 phase) workaround
+    -1,  // 0110: (rate) worn encoder (missing 11 phase) workaround
     -1,  // 0111: ccw end
     -1,  // 1000: ccw end
-    1,   // 1001: (rate) worn decoder (missing 11 phase) workaround
+    1,   // 1001: (rate) worn encoder (missing 11 phase) workaround
     0,   // 1010: noop
     1,   // 1011: cw end
     0,   // 1100: rate

--- a/firmware/application/hw/encoder.cpp
+++ b/firmware/application/hw/encoder.cpp
@@ -32,66 +32,24 @@
 // 12 degrees of rotation.
 //
 // For each encoder "pulse" there are 4 state transitions, and we can choose
-// between looking at all of them (high sensitivity), half of them (medium/default),
-// or one quarter of them (low sensitivity).
-static const int8_t transition_map[][16] = {
-    // Normal (Medium) Sensitivity -- default
-    {
-        0,   // 0000: noop
-        0,   // 0001: ccw start
-        0,   // 0010: cw start
-        0,   // 0011: rate
-        1,   // 0100: cw end
-        0,   // 0101: noop
-        0,   // 0110: rate
-        -1,  // 0111: ccw end
-        -1,  // 1000: ccw end
-        0,   // 1001: rate
-        0,   // 1010: noop
-        1,   // 1011: cw end
-        0,   // 1100: rate
-        0,   // 1101: cw start
-        0,   // 1110: ccw start
-        0,   // 1111: noop
-    },
-    // Low Sensitivity
-    {
-        0,   // 0000: noop
-        0,   // 0001: ccw start
-        0,   // 0010: cw start
-        0,   // 0011: rate
-        1,   // 0100: cw end
-        0,   // 0101: noop
-        0,   // 0110: rate
-        0,   // 0111: ccw end
-        -1,  // 1000: ccw end
-        0,   // 1001: rate
-        0,   // 1010: noop
-        0,   // 1011: cw end
-        0,   // 1100: rate
-        0,   // 1101: cw start
-        0,   // 1110: ccw start
-        0,   // 1111: noop
-    },
-    // High Sensitivity
-    {
-        0,   // 0000: noop
-        -1,  // 0001: ccw start
-        1,   // 0010: cw start
-        0,   // 0011: rate
-        1,   // 0100: cw end
-        0,   // 0101: noop
-        0,   // 0110: rate
-        -1,  // 0111: ccw end
-        -1,  // 1000: ccw end
-        0,   // 1001: rate
-        0,   // 1010: noop
-        1,   // 1011: cw end
-        0,   // 1100: rate
-        1,   // 1101: cw start
-        -1,  // 1110: ccw start
-        0,   // 1111: noop
-    },
+// how many transitions are needed before movement is registered
+static const int8_t transition_map[16] = {
+    0,   // 0000: noop
+    -1,  // 0001: ccw start
+    1,   // 0010: cw start
+    0,   // 0011: rate
+    1,   // 0100: cw end
+    0,   // 0101: noop
+    -1,  // 0110: (rate) worn decoder (missing 11 phase) workaround
+    -1,  // 0111: ccw end
+    -1,  // 1000: ccw end
+    1,   // 1001: (rate) worn decoder (missing 11 phase) workaround
+    0,   // 1010: noop
+    1,   // 1011: cw end
+    0,   // 1100: rate
+    1,   // 1101: cw start
+    -1,  // 1110: ccw start
+    0,   // 1111: noop
 };
 
 int_fast8_t Encoder::update(
@@ -102,6 +60,13 @@ int_fast8_t Encoder::update(
     state <<= 1;
     state |= phase_1;
 
-    // dial sensitivity setting is stored in pmem
-    return transition_map[portapack::persistent_memory::config_encoder_dial_sensitivity()][state & 0xf];
+    int_fast8_t retval = transition_map[state & 0xf];
+
+    transition_count += retval;
+    if (abs(transition_count) >= portapack::persistent_memory::config_encoder_dial_sensitivity())
+        transition_count = 0;
+    else
+        retval = 0;        
+
+    return retval;
 }

--- a/firmware/application/hw/encoder.cpp
+++ b/firmware/application/hw/encoder.cpp
@@ -66,7 +66,7 @@ int_fast8_t Encoder::update(
     if (abs(transition_count) >= portapack::persistent_memory::config_encoder_dial_sensitivity())
         transition_count = 0;
     else
-        retval = 0;        
+        retval = 0;
 
     return retval;
 }

--- a/firmware/application/hw/encoder.cpp
+++ b/firmware/application/hw/encoder.cpp
@@ -40,10 +40,10 @@ static const int8_t transition_map[16] = {
     0,   // 0011: rate
     1,   // 0100: cw end
     0,   // 0101: noop
-    -1,  // 0110: (rate) worn encoder (missing 11 phase) workaround
+    0,   // 0110: rate
     -1,  // 0111: ccw end
     -1,  // 1000: ccw end
-    1,   // 1001: (rate) worn encoder (missing 11 phase) workaround
+    0,   // 1001: rate
     0,   // 1010: noop
     1,   // 1011: cw end
     0,   // 1100: rate
@@ -63,7 +63,7 @@ int_fast8_t Encoder::update(
     int_fast8_t retval = transition_map[state & 0xf];
 
     transition_count += retval;
-    if (abs(transition_count) >= portapack::persistent_memory::config_encoder_dial_sensitivity())
+    if (abs(transition_count) > portapack::persistent_memory::config_encoder_dial_sensitivity())
         transition_count = 0;
     else
         retval = 0;

--- a/firmware/application/hw/encoder.hpp
+++ b/firmware/application/hw/encoder.hpp
@@ -32,6 +32,7 @@ class Encoder {
 
    private:
     uint_fast8_t state{0};
+    int_fast8_t transition_count{0};
 };
 
 #endif /*__ENCODER_H__*/

--- a/firmware/common/portapack_persistent_memory.cpp
+++ b/firmware/common/portapack_persistent_memory.cpp
@@ -363,7 +363,7 @@ void defaults() {
 
     set_config_backlight_timer(backlight_config_t{});
     set_config_splash(true);
-    set_encoder_dial_sensitivity(ENCODER_DIAL_SENSITIVITY_MAX / 2);
+    set_encoder_dial_sensitivity(DIAL_SENSITIVITY_NORMAL);
 
     // Default values for recon app.
     set_recon_autosave_freqs(false);

--- a/firmware/common/portapack_persistent_memory.cpp
+++ b/firmware/common/portapack_persistent_memory.cpp
@@ -363,6 +363,7 @@ void defaults() {
 
     set_config_backlight_timer(backlight_config_t{});
     set_config_splash(true);
+    set_encoder_dial_sensitivity(ENCODER_DIAL_SENSITIVITY_MAX / 2);
 
     // Default values for recon app.
     set_recon_autosave_freqs(false);

--- a/firmware/common/portapack_persistent_memory.hpp
+++ b/firmware/common/portapack_persistent_memory.hpp
@@ -39,6 +39,8 @@
 // persistant memory from/to sdcard flag file
 #define PMEM_SETTING_FILE u"/SETTINGS/pmem_settings"
 
+#define ENCODER_DIAL_SENSITIVITY_MAX 4
+
 using namespace modems;
 using namespace serializer;
 

--- a/firmware/common/portapack_persistent_memory.hpp
+++ b/firmware/common/portapack_persistent_memory.hpp
@@ -39,8 +39,6 @@
 // persistant memory from/to sdcard flag file
 #define PMEM_SETTING_FILE u"/SETTINGS/pmem_settings"
 
-#define ENCODER_DIAL_SENSITIVITY_MAX 4
-
 using namespace modems;
 using namespace serializer;
 
@@ -106,6 +104,15 @@ struct backlight_config_t {
    private:
     backlight_timeout_t _timeout_enum;
     bool _timeout_enabled;
+};
+
+enum encoder_dial_sensitivity {
+    DIAL_SENSITIVITY_HIGHEST = 0,
+    DIAL_SENSITIVITY_HIGH = 1,
+    DIAL_SENSITIVITY_NORMAL = 2,
+    DIAL_SENSITIVITY_LOW = 3,
+    DIAL_SENSITIVITY_LOWEST = 4,
+    NUM_DIAL_SENSITIVITY
 };
 
 namespace cache {

--- a/firmware/common/portapack_persistent_memory.hpp
+++ b/firmware/common/portapack_persistent_memory.hpp
@@ -106,13 +106,6 @@ struct backlight_config_t {
     bool _timeout_enabled;
 };
 
-enum encoder_dial_sensitivity {
-    DIAL_SENSITIVITY_MEDIUM = 0,
-    DIAL_SENSITIVITY_LOW = 1,
-    DIAL_SENSITIVITY_HIGH = 2,
-    NUM_DIAL_SENSITIVITY
-};
-
 namespace cache {
 
 /* Set values in cache to sensible defaults. */


### PR DESCRIPTION
Increase number of setting levels for encoder dial sensitivity from 3 levels to 5 levels.  This change only uses 30 extra bytes of ROM space, and adds intermediate levels between the original 3 levels, for finer tuning of the dial operation.

This PR changes the meaning of the sensitivity levels saved in Pmem, so you may want to adjust your encoder dial setting afterward upgrading or reset Pmem (I did not bump the version).  For users coming from FW version 1.7.3 or earlier, Pmem will get reset to the default medium (2) sensitivity setting.

This PR does NOT resolve the worn encoder hardware issue described in #1273, so I've backed out part of the code change relating to that.