### PR TITLE
Consolidate old and new style app settings

### DIFF
--- a/firmware/application/app_settings.cpp
+++ b/firmware/application/app_settings.cpp
@@ -218,9 +218,6 @@ void copy_from_radio_model(AppSettings& settings) {
 }
 
 /* SettingsManager *************************************************/
-SettingsManager::SettingsManager(std::string_view app_name, Mode mode)
-    : SettingsManager{app_name, mode, {}} {}
-
 SettingsManager::SettingsManager(std::string_view app_name, Mode mode, Options options)
     : SettingsManager{app_name, mode, options, {}} {}
 

--- a/firmware/application/app_settings.hpp
+++ b/firmware/application/app_settings.hpp
@@ -152,8 +152,7 @@ void copy_from_radio_model(AppSettings& settings);
  * the receiver/transmitter models are set before the control ctors run. */
 class SettingsManager {
    public:
-    SettingsManager(std::string_view app_name, Mode mode);
-    SettingsManager(std::string_view app_name, Mode mode, Options options);
+    SettingsManager(std::string_view app_name, Mode mode, Options options = Options::None);
     SettingsManager(std::string_view app_name, Mode mode, SettingBindings additional_settings);
     SettingsManager(std::string_view app_name, Mode mode, Options options, SettingBindings additional_settings);
     ~SettingsManager();

--- a/firmware/application/app_settings.hpp
+++ b/firmware/application/app_settings.hpp
@@ -36,6 +36,9 @@
 #include "max283x.hpp"
 #include "string_format.hpp"
 
+// Bring in the string_view literal.
+using std::literals::operator""sv;
+
 /* Represents a named setting bound to a variable instance. */
 /* Using void* instead of std::variant, because variant is a pain to dispatch over. */
 class BoundSetting {
@@ -101,13 +104,6 @@ bool save_settings(std::string_view store_name, const SettingBindings& bindings)
 
 namespace app_settings {
 
-enum class ResultCode : uint8_t {
-    Ok,                // settings found
-    LoadFailed,        // settings (file) not found
-    SaveFailed,        // unable to save settings
-    SettingsDisabled,  // load/save disabled in settings
-};
-
 enum class Mode : uint8_t {
     RX = 0x01,
     TX = 0x02,
@@ -121,7 +117,6 @@ enum class Options {
     UseGlobalTargetFrequency = 0x0001,
 };
 
-// TODO: separate types for TX/RX or union?
 /* NB: See RX/TX model headers for default values. */
 struct AppSettings {
     Mode mode = Mode::RX;
@@ -146,21 +141,21 @@ struct AppSettings {
     uint8_t volume;
 };
 
-ResultCode load_settings(const std::string& app_name, AppSettings& settings);
-ResultCode save_settings(const std::string& app_name, AppSettings& settings);
-
 /* Copies common values to the receiver/transmitter models. */
 void copy_to_radio_model(const AppSettings& settings);
 
 /* Copies common values from the receiver/transmitter models. */
 void copy_from_radio_model(AppSettings& settings);
 
-/* RAII wrapper for automatically loading and saving settings for an app.
+/* RAII wrapper for automatically loading and saving radio settings for an app.
  * NB: This should be added to a class before any LNA/VGA controls so that
  * the receiver/transmitter models are set before the control ctors run. */
 class SettingsManager {
    public:
-    SettingsManager(std::string app_name, Mode mode, Options options = Options::None);
+    SettingsManager(std::string_view app_name, Mode mode);
+    SettingsManager(std::string_view app_name, Mode mode, Options options);
+    SettingsManager(std::string_view app_name, Mode mode, SettingBindings additional_settings);
+    SettingsManager(std::string_view app_name, Mode mode, Options options, SettingBindings additional_settings);
     ~SettingsManager();
 
     SettingsManager(const SettingsManager&) = delete;
@@ -175,8 +170,9 @@ class SettingsManager {
     AppSettings& raw() { return settings_; }
 
    private:
-    std::string app_name_;
+    std::string_view app_name_;
     AppSettings settings_;
+    SettingBindings bindings_;
     bool loaded_;
 };
 

--- a/firmware/application/apps/pocsag_app.hpp
+++ b/firmware/application/apps/pocsag_app.hpp
@@ -64,15 +64,12 @@ class POCSAGAppView : public View {
 
     NavigationView& nav_;
     RxRadioState radio_state_{};
-    app_settings::SettingsManager settings_{
-        "rx_pocsag",
-        app_settings::Mode::RX};
-
     // Settings
     bool enable_logging = false;
-    SettingsStore settings_store_{
-        "rx_pocsag_ui",
-        {{"enable_logging", &enable_logging}}};
+    app_settings::SettingsManager settings_{
+        "rx_pocsag"sv,
+        app_settings::Mode::RX,
+        {{"enable_logging"sv, &enable_logging}}};
 
     uint32_t last_address = 0xFFFFFFFF;
     pocsag::POCSAGState pocsag_state{};

--- a/firmware/application/apps/ui_text_editor.hpp
+++ b/firmware/application/apps/ui_text_editor.hpp
@@ -227,8 +227,8 @@ class TextEditorView : public View {
     // Settings
     bool enable_zoom = false;
     SettingsStore settings_store_{
-        "notepad",
-        {{"enable_zoom", &enable_zoom}}};
+        "notepad"sv,
+        {{"enable_zoom"sv, &enable_zoom}}};
 
     static constexpr size_t max_edit_length = 1024;
     std::string edit_line_buffer_{};


### PR DESCRIPTION
This moves the existing radio app settings to use the new bound settings code and allows for custom settings to be stored with the radio settings.