### PR TITLE
Small error correction to PR 1367

### DIFF
--- a/firmware/application/ui_record_view.cpp
+++ b/firmware/application/ui_record_view.cpp
@@ -113,7 +113,8 @@ uint32_t RecordView::set_sampling_rate(uint32_t new_sampling_rate) {
      * They are ok as recorded spectrum indication, but they should not be used by Replay app. (the voice speed will be accelerated)
 
      * We keep original black background in all the correct IQ .C16 files BW's Options. */
-    if ((actual_sampling_rate > 8'000'000) || (actual_sampling_rate <= 1'280'000)) {  // yellow REC button means not ok for REC, BW >1Mhz , BW < 150khz
+    if ((actual_sampling_rate > 8'000'000) || (actual_sampling_rate <= 1'600'000)) {  // yellow REC button means not ok for REC, BW >1Mhz , BW <= 100khz due to NG aliasing.
+        // to be updated or removed in the next PR's, according the achieved extended BW's with good quality bandwith REC limits .
         button_record.set_background(ui::Color::yellow());
     } else {
         button_record.set_background(ui::Color::black());

--- a/firmware/common/oversample.hpp
+++ b/firmware/common/oversample.hpp
@@ -46,12 +46,11 @@
  * The oversample rate is used to increase the sample rate to improve SNR and quality.
  * This is also used as the interpolation rate when replaying captures. */
 inline OversampleRate get_oversample_rate(uint32_t sample_rate) {
-    if (sample_rate < 50'000) return OversampleRate::x128;  // 25kk ,16k, 12k5
-    if (sample_rate < 100'000) return OversampleRate::x64;  // 50k
-    if (sample_rate < 150'000) return OversampleRate::x32;  // 100k
-    if (sample_rate < 250'000) return OversampleRate::x16;  // 150k only
+    if (sample_rate < 50'000) return OversampleRate::x128;  // 25kk..12k5, prepared for future, OVS ok, but decim. :128 still not implemented.
+    if (sample_rate < 100'000) return OversampleRate::x64;  // 50k, prepared for future, OVS ok, but decim. :64 still not implemented.
+    if (sample_rate < 250'000) return OversampleRate::x16;  // Now tentatively applied to 150k..100k - but as soon as we got decim :32, (150k x16, and 100k x32)
 
-    return OversampleRate::x8;  // 250k .. 1Mhz
+    return OversampleRate::x8;  // 250k .. 1Mhz, that decim :8 , is already applied.(OVS and decim OK)
 }
 
 /* Gets the actual sample rate for a given sample rate.


### PR DESCRIPTION
Small error correction to previous PR #1367 

Previous one , had wrong spectrum scale of 100k bandwith , (it had the future code settings of some decim not available now .. With that PR, has the correct settings for the 100k ,  of the  tentative and available decimations (still not optimized).
This is ammending the previous small error , now all 3 BW scales are correct , 250k , 150k ,100k 
![image](https://github.com/eried/portapack-mayhem/assets/86470699/112e3928-0ae1-47f7-9757-aa5387770a98)

In this PR , we are marking as a YELLOW icon the low bit rates <=100k , because those ones  are still not finalized , nor  correct.   100k has correct scale in the display , but not good enough anti-aliasing compared to 150k and onwards. 

The previous captured sample that I attached inisde PR 1367 , had also wrong scale (contents was ok , but scale is wrong , this PR is ammending it ) . Anyway , if you want to test it ,  pls find a better RECorded  sample of 150k BW  (captured with upconverted from MF band) . 


[captured_MF_150k.zip](https://github.com/eried/portapack-mayhem/files/12327673/captured_MF_150k.zip)
