### PR TITLE
avoid yellow icon in Audio App (minor issue) 

### DIFF
--- a/firmware/application/ui_record_view.cpp
+++ b/firmware/application/ui_record_view.cpp
@@ -113,7 +113,7 @@ uint32_t RecordView::set_sampling_rate(uint32_t new_sampling_rate) {
      * They are ok as recorded spectrum indication, but they should not be used by Replay app. (the voice speed will be accelerated)
 
      * We keep original black background in all the correct IQ .C16 files BW's Options. */
-    if ((actual_sampling_rate > 8'000'000) || ((actual_sampling_rate <= 1'600'000) && (oversample_rate) > OversampleRate::x8)) {  // yellow REC button means not ok for REC, BW >1Mhz , BW <= 100khz due to NG aliasing.
+    if ((actual_sampling_rate > 8'000'000) || ((actual_sampling_rate <= 1'600'000) && oversample_rate > OversampleRate::x8)) {  // yellow REC button means not ok for REC, BW >1Mhz , BW <= 100khz due to NG aliasing.
         // to be updated or removed in the next PR's, according the achieved extended BW's with good quality bandwith REC limits .
         button_record.set_background(ui::Color::yellow());
     } else {

--- a/firmware/application/ui_record_view.cpp
+++ b/firmware/application/ui_record_view.cpp
@@ -113,7 +113,7 @@ uint32_t RecordView::set_sampling_rate(uint32_t new_sampling_rate) {
      * They are ok as recorded spectrum indication, but they should not be used by Replay app. (the voice speed will be accelerated)
 
      * We keep original black background in all the correct IQ .C16 files BW's Options. */
-    if ((actual_sampling_rate > 8'000'000) || ((actual_sampling_rate <= 1'600'000) && oversample_rate > OversampleRate::x8)) {  // yellow REC button means not ok for REC, BW >1Mhz , BW <= 100khz due to NG aliasing.
+    if ((actual_sampling_rate > 8'000'000) || ((actual_sampling_rate <= 1'600'000) && (oversample_rate > OversampleRate::x8))) {  // yellow REC button means not ok for REC, BW >1Mhz , BW <= 100khz due to NG aliasing.
         // to be updated or removed in the next PR's, according the achieved extended BW's with good quality bandwith REC limits .
         button_record.set_background(ui::Color::yellow());
     } else {

--- a/firmware/application/ui_record_view.cpp
+++ b/firmware/application/ui_record_view.cpp
@@ -113,7 +113,7 @@ uint32_t RecordView::set_sampling_rate(uint32_t new_sampling_rate) {
      * They are ok as recorded spectrum indication, but they should not be used by Replay app. (the voice speed will be accelerated)
 
      * We keep original black background in all the correct IQ .C16 files BW's Options. */
-    if ((actual_sampling_rate > 8'000'000) || (actual_sampling_rate <= 1'600'000)) {  // yellow REC button means not ok for REC, BW >1Mhz , BW <= 100khz due to NG aliasing.
+    if ((actual_sampling_rate > 8'000'000) || ((actual_sampling_rate <= 1'600'000) && (oversample_rate) > OversampleRate::x8)) {  // yellow REC button means not ok for REC, BW >1Mhz , BW <= 100khz due to NG aliasing.
         // to be updated or removed in the next PR's, according the achieved extended BW's with good quality bandwith REC limits .
         button_record.set_background(ui::Color::yellow());
     } else {


### PR DESCRIPTION
In my yesterday Capture PR,  I added a condition to display warning YELLOW REC icon, in the lower Capture App  BW  bit rates that are still not working well  ,( that currently has a sample rates below <= 1M6) .
 
It is strange , but it  seems to have a side effect to the Audio App that it is running its sample rate to 3.072.000 ,  3M  aprox ..., and now it shows a permanent wrong YELLOW icon on it . So far , I could not find that strange side effect logic. 
Anyway , I just  added an additional  AND condition used only in Capture App , to avoid that side effect. (and now it works well in both applications,  Capture and Audio App. ) .  

We agreed that @NotherNgineer  will also have a look on it , to see if  he finds the behind logic , and we can solve it with other PR ,  
If not , we can proceed with this PR . 

 