### PR TITLE
Enable LTO for application code only

### DIFF
--- a/firmware/application/CMakeLists.txt
+++ b/firmware/application/CMakeLists.txt
@@ -44,7 +44,7 @@ if(cpp20_supported)
 else()
 	set(USE_CPPOPT "-std=c++17")
 endif()
-set(USE_CPPOPT "${USE_CPPOPT} -fno-rtti -fno-exceptions -Weffc++ -Wuninitialized -Wno-volatile")
+set(USE_CPPOPT "${USE_CPPOPT} -flto -fno-rtti -fno-exceptions -Weffc++ -Wuninitialized -Wno-volatile")
 
 # Enable this if you want the linker to remove unused code and data
 set(USE_LINK_GC yes)


### PR DESCRIPTION
This experiment is half of the change from PR #1206.  It seems that everything, including SD-over-USB, still works if -flto is only enabled for the application code (and not for baseband code).

A test version is in the test-drive channel on Discord:  https://discord.com/channels/719669764804444213/722101917135798312/1144133635176407060

If anyone finds any issues, please let me know.