### PR TITLE
Disable audio output by default at power-up

### DIFF
--- a/firmware/application/ui_navigation.cpp
+++ b/firmware/application/ui_navigation.cpp
@@ -219,6 +219,7 @@ SystemStatusView::SystemStatusView(
     toggle_mute.set_value(pmem::config_audio_mute());
     toggle_stealth.set_value(pmem::stealth_mode());
 
+    audio::output::stop();
     audio::output::update_audio_mute();
     refresh();
 }


### PR DESCRIPTION
Saves a few milliwatts by disabling audio output until an app enables it.  Issue #1392.