### PR TITLE
Oversample capturing for low bandwidths

### DIFF
--- a/firmware/application/apps/capture_app.cpp
+++ b/firmware/application/apps/capture_app.cpp
@@ -69,9 +69,11 @@ CaptureAppView::CaptureAppView(NavigationView& nav)
         if (base_rate >=25000) {
             // from bw >=25k onwards , we can apply same oversampling factor as original fw ,  x 8.
             sampling_rate = 8 * base_rate;  // We have to match with Decimation by 8 done on baseband side.
+            baseband::set_over_sample_rate(8); 
         } else {
             // Low bit rate , 12k5, 16k, 20k , we need to increase the oversampling factor x 16
             sampling_rate = 16 * base_rate;  // We have to match with Decimation by 16 done on baseband side.
+            baseband::set_over_sample_rate(16); 
         }    
 
         /* Set up proper anti aliasing BPF bandwith in MAX2837 before ADC sampling according to the new added BW Options. */
@@ -85,7 +87,7 @@ CaptureAppView::CaptureAppView(NavigationView& nav)
     };
 
     receiver_model.enable();
-    option_bandwidth.set_selected_index(3);  // Preselected default option 500kHz.
+    option_bandwidth.set_selected_index(7);  // Preselected default option 500kHz.
 
     record_view.on_error = [&nav](std::string message) {
         nav.display_modal("Error", message);

--- a/firmware/application/apps/capture_app.cpp
+++ b/firmware/application/apps/capture_app.cpp
@@ -64,7 +64,15 @@ CaptureAppView::CaptureAppView(NavigationView& nav)
         /* base_rate is used for FFT calculation and display LCD, and also in recording writing SD Card rate. */
         /* ex. sampling_rate values, 4Mhz, when recording 500 kHz (BW) and fs 8 Mhz, when selected 1 Mhz BW ... */
         /* ex. recording 500kHz BW to .C16 file, base_rate clock 500kHz x2(I,Q) x 2 bytes (int signed) =2MB/sec rate SD Card  */
-        auto sampling_rate = 8 * base_rate;  // Decimation by 8 done on baseband side.
+        uint32_t sampling_rate; 
+
+        if (base_rate >=25000) {
+            // from bw >=25k onwards , we can apply same oversampling factor as original fw ,  x 8.
+            sampling_rate = 8 * base_rate;  // We have to match with Decimation by 8 done on baseband side.
+        } else {
+            // Low bit rate , 12k5, 16k, 20k , we need to increase the oversampling factor x 16
+            sampling_rate = 16 * base_rate;  // We have to match with Decimation by 16 done on baseband side.
+        }    
 
         /* Set up proper anti aliasing BPF bandwith in MAX2837 before ADC sampling according to the new added BW Options. */
         auto anti_alias_baseband_bandwidth_filter = filter_bandwidth_for_sampling_rate(sampling_rate);
@@ -77,7 +85,7 @@ CaptureAppView::CaptureAppView(NavigationView& nav)
     };
 
     receiver_model.enable();
