### PR TITLE
Digit Mode for frequency field

### DIFF
--- a/firmware/application/apps/analog_audio_app.hpp
+++ b/firmware/application/apps/analog_audio_app.hpp
@@ -48,9 +48,9 @@ class AMOptionsView : public View {
 
     OptionsField options_config{
         {3 * 8, 0 * 16},
-        6,  // number of blanking characters
+        6,  // Max option length
         {
-            // using  common messages from freqman.cpp
+            // Using common messages from freqman_ui.cpp
         }};
 };
 
@@ -65,9 +65,9 @@ class NBFMOptionsView : public View {
     };
     OptionsField options_config{
         {3 * 8, 0 * 16},
-        4,
+        3,  // Max option length
         {
-            // using  common messages from freqman.cpp
+            // Using common messages from freqman_ui.cpp
         }};
 
     Text text_squelch{
@@ -93,9 +93,9 @@ class WFMOptionsView : public View {
     };
     OptionsField options_config{
         {3 * 8, 0 * 16},
-        4,
+        4,  // Max option length
         {
-            // using  common messages from freqman.cpp
+            // Using common messages from freqman_ui.cpp
         }};
 };
 

--- a/firmware/application/apps/ui_debug.cpp
+++ b/firmware/application/apps/ui_debug.cpp
@@ -264,9 +264,9 @@ void ControlsSwitchesWidget::paint(Painter& painter) {
         {32, 64, 16, 16},  // Down
         {32, 0, 16, 16},   // Up
         {32, 32, 16, 16},  // Select
+        {96, 0, 16, 16},   // Dfu
         {16, 96, 16, 16},  // Encoder phase 0
         {48, 96, 16, 16},  // Encoder phase 1
-        {96, 0, 16, 16},   // Dfu
         {96, 64, 16, 16},  // Touch
     }};
 
@@ -283,9 +283,9 @@ void ControlsSwitchesWidget::paint(Painter& painter) {
         {32 + 1, 64 + 1, 16 - 2, 16 - 2},  // Down
         {32 + 1, 0 + 1, 16 - 2, 16 - 2},   // Up
         {32 + 1, 32 + 1, 16 - 2, 16 - 2},  // Select
+        {96 + 1, 0 + 1, 16 - 2, 16 - 2},   // Dfu
         {16 + 1, 96 + 1, 16 - 2, 16 - 2},  // Encoder phase 0
         {48 + 1, 96 + 1, 16 - 2, 16 - 2},  // Encoder phase 1
-        {96 + 1, 0 + 1, 16 - 2, 16 - 2},   // Dfu
     }};
 
     auto switches_raw = control::debug::switches();

--- a/firmware/application/apps/ui_debug.cpp
+++ b/firmware/application/apps/ui_debug.cpp
@@ -251,7 +251,7 @@ void ControlsSwitchesWidget::on_show() {
 
 bool ControlsSwitchesWidget::on_key(const KeyEvent key) {
     key_event_mask = 1 << toUType(key);
-    long_press_key_event_mask = switch_long_press_occurred((size_t)key) ? key_event_mask : 0;
+    long_press_key_event_mask = key_is_long_pressed(key) ? key_event_mask : 0;
     return true;
 }
 
@@ -354,13 +354,13 @@ DebugControlsView::DebugControlsView(NavigationView& nav) {
     });
 
     button_done.on_select = [&nav](Button&) {
-        switches_long_press_enable(0);
+        set_switches_long_press_config(0);
         nav.pop();
     };
 
     options_switches_mode.on_change = [this](size_t, OptionsField::value_t v) {
         (void)v;
-        switches_long_press_enable(options_switches_mode.selected_index_value());
+        set_switches_long_press_config(options_switches_mode.selected_index_value());
     };
 }
 

