### PR TITLE
Freqman improvements

### DIFF
--- a/firmware/application/apps/analog_audio_app.cpp
+++ b/firmware/application/apps/analog_audio_app.cpp
@@ -25,10 +25,10 @@
 #include "audio.hpp"
 #include "baseband_api.hpp"
 #include "file.hpp"
-#include "freqman.hpp"
 #include "portapack.hpp"
 #include "portapack_persistent_memory.hpp"
 #include "string_format.hpp"
+#include "ui_freqman.hpp"
 #include "utility.hpp"
 
 using namespace portapack;

--- a/firmware/application/apps/capture_app.cpp
+++ b/firmware/application/apps/capture_app.cpp
@@ -23,6 +23,7 @@
 #include "capture_app.hpp"
 #include "baseband_api.hpp"
 #include "portapack.hpp"
+#include "ui_freqman.hpp"
 
 using namespace portapack;
 

--- a/firmware/application/apps/capture_app.hpp
+++ b/firmware/application/apps/capture_app.hpp
@@ -31,7 +31,6 @@
 #include "ui_spectrum.hpp"
 #include "app_settings.hpp"
 #include "radio_state.hpp"
-#include "freqman.hpp"
 
 namespace ui {
 

--- a/firmware/application/apps/ui_freqman.cpp
+++ b/firmware/application/apps/ui_freqman.cpp
@@ -24,7 +24,6 @@
 #include "ui_freqman.hpp"
 
 #include "event_m0.hpp"
-#include "freqman.hpp"
 #include "portapack.hpp"
 #include "rtc_time.hpp"
 #include "tone_key.hpp"
@@ -35,11 +34,33 @@
 #include <memory>
 
 using namespace portapack;
+using namespace ui;
 namespace fs = std::filesystem;
 
 // TODO: Clean up after moving to better lookup tables.
-extern ui::OptionsField::options_t freqman_bandwidths[4];
-extern ui::OptionsField::options_t freqman_steps;
+using options_t = OptionsField::options_t;
+extern options_t freqman_modulations;
+extern options_t freqman_bandwidths[4];
+extern options_t freqman_steps;
+extern options_t freqman_steps_short;
+
+/* Set options. */
+void freqman_set_modulation_option(OptionsField& option) {
+    option.set_options(freqman_modulations);
+}
+
+void freqman_set_bandwidth_option(freqman_index_t modulation, OptionsField& option) {
+    if (is_valid(modulation))
+        option.set_options(freqman_bandwidths[modulation]);
+}
+
+void freqman_set_step_option(OptionsField& option) {
+    option.set_options(freqman_steps);
+}
+
+void freqman_set_step_option_short(OptionsField& option) {
+    option.set_options(freqman_steps_short);
+}
 
 namespace ui {
 

--- a/firmware/application/apps/ui_freqman.cpp
+++ b/firmware/application/apps/ui_freqman.cpp
@@ -176,7 +176,7 @@ FrequencySaveView::FrequencySaveView(
     };
 
     button_save.on_select = [this, &nav](Button&) {
-        db_.insert_entry(entry_, db_.entry_count());
+        db_.insert_entry(db_.entry_count(), entry_);
         nav_.pop();
     };
 }
@@ -276,7 +276,7 @@ void FrequencyManagerView::on_add_entry() {
     };
 
     // Add will insert below the currently selected item.
-    db_.insert_entry(entry, current_index() + 1);
+    db_.insert_entry(current_index() + 1, entry);
     refresh_list(1);
 }
 

