### PR TITLE
Display degree symbol in TPMS, Sonde, and Temperature apps; disabled Font Viewer

### DIFF
--- a/firmware/application/apps/tpms_app.hpp
+++ b/firmware/application/apps/tpms_app.hpp
@@ -147,8 +147,8 @@ class TPMSAppView : public View {
     OptionsField options_temperature{
         {9 * 8, 0 * 16},
         2,
-        {{"\xB0""C", 0},  // 0xB0 is degree ° symbol in our 8x16 font
-         {"\xB0""F", 1}}};
+        {{"\xB0\x43", 0},  // 0xB0 is degree ° symbol in our 8x16 font, 0x43 is "C" (Clang workaround)
+         {"\xB0\x46", 1}}};
 
     RFAmpField field_rf_amp{
         {13 * 8, 0 * 16}};

--- a/firmware/application/apps/tpms_app.hpp
+++ b/firmware/application/apps/tpms_app.hpp
@@ -146,9 +146,9 @@ class TPMSAppView : public View {
 
     OptionsField options_temperature{
         {9 * 8, 0 * 16},
-        1,
-        {{"C", 0},
-         {"F", 1}}};
+        2,
+        {{"\xB0""C", 0},  // 0xB0 is degree ° symbol in our 8x16 font
+         {"\xB0""F", 1}}};
 
     RFAmpField field_rf_amp{
         {13 * 8, 0 * 16}};

--- a/firmware/application/apps/tpms_app.hpp
+++ b/firmware/application/apps/tpms_app.hpp
@@ -147,8 +147,8 @@ class TPMSAppView : public View {
     OptionsField options_temperature{
         {9 * 8, 0 * 16},
         2,
-        {{"\xB0\x43", 0},  // 0xB0 is degree ° symbol in our 8x16 font, 0x43 is "C" (Clang workaround)
-         {"\xB0\x46", 1}}};
+        {{STR_DEGREES_C, 0},
+         {STR_DEGREES_F, 1}}};
 
     RFAmpField field_rf_amp{
         {13 * 8, 0 * 16}};

--- a/firmware/application/apps/ui_debug.cpp
+++ b/firmware/application/apps/ui_debug.cpp
@@ -127,7 +127,7 @@ TemperatureWidget::temperature_t TemperatureWidget::temperature(const sample_t s
 }
 
 std::string TemperatureWidget::temperature_str(const temperature_t temperature) const {
-    return to_string_dec_int(temperature, temp_len - 1) + "C";
+    return to_string_dec_int(temperature, temp_len - 2) + "\xB0""C";  // 0xB0 is degree ° symbol in our 8x16 font
 }
 
 Coord TemperatureWidget::screen_y(
@@ -406,7 +406,7 @@ DebugMenuView::DebugMenuView(NavigationView& nav) {
         {"Touch Test", ui::Color::dark_cyan(), &bitmap_icon_notepad, [&nav]() { nav.push<DebugScreenTest>(); }},
         {"P.Memory", ui::Color::dark_cyan(), &bitmap_icon_memory, [&nav]() { nav.push<DebugPmemView>(); }},
         {"Debug Dump", ui::Color::dark_cyan(), &bitmap_icon_memory, [&nav]() { portapack::persistent_memory::debug_dump(); }},
-        {"Fonts Viewer", ui::Color::dark_cyan(), &bitmap_icon_notepad, [&nav]() { nav.push<DebugFontsView>(); }},
+        //{"Fonts Viewer", ui::Color::dark_cyan(), &bitmap_icon_notepad, [&nav]() { nav.push<DebugFontsView>(); }},  // temporarily disabled to conserve ROM space
     });
     set_max_rows(2);  // allow wider buttons
 }

