### PR TITLE
First pass at custom app-settings support

### DIFF
--- a/firmware/application/app_settings.cpp
+++ b/firmware/application/app_settings.cpp
@@ -21,8 +21,6 @@
  * Boston, MA 02110-1301, USA.
  */
 
-#include "debug.hpp"
-
 #include "app_settings.hpp"
 
 #include "convert.hpp"
@@ -48,7 +46,7 @@ fs::path get_settings_path(const std::string& app_name) {
 
 std::string Setting::to_string() const {
     auto result = std::string{name_} + "=";
-    
+
     if (std::holds_alternative<uint32_t>(value_))
         result += to_string_dec_uint(as_uint());
     else if (std::holds_alternative<std::string>(value_))
@@ -64,8 +62,7 @@ void Setting::parse(std::string_view value) {
         uint32_t parsed = 0;
         parse_int(value, parsed);
         value_ = parsed;
-    }
-    else if (std::holds_alternative<std::string>(value_))
+    } else if (std::holds_alternative<std::string>(value_))
         value_ = std::string{value};
     else if (std::holds_alternative<bool>(value_)) {
         uint8_t parsed = 0;
@@ -92,8 +89,8 @@ Setting* Settings::operator[](std::string_view name) {
     return it != settings_.end() ? &*it : nullptr;
 }
 
-SettingsStore::SettingsStore(std::string_view store_name, Settings settings)
-    : store_name_{store_name}, settings_{std::move(settings)} {
+SettingsStore::SettingsStore(std::string_view store_name, Settings& settings)
+    : store_name_{store_name}, settings_{settings} {
     load_settings(store_name_, settings_);
 }
 
@@ -111,7 +108,7 @@ bool load_settings(std::string_view store_name, Settings& settings) {
 
     auto reader = FileLineReader(f);
     for (const auto& line : reader) {
-        auto cols = split_string(trim(line), '=');
+        auto cols = split_string(line, '=');
 
         if (cols.size() != 2)
             continue;

--- a/firmware/application/app_settings.hpp
+++ b/firmware/application/app_settings.hpp
@@ -86,16 +86,16 @@ class Settings {
 /* RAII wrapper for Settings that loads/saves to the SD card. */
 class SettingsStore {
    public:
-    SettingsStore(std::string_view store_name, Settings settings);
+    SettingsStore(std::string_view store_name, Settings& settings);
     ~SettingsStore();
 
    private:
     std::string_view store_name_;
-    Settings settings_;
+    Settings& settings_;
 };
 
-bool save_settings(std::string_view store_name, const Settings& settings);
 bool load_settings(std::string_view store_name, Settings& settings);
+bool save_settings(std::string_view store_name, const Settings& settings);
 
 namespace app_settings {
 

--- a/firmware/application/apps/pocsag_app.cpp
+++ b/firmware/application/apps/pocsag_app.cpp
@@ -71,7 +71,7 @@ POCSAGAppView::POCSAGAppView(NavigationView& nav)
     if (!settings_.loaded())
         field_frequency.set_value(initial_target_frequency);
 
-    check_log.set_value(ui_settings_[enable_logging]->as_bool());
+    check_log.set_value(enable_logging);
 
     receiver_model.enable();
 
@@ -102,7 +102,7 @@ POCSAGAppView::~POCSAGAppView() {
 
     // Save settings.
     persistent_memory::set_pocsag_ignore_address(sym_ignore.value_dec_u32());
-    ui_settings_[enable_logging]->set(check_log.value());
+    enable_logging = check_log.value();
 
     receiver_model.disable();
     baseband::shutdown();

--- a/firmware/application/apps/pocsag_app.cpp
+++ b/firmware/application/apps/pocsag_app.cpp
@@ -71,7 +71,7 @@ POCSAGAppView::POCSAGAppView(NavigationView& nav)
     if (!settings_.loaded())
         field_frequency.set_value(initial_target_frequency);
 
-    check_log.set_value(ui_settings_[setting_logging]->as_bool());
+    check_log.set_value(ui_settings_[enable_logging]->as_bool());
 
     receiver_model.enable();
 
@@ -102,7 +102,7 @@ POCSAGAppView::~POCSAGAppView() {
 
     // Save settings.
     persistent_memory::set_pocsag_ignore_address(sym_ignore.value_dec_u32());
-    ui_settings_[setting_logging]->set(check_log.value());
+    ui_settings_[enable_logging]->set(check_log.value());
 
     receiver_model.disable();
     baseband::shutdown();

--- a/firmware/application/apps/pocsag_app.cpp
+++ b/firmware/application/apps/pocsag_app.cpp
@@ -71,7 +71,7 @@ POCSAGAppView::POCSAGAppView(NavigationView& nav)
     if (!settings_.loaded())
         field_frequency.set_value(initial_target_frequency);
 
-    check_log.set_value(logging_);
+    check_log.set_value(ui_settings_[setting_logging]->as_bool());
 
     receiver_model.enable();
 
@@ -102,7 +102,7 @@ POCSAGAppView::~POCSAGAppView() {
 
     // Save settings.
     persistent_memory::set_pocsag_ignore_address(sym_ignore.value_dec_u32());
-    logging_ = check_log.value();
+    ui_settings_[setting_logging]->set(check_log.value());
 
     receiver_model.disable();
     baseband::shutdown();

--- a/firmware/application/apps/pocsag_app.cpp
+++ b/firmware/application/apps/pocsag_app.cpp
@@ -71,6 +71,8 @@ POCSAGAppView::POCSAGAppView(NavigationView& nav)
     if (!settings_.loaded())
         field_frequency.set_value(initial_target_frequency);
 
+    check_log.set_value(logging_);
+
     receiver_model.enable();
 
     // TODO: app setting instead?
@@ -88,7 +90,6 @@ POCSAGAppView::POCSAGAppView(NavigationView& nav)
         logger->append(LOG_ROOT_DIR "/POCSAG.TXT");
 
     audio::output::start();
-
     baseband::set_pocsag();
 }
 
@@ -99,8 +100,9 @@ void POCSAGAppView::focus() {
 POCSAGAppView::~POCSAGAppView() {
     audio::output::stop();
 
-    // Save ignored address
+    // Save settings.
     persistent_memory::set_pocsag_ignore_address(sym_ignore.value_dec_u32());
+    logging_ = check_log.value();
 
     receiver_model.disable();
     baseband::shutdown();

--- a/firmware/application/apps/pocsag_app.hpp
+++ b/firmware/application/apps/pocsag_app.hpp
@@ -62,14 +62,17 @@ class POCSAGAppView : public View {
     bool logging() const { return check_log.value(); };
     bool ignore() const { return check_ignore.value(); };
 
-    bool logging_{false};  // For app settings.
-
     NavigationView& nav_;
     RxRadioState radio_state_{};
     app_settings::SettingsManager settings_{
         "rx_pocsag",
-        app_settings::Mode::RX,
-        {{"logging=", &logging_}}};
+        app_settings::Mode::RX};
+
+    static constexpr std::string_view setting_logging = "enable_logging";
+    Settings ui_settings_{
+        {{ setting_logging, false }}
+    };
+    SettingsStore settings_store_{"rx_pocsag_ui", ui_settings_};
 
     uint32_t last_address = 0xFFFFFFFF;
     pocsag::POCSAGState pocsag_state{};

--- a/firmware/application/apps/pocsag_app.hpp
+++ b/firmware/application/apps/pocsag_app.hpp
@@ -62,10 +62,14 @@ class POCSAGAppView : public View {
     bool logging() const { return check_log.value(); };
     bool ignore() const { return check_ignore.value(); };
 
+    bool logging_{false};  // For app settings.
+
     NavigationView& nav_;
     RxRadioState radio_state_{};
     app_settings::SettingsManager settings_{
-        "rx_pocsag", app_settings::Mode::RX};
+        "rx_pocsag",
+        app_settings::Mode::RX,
+        {{"logging=", &logging_}}};
 
     uint32_t last_address = 0xFFFFFFFF;
     pocsag::POCSAGState pocsag_state{};

--- a/firmware/application/apps/pocsag_app.hpp
+++ b/firmware/application/apps/pocsag_app.hpp
@@ -68,10 +68,8 @@ class POCSAGAppView : public View {
         "rx_pocsag",
         app_settings::Mode::RX};
 
-    static constexpr std::string_view setting_logging = "enable_logging";
-    Settings ui_settings_{
-        {{ setting_logging, false }}
-    };
+    static constexpr std::string_view enable_logging = "enable_logging";
+    Settings ui_settings_{{{enable_logging, false}}};
     SettingsStore settings_store_{"rx_pocsag_ui", ui_settings_};
 
     uint32_t last_address = 0xFFFFFFFF;

--- a/firmware/application/apps/pocsag_app.hpp
+++ b/firmware/application/apps/pocsag_app.hpp
@@ -68,9 +68,11 @@ class POCSAGAppView : public View {
         "rx_pocsag",
         app_settings::Mode::RX};
 
-    static constexpr std::string_view enable_logging = "enable_logging";
-    Settings ui_settings_{{{enable_logging, false}}};
-    SettingsStore settings_store_{"rx_pocsag_ui", ui_settings_};
+    // Settings
+    bool enable_logging = false;
+    SettingsStore settings_store_{
+        "rx_pocsag_ui",
+        {{"enable_logging", &enable_logging}}};
 
     uint32_t last_address = 0xFFFFFFFF;
     pocsag::POCSAGState pocsag_state{};

--- a/firmware/application/apps/ui_text_editor.cpp
+++ b/firmware/application/apps/ui_text_editor.cpp
@@ -360,6 +360,8 @@ TextEditorView::TextEditorView(NavigationView& nav)
             &text_size,
         });
 
+    viewer.set_font_zoom(ui_settings_[enable_zoom]->as_bool());
+
     viewer.on_select = [this]() {
         // Treat as if menu button was pressed.
         if (button_menu.on_select)
@@ -382,7 +384,8 @@ TextEditorView::TextEditorView(NavigationView& nav)
     };
 
     menu.on_zoom() = [this]() {
-        viewer.toggle_font_zoom();
+        auto zoomed = viewer.toggle_font_zoom();
+        ui_settings_[enable_zoom]->set(zoomed);
         refresh_ui();
         hide_menu(true);
     };

--- a/firmware/application/apps/ui_text_editor.cpp
+++ b/firmware/application/apps/ui_text_editor.cpp
@@ -360,7 +360,7 @@ TextEditorView::TextEditorView(NavigationView& nav)
             &text_size,
         });
 
-    viewer.set_font_zoom(ui_settings_[enable_zoom]->as_bool());
+    viewer.set_font_zoom(enable_zoom);
 
     viewer.on_select = [this]() {
         // Treat as if menu button was pressed.
@@ -384,8 +384,7 @@ TextEditorView::TextEditorView(NavigationView& nav)
     };
 
     menu.on_zoom() = [this]() {
-        auto zoomed = viewer.toggle_font_zoom();
-        ui_settings_[enable_zoom]->set(zoomed);
+        enable_zoom = viewer.toggle_font_zoom();
         refresh_ui();
         hide_menu(true);
     };

--- a/firmware/application/apps/ui_text_editor.hpp
+++ b/firmware/application/apps/ui_text_editor.hpp
@@ -224,9 +224,11 @@ class TextEditorView : public View {
     void on_show() override;
 
    private:
-    static constexpr std::string_view enable_zoom = "enable_zoom";
-    Settings ui_settings_{{{enable_zoom, false}}};
-    SettingsStore settings_store_{"notepad", ui_settings_};
+    // Settings
+    bool enable_zoom = false;
+    SettingsStore settings_store_{
+        "notepad",
+        {{"enable_zoom", &enable_zoom}}};
 
     static constexpr size_t max_edit_length = 1024;
     std::string edit_line_buffer_{};

--- a/firmware/application/apps/ui_text_editor.hpp
+++ b/firmware/application/apps/ui_text_editor.hpp
@@ -32,6 +32,7 @@
 #include "ui_styles.hpp"
 #include "ui_widget.hpp"
 
+#include "app_settings.hpp"
 #include "file_wrapper.hpp"
 #include "optional.hpp"
 
@@ -80,7 +81,10 @@ class TextViewer : public Widget {
 
     const Style& style() { return *font_style; }
     void set_font_zoom(bool zoom);
-    void toggle_font_zoom() { set_font_zoom(!font_zoom); };
+    bool toggle_font_zoom() {
+        set_font_zoom(!font_zoom);
+        return font_zoom;
+    };
 
    private:
     bool font_zoom{};
@@ -220,6 +224,10 @@ class TextEditorView : public View {
     void on_show() override;
 
    private:
+    static constexpr std::string_view enable_zoom = "enable_zoom";
+    Settings ui_settings_{{{enable_zoom, false}}};
+    SettingsStore settings_store_{"notepad", ui_settings_};
+
     static constexpr size_t max_edit_length = 1024;
     std::string edit_line_buffer_{};
 

--- a/firmware/application/freqman_db.cpp
+++ b/firmware/application/freqman_db.cpp
@@ -268,18 +268,18 @@ std::string to_freqman_string(const freqman_entry& entry) {
 
     switch (entry.type) {
         case freqman_type::Single:
-            append_field("f", to_string_dec_uint64(entry.frequency_a));
+            append_field("f", to_string_dec_uint(entry.frequency_a));
             break;
         case freqman_type::Range:
-            append_field("a", to_string_dec_uint64(entry.frequency_a));
-            append_field("b", to_string_dec_uint64(entry.frequency_b));
+            append_field("a", to_string_dec_uint(entry.frequency_a));
+            append_field("b", to_string_dec_uint(entry.frequency_b));
 
             if (is_valid(entry.step))
                 append_field("s", freqman_entry_get_step_string_short(entry.step));
             break;
         case freqman_type::HamRadio:
-            append_field("r", to_string_dec_uint64(entry.frequency_a));
-            append_field("t", to_string_dec_uint64(entry.frequency_b));
+            append_field("r", to_string_dec_uint(entry.frequency_a));
+            append_field("t", to_string_dec_uint(entry.frequency_b));
 
             if (is_valid(entry.tone))
                 append_field("c", tonekey::tone_key_value_string(entry.tone));

--- a/firmware/application/string_format.cpp
+++ b/firmware/application/string_format.cpp
@@ -59,30 +59,37 @@ static char* to_string_dec_uint_pad_internal(
     return q;
 }
 
-template <typename Int>
-char* to_string_dec_uint_internal(Int n, StringFormatBuffer& buffer, size_t& length) {
+static char* to_string_dec_uint_internal(uint64_t n, StringFormatBuffer& buffer, size_t& length) {
     auto end = &buffer.back();
     auto start = to_string_dec_uint_internal(end, n);
     length = end - start;
     return start;
 }
 
-char* to_string_dec_uint(uint32_t n, StringFormatBuffer& buffer, size_t& length) {
+char* to_string_dec_uint(uint64_t n, StringFormatBuffer& buffer, size_t& length) {
     return to_string_dec_uint_internal(n, buffer, length);
 }
 
-char* to_string_dec_uint64(uint64_t n, StringFormatBuffer& buffer, size_t& length) {
-    return to_string_dec_uint_internal(n, buffer, length);
+char* to_string_dec_int(int64_t n, StringFormatBuffer& buffer, size_t& length) {
+    bool negative = n < 0;
+    auto start = to_string_dec_uint(negative ? -n : n, buffer, length);
+
+    if (negative) {
+        *(--start) = '-';
+        ++length;
+    }
+
+    return start;
 }
 
-std::string to_string_dec_uint(uint32_t n) {
+std::string to_string_dec_int(int64_t n) {
     StringFormatBuffer b{};
     size_t len{};
-    char* str = to_string_dec_uint(n, b, len);
+    char* str = to_string_dec_int(n, b, len);
     return std::string(str, len);
 }
 
-std::string to_string_dec_uint64(uint64_t n) {
+std::string to_string_dec_uint(uint64_t n) {
     StringFormatBuffer b{};
     size_t len{};
     char* str = to_string_dec_uint(n, b, len);
@@ -194,14 +201,14 @@ std::string to_string_rounded_freq(const uint64_t f, int8_t precision) {
     };
 
     if (precision < 1) {
-        final_str = to_string_dec_uint64(f / 1000000);
+        final_str = to_string_dec_uint(f / 1000000);
     } else {
         if (precision > 6)
             precision = 6;
 
         uint32_t divisor = pow10[6 - precision];
 
-        final_str = to_string_dec_uint64(f / 1000000) + "." + to_string_dec_int(((f + (divisor / 2)) / divisor) % pow10[precision], precision, '0');
+        final_str = to_string_dec_uint(f / 1000000) + "." + to_string_dec_int(((f + (divisor / 2)) / divisor) % pow10[precision], precision, '0');
     }
     return final_str;
 }

--- a/firmware/application/string_format.hpp
+++ b/firmware/application/string_format.hpp
@@ -43,17 +43,17 @@ const char unit_prefix[7]{'n', 'u', 'm', 0, 'k', 'M', 'G'};
 
 using StringFormatBuffer = std::array<char, 24>;
 
-/* uint conversion without memory allocations. */
-char* to_string_dec_uint(uint32_t n, StringFormatBuffer& buffer, size_t& length);
-char* to_string_dec_uint64(uint64_t n, StringFormatBuffer& buffer, size_t& length);
+/* Integer conversion without memory allocations. */
+char* to_string_dec_int(int64_t n, StringFormatBuffer& buffer, size_t& length);
+char* to_string_dec_uint(uint64_t n, StringFormatBuffer& buffer, size_t& length);
 
-std::string to_string_dec_uint(uint32_t n);
-std::string to_string_dec_uint64(uint64_t n);
+std::string to_string_dec_int(int64_t n);
+std::string to_string_dec_uint(uint64_t n);
 
 // TODO: Allow l=0 to not fill/justify? Already using this way in ui_spectrum.hpp...
 std::string to_string_bin(const uint32_t n, const uint8_t l = 0);
 std::string to_string_dec_uint(const uint32_t n, const int32_t l, const char fill = ' ');
-std::string to_string_dec_int(const int32_t n, const int32_t l = 0, const char fill = 0);
+std::string to_string_dec_int(const int32_t n, const int32_t l, const char fill = 0);
 std::string to_string_decimal(float decimal, int8_t precision);
 
 std::string to_string_hex(const uint64_t n, const int32_t l = 0);

--- a/firmware/test/application/test_convert.cpp
+++ b/firmware/test/application/test_convert.cpp
@@ -99,4 +99,10 @@ TEST_CASE("It should convert 8-bit.") {
     CHECK_EQ(val, 123);
 }
 
+TEST_CASE("It should convert negative.") {
+    int8_t val = 0;
+    REQUIRE(parse_int("-64", val));
+    CHECK_EQ(val, -64);
+}
+
 TEST_SUITE_END();

--- a/firmware/test/application/test_string_format.cpp
+++ b/firmware/test/application/test_string_format.cpp
@@ -24,12 +24,27 @@
 
 /* TODO: Tests for all string_format functions. */
 
-TEST_CASE("to_string_dec_uint64 returns correct value.") {
-    CHECK_EQ(to_string_dec_uint64(0), "0");
-    CHECK_EQ(to_string_dec_uint64(1), "1");
-    CHECK_EQ(to_string_dec_uint64(1'000'000), "1000000");
-    CHECK_EQ(to_string_dec_uint64(1'234'567'890), "1234567890");
-    CHECK_EQ(to_string_dec_uint64(1'234'567'891), "1234567891");
+TEST_CASE("to_string_dec_int returns correct value.") {
+    CHECK_EQ(to_string_dec_int(0), "0");
+    CHECK_EQ(to_string_dec_int(1), "1");
+    CHECK_EQ(to_string_dec_int(-1), "-1");
+    CHECK_EQ(to_string_dec_int(1'000'000), "1000000");
+    CHECK_EQ(to_string_dec_int(-1'000'000), "-1000000");
+    CHECK_EQ(to_string_dec_int(1'234'567'890), "1234567890");
+    CHECK_EQ(to_string_dec_int(-1'234'567'890), "-1234567890");
+    CHECK_EQ(to_string_dec_int(1'234'567'891), "1234567891");
+    CHECK_EQ(to_string_dec_int(-1'234'567'891), "-1234567891");
+    CHECK_EQ(to_string_dec_int(9'876'543'210), "9876543210");
+    CHECK_EQ(to_string_dec_int(-9'876'543'210), "-9876543210");
+}
+
+TEST_CASE("to_string_dec_uint returns correct value.") {
+    CHECK_EQ(to_string_dec_uint(0), "0");
+    CHECK_EQ(to_string_dec_uint(1), "1");
+    CHECK_EQ(to_string_dec_uint(1'000'000), "1000000");
+    CHECK_EQ(to_string_dec_uint(1'234'567'890), "1234567890");
+    CHECK_EQ(to_string_dec_uint(1'234'567'891), "1234567891");
+    CHECK_EQ(to_string_dec_uint(9'876'543'210), "9876543210");
 }
 
 TEST_CASE("to_string_freq returns correct value.") {


### PR DESCRIPTION
This is the first pass at making a more generic app settings library that is persisted to the SD card.
Currently the old app settings (radio only) and the new app settings are separate.
In the next PR, I will refactor all of the old style settings to use the new code which will reduce the overall code size.
The next PR will also bring back the capability of having all the settings for a single app in the same file -- which may be desirable. 

The final PR reverts back to my original design which "binds" setting variables to the settings file.
This makes it much cleaner to use the settings values in the app code and saves RAM (compared with the variant approach).
This iteration of the PR supports Int64, Int32, Uint32, Uint8, String, and Bool settings. The reason to support more types directly, is so that client apps can have more control over the size of their setting members. Also, since this deals with pointers, we have to ensure some type safety so reads and writes through the pointer don't corrupt memory.

Also in this PR:
- POCSAG RX -- "enable logging" setting is persisted.
- Notepad -- "zoom level" setting is persisted.
- Consolidated to_string functions for int and uint and added some unit tests