-    option_bandwidth.set_selected_index(7);  // Preselected default option 500kHz.
+    option_bandwidth.set_selected_index(3);  // Preselected default option 500kHz.
 
     record_view.on_error = [&nav](std::string message) {
         nav.display_modal("Error", message);

--- a/firmware/application/apps/capture_app.cpp
+++ b/firmware/application/apps/capture_app.cpp
@@ -64,23 +64,19 @@ CaptureAppView::CaptureAppView(NavigationView& nav)
         /* base_rate is used for FFT calculation and display LCD, and also in recording writing SD Card rate. */
         /* ex. sampling_rate values, 4Mhz, when recording 500 kHz (BW) and fs 8 Mhz, when selected 1 Mhz BW ... */
         /* ex. recording 500kHz BW to .C16 file, base_rate clock 500kHz x2(I,Q) x 2 bytes (int signed) =2MB/sec rate SD Card  */
-        uint32_t sampling_rate; 
 
-        if (base_rate >=25000) {
-            // from bw >=25k onwards , we can apply same oversampling factor as original fw ,  x 8.
-            sampling_rate = 8 * base_rate;  // We have to match with Decimation by 8 done on baseband side.
-            baseband::set_over_sample_rate(8); 
-        } else {
-            // Low bit rate , 12k5, 16k, 20k , we need to increase the oversampling factor x 16
-            sampling_rate = 16 * base_rate;  // We have to match with Decimation by 16 done on baseband side.
-            baseband::set_over_sample_rate(16); 
-        }    
+        // For lower bandwidths, (12k5, 16k, 20k), increase the oversample rate to get a higher sample rate.
+        OversampleRate oversample_rate = base_rate >= 25'000 ? OversampleRate::Rate8x : OversampleRate::Rate16x;
 
-        /* Set up proper anti aliasing BPF bandwith in MAX2837 before ADC sampling according to the new added BW Options. */
+        // HackRF suggests a minimum sample rate of 2M.
+        // Oversampling helps get to higher sample rates when recording lower bandwidths.
+        uint32_t sampling_rate = toUType(oversample_rate) * base_rate;
+
+        // Set up proper anti aliasing BPF bandwidth in MAX2837 before ADC sampling according to the new added BW Options.
         auto anti_alias_baseband_bandwidth_filter = filter_bandwidth_for_sampling_rate(sampling_rate);
 
         waterfall.stop();
-        record_view.set_sampling_rate(sampling_rate);
+        record_view.set_sampling_rate(sampling_rate, oversample_rate);  // NB: Actually updates the baseband.
         receiver_model.set_sampling_rate(sampling_rate);
         receiver_model.set_baseband_bandwidth(anti_alias_baseband_bandwidth_filter);
         waterfall.start();

--- a/firmware/application/apps/ui_recon.cpp
+++ b/firmware/application/apps/ui_recon.cpp
@@ -1251,8 +1251,9 @@ size_t ReconView::change_mode(freqman_index_t new_mod) {
     }
     if (new_mod != SPEC_MODULATION) {
         button_audio_app.set_text("AUDIO");
+        // TODO: Oversampling.
         record_view->set_sampling_rate(recording_sampling_rate);
-        // reset receiver model to fix bug when going from SPEC to audio, the sound is distorded
+        // reset receiver model to fix bug when going from SPEC to audio, the sound is distorted
         receiver_model.set_sampling_rate(3072000);
         receiver_model.set_baseband_bandwidth(1750000);
     } else {

--- a/firmware/application/baseband_api.cpp
+++ b/firmware/application/baseband_api.cpp
@@ -352,8 +352,8 @@ void set_sample_rate(const uint32_t sample_rate) {
     send_message(&message);
 }
 
-void set_over_sample_rate(const uint8_t over_sample_rate) {
-    OverSamplerateConfigMessage message{over_sample_rate};
+void set_oversample_rate(OversampleRate oversample_rate) {
+    OversampleRateConfigMessage message{oversample_rate};
     send_message(&message);
 }
 

--- a/firmware/application/baseband_api.cpp
+++ b/firmware/application/baseband_api.cpp
@@ -352,6 +352,11 @@ void set_sample_rate(const uint32_t sample_rate) {
     send_message(&message);
 }
 
+void set_over_sample_rate(const uint8_t over_sample_rate) {
+    OverSamplerateConfigMessage message{over_sample_rate};
+    send_message(&message);
+}
+
 void capture_start(CaptureConfig* const config) {
     CaptureConfigMessage message{config};
     send_message(&message);

--- a/firmware/application/baseband_api.hpp
+++ b/firmware/application/baseband_api.hpp
@@ -95,6 +95,7 @@ void spectrum_streaming_start();
 void spectrum_streaming_stop();
 
 void set_sample_rate(const uint32_t sample_rate);
+void set_over_sample_rate(const uint8_t over_sample_rate);
 void capture_start(CaptureConfig* const config);
 void capture_stop();
 void replay_start(ReplayConfig* const config);

--- a/firmware/application/baseband_api.hpp
+++ b/firmware/application/baseband_api.hpp
@@ -95,7 +95,7 @@ void spectrum_streaming_start();
 void spectrum_streaming_stop();
 
 void set_sample_rate(const uint32_t sample_rate);
-void set_over_sample_rate(const uint8_t over_sample_rate);
+void set_oversample_rate(OversampleRate oversample_rate);
 void capture_start(CaptureConfig* const config);
 void capture_stop();
 void replay_start(ReplayConfig* const config);

--- a/firmware/application/freqman_db.cpp
+++ b/firmware/application/freqman_db.cpp
@@ -74,9 +74,9 @@ options_t freqman_bandwidths[4] = {
     },
     {
         // SPEC -- TODO: these should be indexes.
-        {"8k5", 8500},
-        {"11k", 11000},
+        {"12k5", 12500},
         {"16k", 16000},
+        {"20k", 20000},
         {"25k", 25000},
         {"50k", 50000},
         {"100k", 100000},

--- a/firmware/application/ui_record_view.cpp
+++ b/firmware/application/ui_record_view.cpp
@@ -101,24 +101,27 @@ void RecordView::focus() {
     button_record.focus();
 }
 
-void RecordView::set_sampling_rate(const size_t new_sampling_rate) {
-    /* We are changing "REC" icon background to yellow in  BW rec Options >600kHz
+void RecordView::set_sampling_rate(size_t new_sampling_rate, OversampleRate new_oversample_rate) {
+    /* We are changing "REC" icon background to yellow in BW rec Options >600kHz
         where we are NOT recording full IQ .C16 files (recorded files are decimated ones).
-        Those decimated recorded files,has not the full IQ  samples .
-        are ok as recorded spectrum indication, but they  should not be used by Replay app.
+        Those decimated recorded files, has not the full IQ samples.
+        are ok as recorded spectrum indication, but they should not be used by Replay app.
 
-        We keep original black  background in all the correct IQ .C16 files BW's Options */
-    if (new_sampling_rate > 4800000) {  // > BW >600kHz  (fs=8*BW), (750kHz ...2750kHz)
+        We keep original black background in all the correct IQ .C16 files BW's Options */
+    if (new_sampling_rate > 4'800'000) {  // > BW >600kHz  (fs=8*BW), (750kHz...2750kHz)
         button_record.set_background(ui::Color::yellow());
     } else {
         button_record.set_background(ui::Color::black());
     }
 
-    if (new_sampling_rate != sampling_rate) {
+    if (new_sampling_rate != sampling_rate ||
+        new_oversample_rate != oversample_rate) {
         stop();
 
         sampling_rate = new_sampling_rate;
+        oversample_rate = new_oversample_rate;
         baseband::set_sample_rate(sampling_rate);
+        baseband::set_oversample_rate(oversample_rate);
 
         button_record.hidden(sampling_rate == 0);
         text_record_filename.hidden(sampling_rate == 0);
@@ -162,12 +165,13 @@ void RecordView::start() {
         rtcGetTime(&RTCD1, &datetime);
 
         // ISO 8601
-        std::string date_time = to_string_dec_uint(datetime.year(), 4, '0') +
-                                to_string_dec_uint(datetime.month(), 2, '0') +
-                                to_string_dec_uint(datetime.day(), 2, '0') + "T" +
-                                to_string_dec_uint(datetime.hour()) +
-                                to_string_dec_uint(datetime.minute()) +
-                                to_string_dec_uint(datetime.second());
+        std::string date_time =
+            to_string_dec_uint(datetime.year(), 4, '0') +
+            to_string_dec_uint(datetime.month(), 2, '0') +
+            to_string_dec_uint(datetime.day(), 2, '0') + "T" +
+            to_string_dec_uint(datetime.hour()) +
+            to_string_dec_uint(datetime.minute()) +
+            to_string_dec_uint(datetime.second());
 
         base_path = filename_stem_pattern.string() + "_" + date_time + "_" +
                     trim(to_string_freq(receiver_model.target_frequency())) + "Hz";
@@ -197,10 +201,9 @@ void RecordView::start() {
 
         case FileType::RawS8:
         case FileType::RawS16: {
-            const auto metadata_file_error =
-                write_metadata_file(get_metadata_path(base_path),
-                                    {receiver_model.target_frequency(), sampling_rate / 16});   //TODO , it should be dynamic , based on decimation x8 or x16  writing metadata (freq, and sample rate)
-            // Not sure why sample_rate is div. 8, but stored value matches rate settings.
+            const auto metadata_file_error = write_metadata_file(
+                get_metadata_path(base_path),
+                {receiver_model.target_frequency(), sampling_rate / toUType(oversample_rate)});
             if (metadata_file_error.is_valid()) {
                 handle_error(metadata_file_error.value());
                 return;
@@ -263,18 +266,24 @@ void RecordView::update_status_display() {
         text_record_dropped.set(s);
     }
 
-    /*if (pitch_rssi_enabled) {
-                button_pitch_rssi.invert_colors();
-        }*/
+    /*
+    if (pitch_rssi_enabled) {
+        button_pitch_rssi.invert_colors();
+    }
+    */
 
-    if (sampling_rate) {
+    if (sampling_rate > 0) {
         const auto space_info = std::filesystem::space(u"");
-        const uint32_t bytes_per_second =
-            // - Audio is 1 int16_t per sample or '2' bytes per sample.
-            // - C8 captures 2 (I,Q) int8_t per sample or '2' bytes per sample.
-            // - C16 captures 2 (I,Q) int16_t per sample or '4' bytes per sample.
-            //   Dividing to get actual sample rate because of decimation in proc_capture.
-            file_type == FileType::WAV ? (sampling_rate * 2) : (sampling_rate * ((file_type == FileType::RawS8) ? 2 : 4) / 8);
+        // - Audio is 1 int16_t per sample or '2' bytes per sample.
+        // - C8 captures 2 (I,Q) int8_t per sample or '2' bytes per sample.
+        // - C16 captures 2 (I,Q) int16_t per sample or '4' bytes per sample.
+        const auto bytes_per_sample = file_type == FileType::RawS16 ? 4 : 2;
+        // WAV files are not oversampled, but C8 and C16 are. Divide by the
+        // oversample rate to get the effective sample rate.
+        const auto effective_sampling_rate = file_type == FileType::WAV
+                                                 ? sampling_rate
+                                                 : sampling_rate / toUType(oversample_rate);
+        const uint32_t bytes_per_second = effective_sampling_rate * bytes_per_sample;
         const uint32_t available_seconds = space_info.free / bytes_per_second;
         const uint32_t seconds = available_seconds % 60;
         const uint32_t available_minutes = available_seconds / 60;

--- a/firmware/application/ui_record_view.cpp
+++ b/firmware/application/ui_record_view.cpp
@@ -199,7 +199,7 @@ void RecordView::start() {
         case FileType::RawS16: {
             const auto metadata_file_error =
                 write_metadata_file(get_metadata_path(base_path),
-                                    {receiver_model.target_frequency(), sampling_rate / 8});
+                                    {receiver_model.target_frequency(), sampling_rate / 16});   //TODO , it should be dynamic , based on decimation x8 or x16  writing metadata (freq, and sample rate)
             // Not sure why sample_rate is div. 8, but stored value matches rate settings.
             if (metadata_file_error.is_valid()) {
                 handle_error(metadata_file_error.value());

--- a/firmware/application/ui_record_view.hpp
+++ b/firmware/application/ui_record_view.hpp
@@ -56,7 +56,16 @@ class RecordView : public View {
 
     void focus() override;
 
-    void set_sampling_rate(const size_t new_sampling_rate);
+    /* Sets the sampling rate and the oversampling "decimation" rate.
+     * These values are passed down to the baseband proc_capture. For
+     * Audio (WAV) recording, the OversampleRate should not be
+     * specified and the default will be used. */
+    /* TODO: Currently callers are expected to have already multiplied the
+     * sample_rate with the oversample rate. It would be better move that
+     * logic to a single place. */
+    void set_sampling_rate(
+        size_t new_sampling_rate,
+        OversampleRate new_oversample_rate = OversampleRate::Rate8x);
 
     void set_file_type(const FileType v) { file_type = v; }
 
@@ -90,6 +99,7 @@ class RecordView : public View {
     const size_t write_size;
     const size_t buffer_count;
     size_t sampling_rate{0};
+    OversampleRate oversample_rate{OversampleRate::Rate8x};
     SignalToken signal_token_tick_second{};
 
     Rectangle rect_background{

--- a/firmware/baseband/proc_capture.hpp
+++ b/firmware/baseband/proc_capture.hpp
@@ -50,8 +50,13 @@ class CaptureProcessor : public BasebandProcessor {
         dst.data(),
         dst.size()};
 
-    dsp::decimate::FIRC8xR16x24FS4Decim8 decim_0_8{};       // used for total decim by 16
-    dsp::decimate::FIRC8xR16x24FS4Decim4 decim_0_4{};       // used for total decim by 8
+    /* NB: There are two decimation passes: 0 and 1. In pass 0, one of
+     * the following will be selected based on the oversample rate.
+     * use decim_0_4 for an overall decimation factor of 8.
+     * use decim_0_8 for an overall decimation factor of 16. */
+    dsp::decimate::FIRC8xR16x24FS4Decim4 decim_0_4{};
+    dsp::decimate::FIRC8xR16x24FS4Decim8 decim_0_8{};
+
     dsp::decimate::FIRC16xR16x16Decim2 decim_1{};
     int32_t channel_filter_low_f = 0;
     int32_t channel_filter_high_f = 0;
@@ -62,14 +67,19 @@ class CaptureProcessor : public BasebandProcessor {
     SpectrumCollector channel_spectrum{};
     size_t spectrum_interval_samples = 0;
     size_t spectrum_samples = 0;
+    OversampleRate oversample_rate{OversampleRate::Rate8x};
 
     /* NB: Threads should be the last members in the class definition. */
     BasebandThread baseband_thread{
         baseband_fs, this, baseband::Direction::Receive, /*auto_start*/ false};
     RSSIThread rssi_thread{};
 
-    void samplerate_config(const SamplerateConfigMessage& message);
+    /* Called to update members when the sample rate or oversample rate is changed. */
+    void update_for_rate_change();
     void capture_config(const CaptureConfigMessage& message);
+
+    /* Dispatch to the correct decim_0 based on oversample rate. */
+    buffer_c16_t decim_0_execute(const buffer_c8_t& src, const buffer_c16_t& dst);
 };
 
 #endif /*__PROC_CAPTURE_HPP__*/

--- a/firmware/baseband/proc_capture.hpp
+++ b/firmware/baseband/proc_capture.hpp
@@ -50,7 +50,8 @@ class CaptureProcessor : public BasebandProcessor {
         dst.data(),
         dst.size()};
 
-    dsp::decimate::FIRC8xR16x24FS4Decim8 decim_0{};
+    dsp::decimate::FIRC8xR16x24FS4Decim8 decim_0_8{};       // used for total decim by 16
+    dsp::decimate::FIRC8xR16x24FS4Decim4 decim_0_4{};       // used for total decim by 8
     dsp::decimate::FIRC16xR16x16Decim2 decim_1{};
     int32_t channel_filter_low_f = 0;
     int32_t channel_filter_high_f = 0;

--- a/firmware/baseband/proc_capture.hpp
+++ b/firmware/baseband/proc_capture.hpp
@@ -50,7 +50,7 @@ class CaptureProcessor : public BasebandProcessor {
         dst.data(),
         dst.size()};
 
-    dsp::decimate::FIRC8xR16x24FS4Decim4 decim_0{};
+    dsp::decimate::FIRC8xR16x24FS4Decim8 decim_0{};
     dsp::decimate::FIRC16xR16x16Decim2 decim_1{};
     int32_t channel_filter_low_f = 0;
     int32_t channel_filter_high_f = 0;

--- a/firmware/common/message.hpp
+++ b/firmware/common/message.hpp
@@ -111,7 +111,7 @@ class Message {
         APRSRxConfigure = 54,
         SpectrumPainterBufferRequestConfigure = 55,
         SpectrumPainterBufferResponseConfigure = 56,
-        OverSamplerateConfig = 57,
+        OversampleRateConfig = 57,
         MAX
     };
 
@@ -810,17 +810,22 @@ class SamplerateConfigMessage : public Message {
     const uint32_t sample_rate = 0;
 };
 
-class OverSamplerateConfigMessage : public Message {
-   public:
-    constexpr OverSamplerateConfigMessage(
-        const uint8_t over_sample_rate)
-        : Message{ID::OverSamplerateConfig},
-          over_sample_rate(over_sample_rate) {
-    }
-
-    const uint8_t over_sample_rate = 0;
+/* Controls decimation handling in proc_capture. */
+enum class OversampleRate : uint8_t {
+    Rate8x = 8,
+    Rate16x = 16,
 };
 
+class OversampleRateConfigMessage : public Message {
+   public:
+    constexpr OversampleRateConfigMessage(
+        OversampleRate oversample_rate)
+        : Message{ID::OversampleRateConfig},
+          oversample_rate(oversample_rate) {
+    }
+
+    const OversampleRate oversample_rate{OversampleRate::Rate8x};
+};
 
 class AudioLevelReportMessage : public Message {
    public:

--- a/firmware/common/message.hpp
+++ b/firmware/common/message.hpp
@@ -111,6 +111,7 @@ class Message {
         APRSRxConfigure = 54,
         SpectrumPainterBufferRequestConfigure = 55,
         SpectrumPainterBufferResponseConfigure = 56,
+        OverSamplerateConfig = 57,
         MAX
     };
 
@@ -808,6 +809,18 @@ class SamplerateConfigMessage : public Message {
 
     const uint32_t sample_rate = 0;
 };
+
+class OverSamplerateConfigMessage : public Message {
+   public:
+    constexpr OverSamplerateConfigMessage(
+        const uint8_t over_sample_rate)
+        : Message{ID::OverSamplerateConfig},
+          over_sample_rate(over_sample_rate) {
+    }
+
+    const uint8_t over_sample_rate = 0;
+};
+
 
 class AudioLevelReportMessage : public Message {
    public:


### PR DESCRIPTION
This is the change that @Brumi-2021 and I worked on to improve capture quality for lower bandwidth captures.
The gist of the problem is that HackRF recommends a sample rate of 2M for best results. The capture app used the bandwidth setting to compute the sampling rate, but when the bandwidth was low, the resulting sample rate was also much lower than the recommendation. For example, 20kHz bandwidth * and oversampling rate of 8 gave a sampling rate of 160kHz.

This change increases the oversampling rate from 8 to 16 for lower bandwidth captures (<25kHz) which should improve SNR and capture quality. This change could be extended to add support for higher oversampling rates in the future.

This change has been fully rebased on 'next'.