### PR TITLE
Solve_quality_problem_low_bit_rate_100k_150k_REC_Capture_App

### DIFF
--- a/firmware/application/apps/capture_app.cpp
+++ b/firmware/application/apps/capture_app.cpp
@@ -86,7 +86,7 @@ CaptureAppView::CaptureAppView(NavigationView& nav)
     };
 
     receiver_model.enable();
-    option_bandwidth.set_selected_index(7);  // Preselected default option 500kHz.
+    option_bandwidth.set_selected_index(4);  // Preselected default option 500kHz.
 
     record_view.on_error = [&nav](std::string message) {
         nav.display_modal("Error", message);

--- a/firmware/application/apps/capture_app.cpp
+++ b/firmware/application/apps/capture_app.cpp
@@ -86,7 +86,7 @@ CaptureAppView::CaptureAppView(NavigationView& nav)
     };
 
     receiver_model.enable();
-    option_bandwidth.set_selected_index(4);  // Preselected default option 500kHz.
+    option_bandwidth.set_by_value(500000);  // better by_value than by option_bandwidth.set_selected_index(4), Preselected default option 500kHz.
 
     record_view.on_error = [&nav](std::string message) {
         nav.display_modal("Error", message);

--- a/firmware/application/freqman_db.cpp
+++ b/firmware/application/freqman_db.cpp
@@ -74,12 +74,9 @@ options_t freqman_bandwidths[4] = {
     },
     {
         // SPEC -- TODO: these should be indexes.
-        {"12k5", 12500},
-        {"16k", 16000},
-        {"20k", 20000},
-        {"25k", 25000},
-        {"50k", 50000},
-        {"100k", 100000},
+        {"40k", 40000},
+        {"80k", 80000},
+        {"150k", 150000},
         {"250k", 250000},
         {"500k", 500000}, /* Previous Limit bandwith Option with perfect micro SD write .C16 format operaton.*/
         {"600k", 600000}, /* We doubled x2 previous REC BW limit , now extended BW from 600k to 1M with fast enough SD card in C16 or C8 format .*/

--- a/firmware/application/freqman_db.cpp
+++ b/firmware/application/freqman_db.cpp
@@ -74,8 +74,11 @@ options_t freqman_bandwidths[4] = {
     },
     {
         // SPEC -- TODO: these should be indexes.
-        {"40k", 40000},
-        {"80k", 80000},
+        {"12k5", 12500},
+        {"16k", 16000},
+        {"25k", 25000},
+        {"50k", 50000},
+        {"100k", 100000},
         {"150k", 150000},
         {"250k", 250000},
         {"500k", 500000}, /* Previous Limit bandwith Option with perfect micro SD write .C16 format operaton.*/

--- a/firmware/application/ui/ui_spectrum.cpp
+++ b/firmware/application/ui/ui_spectrum.cpp
@@ -383,7 +383,7 @@ void WaterfallView::on_audio_spectrum() {
 // TODO: Comments below refer to a fixed oversample rate (8x), cleanup.
 uint32_t filter_bandwidth_for_sampling_rate(int32_t sampling_rate) {
     switch (sampling_rate) {   // Use the var fs (sampling_rate) to set up BPF aprox < fs_max / 2 by Nyquist theorem.
-        case 0 ... 2'000'000:  // BW Captured range (0 <= 250kHz max)  fs = 8 x 250 kHz.
+        case 0 ... 3'000'000:  // BW Captured range (0 <= 250kHz max)  fs = 8 x 250 kHz., 16 x 150 khz, 32 x 75 khz, , 64 x 40 khz
             return 1'750'000;  // Minimum BPF MAX2837 for all those lower BW options.
 
         case 4'000'000 ... 6'000'000:  // BW capture range (500k...750kHz max)  fs_max = 8 x 750kHz = 6Mhz

--- a/firmware/application/ui_record_view.cpp
+++ b/firmware/application/ui_record_view.cpp
@@ -113,7 +113,7 @@ uint32_t RecordView::set_sampling_rate(uint32_t new_sampling_rate) {
      * They are ok as recorded spectrum indication, but they should not be used by Replay app. (the voice speed will be accelerated)
 
      * We keep original black background in all the correct IQ .C16 files BW's Options. */
-    if ((actual_sampling_rate > 8'000'000) || (actual_sampling_rate <= 1'280'000) ) {  // yellow REC button means not ok for REC, BW >1Mhz , BW < 150khz
+    if ((actual_sampling_rate > 8'000'000) || (actual_sampling_rate <= 1'280'000)) {  // yellow REC button means not ok for REC, BW >1Mhz , BW < 150khz
         button_record.set_background(ui::Color::yellow());
     } else {
         button_record.set_background(ui::Color::black());

--- a/firmware/application/ui_record_view.cpp
+++ b/firmware/application/ui_record_view.cpp
@@ -113,7 +113,7 @@ uint32_t RecordView::set_sampling_rate(uint32_t new_sampling_rate) {
      * They are ok as recorded spectrum indication, but they should not be used by Replay app. (the voice speed will be accelerated)
 
      * We keep original black background in all the correct IQ .C16 files BW's Options. */
-    if ((actual_sampling_rate > 8'000'000) || (actual_sampling_rate == 1'280'000) || (actual_sampling_rate == 640'000)) {  // yellow REC button means not ok for REC, BW >1Mhz , BW < 150khz
+    if ((actual_sampling_rate > 8'000'000) || (actual_sampling_rate <= 1'280'000) ) {  // yellow REC button means not ok for REC, BW >1Mhz , BW < 150khz
         button_record.set_background(ui::Color::yellow());
     } else {
         button_record.set_background(ui::Color::black());

--- a/firmware/application/ui_record_view.cpp
+++ b/firmware/application/ui_record_view.cpp
@@ -113,7 +113,7 @@ uint32_t RecordView::set_sampling_rate(uint32_t new_sampling_rate) {
      * They are ok as recorded spectrum indication, but they should not be used by Replay app. (the voice speed will be accelerated)
 
      * We keep original black background in all the correct IQ .C16 files BW's Options. */
-    if (actual_sampling_rate > 8'000'000) {  // Till fw 1.7.4  BW limit yellow REC button  was >500khz, now  BW >1Mhz  (fs=8*BW), (>1Mhz ..2M75)
+    if ((actual_sampling_rate > 8'000'000) || (actual_sampling_rate == 1'280'000) || (actual_sampling_rate == 640'000)) {  // yellow REC button means not ok for REC, BW >1Mhz , BW < 150khz
         button_record.set_background(ui::Color::yellow());
     } else {
         button_record.set_background(ui::Color::black());

--- a/firmware/baseband/proc_capture.cpp
+++ b/firmware/baseband/proc_capture.cpp
@@ -42,8 +42,8 @@ void CaptureProcessor::execute(const buffer_c8_t& buffer) {
     const auto decim_0_out = decim_0_execute(buffer, dst_buffer);  // selectable 3 possible decim_0, (/4.  /8 200k soft transition filter , /8 180k sharp )
 
     const auto decim_1_out = baseband_fs < 4800'000
-                                 ? decim_1.execute(decim_0_out, dst_buffer)  // < 500khz double decim. stage
-                                 : decim_0_out;                              // > 500khz single decim. stage
+                                 ? decim_1.execute(decim_0_out, dst_buffer)  // < 600khz double decim. stage , means 500khz and lower bit rates.
+                                 : decim_0_out;                              // >= 600khz single decim. stage , means 600khz and upper bit rates.
 
     const auto& decimator_out = decim_1_out;
     const auto& channel = decimator_out;

--- a/firmware/common/message.hpp
+++ b/firmware/common/message.hpp
@@ -815,6 +815,9 @@ enum class OversampleRate : uint8_t {
 
     /* Oversample rate of 32 times the sample rate. */
     x32 = 32,
+
+    /* Oversample rate of 32 times the sample rate. */
+    x64 = 64,
 };
 
 class SampleRateConfigMessage : public Message {

--- a/firmware/common/message.hpp
+++ b/firmware/common/message.hpp
@@ -818,6 +818,9 @@ enum class OversampleRate : uint8_t {
 
     /* Oversample rate of 64 times the sample rate. */
     x64 = 64,
+
+    /* Oversample rate of 128 times the sample rate. */
+    x128 = 128,
 };
 
 class SampleRateConfigMessage : public Message {

--- a/firmware/common/message.hpp
+++ b/firmware/common/message.hpp
@@ -816,7 +816,7 @@ enum class OversampleRate : uint8_t {
     /* Oversample rate of 32 times the sample rate. */
     x32 = 32,
 
-    /* Oversample rate of 32 times the sample rate. */
+    /* Oversample rate of 64 times the sample rate. */
     x64 = 64,
 };
 

--- a/firmware/common/oversample.hpp
+++ b/firmware/common/oversample.hpp
@@ -46,8 +46,9 @@
  * The oversample rate is used to increase the sample rate to improve SNR and quality.
  * This is also used as the interpolation rate when replaying captures. */
 inline OversampleRate get_oversample_rate(uint32_t sample_rate) {
-    if (sample_rate < 80'000) return OversampleRate::x64;   // 50k   and  40k min
-    if (sample_rate < 150'000) return OversampleRate::x32;  // 100k  and  80k min
+    if (sample_rate < 50'000) return OversampleRate::x128;  // 25kk ,16k, 12k5
+    if (sample_rate < 100'000) return OversampleRate::x64;  // 50k
+    if (sample_rate < 150'000) return OversampleRate::x32;  // 100k
     if (sample_rate < 250'000) return OversampleRate::x16;  // 150k only
 
     return OversampleRate::x8;  // 250k .. 1Mhz

--- a/firmware/common/oversample.hpp
+++ b/firmware/common/oversample.hpp
@@ -46,10 +46,11 @@
  * The oversample rate is used to increase the sample rate to improve SNR and quality.
  * This is also used as the interpolation rate when replaying captures. */
 inline OversampleRate get_oversample_rate(uint32_t sample_rate) {
-    if (sample_rate < 25'000) return OversampleRate::x32;
-    if (sample_rate < 50'000) return OversampleRate::x16;
+    if (sample_rate < 80'000) return OversampleRate::x64;   // 50k   and  40k min
+    if (sample_rate < 150'000) return OversampleRate::x32;  // 100k  and  80k min
+    if (sample_rate < 250'000) return OversampleRate::x16;  // 150k only
 
-    return OversampleRate::x8;
+    return OversampleRate::x8;  // 250k .. 1Mhz
 }
 
 /* Gets the actual sample rate for a given sample rate.


### PR DESCRIPTION
Based on investigations of #1343,  I could see  that the Capture App, in low bit rate REC, only was robust and usefull from >= 250Khz onwards,
Current solution is  OK from ADC sample rate ,  but it is not OK regarding  anti-aliasing filter, therefore we should increase the internal bit rates with higher oversampling / decimation , till having a correct anti-aliasing filters.  

This time , this  PR , is extending  that  lower minimum reliable BW  REC option  from current 250khz to  150khz .
(pending to investigate the two lower bit rates 80k , 40khz that are displayed now  with YELLOW icon , because currently they are  not working well .  (Hopefully improved in next PR's )  

Before that  PR , we could not display correctly any MF upcoverted with many adjacent channels due to too poor anti-aliasing filters (in this case, till now ,  the minimum usefull low REC bit rate was  really : 250 Khz )
![image](https://github.com/eried/portapack-mayhem/assets/86470699/1f7c58ae-ad4f-4ee0-b46c-026687bec88d)

After that PR , we could  extend the Capture RECording  correctly the same band , with even lower  BW 150Khz 
![image](https://github.com/eried/portapack-mayhem/assets/86470699/d4158701-b341-4cd3-ab4b-90e1b4f5c690)
(in this case, the minimum usefull low REC bit rate was : 150 Khz , pending to continue the investigation) 

So as summary , after that PR , we will have now ,  good Capture REC and REPLAY  quality from BW : 150 Khz to 1Mhz 
(pending to try to extend both limits even more,   from BW : 40k min till 2Mhz max (but using  C8 format)  , in next PR's) 
Cheers. 