### PR TITLE
Gps default frequency

### DIFF
--- a/firmware/application/apps/gps_sim_app.cpp
+++ b/firmware/application/apps/gps_sim_app.cpp
@@ -177,6 +177,8 @@ GpsSimAppView::GpsSimAppView(
     if (!settings_.loaded()) {
         field_frequency.set_value(initial_target_frequency);
         sample_rate = 2600000;
+    } else {
+        sample_rate = transmitter_model.sampling_rate();
     }
 
     field_frequency.set_step(5000);

--- a/firmware/application/apps/gps_sim_app.cpp
+++ b/firmware/application/apps/gps_sim_app.cpp
@@ -64,8 +64,6 @@ void GpsSimAppView::on_file_changed(const fs::path& new_file_path) {
     if (metadata) {
         field_frequency.set_value(metadata->center_frequency);
         sample_rate = metadata->sample_rate;
-    } else {
-        sample_rate = 2600000;
     }
 
     // UI Fixup.
@@ -175,6 +173,11 @@ GpsSimAppView::GpsSimAppView(
         &button_play,
         &waterfall,
     });
+
+    if (!settings_.loaded()) {
+        field_frequency.set_value(initial_target_frequency);
+        sample_rate = 2600000;
+    }
 
     field_frequency.set_step(5000);
 

--- a/firmware/application/apps/gps_sim_app.cpp
+++ b/firmware/application/apps/gps_sim_app.cpp
@@ -63,15 +63,15 @@ void GpsSimAppView::on_file_changed(const fs::path& new_file_path) {
 
     if (metadata) {
         field_frequency.set_value(metadata->center_frequency);
-        sample_rate = metadata->sample_rate;
+        transmitter_model.set_sampling_rate(metadata->sample_rate);
     }
 
     // UI Fixup.
-    text_sample_rate.set(unit_auto_scale(sample_rate, 3, 1) + "Hz");
+    text_sample_rate.set(unit_auto_scale(transmitter_model.sampling_rate(), 3, 1) + "Hz");
     progressbar.set_max(file_size);
     text_filename.set(truncate(file_path.filename().string(), 12));
 
-    auto duration = ms_duration(file_size, sample_rate, 2);
+    auto duration = ms_duration(file_size, transmitter_model.sampling_rate(), 2);
     text_duration.set(to_string_time_ms(duration));
 
     button_play.focus();
@@ -127,7 +127,6 @@ void GpsSimAppView::start() {
             });
     }
 
-    transmitter_model.set_sampling_rate(sample_rate);
     transmitter_model.enable();
 }
 
@@ -176,9 +175,7 @@ GpsSimAppView::GpsSimAppView(
 
     if (!settings_.loaded()) {
         field_frequency.set_value(initial_target_frequency);
-        sample_rate = 2600000;
-    } else {
-        sample_rate = transmitter_model.sampling_rate();
+        transmitter_model.set_sampling_rate(2600000);
     }
 
     field_frequency.set_step(5000);

--- a/firmware/application/apps/gps_sim_app.hpp
+++ b/firmware/application/apps/gps_sim_app.hpp
@@ -66,7 +66,6 @@ class GpsSimAppView : public View {
 
     static constexpr ui::Dim header_height = 3 * 16;
 
-    uint32_t sample_rate = 0;
     int32_t tx_gain{47};
     bool rf_amp{true};                                       // aux private var to store temporal, same as Replay App rf_amp user selection.
     static constexpr uint32_t baseband_bandwidth = 3000000;  // filter bandwidth

--- a/firmware/application/apps/gps_sim_app.hpp
+++ b/firmware/application/apps/gps_sim_app.hpp
@@ -54,6 +54,8 @@ class GpsSimAppView : public View {
     std::string title() const override { return "GPS Sim TX"; };
 
    private:
+    static constexpr uint32_t initial_target_frequency = 1575420000;
+
     NavigationView& nav_;
     RxRadioState radio_state_{
         3000000 /* bandwidth */,


### PR DESCRIPTION
Use default GPS L1 frequency when there is no .TXT file and no App Settings file (or Load App Settings is disabled).

Also, use default sampling rate only when no sampling rate is specified in the .ini file (sampling rate in the .ini file was previously ignored).

As usual, any values specified in the .TXT file take precedence over both the .ini file and firmware defaults.