### PR TITLE
Correct estimated capture time in C8 format

### DIFF
--- a/firmware/application/ui_record_view.cpp
+++ b/firmware/application/ui_record_view.cpp
@@ -269,7 +269,12 @@ void RecordView::update_status_display() {
 
     if (sampling_rate) {
         const auto space_info = std::filesystem::space(u"");
-        const uint32_t bytes_per_second = file_type == FileType::WAV ? (sampling_rate * 2) : (sampling_rate / 8 * 4);  // TODO: Why 8/4??
+        const uint32_t bytes_per_second =
+            // - Audio is 1 int16_t per sample or '2' bytes per sample.
+            // - C8 captures 2 (I,Q) int8_t per sample or '2' bytes per sample.
+            // - C16 captures 2 (I,Q) int16_t per sample or '4' bytes per sample.
+            //   Dividing to get actual sample rate because of decimation in proc_capture.
+            file_type == FileType::WAV ? (sampling_rate * 2) : (sampling_rate * ((file_type == FileType::RawS8)? 2 : 4) / 8);
         const uint32_t available_seconds = space_info.free / bytes_per_second;
         const uint32_t seconds = available_seconds % 60;
         const uint32_t available_minutes = available_seconds / 60;

--- a/firmware/application/ui_record_view.cpp
+++ b/firmware/application/ui_record_view.cpp
@@ -274,7 +274,7 @@ void RecordView::update_status_display() {
             // - C8 captures 2 (I,Q) int8_t per sample or '2' bytes per sample.
             // - C16 captures 2 (I,Q) int16_t per sample or '4' bytes per sample.
             //   Dividing to get actual sample rate because of decimation in proc_capture.
-            file_type == FileType::WAV ? (sampling_rate * 2) : (sampling_rate * ((file_type == FileType::RawS8)? 2 : 4) / 8);
+            file_type == FileType::WAV ? (sampling_rate * 2) : (sampling_rate * ((file_type == FileType::RawS8) ? 2 : 4) / 8);
         const uint32_t available_seconds = space_info.free / bytes_per_second;
         const uint32_t seconds = available_seconds % 60;
         const uint32_t available_minutes = available_seconds / 60;

--- a/firmware/application/ui_record_view.hpp
+++ b/firmware/application/ui_record_view.hpp
@@ -42,8 +42,7 @@ class RecordView : public View {
     enum FileType {
         RawS8 = 1,
         RawS16 = 2,
-        RawS32 = 3,
-        WAV = 4,
+        WAV = 3,
     };
 
     RecordView(


### PR DESCRIPTION
Fix issue #1329, and delete enum for unsupported file type RawS32.

Note there is a 1-line merge conflict with PR #1328 which will need to be resolved.