### PR TITLE
XOR cursor support in Notepad

### DIFF
--- a/firmware/application/apps/ui_text_editor.hpp
+++ b/firmware/application/apps/ui_text_editor.hpp
@@ -97,6 +97,7 @@ class TextViewer : public Widget {
 
     void paint_text(Painter& painter, uint32_t line, uint16_t col);
     void paint_cursor(Painter& painter);
+    void clear_cursor(Painter& painter);
 
     void reset_file(FileWrapper* file = nullptr);
 

--- a/firmware/application/apps/ui_text_editor.hpp
+++ b/firmware/application/apps/ui_text_editor.hpp
@@ -97,7 +97,6 @@ class TextViewer : public Widget {
 
     void paint_text(Painter& painter, uint32_t line, uint16_t col);
     void paint_cursor(Painter& painter);
-    void clear_cursor(Painter& painter);
 
     void reset_file(FileWrapper* file = nullptr);
 

--- a/firmware/common/lcd_ili9341.hpp
+++ b/firmware/common/lcd_ili9341.hpp
@@ -100,6 +100,9 @@ class ILI9341 {
     constexpr ui::Dim height() const { return 320; }
     constexpr ui::Rect screen_rect() const { return {0, 0, width(), height()}; }
 
+    void draw_pixels(const ui::Rect r, const ui::Color* const colors, const size_t count);
+    void read_pixels(const ui::Rect r, ui::ColorRGB888* const colors, const size_t count);
+
    private:
     struct scroll_t {
         ui::Coord top_area;
@@ -109,9 +112,6 @@ class ILI9341 {
     };
 
     scroll_t scroll_state;
-
-    void draw_pixels(const ui::Rect r, const ui::Color* const colors, const size_t count);
-    void read_pixels(const ui::Rect r, ui::ColorRGB888* const colors, const size_t count);
 };
 
 } /* namespace lcd */


### PR DESCRIPTION
Per Notepad enhancement suggestion #1310, I found the text under the cursor almost unreadable in the 5x8 font since the cursor rectangle was right up against the character pixels.  I tried different rectangle colors, but it didn't help.  I find this XOR cursor to be much more readable.  Compare the cursor in the following BEFORE & AFTER screen-shots:

BEFORE (the 0 under the cursor looks like an X to me):
![SCR_0002](https://github.com/eried/portapack-mayhem/assets/129641948/fdbb8c63-7f97-4400-99c8-54e5810ec734)

AFTER (the colors are inverted [XOR'd] under the cursor, and clearly a 0):
![SCR_0004](https://github.com/eried/portapack-mayhem/assets/129641948/a3a9850d-10a2-4871-91e6-8ea9fc30d1fb)
