### PR TITLE
Workaround for Capture startup hang

### DIFF
--- a/firmware/application/apps/capture_app.cpp
+++ b/firmware/application/apps/capture_app.cpp
@@ -31,7 +31,6 @@ namespace ui {
 
 CaptureAppView::CaptureAppView(NavigationView& nav)
     : nav_{nav} {
-    freqman_set_bandwidth_option(SPEC_MODULATION, option_bandwidth);
     baseband::run_image(portapack::spi_flash::image_tag_capture);
 
     add_children({
@@ -67,6 +66,7 @@ CaptureAppView::CaptureAppView(NavigationView& nav)
         record_view.set_file_type((RecordView::FileType)file_type);
     };
 
+    freqman_set_bandwidth_option(SPEC_MODULATION, option_bandwidth);
     option_bandwidth.on_change = [this](size_t, uint32_t base_rate) {
         /* base_rate is used for FFT calculation and display LCD, and also in recording writing SD Card rate. */
         /* ex. sampling_rate values, 4Mhz, when recording 500 kHz (BW) and fs 8 Mhz, when selected 1 Mhz BW ... */
@@ -76,12 +76,11 @@ CaptureAppView::CaptureAppView(NavigationView& nav)
         /* Set up proper anti aliasing BPF bandwith in MAX2837 before ADC sampling according to the new added BW Options. */
         auto anti_alias_baseband_bandwidth_filter = filter_bandwidth_for_sampling_rate(sampling_rate);
 
-        baseband::spectrum_streaming_stop();
+        waterfall.stop();
         record_view.set_sampling_rate(sampling_rate);
         receiver_model.set_sampling_rate(sampling_rate);
         receiver_model.set_baseband_bandwidth(anti_alias_baseband_bandwidth_filter);
-        // TODO: baseband::set_spectrum too?
-        baseband::spectrum_streaming_start();
+        waterfall.start();
     };
 
     receiver_model.enable();

--- a/firmware/application/apps/capture_app.cpp
+++ b/firmware/application/apps/capture_app.cpp
@@ -48,14 +48,6 @@ CaptureAppView::CaptureAppView(NavigationView& nav)
         &waterfall,
     });
 
-    /* THE ONE LINE BELOW IS A TEMPORARY KLUDGE WORKAROUND FOR A MYSTERY M4 BASEBAND HANG ISSUE WHEN THE CAPTURE
-       APP IS THE FIRST APP STARTED AFTER POWER-UP, OR THE CAPTURE APP IS RUN AFTER RUNNING REPLAY WITH A HIGH
-       SAMPLE RATE. IT SHOULD NOT BE NECESSARY SINCE sampling_rate IS ALREADY INITIALIZED BY RADIOSTATE BUT
-       APPARENTLY IS ADDING JUST THE RIGHT AMOUNT OF DELAY.  ISSUE DOES NOT AFFECT ALL PORTAPACK UNITS.
-       INVESTIGATION IS ONGOING, SEE ISSUE #1283. */
-    receiver_model.set_sampling_rate(3072000);
-    /* END MYSTERY HANG WORKAROUND. */
-
     field_frequency_step.set_by_value(receiver_model.frequency_step());
     field_frequency_step.on_change = [this](size_t, OptionsField::value_t v) {
         receiver_model.set_frequency_step(v);

--- a/firmware/application/apps/capture_app.cpp
+++ b/firmware/application/apps/capture_app.cpp
@@ -60,7 +60,6 @@ CaptureAppView::CaptureAppView(NavigationView& nav)
     field_frequency_step.set_by_value(receiver_model.frequency_step());
     field_frequency_step.on_change = [this](size_t, OptionsField::value_t v) {
         receiver_model.set_frequency_step(v);
-        this->field_frequency.set_step(v);
     };
 
     option_format.set_selected_index(0);  // Default to C16
@@ -69,24 +68,24 @@ CaptureAppView::CaptureAppView(NavigationView& nav)
     };
 
     option_bandwidth.on_change = [this](size_t, uint32_t base_rate) {
-        sampling_rate = 8 * base_rate;  // Decimation by 8 done on baseband side
-                                        /* base_rate is used for FFT calculation and display LCD, and also in recording writing SD Card rate. */
+        /* base_rate is used for FFT calculation and display LCD, and also in recording writing SD Card rate. */
         /* ex. sampling_rate values, 4Mhz, when recording 500 kHz (BW) and fs 8 Mhz, when selected 1 Mhz BW ... */
         /* ex. recording 500kHz BW to .C16 file, base_rate clock 500kHz x2(I,Q) x 2 bytes (int signed) =2MB/sec rate SD Card  */
-        waterfall.on_hide();
+        auto sampling_rate = 8 * base_rate;  // Decimation by 8 done on baseband side.
 
         /* Set up proper anti aliasing BPF bandwith in MAX2837 before ADC sampling according to the new added BW Options. */
         auto anti_alias_baseband_bandwidth_filter = filter_bandwidth_for_sampling_rate(sampling_rate);
 
+        baseband::spectrum_streaming_stop();
         record_view.set_sampling_rate(sampling_rate);
         receiver_model.set_sampling_rate(sampling_rate);
         receiver_model.set_baseband_bandwidth(anti_alias_baseband_bandwidth_filter);
-
-        waterfall.on_show();
+        // TODO: baseband::set_spectrum too?
+        baseband::spectrum_streaming_start();
     };
 
-    option_bandwidth.set_selected_index(7);  // Preselected default option 500kHz.
     receiver_model.enable();
+    option_bandwidth.set_selected_index(7);  // Preselected default option 500kHz.
 
     record_view.on_error = [&nav](std::string message) {
         nav.display_modal("Error", message);
@@ -96,11 +95,6 @@ CaptureAppView::CaptureAppView(NavigationView& nav)
 CaptureAppView::~CaptureAppView() {
     receiver_model.disable();
     baseband::shutdown();
-}
-
-void CaptureAppView::on_hide() {
-    waterfall.on_hide();
-    View::on_hide();
 }
 
 void CaptureAppView::set_parent_rect(const Rect new_parent_rect) {

--- a/firmware/application/apps/capture_app.hpp
+++ b/firmware/application/apps/capture_app.hpp
@@ -39,7 +39,6 @@ class CaptureAppView : public View {
     CaptureAppView(NavigationView& nav);
     ~CaptureAppView();
 
-    void on_hide() override;
     void focus() override;
     void set_parent_rect(const Rect new_parent_rect) override;
 
@@ -53,8 +52,6 @@ class CaptureAppView : public View {
     app_settings::SettingsManager settings_{
         "rx_capture", app_settings::Mode::RX,
         app_settings::Options::UseGlobalTargetFrequency};
-
-    uint32_t sampling_rate = 0;
 
     Labels labels{
         {{0 * 8, 1 * 16}, "Rate:", Color::light_grey()},

--- a/firmware/application/baseband_api.cpp
+++ b/firmware/application/baseband_api.cpp
@@ -31,6 +31,16 @@
 
 #include "core_control.hpp"
 
+/* Set true to enable additional checks to ensure 
+ * M4 and M0 are synchronized before passing messages. */
+static constexpr bool enforce_core_sync = true;
+
+/* Set true to enable check for baseband messages getting stuck.
+ * This implies the baseband thread is not dequeuing and has probably stalled.
+ * NB: This check adds a small amout of overhead to the message sending code
+ * and may impact application perf if it is sending a lot of messages. */
+static constexpr bool check_for_message_hang = true;
+
 using namespace portapack;
 
 namespace baseband {
@@ -40,12 +50,18 @@ static void send_message(const Message* const message) {
     // another message is present before setting new message.
     shared_memory.baseband_message = message;
     creg::m0apptxevent::assert_event();
-    auto count = UINT32_MAX;
-    while (shared_memory.baseband_message && --count)
-        /* spin */;
 
-    if (!count)
-        chDbgPanic("Baseband Send Fail");
+    if constexpr (check_for_message_hang) {
+        auto count = UINT32_MAX;
+        while (shared_memory.baseband_message && --count)
+            /* spin */;
+
+        if (count == 0)
+            chDbgPanic("Baseband Send Fail");
+    } else {
+        while (shared_memory.baseband_message)
+            /* spin */;
+    }
 }
 
 void AMConfig::apply() const {
@@ -293,13 +309,15 @@ void run_image(const spi_flash::image_tag_t image_tag) {
 
     creg::m4txevent::enable();
 
-    // Wait 3 seconds for baseband to start handling events.
-    auto count = 3'000u;
-    while (!shared_memory.baseband_ready && --count)
-        chThdSleepMilliseconds(1);
+    if constexpr (enforce_core_sync) {
+        // Wait 3 seconds for baseband to start handling events.
+        auto count = 3'000u;
+        while (!shared_memory.baseband_ready && --count)
+            chThdSleepMilliseconds(1);
 
-    if (!count)
-        chDbgPanic("Baseband Sync Fail");
+        if (!count)
+            chDbgPanic("Baseband Sync Fail");
+    }
 }
 
 void shutdown() {

--- a/firmware/application/baseband_api.cpp
+++ b/firmware/application/baseband_api.cpp
@@ -31,7 +31,7 @@
 
 #include "core_control.hpp"
 
-/* Set true to enable additional checks to ensure 
+/* Set true to enable additional checks to ensure
  * M4 and M0 are synchronized before passing messages. */
 static constexpr bool enforce_core_sync = true;
 

--- a/firmware/application/baseband_api.cpp
+++ b/firmware/application/baseband_api.cpp
@@ -310,12 +310,12 @@ void run_image(const spi_flash::image_tag_t image_tag) {
     creg::m4txevent::enable();
 
     if constexpr (enforce_core_sync) {
-        // Wait 3 seconds for baseband to start handling events.
+        // Wait up to 3 seconds for baseband to start handling events.
         auto count = 3'000u;
         while (!shared_memory.baseband_ready && --count)
             chThdSleepMilliseconds(1);
 
-        if (!count)
+        if (count == 0)
             chDbgPanic("Baseband Sync Fail");
     }
 }

--- a/firmware/application/core_control.cpp
+++ b/firmware/application/core_control.cpp
@@ -20,21 +20,20 @@
  * Boston, MA 02110-1301, USA.
  */
 
-#include "core_control.hpp"
-
-#include "hal.h"
-
-#include "lpc43xx_cpp.hpp"
-using namespace lpc43xx;
-
-#include "message.hpp"
 #include "baseband_api.hpp"
+#include "core_control.hpp"
+#include "hal.h"
+#include "lpc43xx_cpp.hpp"
 #include "lz4.h"
+#include "message.hpp"
 
 #include <cstring>
 
-void m4_init(const portapack::spi_flash::image_tag_t image_tag, const portapack::memory::region_t to, const bool full_reset) {
-    const portapack::spi_flash::chunk_t* chunk = reinterpret_cast<const portapack::spi_flash::chunk_t*>(portapack::spi_flash::images.base());
+using namespace lpc43xx;
+using namespace portapack;
+
+void m4_init(const spi_flash::image_tag_t image_tag, const memory::region_t to, const bool full_reset) {
+    const spi_flash::chunk_t* chunk = reinterpret_cast<const spi_flash::chunk_t*>(spi_flash::images.base());
     while (chunk->tag) {
         if (chunk->tag == image_tag) {
             const void* src = &chunk->data[0];
@@ -49,9 +48,8 @@ void m4_init(const portapack::spi_flash::image_tag_t image_tag, const portapack:
             LPC_CREG->M4MEMMAP = to.base();
 
             /* Reset M4 core and optionally all peripherals */
-            LPC_RGU->RESET_CTRL[0] = (full_reset) ? (1 << 1)   // PERIPH_RST
-                                                  : (1 << 13)  // M4_RST
-                ;
+            LPC_RGU->RESET_CTRL[0] = (full_reset) ? (1 << 1)    // PERIPH_RST
+                                                  : (1 << 13);  // M4_RST
 
             return;
         }

--- a/firmware/application/radio.cpp
+++ b/firmware/application/radio.cpp
@@ -238,6 +238,7 @@ void set_baseband_filter_bandwidth(const uint32_t bandwidth_minimum) {
 
 void set_baseband_rate(const uint32_t rate) {
     portapack::clock_manager.set_sampling_frequency(rate);
+    // TODO: actually set baseband too?
 }
 
 void set_antenna_bias(const bool on) {

--- a/firmware/application/ui/ui_spectrum.cpp
+++ b/firmware/application/ui/ui_spectrum.cpp
@@ -308,13 +308,25 @@ WaterfallView::WaterfallView(const bool cursor) {
 }
 
 void WaterfallView::on_show() {
-    // TODO: Assert that baseband is not shutdown.
-    baseband::spectrum_streaming_start();
+    start();
 }
 
 void WaterfallView::on_hide() {
-    // TODO: Assert that baseband is not shutdown.
-    baseband::spectrum_streaming_stop();
+    stop();
+}
+
+void WaterfallView::start() {
+    if (!running_) {
+        baseband::spectrum_streaming_start();
+        running_ = true;
+    }
+}
+
+void WaterfallView::stop() {
+    if (running_) {
+        baseband::spectrum_streaming_stop();
+        running_ = false;
+    }
 }
 
 void WaterfallView::show_audio_spectrum_view(const bool show) {

--- a/firmware/application/ui/ui_spectrum.hpp
+++ b/firmware/application/ui/ui_spectrum.hpp
@@ -131,11 +131,14 @@ class WaterfallView : public View {
     WaterfallView& operator=(const WaterfallView&) = delete;
     WaterfallView& operator=(WaterfallView&&) = delete;
 
+    // TODO: remove these, use start/stop directly instead.
     void on_show() override;
     void on_hide() override;
 
-    void set_parent_rect(const Rect new_parent_rect) override;
+    void start();
+    void stop();
 
+    void set_parent_rect(const Rect new_parent_rect) override;
     void show_audio_spectrum_view(const bool show);
 
    private:
@@ -147,6 +150,7 @@ class WaterfallView : public View {
 
     WaterfallWidget waterfall_widget{};
     FrequencyScale frequency_scale{};
+    bool running_{false};
 
     ChannelSpectrumFIFO* channel_fifo{nullptr};
     AudioSpectrum* audio_spectrum_data{nullptr};

--- a/firmware/application/ui_navigation.cpp
+++ b/firmware/application/ui_navigation.cpp
@@ -497,13 +497,8 @@ ReceiversMenuView::ReceiversMenuView(NavigationView& nav) {
         add_items({{"..", Color::light_grey(), &bitmap_icon_previous, [&nav]() { nav.pop(); }}});
     }
     add_items({
-        {
-            "ADS-B",
-            Color::green(),
-            &bitmap_icon_adsb,
-            [&nav]() { nav.push<ADSBRxView>(); },
-        },
-        //{ "ACARS",	Color::yellow(),	&bitmap_icon_adsb,			[&nav](){ nav.push<ACARSAppView>(); }, },
+        {"ADS-B", Color::green(), &bitmap_icon_adsb, [&nav]() { nav.push<ADSBRxView>(); }},
+        //{ "ACARS",	Color::yellow(),	&bitmap_icon_adsb,			[&nav](){ nav.push<ACARSAppView>(); }},
         {"AIS Boats", Color::green(), &bitmap_icon_ais, [&nav]() { nav.push<AISAppView>(); }},
         {"AFSK", Color::yellow(), &bitmap_icon_modem, [&nav]() { nav.push<AFSKRxView>(); }},
         {"BTLE", Color::yellow(), &bitmap_icon_btle, [&nav]() { nav.push<BTLERxView>(); }},

--- a/firmware/baseband/event_m4.cpp
+++ b/firmware/baseband/event_m4.cpp
@@ -61,6 +61,10 @@ void EventDispatcher::run() {
 
     lpc43xx::creg::m0apptxevent::enable();
 
+    // Handle any baseband messages that may have been sent
+    // before the event was enabled.
+    handle_baseband_queue();
+
     while (is_running) {
         const auto events = wait();
         dispatch(events);

--- a/firmware/baseband/event_m4.cpp
+++ b/firmware/baseband/event_m4.cpp
@@ -19,20 +19,17 @@
  * Boston, MA 02110-1301, USA.
  */
 
-#include "event_m4.hpp"
-#include "debug.hpp"
-
-#include "portapack_shared_memory.hpp"
-
-#include "message_queue.hpp"
-
 #include "ch.h"
-
+#include "debug.hpp"
+#include "event_m4.hpp"
 #include "lpc43xx_cpp.hpp"
-using namespace lpc43xx;
+#include "message_queue.hpp"
+#include "portapack_shared_memory.hpp"
 
 #include <cstdint>
 #include <array>
+
+using namespace lpc43xx;
 
 extern "C" {
 
@@ -61,9 +58,9 @@ void EventDispatcher::run() {
 
     lpc43xx::creg::m0apptxevent::enable();
 
-    // Hack to indicate to the M0 thread that
+    // Indicate to the M0 thread that
     // M4 is ready to receive message events.
-    shared_memory.baseband_message = nullptr;
+    shared_memory.set_baseband_ready();
 
     while (is_running) {
         const auto events = wait();

--- a/firmware/baseband/event_m4.cpp
+++ b/firmware/baseband/event_m4.cpp
@@ -61,9 +61,9 @@ void EventDispatcher::run() {
 
     lpc43xx::creg::m0apptxevent::enable();
 
-    // Handle any baseband messages that may have been sent
-    // before the event was enabled.
-    handle_baseband_queue();
+    // Hack to indicate to the M0 thread that
+    // M4 is ready to receive message events.
+    shared_memory.baseband_message = nullptr;
 
     while (is_running) {
         const auto events = wait();

--- a/firmware/baseband/proc_capture.cpp
+++ b/firmware/baseband/proc_capture.cpp
@@ -31,9 +31,13 @@ CaptureProcessor::CaptureProcessor() {
     decim_1.configure(taps_200k_decim_1.taps, 131072);
 
     channel_spectrum.set_decimation_factor(1);
+    ready = true;
 }
 
 void CaptureProcessor::execute(const buffer_c8_t& buffer) {
+    if (!ready)
+        return;
+
     /* 2.4576MHz, 2048 samples */
     const auto decim_0_out = decim_0.execute(buffer, dst_buffer);
     const auto decim_1_out = decim_1.execute(decim_0_out, dst_buffer);

--- a/firmware/baseband/proc_capture.cpp
+++ b/firmware/baseband/proc_capture.cpp
@@ -23,9 +23,7 @@
 #include "proc_capture.hpp"
 
 #include "dsp_fir_taps.hpp"
-
 #include "event_m4.hpp"
-
 #include "utility.hpp"
 
 CaptureProcessor::CaptureProcessor() {

--- a/firmware/baseband/proc_capture.hpp
+++ b/firmware/baseband/proc_capture.hpp
@@ -49,6 +49,12 @@ class CaptureProcessor : public BasebandProcessor {
     size_t baseband_fs = 0;
     static constexpr auto spectrum_rate_hz = 50.0f;
 
+    // NB: For some reason this initialization can cause the M4 to hang.
+    // Moving it to the first member spot seems to alleviate that. ???
+    SpectrumCollector channel_spectrum{};
+    size_t spectrum_interval_samples = 0;
+    size_t spectrum_samples = 0;
+
     BasebandThread baseband_thread{baseband_fs, this, NORMALPRIO + 20, baseband::Direction::Receive};
     RSSIThread rssi_thread{NORMALPRIO + 10};
 
@@ -64,10 +70,6 @@ class CaptureProcessor : public BasebandProcessor {
     int32_t channel_filter_transition = 0;
 
     std::unique_ptr<StreamInput> stream{};
-
-    SpectrumCollector channel_spectrum{};
-    size_t spectrum_interval_samples = 0;
-    size_t spectrum_samples = 0;
 
     void samplerate_config(const SamplerateConfigMessage& message);
     void capture_config(const CaptureConfigMessage& message);

--- a/firmware/baseband/proc_capture.hpp
+++ b/firmware/baseband/proc_capture.hpp
@@ -46,14 +46,12 @@ class CaptureProcessor : public BasebandProcessor {
 
    private:
     // TODO: Repeated value needs to be transmitted from application side.
-    size_t baseband_fs = 0;
+    size_t baseband_fs = 3072000;
     static constexpr auto spectrum_rate_hz = 50.0f;
 
-    // NB: For some reason this initialization can cause the M4 to hang.
-    // Moving it to the first member spot seems to alleviate that. ???
-    SpectrumCollector channel_spectrum{};
-    size_t spectrum_interval_samples = 0;
-    size_t spectrum_samples = 0;
+    // HACK: BasebandThread starts immediately and starts sending data to members
+    // before they are initialized. This is a workaround to prevent uninit data problems.
+    bool ready = false;
 
     BasebandThread baseband_thread{baseband_fs, this, NORMALPRIO + 20, baseband::Direction::Receive};
     RSSIThread rssi_thread{NORMALPRIO + 10};
@@ -70,6 +68,10 @@ class CaptureProcessor : public BasebandProcessor {
     int32_t channel_filter_transition = 0;
 
     std::unique_ptr<StreamInput> stream{};
+
+    SpectrumCollector channel_spectrum{};
+    size_t spectrum_interval_samples = 0;
+    size_t spectrum_samples = 0;
 
     void samplerate_config(const SamplerateConfigMessage& message);
     void capture_config(const CaptureConfigMessage& message);

--- a/firmware/baseband/proc_gps_sim.hpp
+++ b/firmware/baseband/proc_gps_sim.hpp
@@ -43,7 +43,7 @@ class ReplayProcessor : public BasebandProcessor {
     void on_message(const Message* const message) override;
 
    private:
-    size_t baseband_fs = 0;
+    size_t baseband_fs = 3072000;
     static constexpr auto spectrum_rate_hz = 50.0f;
 
     BasebandThread baseband_thread{baseband_fs, this, NORMALPRIO + 20, baseband::Direction::Transmit};

--- a/firmware/baseband/proc_replay.hpp
+++ b/firmware/baseband/proc_replay.hpp
@@ -42,7 +42,7 @@ class ReplayProcessor : public BasebandProcessor {
     void on_message(const Message* const message) override;
 
    private:
-    size_t baseband_fs = 0;
+    size_t baseband_fs = 3072000;
     static constexpr auto spectrum_rate_hz = 50.0f;
 
     BasebandThread baseband_thread{baseband_fs, this, NORMALPRIO + 20, baseband::Direction::Transmit};

--- a/firmware/common/portapack_shared_memory.hpp
+++ b/firmware/common/portapack_shared_memory.hpp
@@ -65,6 +65,11 @@ struct SharedMemory {
         uint8_t data[512];
     } bb_data{{{{0, 0}}, 0, {0}}};
 
+    // Set by the M4 to indicate that the baseband app is ready.
+    bool volatile baseband_ready{false};
+    void clear_baseband_ready() { baseband_ready = false; }
+    void set_baseband_ready() { baseband_ready = true; }
+
     uint8_t volatile request_m4_performance_counter{0};
     uint8_t volatile m4_cpu_usage{0};
     uint16_t volatile m4_stack_usage{0};


### PR DESCRIPTION
This PR adds a more reliable workaround for the baseband threading problem in proc_capture.
The gist of the underlying bug is that the baseband processor BasebandThread starts pushing event data to the baseband processor immediately once it's initialized in its ctor. This is a problem though because the BasebandThread is a class-member with an in-body initializer. This means that the rest of the baseband processor's members are still in the process of being initialized when they may start being used.

This workaround just sets a flag when the processor is done setting up before it actually starts processing buffers.
The right fix will be to change the threading to separate init from run.

There are a few additional changes in the PR that help harden the M0/M4 messaging.
- Enforce synchronization with baseband image startup.
    - This causes the M0 to wait for the M4 to signal that it has started its event handling before the M0 thread continues.
    - This ensures that the M0 can't send events to the baseband until it's listening.
    - There's a panic if the M4 doesn't start up in 3 seconds. This will help us debug baseband processor problems (like this one)
 - Check that the baseband_message gets picked up after being sent.
     - This limits the number of spins the M0 will try before it panics. This can help us diagnose hangs where the M0 stalls waiting for the M4 to pick up an event. (Would've been useful to diagnose hangs caused by the Waterfall control)
 - Additional hardening and code cleanup.

[Adding mention of issue #1283]