### PR TITLE
Load App Settings *after* initializing RadioState

### DIFF
--- a/firmware/application/apps/ui_scanner.hpp
+++ b/firmware/application/apps/ui_scanner.hpp
@@ -110,11 +110,11 @@ class ScannerView : public View {
     std::string title() const override { return "Scanner"; };
 
    private:
+    RxRadioState radio_state_{};
     app_settings::SettingsManager settings_{
         "rx_scanner", app_settings::Mode::RX};
 
     NavigationView& nav_;
-    RxRadioState radio_state_{};
 
     void start_scan_thread();
     void restart_scan();


### PR DESCRIPTION
RadioState constructor was reinitializing some fields that are saved in App Settings.  In order for App Settings to be loaded correctly, SettingsManager constructor needs to be after RadioState.