### PR TITLE
Remove experimental support for Replaying C32 files

### DIFF
--- a/firmware/application/apps/ui_fileman.cpp
+++ b/firmware/application/apps/ui_fileman.cpp
@@ -41,7 +41,6 @@ static const fs::path txt_ext{u".TXT"};
 static const fs::path ppl_ext{u".PPL"};
 static const fs::path c8_ext{u".C8"};
 static const fs::path c16_ext{u".C16"};
-static const fs::path c32_ext{u".C32"};
 static const fs::path cxx_ext{u".C*"};
 static const fs::path png_ext{u".PNG"};
 static const fs::path bmp_ext{u".BMP"};
@@ -87,8 +86,6 @@ fs::path get_partner_file(fs::path path) {
         path.replace_extension(c8_ext);
         if (!fs::file_exists(path))
             path.replace_extension(c16_ext);
-        if (!fs::file_exists(path))
-            path.replace_extension(c32_ext);
     } else
         return {};
 

--- a/firmware/application/apps/ui_fileman.hpp
+++ b/firmware/application/apps/ui_fileman.hpp
@@ -76,7 +76,6 @@ class FileManBaseView : public View {
         {u".BMP", &bitmap_icon_file_image, ui::Color::green()},
         {u".C8", &bitmap_icon_file_iq, ui::Color::dark_cyan()},
         {u".C16", &bitmap_icon_file_iq, ui::Color::dark_cyan()},
-        {u".C32", &bitmap_icon_file_iq, ui::Color::dark_cyan()},
         {u".WAV", &bitmap_icon_file_wav, ui::Color::dark_magenta()},
         {u".PPL", &bitmap_icon_file_iq, ui::Color::white()},  // PPL is the file extension for playlist app
         {u"", &bitmap_icon_file, ui::Color::light_grey()}     // NB: Must be last.

--- a/firmware/application/file.cpp
+++ b/firmware/application/file.cpp
@@ -31,7 +31,6 @@
 namespace fs = std::filesystem;
 static const fs::path c8_ext{u".C8"};
 static const fs::path c16_ext{u".C16"};
-static const fs::path c32_ext{u".C32"};
 
 Optional<File::Error> File::open_fatfs(const std::filesystem::path& filename, BYTE mode) {
     auto result = f_open(&f, reinterpret_cast<const TCHAR*>(filename.c_str()), mode);
@@ -515,7 +514,7 @@ bool path_iequal(
 
 bool is_cxx_capture_file(const path& filename) {
     auto ext = filename.extension();
-    return path_iequal(c8_ext, ext) || path_iequal(c16_ext, ext) || path_iequal(c32_ext, ext);
+    return path_iequal(c8_ext, ext) || path_iequal(c16_ext, ext);
 }
 
 uint8_t capture_file_sample_size(const path& filename) {
@@ -523,8 +522,6 @@ uint8_t capture_file_sample_size(const path& filename) {
         return sizeof(complex8_t);
     if (path_iequal(filename.extension(), c16_ext))
         return sizeof(complex16_t);
-    if (path_iequal(filename.extension(), c32_ext))
-        return sizeof(complex32_t);
     return 0;
 }
 

--- a/firmware/application/io_convert.hpp
+++ b/firmware/application/io_convert.hpp
@@ -32,7 +32,6 @@
 namespace file_convert {
 
 void c8_to_c16(const void* buffer, File::Size bytes);
-void c32_to_c16(const void* buffer, File::Size bytes);
 void c16_to_c8(const void* buffer, File::Size bytes);
 
 } /* namespace file_convert */
@@ -52,7 +51,6 @@ class FileConvertReader : public stream::Reader {
     const File& file() const& { return file_; }
 
     bool convert_c8_to_c16{};
-    bool convert_c32_to_c16{};
 
    protected:
     File file_{};


### PR DESCRIPTION
Even after fixing a minor bug in the convert_c32_to_c16() function (store operation was using uint8 vs uint16), there was still a lot of noise in the playback stream and it was playing at half speed;  apparently a buffer streaming issue that I don't understand.

The experimental C32 playback support was just introduced yesterday with the C8 support, but nobody was asking for the C32 anyways, so removing it to alleviate any user complaints that it doesn't work.