### PR TITLE
Looking Glass - persist range/preset settings, UI tweaks

### DIFF
--- a/firmware/application/apps/ui_looking_glass_app.cpp
+++ b/firmware/application/apps/ui_looking_glass_app.cpp
@@ -93,7 +93,7 @@ void GlassView::reset_live_view(bool clear_screen) {
     if (clear_screen) {
         // only clear screen in peak mode
         if (live_frequency_view == 2) {
-            display.fill_rectangle({{0, 108 + 16}, {SCREEN_W, 320 - (108 + 16)}}, {0, 0, 0});
+            display.fill_rectangle({{0, 108 + 16}, {SCREEN_W, SCREEN_H - (108 + 16)}}, {0, 0, 0});
         }
     }
 }
@@ -126,9 +126,9 @@ void GlassView::add_spectrum_pixel(uint8_t power) {
                 uint8_t color_gradient = (point * 255) / 212;
                 // clear if not in peak view
                 if (live_frequency_view != 2) {
-                    display.fill_rectangle({{xpos, 108 + 16}, {1, 320 - point}}, {0, 0, 0});
+                    display.fill_rectangle({{xpos, 108 + 16}, {1, SCREEN_H - point}}, {0, 0, 0});
                 }
-                display.fill_rectangle({{xpos, 320 - point}, {1, point}}, {color_gradient, 0, uint8_t(255 - color_gradient)});
+                display.fill_rectangle({{xpos, SCREEN_H - point}, {1, point}}, {color_gradient, 0, uint8_t(255 - color_gradient)});
             }
             if (last_max_freq != max_freq_hold) {
                 last_max_freq = max_freq_hold;
@@ -223,8 +223,7 @@ void GlassView::on_range_changed() {
         looking_glass_sampling_rate = looking_glass_bandwidth;
         each_bin_size = looking_glass_bandwidth / SCREEN_W;
         looking_glass_step = looking_glass_bandwidth;
-        f_center_ini = f_min + (looking_glass_bandwidth / 2);                            // Initial center frequency for sweep
-        portapack::display.fill_rectangle({17 * 8, 4 * 16, 2 * 8, 16}, Color::black());  // Clear old marker and whole marker rectangle btw
+        f_center_ini = f_min + (looking_glass_bandwidth / 2);  // Initial center frequency for sweep
     } else {
         // view is made in multiple pass, use original bin picking
         mode = scan_type.selected_index_value();

--- a/firmware/application/apps/ui_looking_glass_app.hpp
+++ b/firmware/application/apps/ui_looking_glass_app.hpp
@@ -73,8 +73,8 @@ class GlassView : public View {
     NavigationView& nav_;
     RxRadioState radio_state_{ReceiverModel::Mode::SpectrumAnalysis};
     // Settings
-    rf::Frequency f_min = 0;
-    rf::Frequency f_max = 0;
+    rf::Frequency f_min = 260 * MHZ_DIV;  // Default to 315/433 remote range.
+    rf::Frequency f_max = 500 * MHZ_DIV;
     uint8_t preset_index = 0;
     app_settings::SettingsManager settings_{
         "rx_glass"sv,
@@ -92,8 +92,9 @@ class GlassView : public View {
     };
 
     std::vector<preset_entry> presets_db{};
-    void clip_min(int32_t v, bool trigger_update = true);
-    void clip_max(int32_t v, bool trigger_update = true);
+    void update_min(int32_t v);
+    void update_max(int32_t v);
+    void update_range_field();
     void get_max_power(const ChannelSpectrum& spectrum, uint8_t bin, uint8_t& max_power);
     rf::Frequency get_freq_from_bin_pos(uint8_t pos);
     void on_marker_change();
@@ -119,7 +120,7 @@ class GlassView : public View {
     rf::Frequency marker_pixel_step{0};
     // size of one spectrum bin in Hz
     rf::Frequency each_bin_size{0};
-    // consumed number of Hz, used to know if we have filled a 'bag' , a corresponding pixel length on screen
+    // consumed number of Hz, used to know if we have filled a 'bag', a corresponding pixel length on screen
     rf::Frequency bins_Hz_size{0};
     rf::Frequency looking_glass_sampling_rate{0};
     rf::Frequency looking_glass_bandwidth{0};
@@ -147,10 +148,10 @@ class GlassView : public View {
     uint8_t ignore_dc = 0;
 
     Labels labels{
-        {{0, 0}, "MIN:     MAX:     LNA   VGA  ", Color::light_grey()},
+        {{0, 0 * 16}, "MIN:     MAX:     LNA   VGA  ", Color::light_grey()},
         {{0, 1 * 16}, "RANGE:       FILTER:     AMP:", Color::light_grey()},
         {{0, 2 * 16}, "PRESET:", Color::light_grey()},
-        {{0, 3 * 16}, "MARKER:            MHz", Color::light_grey()},
+        {{0, 3 * 16}, "MARKER:          MHz", Color::light_grey()},
         {{0, 4 * 16}, "RES:    STEP:", Color::light_grey()}};
 
     NumberField field_frequency_min{
@@ -173,8 +174,8 @@ class GlassView : public View {
     VGAGainField field_vga{
         {27 * 8, 0 * 16}};
 
-    Button button_range{
-        {7 * 8, 1 * 16, 4 * 8, 16},
+    TextField field_range{
+        {6 * 8, 1 * 16, 6 * 8, 16},
         ""};
 
     OptionsField filter_config{
@@ -192,13 +193,11 @@ class GlassView : public View {
     OptionsField range_presets{
         {7 * 8, 2 * 16},
         20,
-        {
-            {" NONE (WIFI 2.4GHz)", 0},
-        }};
+        {}};
 
-    ButtonWithEncoder button_marker{
-        {7 * 8, 3 * 16, 10 * 8, 16},
-        " "};
+    TextField field_marker{
+        {7 * 8, 3 * 16, 9 * 8, 16},
+        ""};
 
     NumberField field_trigger{
         {4 * 8, 4 * 16},

--- a/firmware/common/ui_widget.cpp
+++ b/firmware/common/ui_widget.cpp
@@ -1764,6 +1764,15 @@ bool TextField::on_key(KeyEvent key) {
     return false;
 }
 
+bool TextField::on_encoder(EncoderEvent delta) {
+    if (on_encoder_change) {
+        on_encoder_change(*this, delta);
+        return true;
+    }
+
+    return false;
+}
+
 /* NumberField ***********************************************************/
 
 NumberField::NumberField(

--- a/firmware/common/ui_widget.hpp
+++ b/firmware/common/ui_widget.hpp
@@ -694,6 +694,7 @@ class TextField : public Text {
    public:
     std::function<void(TextField&)> on_select{};
     std::function<void(TextField&)> on_change{};
+    std::function<void(TextField&, EncoderEvent)> on_encoder_change{};
 
     TextField(Rect parent_rect, std::string text);
 
@@ -701,6 +702,7 @@ class TextField : public Text {
     void set_text(std::string_view value);
 
     bool on_key(KeyEvent key) override;
+    bool on_encoder(EncoderEvent delta) override;
 
    private:
     using Text::set;


### PR DESCRIPTION
This change adds the concept of a "Manual" preset to Looking Glass.
When the frequency range is manually set, the preset will be set to "Manual".
When app settings are enabled, the frequency range and preset last used will be loaded on start.
This makes moving between Audio and Glass easier because Glass range is not reset.

Also
* use TextFields for Range and Marker controls instead of buttons. It looks nicer because the button rectangle isn't drawn and text is left-aligned.
* Minor code cleanup (consistent names, remove unused param names, typos).