### PR TITLE
Progress bar for Notepad IO

### DIFF
--- a/firmware/test/application/test_file_wrapper.cpp
+++ b/firmware/test/application/test_file_wrapper.cpp
@@ -435,4 +435,29 @@ SCENARIO("Delete line.") {
     }
 }
 
+SCENARIO("It calls on_read_progress while reading.") {
+    GIVEN("A file larger than internal buffer_size (512)") {
+        std::string content = std::string(599, 'a');
+        content.push_back('x');
+        MockFile f{content};
+
+        auto w = wrap_buffer(f);
+        auto init_line_count = w.line_count();
+        auto init_size = w.size();
+        auto called = false;
+
+        w.on_read_progress = [&called](auto, auto) {
+            called = true;
+        };
+
+        WHEN("Replacing range with larger size") {
+            w.replace_range({0, 2}, "bbb");
+
+            THEN("callback should be called.") {
+                CHECK(called);
+            }
+        }
+    }
+}
+
 TEST_SUITE_END();


### PR DESCRIPTION
This is an attempt to add IO progress reporting for Notepad so it doesn't look hung when doing work.
There's still one long IO operation (the temp file copy) that looks like a hang.
Could add a progress callback on copy_file? I tried a paint hack to write a little warning before copying the file, but it caused an ISR stack overflow??

It doesn't help the edit scenario too much when files start getting large, but it's nice (especially on first open) to see an indicator that the device didn't fault.