### PR TITLE
Force TCXO toggle setting for R9

### DIFF
--- a/.github/workflows/changelog.py
+++ b/.github/workflows/changelog.py
@@ -29,7 +29,7 @@ def print_nightly_changelog():
 
 
 def handle_get_request(path, offset=None):
-    headers = {"Authorization": f"Bearer {token}"}
+    headers = {} if token == None else {"Authorization": f"Bearer {token}"}
     params = {"since": offset}
     url_base = f"https://api.github.com/repos/{repo_owner}/{repo_name}/"
     response = requests.get(url_base + path, headers=headers, params=params)

--- a/firmware/application/apps/ui_settings.cpp
+++ b/firmware/application/apps/ui_settings.cpp
@@ -224,13 +224,13 @@ SetRadioView::SetRadioView(
     };
 
     force_tcxo.set_value(pmem::config_force_tcxo());
-    force_tcxo.on_select = [this](Checkbox&, bool v) {
-        // v ? clock_manager.set_reference({ClockManager::ReferenceSource::External, 10000000})
+    force_tcxo.on_select = [this](Checkbox&, bool checked) {
+        // checked ? clock_manager.set_reference({ClockManager::ReferenceSource::External, 10000000})
         //   : clock_manager.set_reference({ClockManager::ReferenceSource::Xtal, 25000000});
 
         /*
         Sadly we cannot do:
-        clock_manager.set_reference(clock_manager.choose_reference(v));
+        clock_manager.set_reference(clock_manager.choose_reference(checked));
         As it actaully causes the device to freeze/crash. I will fix this in the next PR (@jLynx)
         */
 

--- a/firmware/application/apps/ui_settings.cpp
+++ b/firmware/application/apps/ui_settings.cpp
@@ -225,8 +225,8 @@ SetRadioView::SetRadioView(
 
     force_tcxo.set_value(pmem::config_force_tcxo());
     force_tcxo.on_select = [this](Checkbox&, bool v) {
-        v ? clock_manager.set_reference({ClockManager::ReferenceSource::External, 10000000})
-          : clock_manager.set_reference({ClockManager::ReferenceSource::Xtal, 25000000});
+        // v ? clock_manager.set_reference({ClockManager::ReferenceSource::External, 10000000})
+        //   : clock_manager.set_reference({ClockManager::ReferenceSource::Xtal, 25000000});
 
         /*
         Sadly we cannot do:

--- a/firmware/application/apps/ui_settings.cpp
+++ b/firmware/application/apps/ui_settings.cpp
@@ -226,6 +226,7 @@ SetRadioView::SetRadioView(
     force_tcxo.on_select = [this](Checkbox&, bool v) {
         // Check if R9
         // If checked, set it to use External now
+        // We want to enable it right away, so if the system freezes, we havent clicked save yet
 
         send_system_refresh();
     };

--- a/firmware/application/apps/ui_settings.cpp
+++ b/firmware/application/apps/ui_settings.cpp
@@ -225,7 +225,14 @@ SetRadioView::SetRadioView(
 
     force_tcxo.set_value(pmem::config_force_tcxo());
     force_tcxo.on_select = [this](Checkbox&, bool v) {
+        v ? clock_manager.set_reference({ClockManager::ReferenceSource::External, 10000000})
+          : clock_manager.set_reference({ClockManager::ReferenceSource::Xtal, 25000000});
+
+        /*
+        Sadly we cannot do:
         clock_manager.set_reference(clock_manager.choose_reference(v));
+        As it actaully causes the device to freeze/crash. I will fix this in the next PR (@jLynx)
+        */
 
         send_system_refresh();
     };

--- a/firmware/application/apps/ui_settings.cpp
+++ b/firmware/application/apps/ui_settings.cpp
@@ -160,26 +160,16 @@ SetRadioView::SetRadioView(
         });
     }
 
-    if (hackrf_r9) {
-        add_children({&check_clkout,
-                      &field_clkout_freq,
-                      &labels_clkout_khz,
-                      &value_freq_step,
-                      &labels_bias,
-                      &check_bias,
-                      &force_tcxo,
-                      &button_save,
-                      &button_cancel});
-    } else {
-        add_children({&check_clkout,
-                      &field_clkout_freq,
-                      &labels_clkout_khz,
-                      &value_freq_step,
-                      &labels_bias,
-                      &check_bias,
-                      &button_save,
-                      &button_cancel});
-    }
+    add_children({&check_clkout,
+                  &field_clkout_freq,
+                  &labels_clkout_khz,
+                  &value_freq_step,
+                  &labels_bias,
+                  &check_bias,
+                  &button_save,
+                  &button_cancel});
+    if (hackrf_r9)
+        add_children({&force_tcxo});
 
     SetFrequencyCorrectionModel model{
         static_cast<int8_t>(pmem::correction_ppb() / 1000), 0};
@@ -235,11 +225,7 @@ SetRadioView::SetRadioView(
 
     force_tcxo.set_value(pmem::config_force_tcxo());
     force_tcxo.on_select = [this](Checkbox&, bool v) {
-        if (v) {
-            clock_manager.set_reference(clock_manager.choose_reference(true));
-        } else {
-            clock_manager.set_reference(clock_manager.choose_reference());
-        }
+        clock_manager.set_reference(clock_manager.choose_reference(v));
 
         send_system_refresh();
     };

--- a/firmware/application/apps/ui_settings.cpp
+++ b/firmware/application/apps/ui_settings.cpp
@@ -166,6 +166,7 @@ SetRadioView::SetRadioView(
                   &value_freq_step,
                   &labels_bias,
                   &check_bias,
+                  &force_tcxo,
                   &button_save,
                   &button_cancel});
 
@@ -221,10 +222,19 @@ SetRadioView::SetRadioView(
         send_system_refresh();
     };
 
+    force_tcxo.set_value(pmem::config_force_tcxo());
+    force_tcxo.on_select = [this](Checkbox&, bool v) {
+        // Check if R9
+        // If checked, set it to use External now
+
+        send_system_refresh();
+    };
+
     button_save.on_select = [this, &nav](Button&) {
         const auto model = this->form_collect();
         pmem::set_correction_ppb(model.ppm * 1000);
         pmem::set_clkout_freq(model.freq);
+        pmem::set_config_force_tcxo(force_tcxo.value());
         clock_manager.enable_clock_output(pmem::clkout_enabled());
         nav.pop();
     };

--- a/firmware/application/apps/ui_settings.cpp
+++ b/firmware/application/apps/ui_settings.cpp
@@ -227,6 +227,7 @@ SetRadioView::SetRadioView(
         // Check if R9
         // If checked, set it to use External now
         // We want to enable it right away, so if the system freezes, we havent clicked save yet
+        const auto reference = clock_manager.get_reference();
 
         send_system_refresh();
     };

--- a/firmware/application/apps/ui_settings.hpp
+++ b/firmware/application/apps/ui_settings.hpp
@@ -185,6 +185,11 @@ class SetRadioView : public View {
         5,
         "Turn on bias voltage"};
 
+    Checkbox force_tcxo{
+        {18, 14 * 16},
+        5,
+        "Force external TCXO"};
+
     Button button_save{
         {2 * 8, 16 * 16, 12 * 8, 32},
         "Save"};

--- a/firmware/application/clock_manager.cpp
+++ b/firmware/application/clock_manager.cpp
@@ -264,11 +264,11 @@ void ClockManager::init_clock_generator() {
 
     // ToDo: Remove this code below
     //  set_reference(choose_reference(portapack::persistent_memory::config_force_tcxo()));
-    //  if (portapack::persistent_memory::config_force_tcxo())
-    //      set_reference({ClockManager::ReferenceSource::External, 10000000});
-    //  else
-    //      set_reference(choose_reference());
-    set_reference(choose_reference());
+     if (portapack::persistent_memory::config_force_tcxo())
+         set_reference({ClockManager::ReferenceSource::External, 10000000});
+     else
+         set_reference(choose_reference());
+    // set_reference(choose_reference());
 
     clock_generator.disable_output(clock_generator_output_mcu_clkin);
 

--- a/firmware/application/clock_manager.cpp
+++ b/firmware/application/clock_manager.cpp
@@ -263,11 +263,11 @@ void ClockManager::init_clock_generator() {
     clock_generator.enable_output(clock_generator_output_mcu_clkin);
 
     // ToDo: Remove this code below
-    //  set_reference(choose_reference(portapack::persistent_memory::config_force_tcxo()));
-     if (portapack::persistent_memory::config_force_tcxo())
-         set_reference({ClockManager::ReferenceSource::External, 10000000});
-     else
-         set_reference(choose_reference());
+    set_reference(choose_reference(portapack::persistent_memory::config_force_tcxo()));
+    // if (portapack::persistent_memory::config_force_tcxo())
+    //     set_reference({ClockManager::ReferenceSource::External, 10000000});
+    // else
+    //     set_reference(choose_reference());
     // set_reference(choose_reference());
 
     clock_generator.disable_output(clock_generator_output_mcu_clkin);
@@ -333,6 +333,11 @@ uint32_t ClockManager::measure_gp_clkin_frequency() {
     return get_frequency_monitor_measurement_in_hertz();
 }
 
+/*
+With the new R9 devices, the detection method is actually incorrect. But the problem is there are a bunch of PortaPacks that have been built with their TCXO out of spec (It needs a 3.3Vpp, but they all seem to have a 1Vpp).
+This means when using the correct detection method, it will detect the TCXO but the device would sometime/always crash (Seems to be luck of the draw how stable your device is with an out of spec TCXO).
+So since we don't want everyone's devices crashing by fixing the detection method (Well everyone with an out of spec TCXO, which seems to be 90% of R9 users), we have hidden it behind this toggle.
+*/
 bool ClockManager::loss_of_signal(bool useRealCheck) {
     if (hackrf_r9) {
         if (useRealCheck) {

--- a/firmware/application/clock_manager.cpp
+++ b/firmware/application/clock_manager.cpp
@@ -327,9 +327,9 @@ uint32_t ClockManager::measure_gp_clkin_frequency() {
     return get_frequency_monitor_measurement_in_hertz();
 }
 
-bool ClockManager::loss_of_signal(bool trueCheck) {
+bool ClockManager::loss_of_signal(bool useRealCheck) {
     if (hackrf_r9) {
-        if (trueCheck) {
+        if (useRealCheck) {
             const auto frequency = measure_gp_clkin_frequency();
             return (frequency < 9850000) || (frequency > 10150000);
         } else {
@@ -340,12 +340,12 @@ bool ClockManager::loss_of_signal(bool trueCheck) {
     }
 }
 
-ClockManager::ReferenceSource ClockManager::detect_reference_source(bool trueCheck) {
-    if (loss_of_signal(trueCheck)) {
+ClockManager::ReferenceSource ClockManager::detect_reference_source(bool useRealCheck) {
+    if (loss_of_signal(useRealCheck)) {
         // No external reference. Turn on PortaPack reference (if present).
         portapack_tcxo_enable();
 
-        if (loss_of_signal(trueCheck)) {
+        if (loss_of_signal(useRealCheck)) {
             // No PortaPack reference was detected. Choose the HackRF crystal as the reference.
             return ReferenceSource::Xtal;
         } else {
@@ -356,14 +356,14 @@ ClockManager::ReferenceSource ClockManager::detect_reference_source(bool trueChe
     }
 }
 
-ClockManager::Reference ClockManager::choose_reference(bool trueCheck) {
+ClockManager::Reference ClockManager::choose_reference(bool useRealCheck) {
     if (hackrf_r9) {
         gpio_r9_clkin_en.write(1);
         volatile uint32_t delay = 240000 + 24000;
         while (delay--)
             ;
     }
-    const auto detected_reference = detect_reference_source(trueCheck);
+    const auto detected_reference = detect_reference_source(useRealCheck);
 
     if ((detected_reference == ReferenceSource::External) ||
         (detected_reference == ReferenceSource::PortaPack)) {

--- a/firmware/application/clock_manager.cpp
+++ b/firmware/application/clock_manager.cpp
@@ -262,7 +262,13 @@ void ClockManager::init_clock_generator() {
             .clk_pdn(ClockControl::ClockPowerDown::Power_On));
     clock_generator.enable_output(clock_generator_output_mcu_clkin);
 
-    set_reference(choose_reference(portapack::persistent_memory::config_force_tcxo()));
+    // ToDo: Remove this code below
+    //  set_reference(choose_reference(portapack::persistent_memory::config_force_tcxo()));
+    //  if (portapack::persistent_memory::config_force_tcxo())
+    //      set_reference({ClockManager::ReferenceSource::External, 10000000});
+    //  else
+    //      set_reference(choose_reference());
+    set_reference(choose_reference());
 
     clock_generator.disable_output(clock_generator_output_mcu_clkin);
 

--- a/firmware/application/clock_manager.hpp
+++ b/firmware/application/clock_manager.hpp
@@ -77,7 +77,7 @@ class ClockManager {
 
     void set_reference(Reference r);
 
-    Reference choose_reference(bool trueCuseRealCheckheck = false);
+    Reference choose_reference(bool useRealCheck = false);
 
     void enable_clock_output(bool enable);
 

--- a/firmware/application/clock_manager.hpp
+++ b/firmware/application/clock_manager.hpp
@@ -75,6 +75,10 @@ class ClockManager {
 
     Reference get_reference() const;
 
+    void set_reference(Reference r);
+
+    Reference choose_reference(bool trueCheck = false);
+
     void enable_clock_output(bool enable);
 
    private:
@@ -93,9 +97,8 @@ class ClockManager {
 
     uint32_t measure_gp_clkin_frequency();
 
-    ReferenceSource detect_reference_source();
-    Reference choose_reference();
-    bool loss_of_signal();
+    ReferenceSource detect_reference_source(bool trueCheck = false);
+    bool loss_of_signal(bool trueCheck = false);
 };
 
 #endif /*__CLOCK_MANAGER_H__*/

--- a/firmware/application/clock_manager.hpp
+++ b/firmware/application/clock_manager.hpp
@@ -77,7 +77,7 @@ class ClockManager {
 
     void set_reference(Reference r);
 
-    Reference choose_reference(bool trueCheck = false);
+    Reference choose_reference(bool trueCuseRealCheckheck = false);
 
     void enable_clock_output(bool enable);
 
@@ -97,8 +97,8 @@ class ClockManager {
 
     uint32_t measure_gp_clkin_frequency();
 
-    ReferenceSource detect_reference_source(bool trueCheck = false);
-    bool loss_of_signal(bool trueCheck = false);
+    ReferenceSource detect_reference_source(bool useRealCheck = false);
+    bool loss_of_signal(bool useRealCheck = false);
 };
 
 #endif /*__CLOCK_MANAGER_H__*/

--- a/firmware/application/portapack.cpp
+++ b/firmware/application/portapack.cpp
@@ -408,6 +408,9 @@ bool init() {
 
     portapack::io.init();
 
+    /* Cache some configuration data from persistent memory. */
+    persistent_memory::cache::init();
+
     clock_manager.init_clock_generator();
 
     i2c0.stop();
@@ -467,16 +470,16 @@ bool init() {
     controls_init();
     chThdSleepMilliseconds(10);
 
-    /* Cache some configuration data from persistent memory. */
-    persistent_memory::cache::init();
+    // /* Cache some configuration data from persistent memory. */
+    // persistent_memory::cache::init();
 
     clock_manager.set_reference_ppb(persistent_memory::correction_ppb());
     clock_manager.enable_if_clocks();
     clock_manager.enable_codec_clocks();
 
     // ToDo: Fix this so we dont need to specify them like I have done
-    persistent_memory::config_force_tcxo() ? clock_manager.set_reference({ClockManager::ReferenceSource::External, 10000000})
-                                           : clock_manager.set_reference({ClockManager::ReferenceSource::Xtal, 25000000});
+    // persistent_memory::config_force_tcxo() ? clock_manager.set_reference({ClockManager::ReferenceSource::External, 10000000})
+    //                                        : clock_manager.set_reference({ClockManager::ReferenceSource::Xtal, 25000000});
 
     radio::init();
 

--- a/firmware/application/portapack.cpp
+++ b/firmware/application/portapack.cpp
@@ -473,6 +473,11 @@ bool init() {
     clock_manager.set_reference_ppb(persistent_memory::correction_ppb());
     clock_manager.enable_if_clocks();
     clock_manager.enable_codec_clocks();
+
+    // ToDo: Fix this so we dont need to specify them like I have done
+    persistent_memory::config_force_tcxo() ? clock_manager.set_reference({ClockManager::ReferenceSource::External, 10000000})
+                                           : clock_manager.set_reference({ClockManager::ReferenceSource::Xtal, 25000000});
+
     radio::init();
 
     sdcStart(&SDCD1, nullptr);

--- a/firmware/common/portapack_persistent_memory.cpp
+++ b/firmware/common/portapack_persistent_memory.cpp
@@ -142,7 +142,7 @@ static_assert(sizeof(ui_config2_t) == sizeof(uint32_t));
 struct misc_config_t {
     bool mute_audio : 1;
     bool disable_speaker : 1;
-    bool UNUSED_2 : 1;
+    bool config_force_tcxo : 1;
     bool UNUSED_3 : 1;
     bool UNUSED_4 : 1;
     bool UNUSED_5 : 1;
@@ -363,6 +363,7 @@ void defaults() {
 
     set_config_backlight_timer(backlight_config_t{});
     set_config_splash(true);
+    set_config_force_tcxo(false);
     set_encoder_dial_sensitivity(DIAL_SENSITIVITY_NORMAL);
 
     // Default values for recon app.
@@ -549,6 +550,10 @@ bool config_speaker_disable() {
     return data->misc_config.disable_speaker;
 }
 
+bool config_force_tcxo() {
+    return data->misc_config.config_force_tcxo;
+}
+
 bool stealth_mode() {
     return data->ui_config.stealth_mode;
 }
@@ -608,6 +613,10 @@ void set_config_audio_mute(bool v) {
 
 void set_config_speaker_disable(bool v) {
     data->misc_config.disable_speaker = v;
+}
+
+void set_config_force_tcxo(bool v) {
+    data->misc_config.config_force_tcxo = v;
 }
 
 void set_stealth_mode(bool v) {
@@ -964,6 +973,8 @@ bool debug_dump() {
     // misc_config bits
     pmem_dump_file.write_line("misc_config config_audio_mute: " + to_string_dec_int(config_audio_mute()));
     pmem_dump_file.write_line("misc_config config_speaker_disable: " + to_string_dec_int(config_speaker_disable()));
+    pmem_dump_file.write_line("ui_config config_force_tcxo: " + to_string_dec_uint(config_force_tcxo()));
+    
     // receiver_model
     pmem_dump_file.write_line("\n[Receiver Model]");
     pmem_dump_file.write_line("target_frequency: " + to_string_dec_uint(receiver_model.target_frequency()));

--- a/firmware/common/portapack_persistent_memory.cpp
+++ b/firmware/common/portapack_persistent_memory.cpp
@@ -974,7 +974,7 @@ bool debug_dump() {
     pmem_dump_file.write_line("misc_config config_audio_mute: " + to_string_dec_int(config_audio_mute()));
     pmem_dump_file.write_line("misc_config config_speaker_disable: " + to_string_dec_int(config_speaker_disable()));
     pmem_dump_file.write_line("ui_config config_force_tcxo: " + to_string_dec_uint(config_force_tcxo()));
-    
+
     // receiver_model
     pmem_dump_file.write_line("\n[Receiver Model]");
     pmem_dump_file.write_line("target_frequency: " + to_string_dec_uint(receiver_model.target_frequency()));

--- a/firmware/common/portapack_persistent_memory.hpp
+++ b/firmware/common/portapack_persistent_memory.hpp
@@ -175,6 +175,7 @@ void set_stealth_mode(const bool v);
 uint8_t config_cpld();
 void set_config_cpld(uint8_t i);
 
+bool config_force_tcxo();
 bool config_splash();
 bool config_converter();
 bool config_updown_converter();
@@ -195,6 +196,7 @@ void set_gui_return_icon(bool v);
 void set_load_app_settings(bool v);
 void set_save_app_settings(bool v);
 void set_show_bigger_qr_code(bool v);
+void set_config_force_tcxo(bool v);
 void set_config_splash(bool v);
 bool config_converter();
 bool config_updown_converter();


### PR DESCRIPTION
For the R9 devices, we need to have a setting to force TCXO as if we auto detect this the devices crash. 

For the older non R9 HackRF's the detection method for the TCXO was fine and didn't cause any issue.
With the new R9 devices, the detection method is actually incorrect. But the problem is there are a bunch of PortaPacks that have been built with their TCXO out of spec ([It needs a 3.3Vpp, but they all seem to have a 1Vpp](https://hackrf.readthedocs.io/en/latest/external_clock_interface.html)). 
This means when using the correct detection method, it will detect the TCXO but the device would sometime/always crash (Seems to be luck of the draw how stable your device is with an out of spec TCXO). 
So since we don't want everyone's devices crashing by fixing the detection method _(Well everyone with an out of spec TCXO, which seems to be 90% of R9 users)_, we have hidden it behind this toggle. 

When you enable it, it then instantly try's the new detection method and switches over to the TCXO on the PortaPacks if its detected. At this point your device will either work perfectly fine (Which means you likely have a in spec TCXO, yay!), or your device will freeze. If it freezes, all you need to do is press the reset button and you are back up and running.

If you device works, then clicking save will save these changes so from now on your device will your your PortaPacks's TCXO if it detects it.

If you have an R9 device, then you will see the new ``Force external TCXO`` checkbox option in Settings > Radio
![SCR_0001](https://github.com/eried/portapack-mayhem/assets/4393979/a4ed95de-3709-4274-b322-b53368d14ecf)

If you do not have an R9, then this setting is hidden as this does not apply to you.

Test bin here: 
[portapack-h1_h2-mayhem v2.zip](https://github.com/eried/portapack-mayhem/files/12182077/portapack-h1_h2-mayhem.v2.zip)




Credit to @bernd-herzog for finding out the true way to check for a TCXO 
