### PR TITLE
Display error message when trying to delete non-empty directory

### DIFF
--- a/firmware/application/apps/ui_fileman.cpp
+++ b/firmware/application/apps/ui_fileman.cpp
@@ -440,8 +440,8 @@ void FileManagerView::on_rename(std::string_view hint) {
 }
 
 void FileManagerView::on_delete() {
-    if (is_nonempty_directory(get_selected_full_path())) {
-        nav_.display_modal("Delete", "Directory not empty");
+    if (!is_empty_directory(get_selected_full_path())) {
+        nav_.display_modal("Delete", "Directory not empty!");
         return;
     }
 

--- a/firmware/application/apps/ui_fileman.cpp
+++ b/firmware/application/apps/ui_fileman.cpp
@@ -440,7 +440,7 @@ void FileManagerView::on_rename(std::string_view hint) {
 }
 
 void FileManagerView::on_delete() {
-    if (!is_empty_directory(get_selected_full_path())) {
+    if (is_directory(get_selected_full_path()) && !is_empty_directory(get_selected_full_path())) {
         nav_.display_modal("Delete", "Directory not empty!");
         return;
     }

--- a/firmware/application/apps/ui_fileman.cpp
+++ b/firmware/application/apps/ui_fileman.cpp
@@ -440,6 +440,11 @@ void FileManagerView::on_rename(std::string_view hint) {
 }
 
 void FileManagerView::on_delete() {
+    if (is_nonempty_directory(get_selected_full_path())) {
+        nav_.display_modal("Delete", "Directory not empty");
+        return;
+    }
+
     auto name = get_selected_entry().path.filename().string();
     nav_.push<ModalMessageView>(
         "Delete", "Delete " + name + "\nAre you sure?", YESNO,

--- a/firmware/application/file.cpp
+++ b/firmware/application/file.cpp
@@ -568,6 +568,17 @@ bool is_directory(const path& file_path) {
     return fr == FR_OK && is_directory(static_cast<file_status>(filinfo.fattrib));
 }
 
+bool is_nonempty_directory(const path& file_path) {
+    DIR dir;
+    FILINFO filinfo;
+    
+    if (!is_directory(file_path))
+        return false;
+
+    auto result = f_findfirst(&dir, &filinfo, reinterpret_cast<const TCHAR*>(file_path.c_str()), (const TCHAR*)u"*");
+    return ((result == FR_OK) && (filinfo.fname[0] != (TCHAR)'\0'));
+}
+
 space_info space(const path& p) {
     DWORD free_clusters{0};
     FATFS* fs;

--- a/firmware/application/file.cpp
+++ b/firmware/application/file.cpp
@@ -571,7 +571,7 @@ bool is_directory(const path& file_path) {
 bool is_nonempty_directory(const path& file_path) {
     DIR dir;
     FILINFO filinfo;
-    
+
     if (!is_directory(file_path))
         return false;
 

--- a/firmware/application/file.cpp
+++ b/firmware/application/file.cpp
@@ -568,7 +568,7 @@ bool is_directory(const path& file_path) {
     return fr == FR_OK && is_directory(static_cast<file_status>(filinfo.fattrib));
 }
 
-bool is_nonempty_directory(const path& file_path) {
+bool is_empty_directory(const path& file_path) {
     DIR dir;
     FILINFO filinfo;
 
@@ -576,7 +576,7 @@ bool is_nonempty_directory(const path& file_path) {
         return false;
 
     auto result = f_findfirst(&dir, &filinfo, reinterpret_cast<const TCHAR*>(file_path.c_str()), (const TCHAR*)u"*");
-    return ((result == FR_OK) && (filinfo.fname[0] != (TCHAR)'\0'));
+    return !((result == FR_OK) && (filinfo.fname[0] != (TCHAR)'\0'));
 }
 
 space_info space(const path& p) {

--- a/firmware/application/file.hpp
+++ b/firmware/application/file.hpp
@@ -248,6 +248,7 @@ bool is_directory(const file_status s);
 bool is_regular_file(const file_status s);
 bool file_exists(const path& file_path);
 bool is_directory(const path& file_path);
+bool is_nonempty_directory(const path& file_path);
 
 space_info space(const path& p);
 

--- a/firmware/application/file.hpp
+++ b/firmware/application/file.hpp
@@ -248,7 +248,7 @@ bool is_directory(const file_status s);
 bool is_regular_file(const file_status s);
 bool file_exists(const path& file_path);
 bool is_directory(const path& file_path);
-bool is_nonempty_directory(const path& file_path);
+bool is_empty_directory(const path& file_path);
 
 space_info space(const path& p);
 


### PR DESCRIPTION
Per issue #1318, just display an error message instead of asking "Are you sure?" (and then not doing it) when the user is trying to delete a non-empty directory.