### PR TITLE
Show file count in each directory, and moved "Too many files" message

### DIFF
--- a/firmware/application/apps/ui_fileman.cpp
+++ b/firmware/application/apps/ui_fileman.cpp
@@ -185,7 +185,6 @@ FileManBaseView::FileManBaseView(
       extension_filter{filter} {
     add_children({&labels,
                   &text_current,
-                  &text_info,
                   &button_exit});
 
     button_exit.on_select = [this, &nav](Button&) {
@@ -250,8 +249,10 @@ void FileManBaseView::refresh_list() {
         auto entry_name = truncate(entry.path, 20);
 
         if (entry.is_directory) {
+            auto size_str = (entry.path == parent_dir_path)? "" : to_string_dec_uint(file_count(entry.path));
+
             menu_view.add_item(
-                {entry_name,
+                {entry_name + std::string(21 - entry_name.length(), ' ') + size_str,
                  ui::Color::yellow(),
                  &bitmap_icon_dir,
                  [this](KeyEvent key) {
@@ -278,7 +279,6 @@ void FileManBaseView::refresh_list() {
             break;
     }
 
-    text_info.set(menu_view.item_count() >= max_items_shown ? "Too many files!" : "");
     menu_view.set_highlighted(prev_highlight);
 }
 
@@ -342,7 +342,6 @@ FileSaveView::FileSaveView(
         file_{ file }
 {
         add_children({
-                &labels,
                 &text_path,
                 &button_edit_path,
                 &text_name,
@@ -546,7 +545,6 @@ FileManagerView::FileManagerView(
 
     add_children({
         &menu_view,
-        &labels,
         &text_date,
         &button_rename,
         &button_delete,
@@ -560,10 +558,16 @@ FileManagerView::FileManagerView(
     });
 
     menu_view.on_highlight = [this]() {
-        if (selected_is_valid())
-            text_date.set(to_string_FAT_timestamp(file_created_date(get_selected_full_path())));
-        else
-            text_date.set("");
+        if (menu_view.highlighted_index() >= max_items_shown - 1) {
+            text_date.set_style(&Styles::red);
+            text_date.set("Too many files!");
+        } else {
+            text_date.set_style(&Styles::grey);
+            if (selected_is_valid())
+                text_date.set((is_directory(get_selected_full_path())? "Created " : "Modified ") + to_string_FAT_timestamp(file_created_date(get_selected_full_path())));
+            else
+                text_date.set("");
+        }
     };
 
     refresh_list();

--- a/firmware/application/apps/ui_fileman.hpp
+++ b/firmware/application/apps/ui_fileman.hpp
@@ -115,11 +115,6 @@ class FileManBaseView : public View {
         {0, 2 * 8, 240, 26 * 8},
         true};
 
-    // HACK: for item count limit.
-    Text text_info{
-        {1 * 8, 35 * 8, 15 * 8, 16},
-        ""};
-
     Button button_exit{
         {22 * 8, 34 * 8, 8 * 8, 32},
         "Exit"};
@@ -218,11 +213,8 @@ class FileManagerView : public FileManBaseView {
     // True if the selected entry is a real file item.
     bool selected_is_valid() const;
 
-    Labels labels{
-        {{0, 26 * 8}, "Created ", Color::light_grey()}};
-
     Text text_date{
-        {8 * 8, 26 * 8, 19 * 8, 16},
+        {0 * 8, 26 * 8, 28 * 8, 16},
         ""};
 
     NewButton button_rename{

--- a/firmware/application/file.cpp
+++ b/firmware/application/file.cpp
@@ -579,6 +579,17 @@ bool is_empty_directory(const path& file_path) {
     return !((result == FR_OK) && (filinfo.fname[0] != (TCHAR)'\0'));
 }
 
+int file_count(const path& directory) {
+    int count{0};
+
+    for (auto& entry : std::filesystem::directory_iterator(directory, (const TCHAR*)u"*")) {
+        (void)entry;  // avoid unused warning
+        ++count;
+    }
+
+    return count;
+}
+
 space_info space(const path& p) {
     DWORD free_clusters{0};
     FATFS* fs;

--- a/firmware/application/file.hpp
+++ b/firmware/application/file.hpp
@@ -250,6 +250,8 @@ bool file_exists(const path& file_path);
 bool is_directory(const path& file_path);
 bool is_empty_directory(const path& file_path);
 
+int file_count(const path& dir_path);
+
 space_info space(const path& p);
 
 } /* namespace filesystem */


### PR DESCRIPTION
Per issue #1366:

1)  File manager now displays file count in each directory.

2)  "Too many files!" message appears in red, in place of the date, when >100 files and the last file is highlighted.  (Instead of appearing underneath the Notepad & Rename buttons)

3)  For files, the word "Modified" is displayed in place of "Created" ("Created" is still used when a directory is selected).

4)  "Created/Modified" word is displayed at the same time as the file date/time, so there's no weird case where the word "Created" is displayed without the date/time, or case where date/time is displayed alone.

Example screen-shots below:
![SCR_0009](https://github.com/eried/portapack-mayhem/assets/129641948/601def87-a206-48c1-8f55-cfe4c88cddb3)
![too-many-files](https://github.com/eried/portapack-mayhem/assets/129641948/f6c4afe6-2654-4e61-819d-8fa288869253)

