### PR TITLE
Fix baseband thread init order bug for all procs.

### DIFF
--- a/firmware/baseband/proc_acars.cpp
+++ b/firmware/baseband/proc_acars.cpp
@@ -32,6 +32,7 @@ ACARSProcessor::ACARSProcessor() {
     decim_0.configure(taps_11k0_decim_0.taps, 33554432);
     decim_1.configure(taps_11k0_decim_1.taps, 131072);
     packet.clear();
+    baseband_thread.start();
 }
 
 void ACARSProcessor::execute(const buffer_c8_t& buffer) {

--- a/firmware/baseband/proc_acars.hpp
+++ b/firmware/baseband/proc_acars.hpp
@@ -110,9 +110,6 @@ class ACARSProcessor : public BasebandProcessor {
    private:
     static constexpr size_t baseband_fs = 2457600;
 
-    BasebandThread baseband_thread{baseband_fs, this, NORMALPRIO + 20, baseband::Direction::Receive};
-    RSSIThread rssi_thread{NORMALPRIO + 10};
-
     std::array<complex16_t, 512> dst{};
     const buffer_c16_t dst_buffer{
         dst.data(),
@@ -137,6 +134,11 @@ class ACARSProcessor : public BasebandProcessor {
                 }
         };*/
     baseband::Packet packet{};
+
+    /* NB: Threads should be the last members in the class definition. */
+    BasebandThread baseband_thread{
+        baseband_fs, this, baseband::Direction::Receive, /*auto_start*/ false};
+    RSSIThread rssi_thread{};
 
     void consume_symbol(const float symbol);
     void payload_handler(const baseband::Packet& packet);

--- a/firmware/baseband/proc_adsbrx.hpp
+++ b/firmware/baseband/proc_adsbrx.hpp
@@ -36,14 +36,10 @@ using namespace adsb;
 class ADSBRXProcessor : public BasebandProcessor {
    public:
     void execute(const buffer_c8_t& buffer) override;
-
     void on_message(const Message* const message) override;
 
    private:
     static constexpr size_t baseband_fs = 2000000;
-
-    BasebandThread baseband_thread{baseband_fs, this, NORMALPRIO + 20, baseband::Direction::Receive};
-    RSSIThread rssi_thread{NORMALPRIO + 10};
 
     ADSBFrame frame{};
     bool configured{false};
@@ -58,6 +54,10 @@ class ADSBRXProcessor : public BasebandProcessor {
     uint32_t sample{0};
     int32_t re{}, im{};
     int32_t amp{0};
+
+    /* NB: Threads should be the last members in the class definition. */
+    BasebandThread baseband_thread{baseband_fs, this, baseband::Direction::Receive};
+    RSSIThread rssi_thread{};
 };
 
 #endif

--- a/firmware/baseband/proc_adsbtx.hpp
+++ b/firmware/baseband/proc_adsbtx.hpp
@@ -29,13 +29,10 @@
 class ADSBTXProcessor : public BasebandProcessor {
    public:
     void execute(const buffer_c8_t& buffer) override;
-
     void on_message(const Message* const p) override;
 
    private:
     bool configured = false;
-
-    BasebandThread baseband_thread{4000000, this, NORMALPRIO + 20, baseband::Direction::Transmit};
 
     const complex8_t am_lut[4] = {
         {127, 0},
@@ -48,6 +45,9 @@ class ADSBTXProcessor : public BasebandProcessor {
     uint32_t phase{0};
 
     TXProgressMessage txprogress_message{};
+
+    /* NB: Threads should be the last members in the class definition. */
+    BasebandThread baseband_thread{4000000, this, baseband::Direction::Transmit};
 };
 
 #endif

--- a/firmware/baseband/proc_afsk.hpp
+++ b/firmware/baseband/proc_afsk.hpp
@@ -32,13 +32,10 @@
 class AFSKProcessor : public BasebandProcessor {
    public:
     void execute(const buffer_c8_t& buffer) override;
-
     void on_message(const Message* const msg) override;
 
    private:
     bool configured = false;
-
-    BasebandThread baseband_thread{AFSK_SAMPLERATE, this, NORMALPRIO + 20, baseband::Direction::Transmit};
 
     uint32_t afsk_samples_per_bit{0};
     uint32_t afsk_phase_inc_mark{0};
@@ -59,6 +56,9 @@ class AFSKProcessor : public BasebandProcessor {
     int8_t re{0}, im{0};
 
     TXProgressMessage txprogress_message{};
+
+    /* NB: Threads should be the last members in the class definition. */
+    BasebandThread baseband_thread{AFSK_SAMPLERATE, this, baseband::Direction::Transmit};
 };
 
 #endif

--- a/firmware/baseband/proc_afskrx.hpp
+++ b/firmware/baseband/proc_afskrx.hpp
@@ -38,7 +38,6 @@
 class AFSKRxProcessor : public BasebandProcessor {
    public:
     void execute(const buffer_c8_t& buffer) override;
-
     void on_message(const Message* const message) override;
 
    private:
@@ -52,9 +51,6 @@ class AFSKRxProcessor : public BasebandProcessor {
         WAIT_STOP,
         RECEIVE
     };
-
-    BasebandThread baseband_thread{baseband_fs, this, NORMALPRIO + 20, baseband::Direction::Receive};
-    RSSIThread rssi_thread{NORMALPRIO + 10};
 
     std::array<complex16_t, 512> dst{};
     const buffer_c16_t dst_buffer{
@@ -93,9 +89,13 @@ class AFSKRxProcessor : public BasebandProcessor {
     bool trigger_word{};
     bool triggered{};
 
-    void configure(const AFSKRxConfigureMessage& message);
-
     AFSKDataMessage data_message{false, 0};
+
+    /* NB: Threads should be the last members in the class definition. */
+    BasebandThread baseband_thread{baseband_fs, this, baseband::Direction::Receive};
+    RSSIThread rssi_thread{};
+
+    void configure(const AFSKRxConfigureMessage& message);
 };
 
 #endif /*__PROC_TPMS_H__*/

--- a/firmware/baseband/proc_ais.cpp
+++ b/firmware/baseband/proc_ais.cpp
@@ -30,6 +30,7 @@
 AISProcessor::AISProcessor() {
     decim_0.configure(taps_11k0_decim_0.taps, 33554432);
     decim_1.configure(taps_11k0_decim_1.taps, 131072);
+    baseband_thread.start();
 }
 
 void AISProcessor::execute(const buffer_c8_t& buffer) {

--- a/firmware/baseband/proc_ais.hpp
+++ b/firmware/baseband/proc_ais.hpp
@@ -51,9 +51,6 @@ class AISProcessor : public BasebandProcessor {
    private:
     static constexpr size_t baseband_fs = 2457600;
 
-    BasebandThread baseband_thread{baseband_fs, this, NORMALPRIO + 20, baseband::Direction::Receive};
-    RSSIThread rssi_thread{NORMALPRIO + 10};
-
     std::array<complex16_t, 512> dst{};
     const buffer_c16_t dst_buffer{
         dst.data(),
@@ -76,6 +73,11 @@ class AISProcessor : public BasebandProcessor {
         [this](const baseband::Packet& packet) {
             this->payload_handler(packet);
         }};
+
+    /* NB: Threads should be the last members in the class definition. */
+    BasebandThread baseband_thread{
+        baseband_fs, this, baseband::Direction::Receive, /*auto_start*/ false};
+    RSSIThread rssi_thread{};
 
     void consume_symbol(const float symbol);
     void payload_handler(const baseband::Packet& packet);

--- a/firmware/baseband/proc_am_audio.hpp
+++ b/firmware/baseband/proc_am_audio.hpp
@@ -38,16 +38,12 @@
 class NarrowbandAMAudio : public BasebandProcessor {
    public:
     void execute(const buffer_c8_t& buffer) override;
-
     void on_message(const Message* const message) override;
 
    private:
     static constexpr size_t baseband_fs = 3072000;
     static constexpr size_t decim_2_decimation_factor = 4;
     static constexpr size_t channel_filter_decimation_factor = 1;
-
-    BasebandThread baseband_thread{baseband_fs, this, NORMALPRIO + 20, baseband::Direction::Receive};
-    RSSIThread rssi_thread{NORMALPRIO + 10};
 
     std::array<complex16_t, 512> dst{};
     const buffer_c16_t dst_buffer{
@@ -65,6 +61,7 @@ class NarrowbandAMAudio : public BasebandProcessor {
     int32_t channel_filter_low_f = 0;
     int32_t channel_filter_high_f = 0;
     int32_t channel_filter_transition = 0;
+    bool configured{false};
 
     bool modulation_ssb = false;
     dsp::demodulate::AM demod_am{};
@@ -74,7 +71,10 @@ class NarrowbandAMAudio : public BasebandProcessor {
 
     SpectrumCollector channel_spectrum{};
 
-    bool configured{false};
+    /* NB: Threads should be the last members in the class definition. */
+    BasebandThread baseband_thread{baseband_fs, this, baseband::Direction::Receive};
+    RSSIThread rssi_thread{};
+
     void configure(const AMConfigureMessage& message);
     void capture_config(const CaptureConfigMessage& message);
 

--- a/firmware/baseband/proc_am_tv.hpp
+++ b/firmware/baseband/proc_am_tv.hpp
@@ -38,14 +38,10 @@
 class WidebandFMAudio : public BasebandProcessor {
    public:
     void execute(const buffer_c8_t& buffer) override;
-
     void on_message(const Message* const message) override;
 
    private:
     static constexpr size_t baseband_fs = 2000000;
-
-    BasebandThread baseband_thread{baseband_fs, this, NORMALPRIO + 20, baseband::Direction::Receive};
-    RSSIThread rssi_thread{NORMALPRIO + 10};
 
     std::array<complex16_t, 512> dst{};
     const buffer_c16_t dst_buffer{
@@ -55,8 +51,12 @@ class WidebandFMAudio : public BasebandProcessor {
     AudioSpectrum audio_spectrum{};
     TvCollector channel_spectrum{};
     std::array<complex16_t, 256> spectrum{};
-
     bool configured{false};
+
+    /* NB: Threads should be the last members in the class definition. */
+    BasebandThread baseband_thread{baseband_fs, this, baseband::Direction::Receive};
+    RSSIThread rssi_thread{};
+
     void configure(const WFMConfigureMessage& message);
 };
 

--- a/firmware/baseband/proc_aprsrx.hpp
+++ b/firmware/baseband/proc_aprsrx.hpp
@@ -75,7 +75,6 @@ static uint16_t crc_ccitt_tab[256] = {
 class APRSRxProcessor : public BasebandProcessor {
    public:
     void execute(const buffer_c8_t& buffer) override;
-
     void on_message(const Message* const message) override;
 
    private:
@@ -89,9 +88,6 @@ class APRSRxProcessor : public BasebandProcessor {
         WAIT_FRAME,
         IN_FRAME
     };
-
-    BasebandThread baseband_thread{baseband_fs, this, NORMALPRIO + 20, baseband::Direction::Receive};
-    RSSIThread rssi_thread{NORMALPRIO + 10};
 
     std::array<complex16_t, 512> dst{};
     const buffer_c16_t dst_buffer{
@@ -134,6 +130,10 @@ class APRSRxProcessor : public BasebandProcessor {
     bool bit_value{0};
 
     aprs::APRSPacket aprs_packet{};
+
+    /* NB: Threads should be the last members in the class definition. */
+    BasebandThread baseband_thread{baseband_fs, this, baseband::Direction::Receive};
+    RSSIThread rssi_thread{};
 
     void configure(const APRSRxConfigureMessage& message);
     void capture_config(const CaptureConfigMessage& message);

--- a/firmware/baseband/proc_audiotx.hpp
+++ b/firmware/baseband/proc_audiotx.hpp
@@ -37,8 +37,6 @@ class AudioTXProcessor : public BasebandProcessor {
    private:
     static constexpr size_t baseband_fs = 1536000;
 
-    BasebandThread baseband_thread{baseband_fs, this, NORMALPRIO + 20, baseband::Direction::Transmit};
-
     std::unique_ptr<StreamOutput> stream{};
 
     ToneGen tone_gen{};
@@ -61,6 +59,9 @@ class AudioTXProcessor : public BasebandProcessor {
 
     TXProgressMessage txprogress_message{};
     RequestSignalMessage sig_message{RequestSignalMessage::Signal::FillRequest};
+
+    /* NB: Threads should be the last members in the class definition. */
+    BasebandThread baseband_thread{baseband_fs, this, baseband::Direction::Transmit};
 };
 
 #endif

--- a/firmware/baseband/proc_btlerx.hpp
+++ b/firmware/baseband/proc_btlerx.hpp
@@ -39,15 +39,11 @@
 class BTLERxProcessor : public BasebandProcessor {
    public:
     void execute(const buffer_c8_t& buffer) override;
-
     void on_message(const Message* const message) override;
 
    private:
     static constexpr size_t baseband_fs = 4000000;
     static constexpr size_t audio_fs = baseband_fs / 8 / 8 / 2;
-
-    BasebandThread baseband_thread{baseband_fs, this, NORMALPRIO + 20, baseband::Direction::Receive};
-    RSSIThread rssi_thread{NORMALPRIO + 10};
 
     std::array<complex16_t, 512> dst{};
     const buffer_c16_t dst_buffer{
@@ -81,10 +77,13 @@ class BTLERxProcessor : public BasebandProcessor {
     int RB_SIZE{1000};
 
     bool configured{false};
+    AFSKDataMessage data_message{false, 0};
+
+    /* NB: Threads should be the last members in the class definition. */
+    BasebandThread baseband_thread{baseband_fs, this, baseband::Direction::Receive};
+    RSSIThread rssi_thread{};
 
     void configure(const BTLERxConfigureMessage& message);
-
-    AFSKDataMessage data_message{false, 0};
 };
 
 #endif /*__PROC_BTLERX_H__*/

--- a/firmware/baseband/proc_capture.cpp
+++ b/firmware/baseband/proc_capture.cpp
@@ -31,13 +31,10 @@ CaptureProcessor::CaptureProcessor() {
     decim_1.configure(taps_200k_decim_1.taps, 131072);
 
     channel_spectrum.set_decimation_factor(1);
-    ready = true;
+    baseband_thread.start();
 }
 
 void CaptureProcessor::execute(const buffer_c8_t& buffer) {
-    if (!ready)
-        return;
-
     /* 2.4576MHz, 2048 samples */
     const auto decim_0_out = decim_0.execute(buffer, dst_buffer);
     const auto decim_1_out = decim_1.execute(decim_0_out, dst_buffer);

--- a/firmware/baseband/proc_ert.hpp
+++ b/firmware/baseband/proc_ert.hpp
@@ -67,9 +67,6 @@ class ERTProcessor : public BasebandProcessor {
     const size_t samples_per_symbol = channel_sampling_rate / symbol_rate;
     const float clock_recovery_rate = symbol_rate * 2;
 
-    BasebandThread baseband_thread{baseband_sampling_rate, this, NORMALPRIO + 20, baseband::Direction::Receive};
-    RSSIThread rssi_thread{NORMALPRIO + 10};
-
     clock_recovery::ClockRecovery<clock_recovery::FixedErrorFilter> clock_recovery{
         clock_recovery_rate,
         symbol_rate,
@@ -115,6 +112,10 @@ class ERTProcessor : public BasebandProcessor {
     size_t average_count{0};
     float offset_i{0.0f};
     float offset_q{0.0f};
+
+    /* NB: Threads should be the last members in the class definition. */
+    BasebandThread baseband_thread{baseband_sampling_rate, this, baseband::Direction::Receive};
+    RSSIThread rssi_thread{};
 
     float abs(const complex8_t& v);
 };

--- a/firmware/baseband/proc_fsk.hpp
+++ b/firmware/baseband/proc_fsk.hpp
@@ -29,13 +29,10 @@
 class FSKProcessor : public BasebandProcessor {
    public:
     void execute(const buffer_c8_t& buffer) override;
-
     void on_message(const Message* const p) override;
 
    private:
     bool configured = false;
-
-    BasebandThread baseband_thread{2280000, this, NORMALPRIO + 20, baseband::Direction::Transmit};
 
     uint32_t samples_per_bit{0};
     uint32_t length{0};
@@ -48,6 +45,9 @@ class FSKProcessor : public BasebandProcessor {
     uint32_t phase{0}, sphase{0};
 
     TXProgressMessage txprogress_message{};
+
+    /* NB: Threads should be the last members in the class definition. */
+    BasebandThread baseband_thread{2280000, this, baseband::Direction::Transmit};
 };
 
 #endif

--- a/firmware/baseband/proc_gps_sim.hpp
+++ b/firmware/baseband/proc_gps_sim.hpp
@@ -34,19 +34,16 @@
 #include <array>
 #include <memory>
 
-class ReplayProcessor : public BasebandProcessor {
+class GPSReplayProcessor : public BasebandProcessor {
    public:
-    ReplayProcessor();
+    GPSReplayProcessor();
 
     void execute(const buffer_c8_t& buffer) override;
-
     void on_message(const Message* const message) override;
 
    private:
     size_t baseband_fs = 3072000;
     static constexpr auto spectrum_rate_hz = 50.0f;
-
-    BasebandThread baseband_thread{baseband_fs, this, NORMALPRIO + 20, baseband::Direction::Transmit};
 
     std::array<complex8_t, 2048> iq{};
     const buffer_c8_t iq_buffer{
@@ -72,6 +69,10 @@ class ReplayProcessor : public BasebandProcessor {
 
     TXProgressMessage txprogress_message{};
     RequestSignalMessage sig_message{RequestSignalMessage::Signal::FillRequest};
+
+    /* NB: Threads should be the last members in the class definition. */
+    BasebandThread baseband_thread{
+        baseband_fs, this, baseband::Direction::Transmit, /*auto_start*/ false};
 };
 
 #endif /*__PROC_GPS_SIM_HPP__*/

--- a/firmware/baseband/proc_jammer.hpp
+++ b/firmware/baseband/proc_jammer.hpp
@@ -33,13 +33,10 @@ using namespace jammer;
 class JammerProcessor : public BasebandProcessor {
    public:
     void execute(const buffer_c8_t& buffer) override;
-
     void on_message(const Message* const msg) override;
 
    private:
     bool configured{false};
-
-    BasebandThread baseband_thread{3072000, this, NORMALPRIO + 20, baseband::Direction::Transmit};
 
     JammerChannel* jammer_channels{};
 
@@ -54,6 +51,9 @@ class JammerProcessor : public BasebandProcessor {
     int8_t sample{0};
     int8_t re{0}, im{0};
     RetuneMessage message{};
+
+    /* NB: Threads should be the last members in the class definition. */
+    BasebandThread baseband_thread{3072000, this, baseband::Direction::Transmit};
 };
 
 #endif

--- a/firmware/baseband/proc_mictx.hpp
+++ b/firmware/baseband/proc_mictx.hpp
@@ -32,15 +32,12 @@
 class MicTXProcessor : public BasebandProcessor {
    public:
     void execute(const buffer_c8_t& buffer) override;
-
     void on_message(const Message* const msg) override;
 
    private:
     static constexpr size_t baseband_fs = 1536000U;
 
     bool configured{false};
-
-    BasebandThread baseband_thread{baseband_fs, this, NORMALPRIO + 20, baseband::Direction::Transmit};
 
     int16_t audio_data[64];
     buffer_s16_t audio_buffer{
@@ -74,6 +71,9 @@ class MicTXProcessor : public BasebandProcessor {
 
     AudioLevelReportMessage level_message{};
     TXProgressMessage txprogress_message{};
+
+    /* NB: Threads should be the last members in the class definition. */
+    BasebandThread baseband_thread{baseband_fs, this, baseband::Direction::Transmit};
 };
 
 #endif

--- a/firmware/baseband/proc_nfm_audio.hpp
+++ b/firmware/baseband/proc_nfm_audio.hpp
@@ -42,14 +42,10 @@
 class NarrowbandFMAudio : public BasebandProcessor {
    public:
     void execute(const buffer_c8_t& buffer) override;
-
     void on_message(const Message* const message) override;
 
    private:
     static constexpr size_t baseband_fs = 3072000;
-
-    BasebandThread baseband_thread{baseband_fs, this, NORMALPRIO + 20, baseband::Direction::Receive};
-    RSSIThread rssi_thread{NORMALPRIO + 10};
 
     std::array<complex16_t, 512> dst{};
     const buffer_c16_t dst_buffer{
@@ -97,12 +93,16 @@ class NarrowbandFMAudio : public BasebandProcessor {
     static constexpr float ki = 1.0f / k;
 
     bool configured{false};
+    // RequestSignalMessage sig_message { RequestSignalMessage::Signal::Squelched };
+    CodedSquelchMessage ctcss_message{0};
+
+    /* NB: Threads should be the last members in the class definition. */
+    BasebandThread baseband_thread{baseband_fs, this, baseband::Direction::Receive};
+    RSSIThread rssi_thread{};
+
     void pitch_rssi_config(const PitchRSSIConfigureMessage& message);
     void configure(const NBFMConfigureMessage& message);
     void capture_config(const CaptureConfigMessage& message);
-
-    // RequestSignalMessage sig_message { RequestSignalMessage::Signal::Squelched };
-    CodedSquelchMessage ctcss_message{0};
 };
 
 #endif /*__PROC_NFM_AUDIO_H__*/

--- a/firmware/baseband/proc_noop.hpp
+++ b/firmware/baseband/proc_noop.hpp
@@ -31,7 +31,8 @@ class NOOPProcessor : public BasebandProcessor {
     void execute(const buffer_c8_t& buffer) override;
 
    private:
-    BasebandThread baseband_thread{1536000, this, NORMALPRIO + 20, baseband::Direction::Transmit};
+    /* NB: Threads should be the last members in the class definition. */
+    BasebandThread baseband_thread{1536000, this, baseband::Direction::Transmit};
 };
 
 #endif

--- a/firmware/baseband/proc_nrfrx.hpp
+++ b/firmware/baseband/proc_nrfrx.hpp
@@ -39,15 +39,11 @@
 class NRFRxProcessor : public BasebandProcessor {
    public:
     void execute(const buffer_c8_t& buffer) override;
-
     void on_message(const Message* const message) override;
 
    private:
     static constexpr size_t baseband_fs = 4000000;
     static constexpr size_t audio_fs = baseband_fs / 8 / 8 / 2;
-
-    BasebandThread baseband_thread{baseband_fs, this, NORMALPRIO + 20, baseband::Direction::Receive};
-    RSSIThread rssi_thread{NORMALPRIO + 10};
 
     std::array<complex16_t, 512> dst{};
     const buffer_c16_t dst_buffer{
@@ -82,10 +78,13 @@ class NRFRxProcessor : public BasebandProcessor {
     int RB_SIZE{1000};
 
     bool configured{false};
+    AFSKDataMessage data_message{false, 0};
+
+    /* NB: Threads should be the last members in the class definition. */
+    BasebandThread baseband_thread{baseband_fs, this, baseband::Direction::Receive};
+    RSSIThread rssi_thread{};
 
     void configure(const NRFRxConfigureMessage& message);
-
-    AFSKDataMessage data_message{false, 0};
 };
 
 #endif /*__PROC_NRFRX_H__*/

--- a/firmware/baseband/proc_ook.hpp
+++ b/firmware/baseband/proc_ook.hpp
@@ -29,13 +29,10 @@
 class OOKProcessor : public BasebandProcessor {
    public:
     void execute(const buffer_c8_t& buffer) override;
-
     void on_message(const Message* const p) override;
 
    private:
     bool configured = false;
-
-    BasebandThread baseband_thread{2280000, this, NORMALPRIO + 20, baseband::Direction::Transmit};
 
     uint32_t samples_per_bit{0};
     uint8_t repeat{0};
@@ -66,6 +63,9 @@ class OOKProcessor : public BasebandProcessor {
     unsigned int duval_symbol{0};
     size_t scan_progress{0};
     uint8_t scan_done{true};
+
+    /* NB: Threads should be the last members in the class definition. */
+    BasebandThread baseband_thread{2280000, this, baseband::Direction::Transmit};
 
     size_t duval_algo_step();
     void scan_process(const buffer_c8_t& buffer);

--- a/firmware/baseband/proc_pocsag.hpp
+++ b/firmware/baseband/proc_pocsag.hpp
@@ -129,7 +129,6 @@ class SmoothVals {
 class POCSAGProcessor : public BasebandProcessor {
    public:
     void execute(const buffer_c8_t& buffer) override;
-
     void on_message(const Message* const message) override;
 
     int OnDataFrame(int len, int baud);
@@ -137,9 +136,6 @@ class POCSAGProcessor : public BasebandProcessor {
 
    private:
     static constexpr size_t baseband_fs = 3072000;
-
-    BasebandThread baseband_thread{baseband_fs, this, NORMALPRIO + 20, baseband::Direction::Receive};
-    RSSIThread rssi_thread{NORMALPRIO + 10};
 
     std::array<complex16_t, 512> dst{};
     const buffer_c16_t dst_buffer{
@@ -166,7 +162,6 @@ class POCSAGProcessor : public BasebandProcessor {
     // ----------------------------------------
     // Frame extractraction methods and members
     // ----------------------------------------
-   private:
     void initFrameExtraction();
     struct FIFOStruct {
         unsigned long codeword;
@@ -219,6 +214,10 @@ class POCSAGProcessor : public BasebandProcessor {
     bool m_gotSync{false};
     int m_numCode{0};
     bool m_inverted{false};
+
+    /* NB: Threads should be the last members in the class definition. */
+    BasebandThread baseband_thread{baseband_fs, this, baseband::Direction::Receive};
+    RSSIThread rssi_thread{};
 };
 
 #endif /*__PROC_POCSAG_H__*/

--- a/firmware/baseband/proc_rds.hpp
+++ b/firmware/baseband/proc_rds.hpp
@@ -33,13 +33,10 @@
 class RDSProcessor : public BasebandProcessor {
    public:
     void execute(const buffer_c8_t& buffer) override;
-
     void on_message(const Message* const msg) override;
 
    private:
     uint32_t* rdsdata{};
-
-    BasebandThread baseband_thread{2280000, this, NORMALPRIO + 20, baseband::Direction::Transmit};
 
     uint16_t message_length{0};
     int8_t re{0}, im{0};
@@ -132,6 +129,9 @@ class RDSProcessor : public BasebandProcessor {
         0, -14, -27, -41, -53, -66, -77, -88,
         -99, -109, -118, -126, -134, -141, -147, -152,
         -157, -160, -163, -166, -167, -168, -168, -167};
+
+    /* NB: Threads should be the last members in the class definition. */
+    BasebandThread baseband_thread{2280000, this, baseband::Direction::Transmit};
 };
 
 #endif

--- a/firmware/baseband/proc_replay.cpp
+++ b/firmware/baseband/proc_replay.cpp
@@ -38,6 +38,7 @@ ReplayProcessor::ReplayProcessor() {
     channel_spectrum.set_decimation_factor(1);
 
     configured = false;
+    baseband_thread.start();
 }
 
 void ReplayProcessor::execute(const buffer_c8_t& buffer) {

--- a/firmware/baseband/proc_replay.hpp
+++ b/firmware/baseband/proc_replay.hpp
@@ -38,14 +38,11 @@ class ReplayProcessor : public BasebandProcessor {
     ReplayProcessor();
 
     void execute(const buffer_c8_t& buffer) override;
-
     void on_message(const Message* const message) override;
 
    private:
     size_t baseband_fs = 3072000;
     static constexpr auto spectrum_rate_hz = 50.0f;
-
-    BasebandThread baseband_thread{baseband_fs, this, NORMALPRIO + 20, baseband::Direction::Transmit};
 
     std::array<complex16_t, 256> iq{};
     const buffer_c16_t iq_buffer{
@@ -71,6 +68,10 @@ class ReplayProcessor : public BasebandProcessor {
 
     TXProgressMessage txprogress_message{};
     RequestSignalMessage sig_message{RequestSignalMessage::Signal::FillRequest};
+
+    /* NB: Threads should be the last members in the class definition. */
+    BasebandThread baseband_thread{
+        baseband_fs, this, baseband::Direction::Transmit, /*auto_start*/ false};
 };
 
 #endif /*__PROC_REPLAY_HPP__*/

--- a/firmware/baseband/proc_siggen.hpp
+++ b/firmware/baseband/proc_siggen.hpp
@@ -30,13 +30,10 @@
 class SigGenProcessor : public BasebandProcessor {
    public:
     void execute(const buffer_c8_t& buffer) override;
-
     void on_message(const Message* const msg) override;
 
    private:
     bool configured{false};
-
-    BasebandThread baseband_thread{1536000, this, NORMALPRIO + 20, baseband::Direction::Transmit};
 
     uint32_t tone_delta{0}, fm_delta{}, tone_phase{0};
     uint8_t tone_shape{};
@@ -51,6 +48,9 @@ class SigGenProcessor : public BasebandProcessor {
     // uint8_t lfsr { }, bit { };  						// Finally not used lfsr of 8 bits , bit must be 8-bit to allow bit<<7 later in the code */
 
     TXProgressMessage txprogress_message{};
+
+    /* NB: Threads should be the last members in the class definition. */
+    BasebandThread baseband_thread{1536000, this, baseband::Direction::Transmit};
 };
 
 #endif

--- a/firmware/baseband/proc_sonde.cpp
+++ b/firmware/baseband/proc_sonde.cpp
@@ -35,6 +35,7 @@ SondeProcessor::SondeProcessor() {
     audio_output.configure(false);
 
     tone_gen.configure(BEEP_BASE_FREQ, 1.0, ToneGen::tone_type::sine, AUDIO_SAMPLE_RATE);
+    baseband_thread.start();
 }
 
 void SondeProcessor::execute(const buffer_c8_t& buffer) {

--- a/firmware/baseband/proc_sonde.hpp
+++ b/firmware/baseband/proc_sonde.hpp
@@ -131,9 +131,6 @@ class SondeProcessor : public BasebandProcessor {
 
     ToneGen tone_gen{};
 
-    BasebandThread baseband_thread{baseband_fs, this, NORMALPRIO + 20, baseband::Direction::Receive};
-    RSSIThread rssi_thread{NORMALPRIO + 10};
-
     std::array<complex16_t, 512> dst{};
     const buffer_c16_t dst_buffer{
         dst.data(),
@@ -178,6 +175,11 @@ class SondeProcessor : public BasebandProcessor {
             const SondePacketMessage message{sonde::Packet::Type::Vaisala_RS41_SG, packet};
             shared_memory.application_queue.push(message);
         }};
+
+    /* NB: Threads should be the last members in the class definition. */
+    BasebandThread baseband_thread{
+        baseband_fs, this, baseband::Direction::Receive, /*auto_start*/ false};
+    RSSIThread rssi_thread{};
 
     void play_beep();
     void stop_beep();

--- a/firmware/baseband/proc_spectrum_painter.hpp
+++ b/firmware/baseband/proc_spectrum_painter.hpp
@@ -33,7 +33,9 @@ class SpectrumPainterProcessor : public BasebandProcessor {
 
    private:
     bool configured{false};
-    BasebandThread baseband_thread{3072000, this, NORMALPRIO + 20, baseband::Direction::Transmit};
+
+    /* NB: Threads should be the last members in the class definition. */
+    BasebandThread baseband_thread{3072000, this, baseband::Direction::Transmit};
     Thread* thread{nullptr};
 
    protected:

--- a/firmware/baseband/proc_sstvtx.hpp
+++ b/firmware/baseband/proc_sstvtx.hpp
@@ -33,7 +33,6 @@ using namespace sstv;
 class SSTVTXProcessor : public BasebandProcessor {
    public:
     void execute(const buffer_c8_t& buffer) override;
-
     void on_message(const Message* const p) override;
 
    private:
@@ -56,8 +55,6 @@ class SSTVTXProcessor : public BasebandProcessor {
 
     bool configured{false};
 
-    BasebandThread baseband_thread{3072000, this, NORMALPRIO + 20, baseband::Direction::Transmit};
-
     uint32_t vis_code_sequence[10]{};
     sstv_scanline scanline_buffer[2]{};
     uint8_t buffer_flip{0}, substep{0};
@@ -76,6 +73,9 @@ class SSTVTXProcessor : public BasebandProcessor {
     int8_t re{}, im{};
 
     RequestSignalMessage sig_message{RequestSignalMessage::Signal::FillRequest};
+
+    /* NB: Threads should be the last members in the class definition. */
+    BasebandThread baseband_thread{3072000, this, baseband::Direction::Transmit};
 };
 
 #endif

--- a/firmware/baseband/proc_test.cpp
+++ b/firmware/baseband/proc_test.cpp
@@ -29,6 +29,7 @@
 TestProcessor::TestProcessor() {
     decim_0.configure(taps_11k0_decim_0.taps, 33554432);
     decim_1.configure(taps_11k0_decim_1.taps, 131072);
+    baseband_thread.start();
 }
 
 void TestProcessor::execute(const buffer_c8_t& buffer) {

--- a/firmware/baseband/proc_test.hpp
+++ b/firmware/baseband/proc_test.hpp
@@ -52,9 +52,6 @@ class TestProcessor : public BasebandProcessor {
    private:
     static constexpr size_t baseband_fs = 2457600 * 2;
 
-    BasebandThread baseband_thread{baseband_fs, this, NORMALPRIO + 20, baseband::Direction::Receive};
-    RSSIThread rssi_thread{NORMALPRIO + 10};
-
     std::array<complex16_t, 512> dst{};
     const buffer_c16_t dst_buffer{
         dst.data(),
@@ -80,6 +77,11 @@ class TestProcessor : public BasebandProcessor {
             const TestAppPacketMessage message{packet};
             shared_memory.application_queue.push(message);
         }};
+
+    /* NB: Threads should be the last members in the class definition. */
+    BasebandThread baseband_thread{
+        baseband_fs, this, baseband::Direction::Receive, /*auto_start*/ false};
+    RSSIThread rssi_thread{};
 };
 
 #endif /*__PROC_TEST_H__*/

--- a/firmware/baseband/proc_tones.hpp
+++ b/firmware/baseband/proc_tones.hpp
@@ -31,13 +31,10 @@
 class TonesProcessor : public BasebandProcessor {
    public:
     void execute(const buffer_c8_t& buffer) override;
-
     void on_message(const Message* const p) override;
 
    private:
     bool configured = false;
-
-    BasebandThread baseband_thread{1536000, this, NORMALPRIO + 20, baseband::Direction::Transmit};
 
     std::array<int16_t, 32> audio{};  // 2048/64
     const buffer_s16_t audio_buffer{
@@ -63,6 +60,9 @@ class TonesProcessor : public BasebandProcessor {
 
     TXProgressMessage txprogress_message{};
     AudioOutput audio_output{};
+
+    /* NB: Threads should be the last members in the class definition. */
+    BasebandThread baseband_thread{1536000, this, baseband::Direction::Transmit};
 };
 
 #endif

--- a/firmware/baseband/proc_tpms.cpp
+++ b/firmware/baseband/proc_tpms.cpp
@@ -28,6 +28,7 @@
 TPMSProcessor::TPMSProcessor() {
     decim_0.configure(taps_200k_decim_0.taps, 33554432);
     decim_1.configure(taps_200k_decim_1.taps, 131072);
+    baseband_thread.start();
 }
 
 void TPMSProcessor::execute(const buffer_c8_t& buffer) {

--- a/firmware/baseband/proc_tpms.hpp
+++ b/firmware/baseband/proc_tpms.hpp
@@ -74,9 +74,6 @@ class TPMSProcessor : public BasebandProcessor {
    private:
     static constexpr size_t baseband_fs = 2457600;
 
-    BasebandThread baseband_thread{baseband_fs, this, NORMALPRIO + 20, baseband::Direction::Receive};
-    RSSIThread rssi_thread{NORMALPRIO + 10};
-
     std::array<complex16_t, 512> dst{};
     const buffer_c16_t dst_buffer{
         dst.data(),
@@ -141,6 +138,11 @@ class TPMSProcessor : public BasebandProcessor {
             const TPMSPacketMessage message{tpms::SignalType::OOK_8k4_Schrader, packet};
             shared_memory.application_queue.push(message);
         }};
+
+    /* NB: Threads should be the last members in the class definition. */
+    BasebandThread baseband_thread{
+        baseband_fs, this, baseband::Direction::Receive, /*auto_start*/ false};
+    RSSIThread rssi_thread{};
 };
 
 #endif /*__PROC_TPMS_H__*/

--- a/firmware/baseband/proc_wfm_audio.hpp
+++ b/firmware/baseband/proc_wfm_audio.hpp
@@ -38,15 +38,11 @@
 class WidebandFMAudio : public BasebandProcessor {
    public:
     void execute(const buffer_c8_t& buffer) override;
-
     void on_message(const Message* const message) override;
 
    private:
     static constexpr size_t baseband_fs = 3072000;
     static constexpr auto spectrum_rate_hz = 50.0f;
-
-    BasebandThread baseband_thread{baseband_fs, this, NORMALPRIO + 20, baseband::Direction::Receive};
-    RSSIThread rssi_thread{NORMALPRIO + 10};
 
     std::array<complex16_t, 512> dst{};
     const buffer_c16_t dst_buffer{
@@ -93,6 +89,11 @@ class WidebandFMAudio : public BasebandProcessor {
     size_t spectrum_samples = 0;
 
     bool configured{false};
+
+    /* NB: Threads should be the last members in the class definition. */
+    BasebandThread baseband_thread{baseband_fs, this, baseband::Direction::Receive};
+    RSSIThread rssi_thread{};
+
     void configure(const WFMConfigureMessage& message);
     void capture_config(const CaptureConfigMessage& message);
     void post_message(const buffer_c16_t& data);

--- a/firmware/baseband/proc_wideband_spectrum.hpp
+++ b/firmware/baseband/proc_wideband_spectrum.hpp
@@ -37,22 +37,20 @@
 class WidebandSpectrum : public BasebandProcessor {
    public:
     void execute(const buffer_c8_t& buffer) override;
-
     void on_message(const Message* const message) override;
 
    private:
     bool configured = false;
-
     size_t baseband_fs = 20000000;
-
-    BasebandThread baseband_thread{baseband_fs, this, NORMALPRIO + 20};
-    RSSIThread rssi_thread{NORMALPRIO + 10};
 
     SpectrumCollector channel_spectrum{};
 
     std::array<complex16_t, 256> spectrum{};
-
     size_t phase = 0, trigger = 127;
+
+    /* NB: Threads should be the last members in the class definition. */
+    BasebandThread baseband_thread{baseband_fs, this, baseband::Direction::Receive};
+    RSSIThread rssi_thread{};
 };
 
 #endif /*__PROC_WIDEBAND_SPECTRUM_H__*/

--- a/firmware/baseband/rssi_thread.cpp
+++ b/firmware/baseband/rssi_thread.cpp
@@ -32,16 +32,25 @@ WORKING_AREA(rssi_thread_wa, 128);
 
 Thread* RSSIThread::thread = nullptr;
 
-RSSIThread::RSSIThread(const tprio_t priority) {
-    thread = chThdCreateStatic(rssi_thread_wa, sizeof(rssi_thread_wa),
-                               priority, ThreadBase::fn,
-                               this);
+RSSIThread::RSSIThread(bool auto_start, tprio_t priority)
+    : priority_{priority} {
+    if (auto_start) start();
 }
 
 RSSIThread::~RSSIThread() {
-    chThdTerminate(thread);
-    chThdWait(thread);
-    thread = nullptr;
+    if (thread) {
+        chThdTerminate(thread);
+        chThdWait(thread);
+        thread = nullptr;
+    }
+}
+
+void RSSIThread::start() {
+    if (!thread) {
+        thread = chThdCreateStatic(
+            rssi_thread_wa, sizeof(rssi_thread_wa),
+            priority_, ThreadBase::fn, this);
+    }
 }
 
 void RSSIThread::run() {

--- a/firmware/baseband/rssi_thread.hpp
+++ b/firmware/baseband/rssi_thread.hpp
@@ -25,20 +25,32 @@
 #include "thread_base.hpp"
 
 #include <ch.h>
-
 #include <cstdint>
+
+/* NB: Because ThreadBase threads start when then are initialized (by default),
+ * they should be the last members in a Processor class to ensure the rest of the
+ * members are fully initialized before data handling starts. If the Procressor
+ * needs to do additional initialization (in its ctor), set 'auto_start' to false
+ * and manually call 'start()' on the thread.
+ * This isn't as relevant for RSSIThread which is entirely self-contained, but
+ * it's good practice to keep all the thread-init together. */
 
 class RSSIThread : public ThreadBase {
    public:
-    RSSIThread(const tprio_t priority);
+    RSSIThread(
+        bool auto_start = true,
+        tprio_t priority = (NORMALPRIO + 10));
     ~RSSIThread();
+
+    void start() override;
 
    private:
     void run() override;
 
-    static Thread* thread;
+    const tprio_t priority_;
 
-    const uint32_t sampling_rate{400000};
+    static Thread* thread;
+    static constexpr uint32_t sampling_rate{400000};
 };
 
 #endif /*__RSSI_THREAD_H__*/

--- a/firmware/common/thread_base.hpp
+++ b/firmware/common/thread_base.hpp
@@ -28,6 +28,8 @@ class ThreadBase {
    public:
     virtual ~ThreadBase() = default;
 
+    virtual void start() = 0;
+
    protected:
     static msg_t fn(void* arg) {
         auto obj = static_cast<ThreadBase*>(arg);


### PR DESCRIPTION
This change should hopefully address all possible baseband processor initialization race conditions.
In C++ the in-body initializers are run in declaration order. This means that the baseband_thread will start running immediately upon its declaration. This means that it will start sending data to the processor while the processor itself is still initializing which can cause all kinds of undefined behavior.

This change has two main parts.
1) Move the thread declarations to the ends of all the classes so the processor will be otherwise initialized when the baseband_thread starts.
2) Some processors have custom constructor definitions to set up additional member state. For those, it's best to delay the baseband_thread start until the end of the constructor. To support this, I added a "start" method to ThreadBase and decoupled initialization from start. I changed the thread constructor to make the defaults behave like it had previously.