### PR TITLE
Recon: fixed behavior of auto update m-ranges

### DIFF
--- a/firmware/application/apps/ui_recon.cpp
+++ b/firmware/application/apps/ui_recon.cpp
@@ -581,10 +581,8 @@ ReconView::ReconView(NavigationView& nav)
         if (!frequency_range.min || !frequency_range.max) {
             nav_.display_modal("Error", "Both START and END freqs\nneed a value");
         } else {
-            if (frequency_range.min > frequency_range.max) {                      // xor swap
-                frequency_range.min = frequency_range.min ^ frequency_range.max;  // addition
-                frequency_range.max = frequency_range.min ^ frequency_range.max;  // max will contain min
-                frequency_range.min = frequency_range.min ^ frequency_range.max;  // min will becom max
+            if (frequency_range.min > frequency_range.max) {
+                std::swap(frequency_range.min, frequency_range.max);
                 button_manual_start.set_text(to_string_short_freq(frequency_range.min));
                 button_manual_end.set_text(to_string_short_freq(frequency_range.max));
             }

--- a/firmware/application/apps/ui_recon.cpp
+++ b/firmware/application/apps/ui_recon.cpp
@@ -898,6 +898,8 @@ void ReconView::on_statistics_update(const ChannelStatistics& statistics) {
         if (!timer) {
             status = 0;
             freq_lock = 0;
+            last_freq_lock = -1;  // need to reset these two as else the green coloration can not occur on consecutive matches
+            last_nb_match = -1;
             timer = local_recon_lock_duration;
             big_display.set_style(&Styles::white);
         }

--- a/firmware/application/apps/ui_recon.hpp
+++ b/firmware/application/apps/ui_recon.hpp
@@ -70,6 +70,7 @@ class ReconView : public View {
     app_settings::SettingsManager settings_{
         "rx_recon", app_settings::Mode::RX};
 
+    void check_update_ranges_from_current();
     void set_loop_config(bool v);
     void clear_freqlist_for_ui_action();
     void reset_indexes();


### PR DESCRIPTION
Fixed behavior of auto update m-ranges:
-only auto update if option is checked
-use load and save from sd to restore from user input if option is not checked
-factorized update ranges