### PR TITLE
Touch Test tweak & Scanner default squelch

### DIFF
--- a/firmware/application/apps/ui_debug.cpp
+++ b/firmware/application/apps/ui_debug.cpp
@@ -547,7 +547,7 @@ uint16_t DebugScreenTest::semirand() {
 }
 
 void DebugScreenTest::paint(Painter& painter) {
-    painter.fill_rectangle({0, 16, screen_width, screen_height-16}, Color::white());
+    painter.fill_rectangle({0, 16, screen_width, screen_height - 16}, Color::white());
     painter.draw_string({10 * 8, screen_height / 2}, Styles::white, "Use Stylus");
     pen_color = semirand();
 }

--- a/firmware/application/apps/ui_debug.cpp
+++ b/firmware/application/apps/ui_debug.cpp
@@ -540,14 +540,14 @@ bool DebugScreenTest::on_touch(const TouchEvent event) {
 }
 
 uint16_t DebugScreenTest::semirand() {
-    static uint64_t seed{0x31415926DEADBEEF};
+    static uint64_t seed{0x0102030405060708};
     seed = seed * 137;
     seed = (seed >> 1) | ((seed & 0x01) << 63);
     return (uint16_t)seed;
 }
 
 void DebugScreenTest::paint(Painter& painter) {
-    painter.fill_rectangle({0, 0, screen_width, screen_height}, Color::white());
+    painter.fill_rectangle({0, 16, screen_width, screen_height-16}, Color::white());
     painter.draw_string({10 * 8, screen_height / 2}, Styles::white, "Use Stylus");
     pen_color = semirand();
 }

--- a/firmware/application/apps/ui_scanner.cpp
+++ b/firmware/application/apps/ui_scanner.cpp
@@ -564,7 +564,7 @@ ScannerView::ScannerView(
     field_lock_wait.set_value(2);
 
     field_squelch.on_change = [this](int32_t v) { squelch = v; };
-    field_squelch.set_value(-10);
+    field_squelch.set_value(-30);
 
     // LEARN FREQUENCIES
     std::string scanner_txt = "SCANNER";


### PR DESCRIPTION
In Touch Test:
* Leave the navigation/title bar visible at start, so it's more clear that it remains active (it can still be drawn over though for testing that part of the touchscreen).
* Trying another randomizer seed.

In Scanner:
* Change default Squelch value.  (Still need to address squelch differences between apps & modulation types, someday)