### PR TITLE
Finalise all low bit rate Capture App with x64

### DIFF
--- a/firmware/application/freqman_db.cpp
+++ b/firmware/application/freqman_db.cpp
@@ -76,7 +76,7 @@ options_t freqman_bandwidths[4] = {
         // SPEC -- TODO: these should be indexes.
         {"12k5", 12500},
         {"16k", 16000},
-        {"25k", 25000},
+        {"32k", 32000},
         {"50k", 50000},
         {"75k", 75000},
         {"100k", 100000},

--- a/firmware/application/freqman_db.cpp
+++ b/firmware/application/freqman_db.cpp
@@ -76,6 +76,7 @@ options_t freqman_bandwidths[4] = {
         // SPEC -- TODO: these should be indexes.
         {"12k5", 12500},
         {"16k", 16000},
+        {"25k", 25000},
         {"32k", 32000},
         {"50k", 50000},
         {"75k", 75000},

--- a/firmware/application/ui_record_view.cpp
+++ b/firmware/application/ui_record_view.cpp
@@ -113,8 +113,7 @@ uint32_t RecordView::set_sampling_rate(uint32_t new_sampling_rate) {
      * They are ok as recorded spectrum indication, but they should not be used by Replay app. (the voice speed will be accelerated)
 
      * We keep original black background in all the correct IQ .C16 files BW's Options. */
-    if ((actual_sampling_rate > 8'000'000) || ((actual_sampling_rate <= 1'600'000) && (oversample_rate > OversampleRate::x8))) {  // yellow REC button means not ok for REC, BW >1Mhz , BW <= 100khz due to NG aliasing.
-        // to be updated or removed in the next PR's, according the achieved extended BW's with good quality bandwith REC limits .
+    if (actual_sampling_rate > 8'000'000) {  // yellow REC button means not ok for REC, BW >1Mhz  (BW from 12k5 till 1Mhz OK for REC and Replay)
         button_record.set_background(ui::Color::yellow());
     } else {
         button_record.set_background(ui::Color::black());
@@ -145,11 +144,11 @@ OversampleRate RecordView::get_oversample_rate(uint32_t sample_rate) {
 
     auto rate = ::get_oversample_rate(sample_rate);
 
-    // Currently proc_capture only supports x8, x16, x32 for decimation.
-    if (rate < OversampleRate::x8)  // clipping while x4 is not implemented yet.
+    // Currently proc_capture only supports /8, /16, /32 for decimation.
+    if (rate < OversampleRate::x8)  // clipping while /4 is not implemented yet  (it will be used >1Mhz onwards when available)
         rate = OversampleRate::x8;
-    else if (rate > OversampleRate::x32)  // clipping while x64 is not implemented yet .
-        rate = OversampleRate::x32;
+    else if (rate > OversampleRate::x64)  // clipping while /128 is not implemented yet , (but it is not necessary for 12k5)
+        rate = OversampleRate::x64;
 
     return rate;
 }

--- a/firmware/baseband/proc_capture.cpp
+++ b/firmware/baseband/proc_capture.cpp
@@ -120,7 +120,11 @@ void CaptureProcessor::sample_rate_config(const SampleRateConfigMessage& message
             break;
 
         case OversampleRate::x32:
-            decim_1_factor = 2 * decim_1_8.decimation_factor;  // /x32 = /4x8 (we applied additional *2 correction to speed up waterfall, no effect to scale spectrum)
+            decim_1_factor = 2 * decim_1_8.decimation_factor;  // /32 = /4x8 (we applied additional *2 correction to speed up waterfall, no effect to scale spectrum)
+            break;
+
+        case OversampleRate::x64:
+            decim_1_factor = 8 * decim_1_8.decimation_factor;  // /64 = /8x8 (we applied additional *8 correction to speed up waterfall, no effect to scale spectrum)
             break;
 
         default:
@@ -167,6 +171,9 @@ buffer_c16_t CaptureProcessor::decim_0_execute(const buffer_c8_t& src, const buf
         case OversampleRate::x32:
             return decim_0_4.execute(src, dst);  // decim_0 , /4 with double decim stage
 
+        case OversampleRate::x64:
+            return decim_0_8.execute(src, dst);  // decim_0 , /8 with double decim stage
+
         default:
             chDbgPanic("Unhandled OversampleRate");
             return {};
@@ -183,10 +190,13 @@ buffer_c16_t CaptureProcessor::decim_1_execute(const buffer_c16_t& src, const bu
             }
 
         case OversampleRate::x16:
-            return decim_1_2.execute(src, dst);  // total decim /16 = /8x2, applied to 150khz
+            return decim_1_2.execute(src, dst);  // total decim /16 = /8x2, applied to 100khz and 150khz
 
         case OversampleRate::x32:
-            return decim_1_8.execute(src, dst);  // total decim /32 = /4x8, appled to <= 100khz , 75k with margin ,(50k, 25k, 12k5 now also)  ...
+            return decim_1_8.execute(src, dst);  // total decim /32 = /4x8, appled to  75k , 50k, 32k
+
+        case OversampleRate::x64:
+            return decim_1_8.execute(src, dst);  // total decim /64 = /8x8, appled to 16k and 12k5
 
         default:
             chDbgPanic("Unhandled OversampleRate");

--- a/firmware/common/oversample.hpp
+++ b/firmware/common/oversample.hpp
@@ -57,7 +57,7 @@
  * The oversample rate is used to increase the sample rate to improve SNR and quality.
  * This is also used as the interpolation rate when replaying captures. */
 inline OversampleRate get_oversample_rate(uint32_t sample_rate) {
-    if (sample_rate < 25'000) return OversampleRate::x64;   // 16k , 12k5.
+    if (sample_rate < 30'000) return OversampleRate::x64;   // 25k, 16k, 12k5.
     if (sample_rate < 80'000) return OversampleRate::x32;   // 75k, 50k, 32k.
     if (sample_rate < 250'000) return OversampleRate::x16;  // 100k and 150k.
 

--- a/firmware/common/oversample.hpp
+++ b/firmware/common/oversample.hpp
@@ -57,10 +57,9 @@
  * The oversample rate is used to increase the sample rate to improve SNR and quality.
  * This is also used as the interpolation rate when replaying captures. */
 inline OversampleRate get_oversample_rate(uint32_t sample_rate) {
-    if (sample_rate < 50'000) return OversampleRate::x128;  // 25k..12k5, prepared for future, OVS ok, but decim. x128 still not implemented.
-    if (sample_rate < 100'000) return OversampleRate::x64;  // 50k, prepared for future, OVS ok, but decim. x64 still not implemented.
-    if (sample_rate < 150'000) return OversampleRate::x32;  // 100k needs x32
-    if (sample_rate < 250'000) return OversampleRate::x16;  // 150k needs x16
+    if (sample_rate < 25'000) return OversampleRate::x64;   // 16k , 12k5.
+    if (sample_rate < 80'000) return OversampleRate::x32;   // 75k, 50k, 32k.
+    if (sample_rate < 250'000) return OversampleRate::x16;  // 100k and 150k.
 
     return OversampleRate::x8;  // 250k .. 1Mhz, that decim x8 , is already applied.(OVerSampling and decim OK)
 }


### PR DESCRIPTION
Hello , in this PR , we activated the x64  and /64 , and we could finalize the pending low bit rate REC in Capture App,below 75khz   (cont. of yesterday PR , #1380. 

So now , thanks to the dynamic oversampling / decimation , we managed to have a correct REC functionality 
for this range  12k5 .... 1Mhz in C16 / C8 format. 

Initially I thought that we will need to go to x128 ,  but finally it is not need it . 

I evaluated now all range , and made fine tuning about the freq, and the needed sample rate...
As you could imagine it is not simple because we should select the best trade off , of many issues , in terms of achieve
* reasonable "moirée effect" or vertical stripes  in the screen - but easy to solve just make fine tuning +-10Hz center freq. , 
* good enough anti-aliasing filters (no background noise),
* good RF image reject   (or at least acceptable ) 
* good M4 usage % balance, in the 1st DFU DEBUG overlay table ,
* good enough ADC sample rate,

It is functional and I tested Capturing and Replay all low bit rates from 250k , 150k, 100k, 75k, 50k, 32k, 16k,12k5 
and it works well , (same time duration as recorded , and good quality reproduction in a receiver, good coherent recorded file size ,  and good display with inspectrum . 

Just  screenshots of the tested AM  , MF  upconverted captured signals  (sorry I missed the 100k picture but also tested) 
![image](https://github.com/eried/portapack-mayhem/assets/86470699/34b10075-e070-4154-8296-88c4bef5e85a)

 Example  recorded BW 16K ,  with 10 sec, and inspected by inspectrum 
![image](https://github.com/eried/portapack-mayhem/assets/86470699/b4b74d4d-4d48-440c-b3a5-369ac53816db)


It is pending to apply what  @NotherNgineer and @kallanreed  suggested yesterday in my previous PR , but we agreed to finalize before  the hole series of oversampling / decimators and its fine tuning ,  before ,( x8, x16, x32, x64.) (done in this PR)


Notes : 
1-In the Replay List app,   if combining many play files , in the low bit rate, sometimes there is a bug in the screen , showing veritcal stripes , but then replaying the same file isolatedly it works well ,
2-) In the Replay sometimes Hackrf is radiating a captured DC spike in 0Hz,  so when re-radiating it , take into account that it could produce a strange tone in the receiver .  (that can be easily avoid it , just recording with higher BW and apply some offset.
