### PR TITLE
Correct_RXBW_char_7_spaces_in_Mic_App

### DIFF
--- a/firmware/application/apps/ui_mictx.cpp
+++ b/firmware/application/apps/ui_mictx.cpp
@@ -355,9 +355,9 @@ MicTXView::MicTXView(
                 rxaudio(rx_enabled);         // Update now if we have RX audio on
                 options_tone_key.hidden(0);  // we are in FM mode, we should have active the Key-tones & CTCSS option.
 
-                rxbw.emplace_back(" NFM1:8k5  ", 0);  // restore the original dynamic field_rxbw value.
-                rxbw.emplace_back(" NFM2:11k  ", 1);
-                rxbw.emplace_back(" FM  :16k  ", 2);
+                rxbw.emplace_back(" 8k5  ", 0);  // restore the original dynamic field_rxbw value.
+                rxbw.emplace_back(" 11k  ", 1);
+                rxbw.emplace_back(" 16k  ", 2);
                 field_rxbw.set_options(rxbw);  // store that aux GUI option to the field_rxbw.
 
                 field_rxbw.hidden(0);  // we are in FM mode, we need to allow the user set up of the RX NFM BW selection (8K5, 11K, 16K)
@@ -375,9 +375,9 @@ MicTXView::MicTXView(
                 rxaudio(rx_enabled);         // Update now if we have RX audio on
                 options_tone_key.hidden(0);  // we are in WFM mode, we should have active the Key-tones & CTCSS option.
 
-                rxbw.emplace_back("  200k-WFM ", 0);  // We allow the user selection of the 3 x WFM BW filters, (0) WFM-200K, (1) WFM-180K, (2) WFM-40K.
-                rxbw.emplace_back("  180k-WFM ", 1);
-                rxbw.emplace_back("   40k-WFM ", 2);
+                rxbw.emplace_back(" 200k ", 0);  // We allow the user selection of the 3 x WFM BW filters, (0) WFM-200K, (1) WFM-180K, (2) WFM-40K.
+                rxbw.emplace_back(" 180k ", 1);
+                rxbw.emplace_back("  40k ", 2);
                 field_rxbw.set_options(rxbw);  // store that aux GUI option to the field_rxbw.
 
                 field_rxbw.hidden(0);  // we are in WFM mode, we need to show to the user the selected BW WFM filter.
@@ -390,8 +390,8 @@ MicTXView::MicTXView(
                 set_dirty();                             // Refresh display
                 options_tone_key.hidden(1);              // we hide that Key-tones & CTCSS input selecction, (no meaning in AM/DSB/SSB).
 
-                rxbw.emplace_back(" DSB1-9k   ", 0);  // we offer in AM DSB two audio BW 9k / 6k.
-                rxbw.emplace_back(" DSB2-6k   ", 1);
+                rxbw.emplace_back("DSB-9k", 0);  // we offer in AM DSB two audio BW 9k / 6k.
+                rxbw.emplace_back("DSB-6k", 1);
                 field_rxbw.set_options(rxbw);  // store that aux GUI option to the field_rxbw.
 
                 field_rxbw.hidden(0);       // we show fixed RX AM BW 6Khz
@@ -404,7 +404,7 @@ MicTXView::MicTXView(
                 check_rogerbeep.set_value(false);  // reset the possible activation of roger beep, because it is not compatible with SSB, by now.
                 check_rogerbeep.hidden(1);         // hide that roger beep selection.
 
-                rxbw.emplace_back("  USB+3k   ", 0);  // locked a fixed option, to display it.
+                rxbw.emplace_back("USB+3k", 0);  // locked a fixed option, to display it.
                 field_rxbw.set_options(rxbw);         // store that aux GUI option to the field_rxbw.
 
                 set_dirty();  // Refresh display
@@ -415,7 +415,7 @@ MicTXView::MicTXView(
                 check_rogerbeep.set_value(false);  // reset the possible activation of roger beep, because it is not compatible with SSB, by now.
                 check_rogerbeep.hidden(1);         // hide that roger beep selection.
 
-                rxbw.emplace_back("  LSB-3k   ", 0);  // locked a fixed option, to display it.
+                rxbw.emplace_back("LSB-3k", 0);  // locked a fixed option, to display it.
                 field_rxbw.set_options(rxbw);         // store that aux GUI option to the field_rxbw.
 
                 set_dirty();  // Refresh display
@@ -425,8 +425,8 @@ MicTXView::MicTXView(
                 rxaudio(rx_enabled);        // Update now if we have RX audio on
                 check_rogerbeep.hidden(0);  // make visible again the "rogerbeep" selection.
 
-                rxbw.emplace_back("SSB1:USB+3k", 0);  // added dynamically two options (index 0,1) to that DSB-C case to the field_rxbw value.
-                rxbw.emplace_back("SSB2:LSB-3k", 1);
+                rxbw.emplace_back("USB+3k", 0);  // added dynamically two options (index 0,1) to that DSB-C case to the field_rxbw value.
+                rxbw.emplace_back("LSB-3k", 1);
 
                 field_rxbw.set_options(rxbw);  // store that aux GUI option to the field_rxbw.
 

--- a/firmware/application/apps/ui_mictx.cpp
+++ b/firmware/application/apps/ui_mictx.cpp
@@ -25,6 +25,7 @@
 #include "audio.hpp"
 #include "baseband_api.hpp"
 #include "irq_controls.hpp"
+#include "freqman.hpp"
 #include "portapack_hal.hpp"
 #include "string_format.hpp"
 #include "tonesets.hpp"
@@ -355,13 +356,10 @@ MicTXView::MicTXView(
                 rxaudio(rx_enabled);         // Update now if we have RX audio on
                 options_tone_key.hidden(0);  // we are in FM mode, we should have active the Key-tones & CTCSS option.
 
-                rxbw.emplace_back(" 8k5  ", 0);  // restore the original dynamic field_rxbw value.
-                rxbw.emplace_back(" 11k  ", 1);
-                rxbw.emplace_back(" 16k  ", 2);
-                field_rxbw.set_options(rxbw);  // store that aux GUI option to the field_rxbw.
-
-                field_rxbw.hidden(0);  // we are in FM mode, we need to allow the user set up of the RX NFM BW selection (8K5, 11K, 16K)
-                field_bw.hidden(0);    // we are in FM mode, we need to allow FM deviation parameter, in non FM mode.
+                freqman_set_bandwidth_option(NFM_MODULATION, field_rxbw);  // restore dynamic field_rxbw value with NFM options from freqman_db.cpp
+                field_rxbw.set_by_value(2);                                // // bw 16k (2) default
+                field_rxbw.hidden(0);                                      // we are in FM mode, we need to allow the user set up of the RX NFM BW selection (8K5, 11K, 16K)
+                field_bw.hidden(0);                                        // we are in FM mode, we need to allow FM deviation parameter, in non FM mode.
                 break;
             case 1:  //{ "WFM", 1 }
                 enable_am = false;
@@ -375,13 +373,10 @@ MicTXView::MicTXView(
                 rxaudio(rx_enabled);         // Update now if we have RX audio on
                 options_tone_key.hidden(0);  // we are in WFM mode, we should have active the Key-tones & CTCSS option.
 
-                rxbw.emplace_back(" 200k ", 0);  // We allow the user selection of the 3 x WFM BW filters, (0) WFM-200K, (1) WFM-180K, (2) WFM-40K.
-                rxbw.emplace_back(" 180k ", 1);
-                rxbw.emplace_back("  40k ", 2);
-                field_rxbw.set_options(rxbw);  // store that aux GUI option to the field_rxbw.
-
-                field_rxbw.hidden(0);  // we are in WFM mode, we need to show to the user the selected BW WFM filter.
-                field_bw.hidden(0);    // we are in WFM mode, we need to allow WFM deviation parameter, in non FM mode.
+                freqman_set_bandwidth_option(WFM_MODULATION, field_rxbw);  // restore dynamic field_rxbw value with WFM options from freqman_db.cpp
+                field_rxbw.set_by_value(0);                                // bw 200k (0) default
+                field_rxbw.hidden(0);                                      // we are in WFM mode, we need to show to the user the selected BW WFM filter.
+                field_bw.hidden(0);                                        // we are in WFM mode, we need to allow WFM deviation parameter, in non FM mode.
                 break;
             case 2:  //{ "AM", 2 }
                 enable_am = true;
@@ -390,8 +385,8 @@ MicTXView::MicTXView(
                 set_dirty();                             // Refresh display
                 options_tone_key.hidden(1);              // we hide that Key-tones & CTCSS input selecction, (no meaning in AM/DSB/SSB).
 
-                rxbw.emplace_back("DSB-9k", 0);  // we offer in AM DSB two audio BW 9k / 6k.
-                rxbw.emplace_back("DSB-6k", 1);
+                rxbw.emplace_back("DSB 9k", 0);  // we offer in AM DSB two audio BW 9k / 6k.
+                rxbw.emplace_back("DSB 6k", 1);
                 field_rxbw.set_options(rxbw);  // store that aux GUI option to the field_rxbw.
 
                 field_rxbw.hidden(0);       // we show fixed RX AM BW 6Khz
@@ -425,7 +420,7 @@ MicTXView::MicTXView(
                 rxaudio(rx_enabled);        // Update now if we have RX audio on
                 check_rogerbeep.hidden(0);  // make visible again the "rogerbeep" selection.
 
-                rxbw.emplace_back("USB+3k", 0);  // added dynamically two options (index 0,1) to that DSB-C case to the field_rxbw value.
+                rxbw.emplace_back("USB+3k", 0);  // added dynamically two options (index 0,1) to that DSB-SC case to the field_rxbw value.
                 rxbw.emplace_back("LSB-3k", 1);
 
                 field_rxbw.set_options(rxbw);  // store that aux GUI option to the field_rxbw.

--- a/firmware/application/apps/ui_mictx.cpp
+++ b/firmware/application/apps/ui_mictx.cpp
@@ -405,7 +405,7 @@ MicTXView::MicTXView(
                 check_rogerbeep.hidden(1);         // hide that roger beep selection.
 
                 rxbw.emplace_back("USB+3k", 0);  // locked a fixed option, to display it.
-                field_rxbw.set_options(rxbw);         // store that aux GUI option to the field_rxbw.
+                field_rxbw.set_options(rxbw);    // store that aux GUI option to the field_rxbw.
 
                 set_dirty();  // Refresh display
                 break;
@@ -416,7 +416,7 @@ MicTXView::MicTXView(
                 check_rogerbeep.hidden(1);         // hide that roger beep selection.
 
                 rxbw.emplace_back("LSB-3k", 0);  // locked a fixed option, to display it.
-                field_rxbw.set_options(rxbw);         // store that aux GUI option to the field_rxbw.
+                field_rxbw.set_options(rxbw);    // store that aux GUI option to the field_rxbw.
 
                 set_dirty();  // Refresh display
                 break;

--- a/firmware/application/apps/ui_mictx.hpp
+++ b/firmware/application/apps/ui_mictx.hpp
@@ -298,11 +298,11 @@ class MicTXView : public View {
 
     OptionsField field_rxbw{
         {19 * 8, (23 * 8) + 2},
-        3,
+        7,
         {
-            {" NFM1:8k5  ", 0},
-            {" NFM2:11k  ", 1},
-            {" FM  :16k  ", 2},
+            {" 8k5  ", 0},
+            {" 11k  ", 1},
+            {" 16k  ", 2},
         }};
 
     NumberField field_squelch{

--- a/firmware/application/apps/ui_mictx.hpp
+++ b/firmware/application/apps/ui_mictx.hpp
@@ -180,7 +180,7 @@ class MicTXView : public View {
 
     OptionsField options_ak4951_alc_mode{
         {20 * 8, 1 * 8},
-        11,
+        10,  // Label has 10 chars
         {
             {" OFF-12kHz", 0},   // Nothing changed from ORIGINAL, keeping ALL programmable AK4951 Digital Block->OFF, sampling 24Khz)
             {"+12dB-6kHz", 1},   // ALC-> on, (+12dB's) Auto Vol max + Wind Noise cancel + LPF 6kHz + Pre-amp Mic (+21dB=original)
@@ -198,7 +198,7 @@ class MicTXView : public View {
 
     OptionsField options_wm8731_boost_mode{
         {22 * 8, 1 * 8},
-        5,
+        8,  // Label has 8 chars
         {
             {"ON +12dB", 0},  // WM8731 Mic Boost ON, original+12dBs condition, easy to saturate ADC sat in high voice, relative G = +12 dB's respect ref level
             {"ON +06dB", 1},  // WM8731 Mic Boost ON, original+6 dBs condition, easy to saturate ADC sat in high voice, relative G = +06 dB's respect ref level
@@ -300,7 +300,7 @@ class MicTXView : public View {
         {19 * 8, (23 * 8) + 2},
         7,
         {
-            {" 8k5  ", 0},
+            {" 8k5  ", 0},  // Initial dynamic values when we start Mic App.
             {" 11k  ", 1},
             {" 16k  ", 2},
         }};


### PR DESCRIPTION
Minor  GUI correction in the Receiver side of Mic App . 
In some previous commonization PR, that RXBW  field char[size] was wrongly  limmtted to 3 char space .
Previous char[] size was using 12 chars in fw version 1.7.3 was OK 
 ,  now  I have reduced to 7 to keep some naming commonization.




