### PR TITLE
Use new settings API in recon and scanner

### DIFF
--- a/firmware/application/app_settings.cpp
+++ b/firmware/application/app_settings.cpp
@@ -58,7 +58,7 @@ void BoundSetting::parse(std::string_view value) {
             parse_int(value, as<uint8_t>());
             break;
         case SettingType::String:
-            as<std::string>() = std::string{value};
+            as<std::string>() = trim(value);
             break;
         case SettingType::Bool: {
             int parsed = 0;

--- a/firmware/application/app_settings.cpp
+++ b/firmware/application/app_settings.cpp
@@ -2,6 +2,7 @@
  * Copyright (C) 2015 Jared Boone, ShareBrained Technology, Inc.
  * Copyright (C) 2016 Furrtek
  * Copyright (C) 2022 Arjan Onwezen
+ * Copyright (C) 2023 Kyle Reed
  *
  * This file is part of PortaPack.
  *

--- a/firmware/application/app_settings.cpp
+++ b/firmware/application/app_settings.cpp
@@ -106,10 +106,18 @@ void BoundSetting::write(File& file) const {
 
 SettingsStore::SettingsStore(std::string_view store_name, SettingBindings bindings)
     : store_name_{store_name}, bindings_{bindings} {
-    load_settings(store_name_, bindings_);
+    reload();
 }
 
 SettingsStore::~SettingsStore() {
+    save();
+}
+
+void SettingsStore::reload() {
+    load_settings(store_name_, bindings_);
+}
+
+void SettingsStore::save() const {
     save_settings(store_name_, bindings_);
 }
 

--- a/firmware/application/app_settings.hpp
+++ b/firmware/application/app_settings.hpp
@@ -94,6 +94,9 @@ class SettingsStore {
     SettingsStore(std::string_view store_name, SettingBindings bindings);
     ~SettingsStore();
 
+    void reload();
+    void save() const;
+
    private:
     std::string_view store_name_;
     SettingBindings bindings_;

--- a/firmware/application/apps/ui_recon.hpp
+++ b/firmware/application/apps/ui_recon.hpp
@@ -68,7 +68,7 @@ class ReconView : public View {
 
     RxRadioState radio_state_{};
     app_settings::SettingsManager settings_{
-        "rx_recon", app_settings::Mode::RX};
+        "rx_recon"sv, app_settings::Mode::RX};
 
     void check_update_ranges_from_current();
     void set_loop_config(bool v);
@@ -90,8 +90,7 @@ class ReconView : public View {
     void handle_retune();
     void handle_coded_squelch(const uint32_t value);
     void handle_remove_current_item();
-    bool recon_load_config_from_sd();
-    bool recon_save_config_to_sd();
+    void load_persisted_settings();
     bool recon_save_freq(const std::filesystem::path& path, size_t index, bool warn_if_exists);
     // placeholder for possible void recon_start_recording();
     void recon_stop_recording();
@@ -163,6 +162,22 @@ class ReconView : public View {
     std::string freq_file_path{};
     systime_t chrono_start{};
     systime_t chrono_end{};
+
+    // Persisted settings.
+    SettingsStore ui_settings{
+        "recon"sv,
+        {
+            {"input_file"sv, &input_file},
+            {"output_file"sv, &output_file},
+            {"lock_duration"sv, &recon_lock_duration},
+            {"lock_nb_match"sv, &recon_lock_nb_match},
+            {"squelch_level"sv, &squelch},
+            {"match_mode"sv, &recon_match_mode},
+            {"match_wait"sv, &wait},
+            {"match_wait"sv, &wait},
+            {"range_min"sv, &frequency_range.min},
+            {"range_max"sv, &frequency_range.max},
+        }};
 
     std::unique_ptr<RecordView> record_view{};
 

--- a/firmware/application/apps/ui_recon.hpp
+++ b/firmware/application/apps/ui_recon.hpp
@@ -174,7 +174,6 @@ class ReconView : public View {
             {"squelch_level"sv, &squelch},
             {"match_mode"sv, &recon_match_mode},
             {"match_wait"sv, &wait},
-            {"match_wait"sv, &wait},
             {"range_min"sv, &frequency_range.min},
             {"range_max"sv, &frequency_range.max},
         }};

--- a/firmware/application/apps/ui_scanner.cpp
+++ b/firmware/application/apps/ui_scanner.cpp
@@ -319,7 +319,6 @@ ScannerView::ScannerView(
     field_step.set_by_value(receiver_model.frequency_step());                     // Default step interval (Hz)
     change_mode((freqman_index_t)field_mode.selected_index_value());
 
-    // FUTURE: perhaps additional settings should be stored in persistent memory vs using defaults
     rf::Frequency stored_freq = receiver_model.target_frequency();
     frequency_range.min = stored_freq - 1000000;
     button_manual_start.set_text(to_string_short_freq(frequency_range.min));
@@ -522,13 +521,17 @@ ScannerView::ScannerView(
 
     // PRE-CONFIGURATION:
     field_browse_wait.on_change = [this](int32_t v) { browse_wait = v; };
-    field_browse_wait.set_value(5);
+    field_browse_wait.set_value(browse_wait);
 
     field_lock_wait.on_change = [this](int32_t v) { lock_wait = v; };
-    field_lock_wait.set_value(2);
+    field_lock_wait.set_value(lock_wait);
 
     field_squelch.on_change = [this](int32_t v) { squelch = v; };
-    field_squelch.set_value(-30);
+    field_squelch.set_value(squelch);
+
+    // Disable squelch on the model because RSSI handler is where the
+    // actual squelching is applied for this app.
+    receiver_model.set_squelch_level(0);
 
     // LOAD FREQUENCIES
     frequency_file_load(default_scan_file);
@@ -726,9 +729,6 @@ void ScannerView::change_mode(freqman_index_t new_mod) {
 
 void ScannerView::start_scan_thread() {
     receiver_model.enable();
-    // Disable squelch on the model because RSSI handler is where the
-    // actual squelching is applied for this app.
-    receiver_model.set_squelch_level(0);
     show_max_index();
 
     // Start Scanner Thread

--- a/firmware/application/apps/ui_scanner.hpp
+++ b/firmware/application/apps/ui_scanner.hpp
@@ -111,8 +111,19 @@ class ScannerView : public View {
 
    private:
     RxRadioState radio_state_{};
+
+    // Settings
+    uint32_t browse_wait{5};
+    uint32_t lock_wait{2};
+    int32_t squelch{-30};
     app_settings::SettingsManager settings_{
-        "rx_scanner", app_settings::Mode::RX};
+        "rx_scanner"sv,
+        app_settings::Mode::RX,
+        {
+            {"browse_wait"sv, &browse_wait},
+            {"lock_wait"sv, &lock_wait},
+            {"scanner_squelch"sv, &squelch},
+        }};
 
     NavigationView& nav_;
 
@@ -132,14 +143,11 @@ class ScannerView : public View {
     std::string loaded_filename() const;
 
     scanner_range_t frequency_range{0, 0};
-    int32_t squelch{0};
     uint32_t browse_timer{0};
     uint32_t lock_timer{0};
     uint32_t color_timer{0};
     int32_t bigdisplay_current_color{-2};
     rf::Frequency bigdisplay_current_frequency{0};
-    uint32_t browse_wait{0};
-    uint32_t lock_wait{0};
 
     std::filesystem::path loaded_path{};
     std::vector<scanner_entry_t> entries{};


### PR DESCRIPTION
Reuse the new app settings API for Recon to remove custom save/load code.
Also saves squelch/wsa/wsl settings for scanner.