### PR TITLE
Increase REC BW Option till 1Mhz Capture App

### DIFF
--- a/firmware/application/freqman_db.cpp
+++ b/firmware/application/freqman_db.cpp
@@ -82,10 +82,11 @@ options_t freqman_bandwidths[4] = {
         {"100k", 100000},
         {"250k", 250000},
         {"500k", 500000}, /* Previous Limit bandwith Option with perfect micro SD write .C16 format operaton.*/
-        {"600k", 600000}, /* That extended option is still possible to record with FW version Mayhem v1.41 (< 2,5MB/sec) */
+        {"600k", 600000}, /* We doubled x2 previous REC BW limit , now extended BW from 600k to 1M with fast enough SD card in C16 or C8 format .*/
         {"650k", 650000},
-        {"750k", 750000}, /* From this BW onwards, the LCD is ok, but the recorded file is decimated, (not real file size) */
-        {"1100k", 1100000},
+        {"750k", 750000},
+        {"1000k", 1000000}, /* New limit bandwith option for recording in C16 (in fast SD card) or in C8 */
+        {"1500k", 1500000}, /* From this BW onwards, the LCD is ok, but M4 CPU is having periodical sample rec dropps, (not real file size, accelerated replay) */
         {"1750k", 1750000},
         {"2000k", 2000000},
         {"2500k", 2500000},

--- a/firmware/application/ui/ui_spectrum.cpp
+++ b/firmware/application/ui/ui_spectrum.cpp
@@ -390,8 +390,8 @@ uint32_t filter_bandwidth_for_sampling_rate(int32_t sampling_rate) {
                                        // BW 500k...750kHz, ex. 500kHz (fs = 8 x BW = 4Mhz), BW 600kHz (fs = 4,8Mhz), BW 750 kHz (fs = 6Mhz).
             return 2'500'000;          // In some IC, MAX2837 appears as 2250000, but both work similarly.
 
-        case 8'000'000:  // BW capture 1Mhz fs = 8 x 11Mhz = 8Mhz. (1Mhz showed slightly higher noise background).
-            return 3'500'000;
+        case 8'000'000:  // BW capture 1Mhz fs = 8 x 1Mhz = 8Mhz. (1Mhz showed slightly higher noise background).
+            return 3'500'000;           // some low SD cards, if not showing avg. writting speed >4MB/sec, they will produce sammples drop at REC with 1MB and C16 format. 
 
         case 12'000'000:  // BW capture 1,5Mhz, fs = 8 x 1,5Mhz = 12Mhz
                           // Good BPF, good matching, we have some periodical M4 % samples drop.

--- a/firmware/application/ui/ui_spectrum.cpp
+++ b/firmware/application/ui/ui_spectrum.cpp
@@ -390,8 +390,8 @@ uint32_t filter_bandwidth_for_sampling_rate(int32_t sampling_rate) {
                                        // BW 500k...750kHz, ex. 500kHz (fs = 8 x BW = 4Mhz), BW 600kHz (fs = 4,8Mhz), BW 750 kHz (fs = 6Mhz).
             return 2'500'000;          // In some IC, MAX2837 appears as 2250000, but both work similarly.
 
-        case 8'000'000:  // BW capture 1Mhz fs = 8 x 1Mhz = 8Mhz. (1Mhz showed slightly higher noise background).
-            return 3'500'000;           // some low SD cards, if not showing avg. writting speed >4MB/sec, they will produce sammples drop at REC with 1MB and C16 format. 
+        case 8'000'000:        // BW capture 1Mhz fs = 8 x 1Mhz = 8Mhz. (1Mhz showed slightly higher noise background).
+            return 3'500'000;  // some low SD cards, if not showing avg. writting speed >4MB/sec, they will produce sammples drop at REC with 1MB and C16 format.
 
         case 12'000'000:  // BW capture 1,5Mhz, fs = 8 x 1,5Mhz = 12Mhz
                           // Good BPF, good matching, we have some periodical M4 % samples drop.

--- a/firmware/application/ui/ui_spectrum.cpp
+++ b/firmware/application/ui/ui_spectrum.cpp
@@ -390,19 +390,23 @@ uint32_t filter_bandwidth_for_sampling_rate(int32_t sampling_rate) {
                                        // BW 500k...750kHz, ex. 500kHz (fs = 8 x BW = 4Mhz), BW 600kHz (fs = 4,8Mhz), BW 750 kHz (fs = 6Mhz).
             return 2'500'000;          // In some IC, MAX2837 appears as 2250000, but both work similarly.
 
-        case 8'800'000:  // BW capture 1,1Mhz fs = 8 x 1,1Mhz = 8,8Mhz. (1Mhz showed slightly higher noise background).
+        case 8'000'000:  // BW capture 1Mhz fs = 8 x 11Mhz = 8Mhz. (1Mhz showed slightly higher noise background).
             return 3'500'000;
 
+        case 12'000'000:  // BW capture 1,5Mhz, fs = 8 x 1,5Mhz = 12Mhz
+                          // Good BPF, good matching, we have some periodical M4 % samples drop.
+            return 5'000'000;
+
         case 14'000'000:  // BW capture 1,75Mhz, fs = 8 x 1,75Mhz = 14Mhz
-                          // Good BPF, good matching, but LCD flickers, refresh rate should be < 20 Hz, reasonable picture.
+                          // Good BPF, good matching, we have some periodical M4 % samples drop.
             return 5'000'000;
 
         case 16'000'000:  // BW capture 2Mhz, fs = 8 x 2Mhz = 16Mhz
-                          // Good BPF, good matching, but LCD flickers, refresh rate should be < 20 Hz, reasonable picture.
+                          // Good BPF, good matching, we have some periodical M4 % samples drop.
             return 6'000'000;
 
         case 20'000'000:  // BW capture 2,5Mhz, fs = 8 x 2,5 Mhz = 20Mhz
-                          // Good BPF, good matching, but LCD flickers, refresh rate should be < 20 Hz, reasonable picture.
+                          // Good BPF, good matching, we have some periodical M4 % samples drop.
             return 7'000'000;
 
         default:  // BW capture 2,75Mhz, fs = 8 x 2,75Mhz = 22Mhz max ADC sampling and others.

--- a/firmware/application/ui_record_view.cpp
+++ b/firmware/application/ui_record_view.cpp
@@ -107,13 +107,13 @@ uint32_t RecordView::set_sampling_rate(uint32_t new_sampling_rate) {
     auto oversample_rate = get_oversample_rate(new_sampling_rate);
     auto actual_sampling_rate = new_sampling_rate * toUType(oversample_rate);
 
-    /* We are changing "REC" icon background to yellow in BW rec Options >600kHz
-     * where we are NOT recording full IQ .C16 files (recorded files are decimated ones).
-     * Those decimated recorded files, has not the full IQ samples.
-     * are ok as recorded spectrum indication, but they should not be used by Replay app.
+    /* We are changing "REC" icon background to yellow in BW rec Options >1Mhz
+     * > 1Mhz BW options , we are NOT recording full IQ .C16 files (those files has some periodical  missing dropped samples).
+     * Those recorded files, has not the full IQ samples information, looks like decimated in file size.
+     * They are ok as recorded spectrum indication, but they should not be used by Replay app. (the voice speed will be accelerated)
 
      * We keep original black background in all the correct IQ .C16 files BW's Options. */
-    if (actual_sampling_rate > 4'800'000) {  // > BW >600kHz  (fs=8*BW), (750kHz...2750kHz)
+    if (actual_sampling_rate > 8'000'000) {  // Till fw 1.7.4  BW limit yellow REC button  was >500khz, now  BW >1Mhz  (fs=8*BW), (>1Mhz ..2M75)
         button_record.set_background(ui::Color::yellow());
     } else {
         button_record.set_background(ui::Color::black());

--- a/firmware/baseband/proc_capture.hpp
+++ b/firmware/baseband/proc_capture.hpp
@@ -58,7 +58,7 @@ class CaptureProcessor : public BasebandProcessor {
     dsp::decimate::FIRC8xR16x24FS4Decim8 decim_0_8{};
     dsp::decimate::FIRC8xR16x24FS4Decim8 decim_0_8_180k{};
     dsp::decimate::FIRC16xR16x16Decim2 decim_1{};
- 
+
     int32_t channel_filter_low_f = 0;
     int32_t channel_filter_high_f = 0;
     int32_t channel_filter_transition = 0;

--- a/firmware/baseband/proc_capture.hpp
+++ b/firmware/baseband/proc_capture.hpp
@@ -56,8 +56,9 @@ class CaptureProcessor : public BasebandProcessor {
      * use decim_0_8 for an overall decimation factor of 16. */
     dsp::decimate::FIRC8xR16x24FS4Decim4 decim_0_4{};
     dsp::decimate::FIRC8xR16x24FS4Decim8 decim_0_8{};
-
+    dsp::decimate::FIRC8xR16x24FS4Decim8 decim_0_8_180k{};
     dsp::decimate::FIRC16xR16x16Decim2 decim_1{};
+ 
     int32_t channel_filter_low_f = 0;
     int32_t channel_filter_high_f = 0;
     int32_t channel_filter_transition = 0;


### PR DESCRIPTION
Hi , this PR is trying to complete / expland some more  added features of the previous  PR's  #1332 ,  #1336 
Thanks to @kallanreed , now we have ready , al the sw  structure to continue playing and investigating  all those Capture and Replay issues. 

In this PR , we are extending the previous BW Capture limit from 500 Khz to  1Mhz   ( doubling the bandwith rec , so now we have also available good REC options : 600k , 650k, 750k and 1Mhz .and we can select recording in C16 or C8 format.

We are still recommending  to use with full confidence BW <= 500 Khz (SD recording speed <=2MB/sec)  , because it is most likely compatible with the majority of the current SD cards, and the possibility to have M4 dropped sampes is really quite low. 

Beyond those 500Khz,  till 1Mhz BW Capture Options  ,we are stressing the full system , and  you will need to have a resonable fast enough SD card able to record with average Write speed of > 4 MB / sec and low latency  (you can test it yours, through Debug --> SD card ). But if you have some speed rec troubles  with your current  SD card,  thanks to @NotherNgineer , you can change the REC format from C16 --> C8 format , and then we are reducing /2 the amount of writting byte data / sec . (and it should be again OK ) 

I have already tested, and I feel it is working fine, but anyway , let me advance a beta binary in Discord , Test-drive.
Waiting for your test results , here .
Let's continue enjoying about it ! 

Cheers.