--- a/firmware/application/apps/ui_debug.cpp
+++ b/firmware/application/apps/ui_debug.cpp
@@ -127,7 +127,7 @@ TemperatureWidget::temperature_t TemperatureWidget::temperature(const sample_t s
 }
 
 std::string TemperatureWidget::temperature_str(const temperature_t temperature) const {
-    return to_string_dec_int(temperature, temp_len - 2) + "\xB0""C";  // 0xB0 is degree ° symbol in our 8x16 font
+    return to_string_dec_int(temperature, temp_len - 2) + "\xB0\x43";  // 0xB0 is degree ° symbol in our 8x16 font, 0x43 is "C" (Clang workaround)
 }
 
 Coord TemperatureWidget::screen_y(

--- a/firmware/application/apps/ui_debug.cpp
+++ b/firmware/application/apps/ui_debug.cpp
@@ -127,7 +127,7 @@ TemperatureWidget::temperature_t TemperatureWidget::temperature(const sample_t s
 }
 
 std::string TemperatureWidget::temperature_str(const temperature_t temperature) const {
-    return to_string_dec_int(temperature, temp_len - 2) + "\xB0\x43";  // 0xB0 is degree ° symbol in our 8x16 font, 0x43 is "C" (Clang workaround)
+    return to_string_dec_int(temperature, temp_len - 2) + STR_DEGREES_C;
 }
 
 Coord TemperatureWidget::screen_y(

--- a/firmware/application/apps/ui_debug.hpp
+++ b/firmware/application/apps/ui_debug.hpp
@@ -105,7 +105,7 @@ class TemperatureWidget : public Widget {
     static constexpr temperature_t display_temp_min = -10;  // Accomodate negative values, present in cold startup cases
     static constexpr temperature_t display_temp_scale = 3;
     static constexpr int bar_width = 1;
-    static constexpr int temp_len = 4;  // Now scale shows up to 4 chars ("-10C")
+    static constexpr int temp_len = 5;  // Now scale shows up to 5 chars ("-10ºC")
 };
 
 class TemperatureView : public View {

--- a/firmware/application/apps/ui_sonde.cpp
+++ b/firmware/application/apps/ui_sonde.cpp
@@ -194,7 +194,7 @@ void SondeView::on_packet(const sonde::Packet& packet) {
 
         if (temp_humid_info.temp != 0) {
             double decimals = abs(get_decimals(temp_humid_info.temp, 10, true));
-            text_temp.set(to_string_dec_int((int)temp_humid_info.temp) + "." + to_string_dec_uint(decimals, 1) + "\xB0" + "C");  // 0xB0 is degree ° symbol in our 8x16 font
+            text_temp.set(to_string_dec_int((int)temp_humid_info.temp) + "." + to_string_dec_uint(decimals, 1) + "\xB0\x43");  // 0xB0 is degree ° symbol in our 8x16 font, 0x43 is "C" (Clang workaround)
         }
 
         gps_info = packet.get_GPS_data();

--- a/firmware/application/apps/ui_sonde.cpp
+++ b/firmware/application/apps/ui_sonde.cpp
@@ -194,7 +194,7 @@ void SondeView::on_packet(const sonde::Packet& packet) {
 
         if (temp_humid_info.temp != 0) {
             double decimals = abs(get_decimals(temp_humid_info.temp, 10, true));
-            text_temp.set(to_string_dec_int((int)temp_humid_info.temp) + "." + to_string_dec_uint(decimals, 1) + "\xB0""C");  // 0xB0 is degree ° symbol in our 8x16 font
+            text_temp.set(to_string_dec_int((int)temp_humid_info.temp) + "." + to_string_dec_uint(decimals, 1) + "\xB0" + "C");  // 0xB0 is degree ° symbol in our 8x16 font
         }
 
         gps_info = packet.get_GPS_data();

--- a/firmware/application/apps/ui_sonde.cpp
+++ b/firmware/application/apps/ui_sonde.cpp
@@ -194,7 +194,7 @@ void SondeView::on_packet(const sonde::Packet& packet) {
 
         if (temp_humid_info.temp != 0) {
             double decimals = abs(get_decimals(temp_humid_info.temp, 10, true));
-            text_temp.set(to_string_dec_int((int)temp_humid_info.temp) + "." + to_string_dec_uint(decimals, 1) + "\xB0\x43");  // 0xB0 is degree ° symbol in our 8x16 font, 0x43 is "C" (Clang workaround)
+            text_temp.set(to_string_dec_int((int)temp_humid_info.temp) + "." + to_string_dec_uint(decimals, 1) + STR_DEGREES_C);
         }
 
         gps_info = packet.get_GPS_data();

--- a/firmware/application/apps/ui_sonde.cpp
+++ b/firmware/application/apps/ui_sonde.cpp
@@ -194,7 +194,7 @@ void SondeView::on_packet(const sonde::Packet& packet) {
 
         if (temp_humid_info.temp != 0) {
             double decimals = abs(get_decimals(temp_humid_info.temp, 10, true));
-            text_temp.set(to_string_dec_int((int)temp_humid_info.temp) + "." + to_string_dec_uint(decimals, 1) + "C");
+            text_temp.set(to_string_dec_int((int)temp_humid_info.temp) + "." + to_string_dec_uint(decimals, 1) + "\xB0""C");  // 0xB0 is degree ° symbol in our 8x16 font
         }
 
         gps_info = packet.get_GPS_data();

--- a/firmware/common/units.hpp
+++ b/firmware/common/units.hpp
@@ -24,6 +24,9 @@
 
 #include <cstdint>
 
+#define STR_DEGREES_C "\xB0\x43"  // ºC - 0xB0 is degree ° symbol in our 8x16 font, 0x43 is "C"
+#define STR_DEGREES_F "\xB0\x46"  // ºF - 0xB0 is degree ° symbol in our 8x16 font, 0x46 is "F"
+
 namespace units {
 
 class Pressure {


### PR DESCRIPTION
1.  Display degrees symbol before the C/F when showing temperature in the TPMS, Sonde, and Debug->Temperature app.

2.  Disabled the Font Viewer app to conserve ROM space (leaving the code in place so a developer can easily enable when needed).

![SCR_0010](https://github.com/eried/portapack-mayhem/assets/129641948/06b3f363-200a-448e-bad8-b941eeceaf83)
