### PR TITLE
Keyboard tweaks

### DIFF
--- a/firmware/application/ui/ui_alphanum.cpp
+++ b/firmware/application/ui/ui_alphanum.cpp
@@ -53,7 +53,10 @@ AlphanumView::AlphanumView(
     button_shift.on_select = [this]() {
         incr(shift_mode);
 
-        if (shift_mode > ShiftMode::ShiftLock)
+        // Disallow one-time shift in digits/symbols mode
+        if ((mode == 1) && (shift_mode == ShiftMode::Shift))
+            shift_mode = ShiftMode::ShiftLock;
+        else if (shift_mode > ShiftMode::ShiftLock)
             shift_mode = ShiftMode::None;
 
         refresh_keys();

--- a/firmware/application/ui/ui_alphanum.hpp
+++ b/firmware/application/ui/ui_alphanum.hpp
@@ -104,7 +104,7 @@ class AlphanumView : public TextEntryView {
         "<DEL"};
 
     Button button_mode{
-        {16 * 8, 32 * 8 - 3, 5 * 8, 3 * 16 + 3},
+        {16 * 8, 32 * 8 - 3, 6 * 8, 3 * 16 + 3},
         ""};
 };
 

--- a/firmware/application/ui/ui_textentry.hpp
+++ b/firmware/application/ui/ui_textentry.hpp
@@ -50,7 +50,7 @@ class TextEntryView : public View {
 
     TextEdit text_input;
     Button button_ok{
-        {21 * 8, 32 * 8 - 3, 9 * 8, 3 * 16 + 3},
+        {22 * 8, 32 * 8 - 3, 8 * 8, 3 * 16 + 3},
         "OK"};
 };
 


### PR DESCRIPTION
1) Slightly wider "123" button and narrower "OK" button, to make it a little easier to press "123" without accidentally pressing "OK".

2) Disallow the one-time shift in digits/symbols keyboard mode.  (The one-time shift is mainly for capitalizing the first letter of a word using the alphabet keys.  It was slightly confusing for an * character to change to an 8 when pressed.)