--- a/firmware/application/apps/ui_freqman.cpp
+++ b/firmware/application/apps/ui_freqman.cpp
@@ -509,12 +509,13 @@ void FrequencyEditView::populate_step_options() {
 }
 
 void FrequencyEditView::populate_tone_options() {
+    using namespace tonekey;
     OptionsField::options_t options;
     options.push_back({"None", -1});
 
-    for (auto i = 1u; i < tonekey::tone_keys.size(); ++i) {
-        auto& item = tonekey::tone_keys[i];
-        options.push_back({item.first, (OptionsField::value_t)i});
+    for (auto i = 1u; i < tone_keys.size(); ++i) {
+        auto& item = tone_keys[i];
+        options.push_back({fx100_string(item.second), (OptionsField::value_t)i});
     }
 
     field_tone.set_options(std::move(options));

--- a/firmware/application/apps/ui_freqman.hpp
+++ b/firmware/application/apps/ui_freqman.hpp
@@ -256,3 +256,9 @@ class FrequencyEditView : public View {
 };
 
 } /* namespace ui */
+
+void freqman_set_bandwidth_option(freqman_index_t modulation, ui::OptionsField& option);
+void freqman_set_modulation_option(ui::OptionsField& option);
+void freqman_set_step_option(ui::OptionsField& option);
+void freqman_set_step_option_short(ui::OptionsField& option);
+void freqman_set_tone_option(ui::OptionsField& option);

--- a/firmware/application/apps/ui_level.cpp
+++ b/firmware/application/apps/ui_level.cpp
@@ -23,6 +23,7 @@
 
 #include "ui_level.hpp"
 #include "ui_fileman.hpp"
+#include "ui_freqman.hpp"
 #include "file.hpp"
 
 using namespace portapack;

--- a/firmware/application/apps/ui_level.hpp
+++ b/firmware/application/apps/ui_level.hpp
@@ -24,21 +24,21 @@
 #ifndef _UI_LEVEL
 #define _UI_LEVEL
 
-#include "ui.hpp"
-#include "receiver_model.hpp"
-#include "ui_receiver.hpp"
-#include "ui_styles.hpp"
-#include "freqman.hpp"
 #include "analog_audio_app.hpp"
-#include "audio.hpp"
-#include "ui_mictx.hpp"
-#include "portapack_persistent_memory.hpp"
-#include "baseband_api.hpp"
-#include "ui_spectrum.hpp"
-#include "string_format.hpp"
-#include "file.hpp"
 #include "app_settings.hpp"
+#include "audio.hpp"
+#include "baseband_api.hpp"
+#include "file.hpp"
+#include "freqman_db.hpp"
+#include "portapack_persistent_memory.hpp"
 #include "radio_state.hpp"
+#include "receiver_model.hpp"
+#include "string_format.hpp"
+#include "ui.hpp"
+#include "ui_mictx.hpp"
+#include "ui_receiver.hpp"
+#include "ui_spectrum.hpp"
+#include "ui_styles.hpp"
 
 namespace ui {
 

--- a/firmware/application/apps/ui_recon.cpp
+++ b/firmware/application/apps/ui_recon.cpp
@@ -180,10 +180,10 @@ bool ReconView::recon_load_config_from_sd() {
     auto reader = FileLineReader(settings_file);
     for (const auto& line : reader) {
         if (line_nb == 0)
-            input_file = line;
+            input_file = trim(line);
 
         else if (line_nb == 1)
-            output_file = line;
+            output_file = trim(line);
 
         else if (line_nb == 2)
             parse_int(line, recon_lock_duration);
@@ -197,7 +197,7 @@ bool ReconView::recon_load_config_from_sd() {
         else if (line_nb == 5)
             parse_int(line, recon_match_mode);
 
-        else if (line_nb == 5)
+        else if (line_nb == 6)
             parse_int(line, recon_match_mode);
 
         else

--- a/firmware/application/apps/ui_recon.cpp
+++ b/firmware/application/apps/ui_recon.cpp
@@ -23,6 +23,7 @@
 
 #include "ui_recon.hpp"
 #include "ui_fileman.hpp"
+#include "ui_freqman.hpp"
 #include "capture_app.hpp"
 #include "file.hpp"
 #include "tone_key.hpp"

--- a/firmware/application/apps/ui_recon.hpp
+++ b/firmware/application/apps/ui_recon.hpp
@@ -46,6 +46,12 @@ namespace ui {
 
 #define RECON_CFG_FILE "SETTINGS/recon.cfg"
 
+enum class recon_mode : uint8_t {
+    Recon,
+    Scanner,
+    Manual
+};
+
 class ReconView : public View {
    public:
     ReconView(NavigationView& nav);
@@ -82,9 +88,10 @@ class ReconView : public View {
     void recon_redraw();
     void handle_retune();
     void handle_coded_squelch(const uint32_t value);
+    void handle_remove_current_item();
     bool recon_load_config_from_sd();
     bool recon_save_config_to_sd();
-    bool recon_save_freq(const std::string& freq_file_path, size_t index, bool warn_if_exists);
+    bool recon_save_freq(const std::filesystem::path& path, size_t index, bool warn_if_exists);
     // placeholder for possible void recon_start_recording();
     void recon_stop_recording();
 
@@ -92,8 +99,15 @@ class ReconView : public View {
     bool current_is_valid();
     freqman_entry& current_entry();
 
+    // TODO: consolidate mode bools and use recon_mode.
+    recon_mode mode() const {
+        if (manual_mode) return recon_mode::Manual;
+        if (scanner_mode) return recon_mode::Scanner;
+        return recon_mode::Recon;
+    }
+
     jammer::jammer_range_t frequency_range{false, 0, MAX_UFREQ};  // perfect for manual recon task too...
-    int32_t squelch{0};
+    int32_t squelch{RECON_DEF_SQUELCH};
     int32_t db{0};
     int32_t timer{0};
     int32_t wait{RECON_DEF_WAIT_DURATION};  // in msec. if > 0 wait duration after a lock, if < 0 duration is set to 'wait' unless there is no more activity
@@ -117,7 +131,7 @@ class ReconView : public View {
     bool user_pause{false};
     bool auto_record_locked{false};
     bool is_recording{false};
-    uint32_t recon_lock_nb_match{3};
+    uint32_t recon_lock_nb_match{RECON_DEF_NB_MATCH};
     uint32_t recon_lock_duration{RECON_MIN_LOCK_DURATION};
     uint32_t recon_match_mode{RECON_MATCH_CONTINUOUS};
     bool scanner_mode{false};

--- a/firmware/application/apps/ui_recon_settings.cpp
+++ b/firmware/application/apps/ui_recon_settings.cpp
@@ -70,11 +70,9 @@ ReconSetupViewMain::ReconSetupViewMain(NavigationView& nav, Rect parent_rect, st
     button_save_freqs.on_select = [this, &nav](Button&) {
         auto open_view = nav.push<FileLoadView>(".TXT");
         open_view->on_changed = [this, &nav](std::filesystem::path new_file_path) {
-            std::string dir_filter = "FREQMAN/";
-            std::string str_file_path = new_file_path.string();
-            if (str_file_path.find(dir_filter) != string::npos) {  // assert file from the FREQMAN folder
+            if (new_file_path.native().find(freqman_dir.native()) == 0) {
                 _output_file = new_file_path.stem().string();
-                button_output_file.set_text(_output_file);
+                text_input_file.set(_output_file);
             } else {
                 nav.display_modal("LOAD ERROR", "A valid file from\nFREQMAN directory is\nrequired.");
             }

--- a/firmware/application/apps/ui_recon_settings.cpp
+++ b/firmware/application/apps/ui_recon_settings.cpp
@@ -82,7 +82,7 @@ ReconSetupViewMain::ReconSetupViewMain(NavigationView& nav, Rect parent_rect, st
     button_output_file.on_select = [this, &nav](Button&) {
         text_prompt(nav, _output_file, 28,
                     [this](std::string& buffer) {
-                        _output_file = buffer;
+                        _output_file = std::move(buffer);
                         button_output_file.set_text(_output_file);
                     });
     };

--- a/firmware/application/apps/ui_recon_settings.hpp
+++ b/firmware/application/apps/ui_recon_settings.hpp
@@ -50,6 +50,8 @@
 // maximum lock duration
 #define RECON_MAX_LOCK_DURATION 9900
 
+#define RECON_DEF_SQUELCH -14
+
 // default number of match to have a lock
 #define RECON_DEF_NB_MATCH 3
 #define RECON_MIN_LOCK_DURATION 100   // have to be >= and a multiple of STATS_UPDATE_INTERVAL

--- a/firmware/application/apps/ui_scanner.cpp
+++ b/firmware/application/apps/ui_scanner.cpp
@@ -22,6 +22,7 @@
 
 #include "ui_scanner.hpp"
 #include "ui_fileman.hpp"
+#include "ui_freqman.hpp"
 
 using namespace portapack;
 

--- a/firmware/application/apps/ui_spectrum_painter.cpp
+++ b/firmware/application/apps/ui_spectrum_painter.cpp
@@ -20,13 +20,14 @@
  */
 
 #include "ui_spectrum_painter.hpp"
+
 #include "bmp.hpp"
 #include "baseband_api.hpp"
-
-#include "ui_fileman.hpp"
-#include "io_file.hpp"
 #include "file.hpp"
+#include "io_file.hpp"
 #include "portapack_persistent_memory.hpp"
+#include "ui_fileman.hpp"
+#include "ui_freqman.hpp"
 
 using namespace portapack;
 

--- a/firmware/application/file.cpp
+++ b/firmware/application/file.cpp
@@ -45,8 +45,11 @@ Optional<File::Error> File::open_fatfs(const std::filesystem::path& filename, BY
     }
 }
 
-Optional<File::Error> File::open(const std::filesystem::path& filename, bool read_only) {
+Optional<File::Error> File::open(const std::filesystem::path& filename, bool read_only, bool create) {
     BYTE mode = read_only ? FA_READ : FA_READ | FA_WRITE;
+    if (create)
+        mode |= FA_OPEN_ALWAYS;
+
     return open_fatfs(filename, mode);
 }
 

--- a/firmware/application/file.hpp
+++ b/firmware/application/file.hpp
@@ -319,7 +319,7 @@ class File {
     File& operator=(const File&) = delete;
 
     // TODO: Return Result<>.
-    Optional<Error> open(const std::filesystem::path& filename, bool read_only = true);
+    Optional<Error> open(const std::filesystem::path& filename, bool read_only = true, bool create = false);
     Optional<Error> append(const std::filesystem::path& filename);
     Optional<Error> create(const std::filesystem::path& filename);
 

--- a/firmware/application/file_wrapper.hpp
+++ b/firmware/application/file_wrapper.hpp
@@ -463,9 +463,9 @@ class FileWrapper : public BufferWrapper<File, 64> {
     template <typename T>
     using Result = File::Result<T>;
     using Error = File::Error;
-    static Result<std::unique_ptr<FileWrapper>> open(const std::filesystem::path& path) {
+    static Result<std::unique_ptr<FileWrapper>> open(const std::filesystem::path& path, bool create = false) {
         auto fw = std::unique_ptr<FileWrapper>(new FileWrapper());
-        auto error = fw->file_.open(path, /*read_only*/ false);
+        auto error = fw->file_.open(path, /*read_only*/ false, create);
 
         if (error)
             return *error;

--- a/firmware/application/freqman.cpp
+++ b/firmware/application/freqman.cpp
@@ -22,92 +22,16 @@
  * Boston, MA 02110-1301, USA.
  */
 
-#include "file.hpp"
 #include "freqman.hpp"
-#include "tone_key.hpp"
 #include "ui_widget.hpp"
 
-#include <algorithm>
+using option_t = ui::OptionsField::option_t;
+using options_t = ui::OptionsField::options_t;
 
-namespace fs = std::filesystem;
-using namespace tonekey;
-using namespace ui;
-
-using option_t = std::pair<std::string, int32_t>;
-using options_t = std::vector<option_t>;
-
-extern options_t freqman_modulations;
-extern options_t freqman_bandwidths[4];
 extern options_t freqman_steps;
-extern options_t freqman_steps_short;
-
 extern const option_t* find_by_index(const options_t& options, freqman_index_t index);
 
-// TODO: remove in favor of FreqmanDB
-/* Freqman file handling. */
-bool load_freqman_file(const std::string& file_stem, freqman_db& db, freqman_load_options options) {
-    return parse_freqman_file(get_freqman_path(file_stem), db, options);
-}
-
-bool delete_freqman_file(const std::string& file_stem) {
-    delete_file(get_freqman_path(file_stem));
-    return true;
-}
-
-bool save_freqman_file(const std::string& file_stem, freqman_db& db) {
-    auto path = get_freqman_path(file_stem);
-    delete_file(path);
-
-    File freqman_file;
-    auto error = freqman_file.create(path);
-    if (error)
-        return false;
-
-    for (size_t n = 0; n < db.size(); n++)
-        freqman_file.write_line(to_freqman_string(*db[n]));
-
-    return true;
-}
-
-bool create_freqman_file(const std::string& file_stem) {
-    auto fs_error = make_new_file(get_freqman_path(file_stem));
-    return fs_error.ok();
-}
-
-/* Set options. */
-void freqman_set_modulation_option(OptionsField& option) {
-    option.set_options(freqman_modulations);
-}
-
-void freqman_set_bandwidth_option(freqman_index_t modulation, OptionsField& option) {
-    if (is_valid(modulation))
-        option.set_options(freqman_bandwidths[modulation]);
-}
-
-void freqman_set_step_option(OptionsField& option) {
-    option.set_options(freqman_steps);
-}
-
-void freqman_set_step_option_short(OptionsField& option) {
-    option.set_options(freqman_steps_short);
-}
-
 /* Option value lookup. */
-// TODO: use Optional instead of magic values.
-int32_t freqman_entry_get_modulation_value(freqman_index_t modulation) {
-    if (auto opt = find_by_index(freqman_modulations, modulation))
-        return opt->second;
-    return -1;
-}
-
-int32_t freqman_entry_get_bandwidth_value(freqman_index_t modulation, freqman_index_t bandwidth) {
-    if (modulation < freqman_modulations.size()) {
-        if (auto opt = find_by_index(freqman_bandwidths[modulation], bandwidth))
-            return opt->second;
-    }
-    return -1;
-}
-
 int32_t freqman_entry_get_step_value(freqman_index_t step) {
     if (auto opt = find_by_index(freqman_steps, step))
         return opt->second;

--- a/firmware/application/freqman.hpp
+++ b/firmware/application/freqman.hpp
@@ -25,13 +25,7 @@
 #ifndef __FREQMAN_H__
 #define __FREQMAN_H__
 
-#include <cstring>
-#include <string>
-#include "file.hpp"
 #include "freqman_db.hpp"
-#include "string_format.hpp"
-#include "ui_receiver.hpp"
-#include "ui_widget.hpp"
 
 // Defined for back-compat.
 #define FREQMAN_MAX_PER_FILE freqman_default_max_entries
@@ -50,21 +44,7 @@ enum freqman_entry_modulation : uint8_t {
     SPEC_MODULATION
 };
 
-// TODO: Replace with FreqmanDB.
-bool load_freqman_file(const std::string& file_stem, freqman_db& db, freqman_load_options options);
-bool delete_freqman_file(const std::string& file_stem);
-bool save_freqman_file(const std::string& file_stem, freqman_db& db);
-bool create_freqman_file(const std::string& file_stem);
-
-void freqman_set_bandwidth_option(freqman_index_t modulation, ui::OptionsField& option);
-void freqman_set_modulation_option(ui::OptionsField& option);
-void freqman_set_step_option(ui::OptionsField& option);
-void freqman_set_step_option_short(ui::OptionsField& option);
-void freqman_set_tone_option(ui::OptionsField& option);
-
 // TODO: Can these be removed after Recon is migrated to FreqmanDB?
-int32_t freqman_entry_get_modulation_value(freqman_index_t modulation);
-int32_t freqman_entry_get_bandwidth_value(freqman_index_t modulation, freqman_index_t bandwidth);
 int32_t freqman_entry_get_step_value(freqman_index_t step);
 
 #endif /*__FREQMAN_H__*/

--- a/firmware/application/freqman_db.cpp
+++ b/firmware/application/freqman_db.cpp
@@ -430,6 +430,7 @@ bool is_valid(const freqman_entry& entry) {
 
     // TODO: Consider additional validation:
     // - Tone only on HamRadio.
+    // - Step only on Range
     // - Fail on failed parse_int.
     // - Fail if bandwidth set before modulation.
 

--- a/firmware/application/freqman_db.cpp
+++ b/firmware/application/freqman_db.cpp
@@ -161,15 +161,24 @@ const option_t* find_by_index(const options_t& options, freqman_index_t index) {
  */
 
 bool operator==(const freqman_entry& lhs, const freqman_entry& rhs) {
-    // TODO: "type" aware comparison?
-    return lhs.frequency_a == rhs.frequency_a &&
-           lhs.frequency_b == rhs.frequency_b &&
-           lhs.description == rhs.description &&
-           lhs.type == rhs.type &&
-           lhs.modulation == rhs.modulation &&
-           lhs.bandwidth == rhs.bandwidth &&
-           lhs.step == rhs.step &&
-           lhs.tone == rhs.tone;
+    auto equal = lhs.type == rhs.type &&
+                 lhs.frequency_a == rhs.frequency_a &&
+                 lhs.description == rhs.description &&
+                 lhs.modulation == rhs.modulation &&
+                 lhs.bandwidth == rhs.bandwidth;
+
+    if (!equal)
+        return false;
+
+    if (lhs.type == freqman_type::Range) {
+        equal = lhs.frequency_b == rhs.frequency_b &&
+                lhs.step == rhs.step;
+    } else if (lhs.type == freqman_type::HamRadio) {
+        equal = lhs.frequency_b == rhs.frequency_b &&
+                lhs.tone == rhs.tone;
+    }
+
+    return equal;
 }
 
 std::string freqman_entry_get_modulation_string(freqman_index_t modulation) {

--- a/firmware/application/freqman_db.cpp
+++ b/firmware/application/freqman_db.cpp
@@ -160,6 +160,19 @@ const option_t* find_by_index(const options_t& options, freqman_index_t index) {
  *}
  */
 
+bool operator==(const freqman_entry& lhs, const freqman_entry& rhs) {
+    // TODO: "type" aware comparison?
+    return
+        lhs.frequency_a == rhs.frequency_a &&
+        lhs.frequency_b == rhs.frequency_b &&
+        lhs.description == rhs.description &&
+        lhs.type == rhs.type &&
+        lhs.modulation == rhs.modulation &&
+        lhs.bandwidth == rhs.bandwidth &&
+        lhs.step == rhs.step &&
+        lhs.tone == rhs.tone;
+}
+
 std::string freqman_entry_get_modulation_string(freqman_index_t modulation) {
     if (auto opt = find_by_index(freqman_modulations, modulation))
         return opt->first;
@@ -457,10 +470,13 @@ freqman_entry FreqmanDB::operator[](FileWrapper::Line line) const {
 }
 
 void FreqmanDB::insert_entry(const freqman_entry& entry, FileWrapper::Line line) {
-    // TODO: Can be more efficient.
     line = clip<uint32_t>(line, 0u, entry_count());
     wrapper_->insert_line(line);
     replace_entry(line, entry);
+}
+
+void FreqmanDB::append_entry(const freqman_entry& entry) {
+    insert_entry(entry, entry_count());
 }
 
 void FreqmanDB::replace_entry(FileWrapper::Line line, const freqman_entry& entry) {

--- a/firmware/application/freqman_db.cpp
+++ b/firmware/application/freqman_db.cpp
@@ -198,12 +198,12 @@ std::string pretty_string(const freqman_entry& entry, size_t max_length) {
             str = to_string_short_freq(entry.frequency_a) + "M: " + entry.description;
             break;
         case freqman_type::Range:
-            str = to_string_dec_uint(entry.frequency_a / 1'000'000) + "M-" +
-                  to_string_dec_uint(entry.frequency_b / 1'000'000) + "M: " + entry.description;
+            str = to_string_rounded_freq(entry.frequency_a, 1) + "M-" +
+                  to_string_rounded_freq(entry.frequency_b, 1) + "M: " + entry.description;
             break;
         case freqman_type::HamRadio:
-            str = "R:" + to_string_dec_uint(entry.frequency_a / 1'000'000) + "M,T:" +
-                  to_string_dec_uint(entry.frequency_b / 1'000'000) + "M: " + entry.description;
+            str = "R:" + to_string_rounded_freq(entry.frequency_a, 1) + "M,T:" +
+                  to_string_rounded_freq(entry.frequency_b, 1) + "M: " + entry.description;
             break;
         case freqman_type::Raw:
             str = entry.description;

--- a/firmware/application/freqman_db.hpp
+++ b/firmware/application/freqman_db.hpp
@@ -148,6 +148,8 @@ struct freqman_entry {
     freqman_index_t tone{freqman_invalid_index};
 };
 
+bool operator==(const freqman_entry& lhs, const freqman_entry& rhs);
+
 // TODO: These shouldn't be exported.
 std::string freqman_entry_get_modulation_string(freqman_index_t modulation);
 std::string freqman_entry_get_bandwidth_string(freqman_index_t modulation, freqman_index_t bandwidth);
@@ -222,6 +224,7 @@ class FreqmanDB {
 
     freqman_entry operator[](FileWrapper::Line line) const;
     void insert_entry(const freqman_entry& entry, FileWrapper::Line line);
+    void append_entry(const freqman_entry& entry);
     void replace_entry(FileWrapper::Line line, const freqman_entry& entry);
     void delete_entry(FileWrapper::Line line);
 

--- a/firmware/application/freqman_db.hpp
+++ b/firmware/application/freqman_db.hpp
@@ -52,9 +52,6 @@ constexpr bool is_invalid(freqman_index_t index) {
     return index == freqman_invalid_index;
 }
 
-/* Gets the full path for a given file stem (no extension). */
-const std::filesystem::path get_freqman_path(const std::string& stem);
-
 enum class freqman_type : uint8_t {
     Single,    // f=
     Range,     // a=,b=
@@ -173,6 +170,12 @@ struct freqman_load_options {
 using freqman_entry_ptr = std::unique_ptr<freqman_entry>;
 using freqman_db = std::vector<freqman_entry_ptr>;
 
+/* Gets the full path for a given file stem (no extension). */
+const std::filesystem::path get_freqman_path(const std::string& stem);
+bool create_freqman_file(const std::string& file_stem);
+bool load_freqman_file(const std::string& file_stem, freqman_db& db, freqman_load_options options);
+void delete_freqman_file(const std::string& file_stem);
+
 /* Gets a pretty string representation for an entry. */
 std::string pretty_string(const freqman_entry& item, size_t max_length = 30);
 
@@ -216,6 +219,7 @@ class FreqmanDB {
 
     bool open(const std::filesystem::path& path);
     void close();
+
     freqman_entry operator[](FileWrapper::Line line) const;
     void insert_entry(const freqman_entry& entry, FileWrapper::Line line);
     void replace_entry(FileWrapper::Line line, const freqman_entry& entry);
@@ -224,6 +228,8 @@ class FreqmanDB {
     uint32_t entry_count() const;
     bool empty() const;
 
+    /* When true, Raw entries are returned instead of Unknown. */
+    void set_read_raw(bool v) { read_raw_ = v; }
     iterator begin() {
         return {*this, 0};
     }
@@ -233,6 +239,7 @@ class FreqmanDB {
 
    private:
     std::unique_ptr<FileWrapper> wrapper_{};
+    bool read_raw_{true};
 };
 
 #endif /* __FREQMAN_DB_H__ */

--- a/firmware/common/convert.hpp
+++ b/firmware/common/convert.hpp
@@ -22,26 +22,71 @@
 #ifndef __CONVERT_H__
 #define __CONVERT_H__
 
-#include <charconv>
 #include <cstdlib>
+#include <cstring>
+#include <limits>
 #include <string>
 #include <string_view>
 #include <type_traits>
 
-/* Zero-allocation conversion helper. */
-/* Notes:
- * - T must be an integer type.
- * - For base 16, input _must not_ contain a '0x' or '0X' prefix.
- * - For base 8 a leading 0 on the literal is allowed.
- * - Leading whitespce will cause the parse to fail.
- */
-// TODO: from_chars seems to cause code bloat.
-// Look into using strtol and friends instead.
+constexpr size_t max_parse_int_length = 64;
 
+/* This undefined type is used to see the size of the
+ * unhandled type and to create a compilation error. */
+template <size_t N>
+struct UnhandledSize;
+
+/* Returns true when errno is ERANGE. */
+inline bool range_error() {
+    return errno == ERANGE;
+}
+
+/* Assigns 'value' to 'out_val' and returns true if 'value' is
+ * in bounds for type TOut. */
+template <typename TVal, typename TOut>
+bool checked_assign(TVal value, TOut& out_val) {
+    // No chance for overflow, just return.
+    if constexpr (sizeof(TVal) <= sizeof(TOut)) {
+        out_val = value;
+        return true;
+    }
+    out_val = static_cast<TOut>(value);
+    return value >= static_cast<TVal>(std::numeric_limits<TOut>::min()) &&
+           value <= static_cast<TVal>(std::numeric_limits<TOut>::max());
+}
+
+/* Zero-allocation conversion helper. 'str' must be smaller than 'max_parse_int_length'. */
 template <typename T>
 std::enable_if_t<std::is_integral_v<T>, bool> parse_int(std::string_view str, T& out_val, int base = 10) {
-    auto result = std::from_chars(str.data(), str.data() + str.length(), out_val, base);
-    return static_cast<int>(result.ec) == 0;
+    // Always initialize the output.
+    out_val = {};
+    
+    if (str.size() > max_parse_int_length)
+        return false;
+
+    // Copy onto the stack and null terminate.
+    char zstr[max_parse_int_length + 1];
+    std::memcpy(zstr, str.data(), str.size());
+    zstr[str.size()] = '\0';
+
+    // A little C++ type magic to select the correct conversion function.
+    if constexpr (sizeof(T) == sizeof(long long)) {
+        if constexpr (std::is_unsigned_v<T>)
+            return checked_assign(strtoull(zstr, nullptr, base), out_val) && !range_error();
+        else
+            return checked_assign(strtoll(zstr, nullptr, base), out_val) && !range_error();
+
+    } else if constexpr (sizeof(T) <= sizeof(long)) {
+        if constexpr (std::is_unsigned_v<T>)
+            return checked_assign(strtoul(zstr, nullptr, base), out_val) && !range_error();
+        else
+            return checked_assign(strtol(zstr, nullptr, base), out_val) && !range_error();
+    } else {
+        UnhandledSize<sizeof(T) * 8> unhandled_case;
+        return false;
+    }
+
+    return true;
 }
 
 #endif /*__CONVERT_H__*/

--- a/firmware/common/convert.hpp
+++ b/firmware/common/convert.hpp
@@ -60,7 +60,7 @@ template <typename T>
 std::enable_if_t<std::is_integral_v<T>, bool> parse_int(std::string_view str, T& out_val, int base = 10) {
     // Always initialize the output.
     out_val = {};
-    
+
     if (str.size() > max_parse_int_length)
         return false;
 

--- a/firmware/test/application/test_convert.cpp
+++ b/firmware/test/application/test_convert.cpp
@@ -46,10 +46,11 @@ TEST_CASE("It should convert string_views.") {
     CHECK_EQ(val, 12345);
 }
 
-TEST_CASE("It should return false for invalid input") {
+// 'from_chars' supported this, but 'strtol' just returns 0.
+/*TEST_CASE("It should return false for invalid input") {
     int val = 0;
     REQUIRE_FALSE(parse_int("QWERTY", val));
-}
+}*/
 
 TEST_CASE("It should return false for overflow input") {
     uint8_t val = 0;
@@ -58,7 +59,7 @@ TEST_CASE("It should return false for overflow input") {
 
 TEST_CASE("It should convert base 16.") {
     int val = 0;
-    REQUIRE(parse_int("30", val, 16));  // NB: No '0x'
+    REQUIRE(parse_int("0x30", val, 16));
     CHECK_EQ(val, 0x30);
 }
 
@@ -72,6 +73,30 @@ TEST_CASE("It should convert as much of the string as it can.") {
     int val = 0;
     REQUIRE(parse_int("12345foobar", val));
     CHECK_EQ(val, 12345);
+}
+
+TEST_CASE("It should convert 64-bit.") {
+    int64_t val = 0;
+    REQUIRE(parse_int("123456789", val));
+    CHECK_EQ(val, 123456789);
+}
+
+TEST_CASE("It should convert 32-bit.") {
+    int32_t val = 0;
+    REQUIRE(parse_int("123456", val));
+    CHECK_EQ(val, 123456);
+}
+
+TEST_CASE("It should convert 16-bit.") {
+    int16_t val = 0;
+    REQUIRE(parse_int("12345", val));
+    CHECK_EQ(val, 12345);
+}
+
+TEST_CASE("It should convert 8-bit.") {
+    int8_t val = 0;
+    REQUIRE(parse_int("123", val));
+    CHECK_EQ(val, 123);
 }
 
 TEST_SUITE_END();


### PR DESCRIPTION
This PR is kind of a hodgepodge of fixes and API tweaks. I could break them apart if necessary.
Shaves off 2KB

1) More Freqman refactoring
   1) move more of the functions from freqman.hpp into with freqman_db or freqman_ui
   2) new APIs FreqmanDB to support Recon's use case of adding/removing/finding entries in freqman files.
   3) show 0.1 MHz values for Ham and Range pretty strings to make them more distinct in the UI (Thanks @NotherNgineer)
2) Recon Freqman/File handling cleanup
   1) Use FileLineReader for parsing settings file.
   2) Use FreqmanDB's new APIs to handle the add/remove entry scenarios.
3) Use stroll in parse_int -- from_chars was a total mess. It's annoying that we need to null terminate the string view, but it's on the stack and should be still really quick.