--- a/firmware/application/hw/debounce.cpp
+++ b/firmware/application/hw/debounce.cpp
@@ -84,8 +84,8 @@ bool Debounce::feed(const uint8_t bit) {
                 // Button is being held down and long_press support is enabled for this key:
                 // if LONG_PRESS_DELAY is reached then finally report that switch is pressed and set flag
                 // indicating it was a LONG press
-                // (note that repease_support and long_press support are mutually exclusive)
-                if (held_time_ == LONG_PRESS_DELAY) {
+                // (note that repeat_support and long_press support are mutually exclusive)
+                if (held_time_ >= LONG_PRESS_DELAY) {
                     long_press_occurred_ = true;
                     pulse_upon_release_ = 0;
                     held_time_ = 0;

--- a/firmware/application/hw/debounce.hpp
+++ b/firmware/application/hw/debounce.hpp
@@ -31,7 +31,7 @@
 // # of timer0 ticks before a held button starts being counted as repeated presses
 #define REPEAT_INITIAL_DELAY 250
 #define REPEAT_SUBSEQUENT_DELAY 92
-#define LONG_PRESS_DELAY 1000
+#define LONG_PRESS_DELAY 800
 
 class Debounce {
    public:
@@ -45,7 +45,11 @@ class Debounce {
         repeat_enabled_ = true;
     }
 
-    void set_long_press_support(bool v) {
+    bool get_long_press_enabled() const {
+        return long_press_enabled_;
+    }
+
+    void set_long_press_enabled(bool v) {
         long_press_enabled_ = v;
     }
 

--- a/firmware/application/irq_controls.hpp
+++ b/firmware/application/irq_controls.hpp
@@ -28,25 +28,28 @@
 #include "touch.hpp"
 
 // Must be same values as in ui::KeyEvent
-enum class Switch {
+// TODO: Why not just reuse one or the other?
+enum class Switch : uint8_t {
     Right = 0,
     Left = 1,
     Down = 2,
     Up = 3,
     Sel = 4,
-    Dfu = 5,
+    Dfu = 5
 };
 
+// Index with the Switch enum.
 using SwitchesState = std::bitset<6>;
-
 using EncoderPosition = uint32_t;
 
 void controls_init();
 SwitchesState get_switches_state();
 EncoderPosition get_encoder_position();
 touch::Frame get_touch_frame();
-void switches_long_press_enable(SwitchesState v);
-bool switch_long_press_occurred(size_t v);
+
+SwitchesState get_switches_long_press_config();
+void set_switches_long_press_config(SwitchesState switch_config);
+bool switch_is_long_pressed(Switch s);
 
 namespace control {
 namespace debug {

--- a/firmware/application/ui/ui_receiver.cpp
+++ b/firmware/application/ui/ui_receiver.cpp
@@ -20,8 +20,6 @@
  * Boston, MA 02110-1301, USA.
  */
 
-#include "debug.hpp"
-
 #include "irq_controls.hpp"
 #include "max283x.hpp"
 #include "portapack.hpp"

--- a/firmware/application/ui/ui_receiver.cpp
+++ b/firmware/application/ui/ui_receiver.cpp
@@ -85,22 +85,7 @@ bool FrequencyField::on_key(const ui::KeyEvent event) {
 }
 
 bool FrequencyField::on_encoder(const EncoderEvent delta) {
-    if (step == 0) {  // 'Auto' mode.'
-        auto ms = RTT2MS(halGetCounterValue());
-        auto delta_ms = last_ms_ <= ms ? ms - last_ms_ : ms;
-        last_ms_ = ms;
-
-        // The goal is to map 'scale' to a range of about 10 to 10M.
-        // The faster the encoder is rotated, the larger the step.
-        // Linear doesn't feel right. Hyperbolic felt better.
-        // To get these magic numbers, I graphed the function until the
-        // curve shape seemed about right then tested on device.
-        delta_ms = std::min(145ull, delta_ms) + 5;  // Prevent DIV/0
-        int64_t scale = 200'000'000 / (0.001'55 * std::pow(delta_ms, 5.45)) + 8;
-        set_value(value() + (delta * scale));
-    } else {
-        set_value(value() + (delta * step));
-    }
+    set_value(value() + (delta * step));
     return true;
 }
 

--- a/firmware/application/ui/ui_receiver.hpp
+++ b/firmware/application/ui/ui_receiver.hpp
@@ -242,7 +242,6 @@ class FrequencyStepView : public OptionsField {
               parent_pos,
               5,
               {
-                  {" Auto", 0},  /* Faster == larger step. */
                   {"   10", 10}, /* Fine tuning SSB voice pitch,in HF and QO-100 sat #669 */
                   {"   50", 50}, /* added 50Hz/10Hz,but we do not increase GUI digit decimal */
                   {"  100", 100},

--- a/firmware/application/ui/ui_receiver.hpp
+++ b/firmware/application/ui/ui_receiver.hpp
@@ -27,6 +27,7 @@
 #include "ui_painter.hpp"
 #include "ui_widget.hpp"
 
+#include "irq_controls.hpp"
 #include "rf_path.hpp"
 
 #include <cstddef>
@@ -45,6 +46,7 @@ class FrequencyField : public Widget {
     using range_t = rf::FrequencyRange;
 
     FrequencyField(Point parent_pos);
+    ~FrequencyField();
 
     rf::Frequency value() const;
 
@@ -53,18 +55,26 @@ class FrequencyField : public Widget {
 
     void paint(Painter& painter) override;
 
-    bool on_key(ui::KeyEvent event) override;
+    bool on_key(KeyEvent event) override;
     bool on_encoder(EncoderEvent delta) override;
     bool on_touch(TouchEvent event) override;
     void on_focus() override;
+    void on_blur() override;
 
    private:
     const size_t length_;
-    const range_t range;
+    const range_t range_;
+
     rf::Frequency value_{0};
-    rf::Frequency step{25000};
+    rf::Frequency step_{25000};
     uint64_t last_ms_{0};
 
+    uint8_t digit_{3};
+    bool digit_mode_{false};
+    SwitchesState initial_switch_config_{};
+
+    /* Gets the step value for the given digit when in digit_mode. */
+    rf::Frequency digit_step() const;
     rf::Frequency clamp_value(rf::Frequency value);
 };
 

--- a/firmware/common/ui.cpp
+++ b/firmware/common/ui.cpp
@@ -20,6 +20,7 @@
  */
 
 #include "ui.hpp"
+#include "irq_controls.hpp"
 #include "sine_table.hpp"
 #include "utility.hpp"
 
@@ -100,6 +101,16 @@ Point fast_polar_to_point(int32_t angle, uint32_t distance) {
     // polar to compass with y negated for screen drawing
     return Point((int16_sin_s4(((1 << 16) * (-angle + 180)) / 360) * distance) / (1 << 16),
                  (int16_sin_s4(((1 << 16) * (-angle - 90)) / 360) * distance) / (1 << 16));
+}
+
+bool key_is_long_pressed(KeyEvent key) {
+    if (key < KeyEvent::Back) {
+        // TODO: this would make more sense as a flag on KeyEvent
+        // passed up to the UI via event dispatch.
+        return switch_is_long_pressed(static_cast<Switch>(key));
+    }
+
+    return false;
 }
 
 } /* namespace ui */

--- a/firmware/common/ui.hpp
+++ b/firmware/common/ui.hpp
@@ -34,6 +34,10 @@ using Dim = int16_t;
 constexpr uint16_t screen_width = 240;
 constexpr uint16_t screen_height = 320;
 
+/* Dimensions for the default font character. */
+constexpr uint16_t char_width = 8;
+constexpr uint16_t char_height = 16;
+
 struct Color {
     uint16_t v;  // rrrrrGGGGGGbbbbb
 
@@ -328,7 +332,7 @@ struct Bitmap {
     const uint8_t* const data;
 };
 
-enum class KeyEvent {
+enum class KeyEvent : uint8_t {
     /* Ordinals map to bit positions reported by CPLD */
     Right = 0,
     Left = 1,
@@ -355,6 +359,11 @@ struct TouchEvent {
 Point polar_to_point(float angle, uint32_t distance);
 
 Point fast_polar_to_point(int32_t angle, uint32_t distance);
+
+/* Default font glyph size. */
+constexpr Size char_size{char_width, char_height};
+
+bool key_is_long_pressed(KeyEvent key);
 
 } /* namespace ui */
 

--- a/firmware/common/utility.hpp
+++ b/firmware/common/utility.hpp
@@ -53,6 +53,12 @@ constexpr typename std::underlying_type<E>::type toUType(E enumerator) noexcept 
     return static_cast<typename std::underlying_type<E>::type>(enumerator);
 }
 
+/* Increments an enum value. Enumerator values are assumed to be serial. */
+template <typename E>
+void incr(E& e) {
+    e = static_cast<E>(toUType(e) + 1);
+}
+
 inline uint32_t flp2(uint32_t v) {
     v |= v >> 1;
     v |= v >> 2;


### PR DESCRIPTION
This allows frequencies to be edited digit by digit with the d-pad and encoder.
To enter "digit mode", long-press (800ms) Select while the frequency field is highlighted
Once in this mode, up/down or encoder can change the frequency in steps of the power of 10 that is highlighted.
Left/right change the selected digit and the step size accordingly.
Pressing select once again will leave "digit mode".

Additional changes:
- Removes the old "Auto" step mode -- it didn't work well and this is a more reliable replacement.
- Renamed functions dealing with long_press.
- Some IRQ code cleanup (try to pack all button together in IO).
- Minor UI fixed and comment cleanup.