### PR TITLE
Default to AK4951 speaker disabled after pmem reset

### DIFF
--- a/firmware/common/portapack_persistent_memory.cpp
+++ b/firmware/common/portapack_persistent_memory.cpp
@@ -364,6 +364,7 @@ void defaults() {
     set_config_backlight_timer(backlight_config_t{});
     set_config_splash(true);
     set_encoder_dial_sensitivity(DIAL_SENSITIVITY_NORMAL);
+    set_config_speaker_disable(true);  // Disable AK4951 speaker by default (in case of OpenSourceSDRLab H2)
 
     // Default values for recon app.
     set_recon_autosave_freqs(false);


### PR DESCRIPTION
Default AK4951 speaker control icon to disabled when persistent memory is reset, specifically for the OpenSourceSDRLab H2 which overheats when the AK4951 speaker output is enabled (this board uses a separate 3W amplifier chip so doesn't use the AK4951 speaker amp).  See issue #1390 