### PR TITLE
Minor Replay & GPS baseband optimizations

### DIFF
--- a/firmware/application/apps/gps_sim_app.cpp
+++ b/firmware/application/apps/gps_sim_app.cpp
@@ -65,12 +65,12 @@ void GpsSimAppView::on_file_changed(const fs::path& new_file_path) {
         field_frequency.set_value(metadata->center_frequency);
         sample_rate = metadata->sample_rate;
     } else {
-        sample_rate = 500000;
+        sample_rate = 2600000;
     }
 
     // UI Fixup.
     text_sample_rate.set(unit_auto_scale(sample_rate, 3, 1) + "Hz");
-    progressbar.set_max(file_size / 1024);
+    progressbar.set_max(file_size);
     text_filename.set(truncate(file_path.filename().string(), 12));
 
     auto duration = ms_duration(file_size, sample_rate, 2);

--- a/firmware/baseband/proc_gps_sim.cpp
+++ b/firmware/baseband/proc_gps_sim.cpp
@@ -42,34 +42,32 @@ ReplayProcessor::ReplayProcessor() {
 }
 
 void ReplayProcessor::execute(const buffer_c8_t& buffer) {
-    /* 4MHz, 2048 samples */
+    /* 2.6MHz, 2048 samples */
 
     if (!configured) return;
 
-    // File data is in C16 format, we need C8
-    // File samplerate is 500kHz, we're at 4MHz
-    // iq_buffer can only be 512 C16 samples (RAM limitation)
-    // To fill up the 2048-sample C8 buffer, we need:
-    // 2048 samples * 2 bytes per sample = 4096 bytes
-    // Since we're oversampling by 4M/500k = 8, we only need 2048/8 = 256 samples from the file and duplicate them 8 times each
-    // So 256 * 4 bytes per sample (C16) = 1024 bytes from the file
-    if (stream) {                                                             // sizeof(*buffer.p) = sizeof(C8) = 2*int8 = 2 bytes //buffer.count = 2048
-        const size_t bytes_to_read = sizeof(*buffer.p) * 1 * (buffer.count);  // *2 (C16), /8 (oversampling) should be == 1024
+    // File data is in C8 format, which is what we need
+    // File samplerate is 2.6MHz, which is what we need
+    // To fill up the 2048-sample C8 buffer @ 2 bytes per sample = 4096 bytes
+    const size_t bytes_to_read = sizeof(*buffer.p) * 1 * (buffer.count);
+    if (stream) {
         bytes_read += stream->read(iq_buffer.p, bytes_to_read);
     }
 
-    // Fill and "stretch"
-    for (size_t i = 0; i < buffer.count; i++) {
-        auto re_out = iq_buffer.p[i].real();
-        auto im_out = iq_buffer.p[i].imag();
-        buffer.p[i] = {(int8_t)re_out, (int8_t)im_out};
-    }
+    // NB: Couldn't we have just read the data into buffer.p to start with, or some DMA/cache coherency concern?
+    //
+    // for (size_t i = 0; i < buffer.count; i++) {
+    //     auto re_out = iq_buffer.p[i].real();
+    //     auto im_out = iq_buffer.p[i].imag();
+    //     buffer.p[i] = {(int8_t)re_out, (int8_t)im_out};
+    // }
+    memcpy(buffer.p, iq_buffer.p, bytes_to_read);  // memcpy should be more efficient than 1 byte at a time
 
     spectrum_samples += buffer.count;
     if (spectrum_samples >= spectrum_interval_samples) {
         spectrum_samples -= spectrum_interval_samples;
 
-        txprogress_message.progress = bytes_read / 1024;  // Inform UI about progress
+        txprogress_message.progress = bytes_read;  // Inform UI about progress
 
         txprogress_message.done = false;
         shared_memory.application_queue.push(txprogress_message);

--- a/firmware/baseband/proc_gps_sim.cpp
+++ b/firmware/baseband/proc_gps_sim.cpp
@@ -49,19 +49,20 @@ void ReplayProcessor::execute(const buffer_c8_t& buffer) {
     // File data is in C8 format, which is what we need
     // File samplerate is 2.6MHz, which is what we need
     // To fill up the 2048-sample C8 buffer @ 2 bytes per sample = 4096 bytes
-    const size_t bytes_to_read = sizeof(*buffer.p) * 1 * (buffer.count);
     if (stream) {
-        bytes_read += stream->read(iq_buffer.p, bytes_to_read);
-    }
+        const size_t bytes_to_read = sizeof(*buffer.p) * 1 * (buffer.count);
+        size_t bytes_read_this_iteration = stream->read(iq_buffer.p, bytes_to_read);
+        bytes_read += bytes_read_this_iteration;
 
-    // NB: Couldn't we have just read the data into buffer.p to start with, or some DMA/cache coherency concern?
-    //
-    // for (size_t i = 0; i < buffer.count; i++) {
-    //     auto re_out = iq_buffer.p[i].real();
-    //     auto im_out = iq_buffer.p[i].imag();
-    //     buffer.p[i] = {(int8_t)re_out, (int8_t)im_out};
-    // }
-    memcpy(buffer.p, iq_buffer.p, bytes_to_read);  // memcpy should be more efficient than 1 byte at a time
+        // NB: Couldn't we have just read the data into buffer.p to start with, or some DMA/cache coherency concern?
+        //
+        // for (size_t i = 0; i < buffer.count; i++) {
+        //     auto re_out = iq_buffer.p[i].real();
+        //     auto im_out = iq_buffer.p[i].imag();
+        //     buffer.p[i] = {(int8_t)re_out, (int8_t)im_out};
+        // }
+        memcpy(buffer.p, iq_buffer.p, bytes_read_this_iteration);  // memcpy should be more efficient than 1 byte at a time
+    }
 
     spectrum_samples += buffer.count;
     if (spectrum_samples >= spectrum_interval_samples) {

--- a/firmware/baseband/proc_replay.cpp
+++ b/firmware/baseband/proc_replay.cpp
@@ -59,7 +59,7 @@ void ReplayProcessor::execute(const buffer_c8_t& buffer) {
 
     // Fill and "stretch"
     for (size_t i = 0; i < buffer.count; i++) {
-        if (i & 3) {
+        if (i & 7) {
             buffer.p[i] = buffer.p[i - 1];
         } else {
             auto re_out = iq_buffer.p[i >> 3].real() >> 8;


### PR DESCRIPTION
1) When proc_replay was doing the 8X sample "stretching", it was inadvertently doing the math twice as many times as necessary for each C16->C8 conversion.  Only needs to do the math once for every 8 C8 samples generated.

2) Increase efficiency of proc_gps by using memcpy vs byte-by-byte copy from the disk buffer to the transmit buffer.  Also only copy the number of bytes actually read from the file, versus the buffer size.

3) Corrected comments in proc_gps.

4) Set default sample freq to 2.6MHz in GPS Sim app (vs 500KHz) to match the GPS Sim test files.  Only matters if the corresponding .TXT file is not found.

5) Eliminated scaling GPS Sim progress by 1024 (which was a workaround for a ProgressBar widget overflow issue that is now corrected in the widget)