### PR TITLE
Allow changelog to run without a token

### DIFF
--- a/.github/workflows/changelog.py
+++ b/.github/workflows/changelog.py
@@ -29,7 +29,7 @@ def print_nightly_changelog():
 
 
 def handle_get_request(path, offset=None):
-    headers = {"Authorization": f"Bearer {token}"}
+    headers = {} if token == None else {"Authorization": f"Bearer {token}"}
     params = {"since": offset}
     url_base = f"https://api.github.com/repos/{repo_owner}/{repo_name}/"
     response = requests.get(url_base + path, headers=headers, params=params)


### PR DESCRIPTION
@Brumi-2021 was having an issue where his personal nightly were failing because he never added the environment variable for GH_TOKEN containing his PAT token. This fix will solve this problem for him and other users who personally use the nightly script in their own repos.

_This works because we no longer need to have a PAT since we are only doing a single API call, where previously a few commits back we were doing a bunch which did require a PAT_