### PR TITLE
Improve Select button response when Long Press is enabled during CPU-intensive apps (WFM)

### DIFF
--- a/firmware/application/hw/debounce.hpp
+++ b/firmware/application/hw/debounce.hpp
@@ -36,38 +36,22 @@
 class Debounce {
    public:
     bool feed(const uint8_t bit);
-
-    uint8_t state() const {
-        return (pulse_upon_release_) ? 0 : state_;
-    }
-
-    void enable_repeat() {
-        repeat_enabled_ = true;
-    }
-
-    bool get_long_press_enabled() const {
-        return long_press_enabled_;
-    }
-
-    void set_long_press_enabled(bool v) {
-        long_press_enabled_ = v;
-    }
-
-    bool long_press_occurred() {
-        bool v = long_press_occurred_;
-        long_press_occurred_ = false;
-        return v;
-    }
+    uint8_t state();
+    void enable_repeat();
+    bool get_long_press_enabled() const;
+    void set_long_press_enabled(bool v);
+    bool long_press_occurred();
 
    private:
     uint8_t history_{0};
     uint8_t state_{0};
-    bool repeat_enabled_{0};
+    bool repeat_enabled_{false};
     uint16_t repeat_ctr_{0};
     uint16_t held_time_{0};
-    bool pulse_upon_release_{0};
-    bool long_press_enabled_{0};
-    bool long_press_occurred_{0};
+    bool pulse_upon_release_{false};
+    bool simulated_pulse_{false};
+    bool long_press_enabled_{false};
+    bool long_press_occurred_{false};
 };
 
 #endif /*__DEBOUNCE_H__*/

--- a/firmware/application/irq_controls.cpp
+++ b/firmware/application/irq_controls.cpp
@@ -228,6 +228,7 @@ void controls_init() {
         switch_debounce[toUType(i)].enable_repeat();
 }
 
+// Note: Called by event handler or apps, not in ISR, so some presses might be missed during high CPU utilization
 SwitchesState get_switches_state() {
     SwitchesState result;
 


### PR DESCRIPTION
There's still some room for improvement on the select key response when "long press" is enabled, but this change basically resolves the issue with the frequency entry screen not being accessible in WFM mode due to missing "select" key presses.

Looks like several changes in this PR, but most of them were just moving code from the header module to the CPP module, and changing "0' to "false" for bool types.

When Long Press is enabled, the real button press is masked until either the button is released or the long press delay is reached.  When the button is released, a simulated button press occurs.  Previously, the simulated button press would be cleared on the next timer tick, so the EventDispatcher (which calls state()) might miss it.  Now, I have added a "simulated_pulse_" flag to make sure that EventDispatcher sees the simulated pulse before clearing it.

I might have a better fix tomorrow, but this was a simple patch for now that gets the frequency entry screen working again in WFM mode after #1298.