### PR TITLE
Automatically switch to C8 capture format when bandwidth >1.5MHz

### DIFF
--- a/firmware/application/apps/capture_app.cpp
+++ b/firmware/application/apps/capture_app.cpp
@@ -82,6 +82,12 @@ CaptureAppView::CaptureAppView(NavigationView& nav)
         auto anti_alias_filter_bandwidth = filter_bandwidth_for_sampling_rate(actual_sample_rate);
         receiver_model.set_baseband_bandwidth(anti_alias_filter_bandwidth);
 
+        // Automatically switch default capture format to C8 when bandwidth setting is increased to >=1.5MHz
+        if ((bandwidth >= 1500000) && (previous_bandwidth < 1500000)) {
+            option_format.set_selected_index(1);
+        }
+        previous_bandwidth = bandwidth;
+
         waterfall.start();
     };
 

--- a/firmware/application/apps/capture_app.hpp
+++ b/firmware/application/apps/capture_app.hpp
@@ -46,6 +46,7 @@ class CaptureAppView : public View {
 
    private:
     static constexpr ui::Dim header_height = 3 * 16;
+    uint32_t previous_bandwidth{500000};
 
     NavigationView& nav_;
     RxRadioState radio_state_{ReceiverModel::Mode::Capture};


### PR DESCRIPTION
Per Brumi's suggestion, automatically switch the default from C16 to C8 capture format when capture bandwidth setting is increased to >=1.5MHz

The default format change only occurs when bandwidth is increased from a lower setting to 1.5MHz.  The setting can subsequently be changed by the user if desired.  Reducing the bandwidth also does not change the format setting back to C16.