### PR TITLE
Oversample

### DIFF
--- a/firmware/application/apps/capture_app.cpp
+++ b/firmware/application/apps/capture_app.cpp
@@ -60,25 +60,27 @@ CaptureAppView::CaptureAppView(NavigationView& nav)
     };
 
     freqman_set_bandwidth_option(SPEC_MODULATION, option_bandwidth);
-    option_bandwidth.on_change = [this](size_t, uint32_t base_rate) {
-        /* base_rate is used for FFT calculation and display LCD, and also in recording writing SD Card rate. */
+    option_bandwidth.on_change = [this](size_t, uint32_t bandwidth) {
+        /* bandwidth is used for FFT calculation and display LCD, and also in recording writing SD Card rate. */
         /* ex. sampling_rate values, 4Mhz, when recording 500 kHz (BW) and fs 8 Mhz, when selected 1 Mhz BW ... */
-        /* ex. recording 500kHz BW to .C16 file, base_rate clock 500kHz x2(I,Q) x 2 bytes (int signed) =2MB/sec rate SD Card  */
+        /* ex. recording 500kHz BW to .C16 file, bandwidth clock 500kHz x2(I,Q) x 2 bytes (int signed) =2MB/sec rate SD Card. */
 
-        // For lower bandwidths, (12k5, 16k, 20k), increase the oversample rate to get a higher sample rate.
-        OversampleRate oversample_rate = base_rate >= 25'000 ? OversampleRate::Rate8x : OversampleRate::Rate16x;
-
-        // HackRF suggests a minimum sample rate of 2M.
-        // Oversampling helps get to higher sample rates when recording lower bandwidths.
-        uint32_t sampling_rate = toUType(oversample_rate) * base_rate;
-
-        // Set up proper anti aliasing BPF bandwidth in MAX2837 before ADC sampling according to the new added BW Options.
-        auto anti_alias_baseband_bandwidth_filter = filter_bandwidth_for_sampling_rate(sampling_rate);
+        /* Nyquist would imply a sample rate of 2x bandwidth, but because the ADC
+         * provides 2 values (I,Q), the sample_rate can be equal to bandwidth here.*/
+        auto sample_rate = bandwidth;
 
         waterfall.stop();
-        record_view.set_sampling_rate(sampling_rate, oversample_rate);  // NB: Actually updates the baseband.
-        receiver_model.set_sampling_rate(sampling_rate);
-        receiver_model.set_baseband_bandwidth(anti_alias_baseband_bandwidth_filter);
+
+        // record_view determines the correct oversampling to apply and returns the actual sample rate.
+        // NB: record_view is what actually updates proc_capture baseband settings.
+        auto actual_sample_rate = record_view.set_sampling_rate(sample_rate);
+
+        // Need to tell that radio about the actual sampling rate.
+        receiver_model.set_sampling_rate(actual_sample_rate);
+
+        // Get suitable anti-aliasing BPF bandwidth for MAX2837 given the actual sample rate.
+        auto anti_alias_filter_bandwidth = filter_bandwidth_for_sampling_rate(actual_sample_rate);
+        receiver_model.set_baseband_bandwidth(anti_alias_filter_bandwidth);
         waterfall.start();
     };
 

--- a/firmware/application/apps/capture_app.cpp
+++ b/firmware/application/apps/capture_app.cpp
@@ -61,13 +61,13 @@ CaptureAppView::CaptureAppView(NavigationView& nav)
 
     freqman_set_bandwidth_option(SPEC_MODULATION, option_bandwidth);
     option_bandwidth.on_change = [this](size_t, uint32_t bandwidth) {
-        /* bandwidth is used for FFT calculation and display LCD, and also in recording writing SD Card rate. */
-        /* ex. sampling_rate values, 4Mhz, when recording 500 kHz (BW) and fs 8 Mhz, when selected 1 Mhz BW ... */
-        /* ex. recording 500kHz BW to .C16 file, bandwidth clock 500kHz x2(I,Q) x 2 bytes (int signed) =2MB/sec rate SD Card. */
-
         /* Nyquist would imply a sample rate of 2x bandwidth, but because the ADC
-         * provides 2 values (I,Q), the sample_rate can be equal to bandwidth here.*/
+         * provides 2 values (I,Q), the sample_rate is equal to bandwidth here. */
         auto sample_rate = bandwidth;
+
+        /* base_rate (bandwidth) is used for FFT calculation and display LCD, and also in recording writing SD Card rate. */
+        /* ex. sampling_rate values, 4Mhz, when recording 500 kHz (BW) and fs 8 Mhz, when selected 1 Mhz BW ... */
+        /* ex. recording 500kHz BW to .C16 file, base_rate clock 500kHz x2(I,Q) x 2 bytes (int signed) =2MB/sec rate SD Card. */
 
         waterfall.stop();
 
@@ -75,12 +75,13 @@ CaptureAppView::CaptureAppView(NavigationView& nav)
         // NB: record_view is what actually updates proc_capture baseband settings.
         auto actual_sample_rate = record_view.set_sampling_rate(sample_rate);
 
-        // Need to tell that radio about the actual sampling rate.
+        // Update the radio model with the actual sampling rate.
         receiver_model.set_sampling_rate(actual_sample_rate);
 
         // Get suitable anti-aliasing BPF bandwidth for MAX2837 given the actual sample rate.
         auto anti_alias_filter_bandwidth = filter_bandwidth_for_sampling_rate(actual_sample_rate);
         receiver_model.set_baseband_bandwidth(anti_alias_filter_bandwidth);
+
         waterfall.start();
     };
 

--- a/firmware/application/apps/replay_app.cpp
+++ b/firmware/application/apps/replay_app.cpp
@@ -124,7 +124,7 @@ void ReplayAppView::start() {
 
     if (reader) {
         button_play.set_bitmap(&bitmap_stop);
-        baseband::set_sample_rate(sample_rate * 8);
+        baseband::set_sample_rate(sample_rate, OversampleRate::x8);
 
         replay_thread = std::make_unique<ReplayThread>(
             std::move(reader),
@@ -136,7 +136,7 @@ void ReplayAppView::start() {
             });
     }
 
-    transmitter_model.set_sampling_rate(sample_rate * 8);
+    transmitter_model.set_sampling_rate(sample_rate * toUType(OversampleRate::x8));
     transmitter_model.set_baseband_bandwidth(baseband_bandwidth);
     transmitter_model.enable();
 

--- a/firmware/application/apps/ui_playlist.cpp
+++ b/firmware/application/apps/ui_playlist.cpp
@@ -270,8 +270,7 @@ void PlaylistView::send_current_track() {
     baseband::set_sample_rate(current()->metadata.sample_rate,
                               get_oversample_rate(current()->metadata.sample_rate));
 
-    // ReplayThread starts immediately on construction so
-    // these need to be set before creating the ReplayThread.
+    // ReplayThread starts immediately on construction; must be set before creating.
     transmitter_model.set_target_frequency(current()->metadata.center_frequency);
     transmitter_model.set_sampling_rate(get_actual_sample_rate(current()->metadata.sample_rate));
     transmitter_model.set_baseband_bandwidth(baseband_bandwidth);

--- a/firmware/application/baseband_api.cpp
+++ b/firmware/application/baseband_api.cpp
@@ -347,13 +347,8 @@ void spectrum_streaming_stop() {
     send_message(&message);
 }
 
-void set_sample_rate(const uint32_t sample_rate) {
-    SamplerateConfigMessage message{sample_rate};
-    send_message(&message);
-}
-
-void set_oversample_rate(OversampleRate oversample_rate) {
-    OversampleRateConfigMessage message{oversample_rate};
+void set_sample_rate(uint32_t sample_rate, OversampleRate oversample_rate) {
+    SampleRateConfigMessage message{sample_rate, oversample_rate};
     send_message(&message);
 }
 

--- a/firmware/application/baseband_api.hpp
+++ b/firmware/application/baseband_api.hpp
@@ -94,8 +94,8 @@ void shutdown();
 void spectrum_streaming_start();
 void spectrum_streaming_stop();
 
-void set_sample_rate(const uint32_t sample_rate);
-void set_oversample_rate(OversampleRate oversample_rate);
+/* NB: sample_rate should be desired rate. Don't pre-scale. */
+void set_sample_rate(uint32_t sample_rate, OversampleRate oversample_rate = OversampleRate::None);
 void capture_start(CaptureConfig* const config);
 void capture_stop();
 void replay_start(ReplayConfig* const config);

--- a/firmware/application/replay_thread.cpp
+++ b/firmware/application/replay_thread.cpp
@@ -80,6 +80,8 @@ uint32_t ReplayThread::run() {
         chThdSleep(100);
     };
 
+    constexpr size_t block_size = 512;
+
     // While empty buffers fifo is not empty...
     while (!buffers.empty()) {
         prefill_buffer = buffers.get_prefill();
@@ -87,10 +89,10 @@ uint32_t ReplayThread::run() {
         if (prefill_buffer == nullptr) {
             buffers.put_app(prefill_buffer);
         } else {
-            size_t blocks = config.read_size / 512;
+            size_t blocks = config.read_size / block_size;
 
             for (size_t c = 0; c < blocks; c++) {
-                auto read_result = reader->read(&((uint8_t*)prefill_buffer->data())[c * 512], 512);
+                auto read_result = reader->read(&((uint8_t*)prefill_buffer->data())[c * block_size], block_size);
                 if (read_result.is_error()) {
                     return READ_ERROR;
                 }

--- a/firmware/application/ui/ui_spectrum.cpp
+++ b/firmware/application/ui/ui_spectrum.cpp
@@ -380,33 +380,34 @@ void WaterfallView::on_audio_spectrum() {
 
 } /* namespace spectrum */
 
+// TODO: Comments below refer to a fixed oversample rate (8x), cleanup.
 uint32_t filter_bandwidth_for_sampling_rate(int32_t sampling_rate) {
-    switch (sampling_rate) {  // Use the var fs (sampling_rate) to set up BPF aprox < fs_max / 2 by Nyquist theorem.
-        case 0 ... 2000000:   // BW Captured range (0 <= 250kHz max)  fs = 8 x 250 kHz.
-            return 1750000;   // Minimum BPF MAX2837 for all those lower BW options.
+    switch (sampling_rate) {   // Use the var fs (sampling_rate) to set up BPF aprox < fs_max / 2 by Nyquist theorem.
+        case 0 ... 2'000'000:  // BW Captured range (0 <= 250kHz max)  fs = 8 x 250 kHz.
+            return 1'750'000;  // Minimum BPF MAX2837 for all those lower BW options.
 
-        case 4000000 ... 6000000:  // BW capture range (500k...750kHz max)  fs_max = 8 x 750kHz = 6Mhz
-                                   // BW 500k...750kHz, ex. 500kHz (fs = 8 x BW = 4Mhz), BW 600kHz (fs = 4,8Mhz), BW 750 kHz (fs = 6Mhz).
-            return 2500000;        // In some IC, MAX2837 appears as 2250000, but both work similarly.
+        case 4'000'000 ... 6'000'000:  // BW capture range (500k...750kHz max)  fs_max = 8 x 750kHz = 6Mhz
+                                       // BW 500k...750kHz, ex. 500kHz (fs = 8 x BW = 4Mhz), BW 600kHz (fs = 4,8Mhz), BW 750 kHz (fs = 6Mhz).
+            return 2'500'000;          // In some IC, MAX2837 appears as 2250000, but both work similarly.
 
-        case 8800000:  // BW capture 1,1Mhz fs = 8 x 1,1Mhz = 8,8Mhz. (1Mhz showed slightly higher noise background).
-            return 3500000;
+        case 8'800'000:  // BW capture 1,1Mhz fs = 8 x 1,1Mhz = 8,8Mhz. (1Mhz showed slightly higher noise background).
+            return 3'500'000;
 
-        case 14000000:  // BW capture 1,75Mhz, fs = 8 x 1,75Mhz = 14Mhz
-                        // Good BPF, good matching, but LCD flickers, refresh rate should be < 20 Hz, reasonable picture.
-            return 5000000;
+        case 14'000'000:  // BW capture 1,75Mhz, fs = 8 x 1,75Mhz = 14Mhz
+                          // Good BPF, good matching, but LCD flickers, refresh rate should be < 20 Hz, reasonable picture.
+            return 5'000'000;
 
-        case 16000000:  // BW capture 2Mhz, fs = 8 x 2Mhz = 16Mhz
-                        // Good BPF, good matching, but LCD flickers, refresh rate should be < 20 Hz, reasonable picture.
-            return 6000000;
+        case 16'000'000:  // BW capture 2Mhz, fs = 8 x 2Mhz = 16Mhz
+                          // Good BPF, good matching, but LCD flickers, refresh rate should be < 20 Hz, reasonable picture.
+            return 6'000'000;
 
-        case 20000000:  // BW capture 2,5Mhz, fs = 8 x 2,5 Mhz = 20Mhz
-                        // Good BPF, good matching, but LCD flickers, refresh rate should be < 20 Hz, reasonable picture.
-            return 7000000;
+        case 20'000'000:  // BW capture 2,5Mhz, fs = 8 x 2,5 Mhz = 20Mhz
+                          // Good BPF, good matching, but LCD flickers, refresh rate should be < 20 Hz, reasonable picture.
+            return 7'000'000;
 
         default:  // BW capture 2,75Mhz, fs = 8 x 2,75Mhz = 22Mhz max ADC sampling and others.
                   // We tested also 9Mhz FPB slightly too much noise floor, better at 8Mhz.
-            return 8000000;
+            return 8'000'000;
     }
 }
 

--- a/firmware/application/ui_record_view.cpp
+++ b/firmware/application/ui_record_view.cpp
@@ -103,26 +103,26 @@ void RecordView::focus() {
 }
 
 uint32_t RecordView::set_sampling_rate(uint32_t new_sampling_rate) {
-    /* We are changing "REC" icon background to yellow in BW rec Options >600kHz
-        where we are NOT recording full IQ .C16 files (recorded files are decimated ones).
-        Those decimated recorded files, has not the full IQ samples.
-        are ok as recorded spectrum indication, but they should not be used by Replay app.
+    // Determine the oversampling needed (if any) and the actual sampling rate.
+    auto oversample_rate = get_oversample_rate(new_sampling_rate);
+    auto actual_sampling_rate = new_sampling_rate * toUType(oversample_rate);
 
-        We keep original black background in all the correct IQ .C16 files BW's Options */
-    if (new_sampling_rate > 4'800'000) {  // > BW >600kHz  (fs=8*BW), (750kHz...2750kHz)
+    /* We are changing "REC" icon background to yellow in BW rec Options >600kHz
+     * where we are NOT recording full IQ .C16 files (recorded files are decimated ones).
+     * Those decimated recorded files, has not the full IQ samples.
+     * are ok as recorded spectrum indication, but they should not be used by Replay app.
+
+     * We keep original black background in all the correct IQ .C16 files BW's Options. */
+    if (actual_sampling_rate > 4'800'000) {  // > BW >600kHz  (fs=8*BW), (750kHz...2750kHz)
         button_record.set_background(ui::Color::yellow());
     } else {
         button_record.set_background(ui::Color::black());
     }
 
-    // Determine the oversampling needed (if any) and the actual sampling rate.
-    auto oversample_rate = get_oversample_rate(new_sampling_rate);
-    auto actual_sampling_rate = new_sampling_rate * toUType(oversample_rate);
-
-    if (sampling_rate != actual_sampling_rate) {
+    if (sampling_rate != new_sampling_rate) {
         stop();
 
-        sampling_rate = actual_sampling_rate;
+        sampling_rate = new_sampling_rate;
         baseband::set_sample_rate(sampling_rate, oversample_rate);
 
         button_record.hidden(sampling_rate == 0);

--- a/firmware/application/ui_record_view.cpp
+++ b/firmware/application/ui_record_view.cpp
@@ -30,6 +30,7 @@ using namespace portapack;
 
 #include "baseband_api.hpp"
 #include "metadata_file.hpp"
+#include "oversample.hpp"
 #include "rtc_time.hpp"
 #include "string_format.hpp"
 #include "utility.hpp"
@@ -101,7 +102,7 @@ void RecordView::focus() {
     button_record.focus();
 }
 
-void RecordView::set_sampling_rate(size_t new_sampling_rate, OversampleRate new_oversample_rate) {
+uint32_t RecordView::set_sampling_rate(uint32_t new_sampling_rate) {
     /* We are changing "REC" icon background to yellow in BW rec Options >600kHz
         where we are NOT recording full IQ .C16 files (recorded files are decimated ones).
         Those decimated recorded files, has not the full IQ samples.
@@ -114,14 +115,15 @@ void RecordView::set_sampling_rate(size_t new_sampling_rate, OversampleRate new_
         button_record.set_background(ui::Color::black());
     }
 
-    if (new_sampling_rate != sampling_rate ||
-        new_oversample_rate != oversample_rate) {
+    // Determine the oversampling needed (if any) and the actual sampling rate.
+    auto oversample_rate = get_oversample_rate(new_sampling_rate);
+    auto actual_sampling_rate = new_sampling_rate * toUType(oversample_rate);
+
+    if (sampling_rate != actual_sampling_rate) {
         stop();
 
-        sampling_rate = new_sampling_rate;
-        oversample_rate = new_oversample_rate;
-        baseband::set_sample_rate(sampling_rate);
-        baseband::set_oversample_rate(oversample_rate);
+        sampling_rate = actual_sampling_rate;
+        baseband::set_sample_rate(sampling_rate, oversample_rate);
 
         button_record.hidden(sampling_rate == 0);
         text_record_filename.hidden(sampling_rate == 0);
@@ -131,6 +133,16 @@ void RecordView::set_sampling_rate(size_t new_sampling_rate, OversampleRate new_
 
         update_status_display();
     }
+
+    return actual_sampling_rate;
+}
+
+OversampleRate RecordView::get_oversample_rate(uint32_t sample_rate) {
+    // No oversampling necessary for baseband audio processors.
+    if (file_type == FileType::WAV)
+        return OversampleRate::None;
+
+    return ::get_oversample_rate(sample_rate);
 }
 
 // Setter for datetime and frequency filename
@@ -202,8 +214,7 @@ void RecordView::start() {
         case FileType::RawS8:
         case FileType::RawS16: {
             const auto metadata_file_error = write_metadata_file(
-                get_metadata_path(base_path),
-                {receiver_model.target_frequency(), sampling_rate / toUType(oversample_rate)});
+                get_metadata_path(base_path), {receiver_model.target_frequency(), sampling_rate});
             if (metadata_file_error.is_valid()) {
                 handle_error(metadata_file_error.value());
                 return;
@@ -278,12 +289,7 @@ void RecordView::update_status_display() {
         // - C8 captures 2 (I,Q) int8_t per sample or '2' bytes per sample.
         // - C16 captures 2 (I,Q) int16_t per sample or '4' bytes per sample.
         const auto bytes_per_sample = file_type == FileType::RawS16 ? 4 : 2;
-        // WAV files are not oversampled, but C8 and C16 are. Divide by the
-        // oversample rate to get the effective sample rate.
-        const auto effective_sampling_rate = file_type == FileType::WAV
-                                                 ? sampling_rate
-                                                 : sampling_rate / toUType(oversample_rate);
-        const uint32_t bytes_per_second = effective_sampling_rate * bytes_per_sample;
+        const uint32_t bytes_per_second = sampling_rate * bytes_per_sample;
         const uint32_t available_seconds = space_info.free / bytes_per_second;
         const uint32_t seconds = available_seconds % 60;
         const uint32_t available_minutes = available_seconds / 60;

--- a/firmware/application/ui_record_view.cpp
+++ b/firmware/application/ui_record_view.cpp
@@ -142,7 +142,15 @@ OversampleRate RecordView::get_oversample_rate(uint32_t sample_rate) {
     if (file_type == FileType::WAV)
         return OversampleRate::None;
 
-    return ::get_oversample_rate(sample_rate);
+    auto rate = ::get_oversample_rate(sample_rate);
+
+    // Currently proc_capture only supports x8 and x16 for decimation.
+    if (rate < OversampleRate::x8)
+        rate = OversampleRate::x8;
+    else if (rate > OversampleRate::x16)
+        rate = OversampleRate::x16;
+
+    return rate;
 }
 
 // Setter for datetime and frequency filename

--- a/firmware/application/ui_record_view.hpp
+++ b/firmware/application/ui_record_view.hpp
@@ -56,16 +56,11 @@ class RecordView : public View {
 
     void focus() override;
 
-    /* Sets the sampling rate and the oversampling "decimation" rate.
-     * These values are passed down to the baseband proc_capture. For
-     * Audio (WAV) recording, the OversampleRate should not be
-     * specified and the default will be used. */
-    /* TODO: Currently callers are expected to have already multiplied the
-     * sample_rate with the oversample rate. It would be better move that
-     * logic to a single place. */
-    void set_sampling_rate(
-        size_t new_sampling_rate,
-        OversampleRate new_oversample_rate = OversampleRate::Rate8x);
+    /* Sets the sampling rate for the baseband.
+     * NB: Do not pre-apply any oversampling. This function will determine
+     * the correct amount of oversampling and return the actual sample rate
+     * that can be used to configure the radio or other UI element. */
+    uint32_t set_sampling_rate(uint32_t new_sampling_rate);
 
     void set_file_type(const FileType v) { file_type = v; }
 
@@ -87,6 +82,8 @@ class RecordView : public View {
     void handle_capture_thread_done(const File::Error error);
     void handle_error(const File::Error error);
 
+    OversampleRate get_oversample_rate(uint32_t sample_rate);
+
     // bool pitch_rssi_enabled = false;
 
     // Time Stamp
@@ -98,8 +95,7 @@ class RecordView : public View {
     FileType file_type;
     const size_t write_size;
     const size_t buffer_count;
-    size_t sampling_rate{0};
-    OversampleRate oversample_rate{OversampleRate::Rate8x};
+    uint32_t sampling_rate{0};
     SignalToken signal_token_tick_second{};
 
     Rectangle rect_background{

--- a/firmware/baseband/proc_audiotx.cpp
+++ b/firmware/baseband/proc_audiotx.cpp
@@ -77,8 +77,8 @@ void AudioTXProcessor::on_message(const Message* const message) {
             replay_config(*reinterpret_cast<const ReplayConfigMessage*>(message));
             break;
 
-        case Message::ID::SamplerateConfig:
-            samplerate_config(*reinterpret_cast<const SamplerateConfigMessage*>(message));
+        case Message::ID::SampleRateConfig:
+            sample_rate_config(*reinterpret_cast<const SampleRateConfigMessage*>(message));
             break;
 
         case Message::ID::FIFOData:
@@ -108,7 +108,7 @@ void AudioTXProcessor::replay_config(const ReplayConfigMessage& message) {
     }
 }
 
-void AudioTXProcessor::samplerate_config(const SamplerateConfigMessage& message) {
+void AudioTXProcessor::sample_rate_config(const SampleRateConfigMessage& message) {
     resample_inc = (((uint64_t)message.sample_rate) << 16) / baseband_fs;  // 16.16 fixed point message.sample_rate
 }
 

--- a/firmware/baseband/proc_audiotx.hpp
+++ b/firmware/baseband/proc_audiotx.hpp
@@ -53,7 +53,7 @@ class AudioTXProcessor : public BasebandProcessor {
     bool configured{false};
     uint32_t bytes_read{0};
 
-    void samplerate_config(const SamplerateConfigMessage& message);
+    void sample_rate_config(const SampleRateConfigMessage& message);
     void audio_config(const AudioTXConfigMessage& message);
     void replay_config(const ReplayConfigMessage& message);
 

--- a/firmware/baseband/proc_capture.cpp
+++ b/firmware/baseband/proc_capture.cpp
@@ -80,7 +80,7 @@ void CaptureProcessor::on_message(const Message* const message) {
 }
 
 void CaptureProcessor::sample_rate_config(const SampleRateConfigMessage& message) {
-    baseband_fs = message.sample_rate;
+    baseband_fs = message.sample_rate * toUType(message.oversample_rate);
     oversample_rate = message.oversample_rate;
 
     baseband_thread.set_sampling_rate(baseband_fs);

--- a/firmware/baseband/proc_capture.hpp
+++ b/firmware/baseband/proc_capture.hpp
@@ -42,7 +42,6 @@ class CaptureProcessor : public BasebandProcessor {
     void on_message(const Message* const message) override;
 
    private:
-    /* Called to update members when the sample rate or oversample rate is changed. */
     size_t baseband_fs = 3072000;  // aka: sample_rate
     static constexpr auto spectrum_rate_hz = 50.0f;
 

--- a/firmware/baseband/proc_capture.hpp
+++ b/firmware/baseband/proc_capture.hpp
@@ -42,7 +42,8 @@ class CaptureProcessor : public BasebandProcessor {
     void on_message(const Message* const message) override;
 
    private:
-    size_t baseband_fs = 3072000;
+    /* Called to update members when the sample rate or oversample rate is changed. */
+    size_t baseband_fs = 3072000;  // aka: sample_rate
     static constexpr auto spectrum_rate_hz = 50.0f;
 
     std::array<complex16_t, 512> dst{};
@@ -67,15 +68,14 @@ class CaptureProcessor : public BasebandProcessor {
     SpectrumCollector channel_spectrum{};
     size_t spectrum_interval_samples = 0;
     size_t spectrum_samples = 0;
-    OversampleRate oversample_rate{OversampleRate::Rate8x};
+    OversampleRate oversample_rate{OversampleRate::x8};
 
     /* NB: Threads should be the last members in the class definition. */
     BasebandThread baseband_thread{
         baseband_fs, this, baseband::Direction::Receive, /*auto_start*/ false};
     RSSIThread rssi_thread{};
 
-    /* Called to update members when the sample rate or oversample rate is changed. */
-    void update_for_rate_change();
+    void sample_rate_config(const SampleRateConfigMessage& message);
     void capture_config(const CaptureConfigMessage& message);
 
     /* Dispatch to the correct decim_0 based on oversample rate. */

--- a/firmware/baseband/proc_gps_sim.cpp
+++ b/firmware/baseband/proc_gps_sim.cpp
@@ -46,7 +46,7 @@ void GPSReplayProcessor::execute(const buffer_c8_t& buffer) {
     /* 2.6MHz, 2048 samples */
 
     if (!configured || !stream) return;
-    
+
     // File data is in C8 format, which is what we need
     // File samplerate is 2.6MHz, which is what we need
     // To fill up the 2048-sample C8 buffer @ 2 bytes per sample = 4096 bytes

--- a/firmware/baseband/proc_gps_sim.cpp
+++ b/firmware/baseband/proc_gps_sim.cpp
@@ -46,7 +46,7 @@ void GPSReplayProcessor::execute(const buffer_c8_t& buffer) {
     /* 2.6MHz, 2048 samples */
 
     if (!configured || !stream) return;
-
+    
     // File data is in C8 format, which is what we need
     // File samplerate is 2.6MHz, which is what we need
     // To fill up the 2048-sample C8 buffer @ 2 bytes per sample = 4096 bytes
@@ -83,8 +83,8 @@ void GPSReplayProcessor::on_message(const Message* const message) {
             channel_spectrum.on_message(message);
             break;
 
-        case Message::ID::SamplerateConfig:
-            samplerate_config(*reinterpret_cast<const SamplerateConfigMessage*>(message));
+        case Message::ID::SampleRateConfig:
+            sample_rate_config(*reinterpret_cast<const SampleRateConfigMessage*>(message));
             break;
 
         case Message::ID::ReplayConfig:
@@ -103,7 +103,7 @@ void GPSReplayProcessor::on_message(const Message* const message) {
     }
 }
 
-void GPSReplayProcessor::samplerate_config(const SamplerateConfigMessage& message) {
+void GPSReplayProcessor::sample_rate_config(const SampleRateConfigMessage& message) {
     baseband_fs = message.sample_rate;
     baseband_thread.set_sampling_rate(baseband_fs);
     spectrum_interval_samples = baseband_fs / spectrum_rate_hz;

--- a/firmware/baseband/proc_gps_sim.hpp
+++ b/firmware/baseband/proc_gps_sim.hpp
@@ -64,7 +64,7 @@ class GPSReplayProcessor : public BasebandProcessor {
     bool configured{false};
     uint32_t bytes_read{0};
 
-    void samplerate_config(const SamplerateConfigMessage& message);
+    void sample_rate_config(const SampleRateConfigMessage& message);
     void replay_config(const ReplayConfigMessage& message);
 
     TXProgressMessage txprogress_message{};

--- a/firmware/baseband/proc_replay.cpp
+++ b/firmware/baseband/proc_replay.cpp
@@ -55,6 +55,9 @@ void ReplayProcessor::execute(const buffer_c8_t& buffer) {
     // 2048 samples * 2 bytes per sample = 4096 bytes
     // Since we're oversampling by 4M/500k = 8, we only need 2048/8 = 256 samples from the file and duplicate them 8 times each
     // So 256 * 4 bytes per sample (C16) = 1024 bytes from the file
+
+    // Is it a requirement to hit 4M here? i.e. this only supports 500k?
+
     const size_t bytes_to_read = sizeof(*buffer.p) * 2 * (buffer.count / 8);  // *2 (C16), /8 (oversampling) should be == 1024
     size_t bytes_read_this_iteration = stream->read(iq_buffer.p, bytes_to_read);
     size_t oversamples_this_iteration = bytes_read_this_iteration * 8 / (sizeof(*buffer.p) * 2);
@@ -112,6 +115,7 @@ void ReplayProcessor::on_message(const Message* const message) {
 
 void ReplayProcessor::sample_rate_config(const SampleRateConfigMessage& message) {
     baseband_fs = message.sample_rate;
+    oversample_rate = message.oversample_rate;
     baseband_thread.set_sampling_rate(baseband_fs);
     spectrum_interval_samples = baseband_fs / spectrum_rate_hz;
 }

--- a/firmware/baseband/proc_replay.cpp
+++ b/firmware/baseband/proc_replay.cpp
@@ -76,7 +76,7 @@ void ReplayProcessor::execute(const buffer_c8_t& buffer) {
     // Read the C16 IQ data from the source stream.
     size_t current_bytes_read = stream->read(iq_buffer.p, bytes_to_read);
 
-    // Compute the number of samples were actuall read from the source.
+    // Compute the number of samples were actually read from the source.
     size_t samples_read = current_bytes_read / sizeof(buffer_c16_t::Type);
 
     // Write converted source samples to the output buffer with interpolation.

--- a/firmware/baseband/proc_replay.cpp
+++ b/firmware/baseband/proc_replay.cpp
@@ -63,7 +63,7 @@ void ReplayProcessor::execute(const buffer_c8_t& buffer) {
 
     // Fill and "stretch"
     for (size_t i = 0; i < oversamples_this_iteration; i++) {
-        if (i & 7) {
+        if (i > 0) {
             buffer.p[i] = buffer.p[i - 1];
         } else {
             auto re_out = iq_buffer.p[i >> 3].real() >> 8;
@@ -90,8 +90,8 @@ void ReplayProcessor::on_message(const Message* const message) {
             channel_spectrum.on_message(message);
             break;
 
-        case Message::ID::SamplerateConfig:
-            samplerate_config(*reinterpret_cast<const SamplerateConfigMessage*>(message));
+        case Message::ID::SampleRateConfig:
+            sample_rate_config(*reinterpret_cast<const SampleRateConfigMessage*>(message));
             break;
 
         case Message::ID::ReplayConfig:
@@ -110,7 +110,7 @@ void ReplayProcessor::on_message(const Message* const message) {
     }
 }
 
-void ReplayProcessor::samplerate_config(const SamplerateConfigMessage& message) {
+void ReplayProcessor::sample_rate_config(const SampleRateConfigMessage& message) {
     baseband_fs = message.sample_rate;
     baseband_thread.set_sampling_rate(baseband_fs);
     spectrum_interval_samples = baseband_fs / spectrum_rate_hz;

--- a/firmware/baseband/proc_replay.hpp
+++ b/firmware/baseband/proc_replay.hpp
@@ -59,7 +59,7 @@ class ReplayProcessor : public BasebandProcessor {
     bool configured{false};
     uint32_t bytes_read{0};
 
-    void samplerate_config(const SamplerateConfigMessage& message);
+    void sample_rate_config(const SampleRateConfigMessage& message);
     void replay_config(const ReplayConfigMessage& message);
 
     TXProgressMessage txprogress_message{};

--- a/firmware/baseband/proc_replay.hpp
+++ b/firmware/baseband/proc_replay.hpp
@@ -58,6 +58,7 @@ class ReplayProcessor : public BasebandProcessor {
 
     bool configured{false};
     uint32_t bytes_read{0};
+    OversampleRate oversample_rate = OversampleRate::x8;
 
     void sample_rate_config(const SampleRateConfigMessage& message);
     void replay_config(const ReplayConfigMessage& message);

--- a/firmware/baseband/proc_replay.hpp
+++ b/firmware/baseband/proc_replay.hpp
@@ -44,6 +44,7 @@ class ReplayProcessor : public BasebandProcessor {
     size_t baseband_fs = 3072000;
     static constexpr auto spectrum_rate_hz = 50.0f;
 
+    // Holds the read IQ data chunk from the file to send.
     std::array<complex16_t, 256> iq{};
 
     int32_t channel_filter_low_f = 0;

--- a/firmware/common/buffer.hpp
+++ b/firmware/common/buffer.hpp
@@ -49,6 +49,7 @@ using Timestamp = lpc43xx::rtc::RTC;
 
 template <typename T>
 struct buffer_t {
+    using Type = T;
     T* const p;
     const size_t count;
     const uint32_t sampling_rate;

--- a/firmware/common/message.hpp
+++ b/firmware/common/message.hpp
@@ -804,11 +804,17 @@ enum class OversampleRate : uint8_t {
     None = 1,
     x1 = None,
 
+    // 4x would make sense to have, but need to ensure it doesn't
+    // overrun the IQ read buffer in proc_replay.
+
     /* Oversample rate of 8 times the sample rate. */
     x8 = 8,
 
     /* Oversample rate of 16 times the sample rate. */
     x16 = 16,
+
+    /* Oversample rate of 32 times the sample rate. */
+    x32 = 32,
 };
 
 class SampleRateConfigMessage : public Message {

--- a/firmware/common/message.hpp
+++ b/firmware/common/message.hpp
@@ -78,7 +78,7 @@ class Message {
         ReplayThreadDone = 21,
         AFSKRxConfigure = 22,
         StatusRefresh = 23,
-        SamplerateConfig = 24,
+        SampleRateConfig = 24,
         BTLERxConfigure = 25,
         NRFRxConfigure = 26,
         TXProgress = 27,
@@ -111,7 +111,6 @@ class Message {
         APRSRxConfigure = 54,
         SpectrumPainterBufferRequestConfigure = 55,
         SpectrumPainterBufferResponseConfigure = 56,
-        OversampleRateConfig = 57,
         MAX
     };
 
@@ -799,32 +798,31 @@ class RetuneMessage : public Message {
     uint32_t range = 0;
 };
 
-class SamplerateConfigMessage : public Message {
-   public:
-    constexpr SamplerateConfigMessage(
-        const uint32_t sample_rate)
-        : Message{ID::SamplerateConfig},
-          sample_rate(sample_rate) {
-    }
-
-    const uint32_t sample_rate = 0;
-};
-
-/* Controls decimation handling in proc_capture. */
+/* Oversample/Interpolation sample rate multipliers. */
 enum class OversampleRate : uint8_t {
-    Rate8x = 8,
-    Rate16x = 16,
+    /* Use either to indicate there's no oversampling needed. */
+    None = 1,
+    x1 = None,
+
+    /* Oversample rate of 8 times the sample rate. */
+    x8 = 8,
+
+    /* Oversample rate of 16 times the sample rate. */
+    x16 = 16,
 };
 
-class OversampleRateConfigMessage : public Message {
+class SampleRateConfigMessage : public Message {
    public:
-    constexpr OversampleRateConfigMessage(
+    constexpr SampleRateConfigMessage(
+        uint32_t sample_rate,
         OversampleRate oversample_rate)
-        : Message{ID::OversampleRateConfig},
+        : Message{ID::SampleRateConfig},
+          sample_rate(sample_rate),
           oversample_rate(oversample_rate) {
     }
 
-    const OversampleRate oversample_rate{OversampleRate::Rate8x};
+    const uint32_t sample_rate = 0;
+    const OversampleRate oversample_rate = OversampleRate::None;
 };
 
 class AudioLevelReportMessage : public Message {

--- a/firmware/common/oversample.hpp
+++ b/firmware/common/oversample.hpp
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2023 Kyle Reed, zxkmm
+ *
+ * This file is part of PortaPack.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+/* Helpers for handling oversampling and interpolation. */
+
+#ifndef __OVERSAMPLE_H__
+#define __OVERSAMPLE_H__
+
+#include "message.hpp"
+#include "utility.hpp"
+
+/* TODO:
+ * The decision to oversample/interpolate should only be a baseband concern.
+ * However, the baseband can't set up the radio (M0 code), so the apps also
+ * need to know about the "actual" sample rate so the radio settings can be
+ * applied correctly. Ideally the baseband would tell the apps what the
+ * actual sample rate is. Currently the apps are telling the baseband and
+ * that feels like a separation of concerns problem. */
+
+/* HackRF suggests a minimum sample rate of 2M so a oversample rate is applied
+ * to the sample rate (pre-scale) to get the sample rate closer to that target.
+ * The baseband needs to know how to correctly decimate (or interpolate) so
+ * the set of allowed scalars is fixed (See OversampleRate enum). */
+
+
+/* Gets the oversample rate for a given sample rate.
+ * The oversample rate is used to increase the sample rate to improve SNR and quality.
+ * This is also used as the interpolation rate when replaying captures. */
+inline OversampleRate get_oversample_rate(uint32_t sample_rate) {
+    // For lower bandwidths, (12k5, 16k, 20k), use the higher oversample rate.
+    return sample_rate >= 25'000 ? OversampleRate::x8 : OversampleRate::x16;
+}
+
+/* Gets the actual sample rate for a given sample rate.
+ * This is the rate with the correct oversampling rate applied. */
+inline uint32_t get_actual_sample_rate(uint32_t sample_rate) {
+    return sample_rate * toUType(get_oversample_rate(sample_rate));
+}
+
+#endif /*__OVERSAMPLE_H__*/

--- a/firmware/common/oversample.hpp
+++ b/firmware/common/oversample.hpp
@@ -38,14 +38,18 @@
 /* HackRF suggests a minimum sample rate of 2M so a oversample rate is applied
  * to the sample rate (pre-scale) to get the sample rate closer to that target.
  * The baseband needs to know how to correctly decimate (or interpolate) so
- * the set of allowed scalars is fixed (See OversampleRate enum). */
+ * the set of allowed scalars is fixed (See OversampleRate enum).
+ * In testing, a minimum rate of 400kHz seems to the functional minimum.
+ */
 
 /* Gets the oversample rate for a given sample rate.
  * The oversample rate is used to increase the sample rate to improve SNR and quality.
  * This is also used as the interpolation rate when replaying captures. */
 inline OversampleRate get_oversample_rate(uint32_t sample_rate) {
-    // For lower bandwidths, (12k5, 16k, 20k, 25k), use the higher oversample rate.
-    return sample_rate <= 25'000 ? OversampleRate::x16 : OversampleRate::x8;
+    if (sample_rate < 25'000) return OversampleRate::x32;
+    if (sample_rate < 50'000) return OversampleRate::x16;
+
+    return OversampleRate::x8;
 }
 
 /* Gets the actual sample rate for a given sample rate.

--- a/firmware/common/oversample.hpp
+++ b/firmware/common/oversample.hpp
@@ -40,7 +40,6 @@
  * The baseband needs to know how to correctly decimate (or interpolate) so
  * the set of allowed scalars is fixed (See OversampleRate enum). */
 
-
 /* Gets the oversample rate for a given sample rate.
  * The oversample rate is used to increase the sample rate to improve SNR and quality.
  * This is also used as the interpolation rate when replaying captures. */

--- a/firmware/common/oversample.hpp
+++ b/firmware/common/oversample.hpp
@@ -44,8 +44,8 @@
  * The oversample rate is used to increase the sample rate to improve SNR and quality.
  * This is also used as the interpolation rate when replaying captures. */
 inline OversampleRate get_oversample_rate(uint32_t sample_rate) {
-    // For lower bandwidths, (12k5, 16k, 20k), use the higher oversample rate.
-    return sample_rate >= 25'000 ? OversampleRate::x8 : OversampleRate::x16;
+    // For lower bandwidths, (12k5, 16k, 20k, 25k), use the higher oversample rate.
+    return sample_rate <= 25'000 ? OversampleRate::x16 : OversampleRate::x8;
 }
 
 /* Gets the actual sample rate for a given sample rate.


### PR DESCRIPTION
This change has a few goals:
1) Consolidate oversampling/interpolation math into a few locations. The previous code had magic numbers all over the place because there were too many classes that were aware of the fact that the sample_rate was being modified.

After this change, all code that doesn't need to know about oversampling/interpolation will work with the sample rate that is displayed in the UI and won't have to manually scale the sample rate.

2) Dynamically interpolate when replaying. @Brumi-2021 has done some experiments and found that the minimum sample_rate that HackRF will send reliably is 400kHz. This change will interpolate samples up to x32 (to support < 25k). This does _not_ lower the interpolation rate (to x1/x2/x4) because that will require a larger read buffer and testing that is out of scope for this change. The code can be easily modified to support these lower rates, but will require future work.

One thing to note, it would be good if we supported x32 for oversampling, but that requires more decimator changes to proc_capture so the oversample rates are forced to x8 or x16 in ui_record_view.cpp. More investigation into decimation is required. It may be possible to apply the same decimator multiple times which would make it easier to support dynamic decimation without having to add even more decimators to proc_capture.

Here's a PR build of this change for testing:
[dynamic_interpolation_portapack-h1_h2-mayhem.bin.zip](https://github.com/eried/portapack-mayhem/files/12243036/dynamic_interpolation_portapack-h1_h2-mayhem.bin.zip)
