### PR TITLE
Support for displaying stack on screen after a fault (for debug)

### DIFF
--- a/firmware/application/debug.cpp
+++ b/firmware/application/debug.cpp
@@ -145,17 +145,19 @@ void runtime_error(uint8_t source) {
     }
 }
 
+// This function should only be called with interrupts disabled due to reading swizzled_switches()
 // Using the stack while dumping the stack isn't ideal, but hopefully anything imporant is still on the call stack.
 void draw_stack_dump() {
     Painter painter;
-    uint32_t* p;
-    constexpr int border = 8;
+    uint32_t* p{&__process_stack_base__};
+    constexpr int border{8};
     int x, y;
     int n{0};
     bool clear_rect{true};
-    bool data_found{false};
+    bool first_pass{true};
 
-    for (p = &__process_stack_base__; p < &__process_stack_end__; p++) {
+    // NOTE: Stays in this loop forever unless LEFT button pressed
+    while (1) {
         if (clear_rect) {
             painter.fill_rectangle(
                 {border, border, portapack::display.width() - (border * 2), portapack::display.height() - (border * 2)},
@@ -164,65 +166,90 @@ void draw_stack_dump() {
             clear_rect = false;
         }
 
-        // skip past unused stack words
-        if (!data_found) {
-            if (*p == CRT0_STACKS_FILL_PATTERN)
-                continue;
-            else {
-                data_found = true;
-                auto stack_space_left = p - &__process_stack_base__;
+        // skip past unused stack words on 1st pass
+        if (first_pass) {
+            first_pass = false;
+            while ((*p == CRT0_STACKS_FILL_PATTERN) && (p < &__process_stack_end__))
+                p++;
 
-                // NOTE: in situations like a hard fault it seems not possible to write strings longer than 16 characters.
-                painter.draw_string({x, y}, Styles::white_small, to_string_hex((uint32_t)&__process_stack_base__, 8));
-                x += 8 * 5;
-                painter.draw_string({x, y}, Styles::white_small, ": M0 STACK");
-                x = border;
-                y += 8;
+            auto stack_space_left = p - &__process_stack_base__;
 
-                // align subsequent lines to start on 16-byte boundaries
-                p -= (stack_space_left & 3);
-            }
-        }
-
-        // show address
-        if (n++ == 0) {
-            painter.draw_string({x, y}, Styles::white_small, to_string_hex((uint32_t)p, 8) + ":");
-            x += 9 * 5;
-        }
-
-        // show stack word -- highlight if a possible code address (low bit will be set too for !thumb)
-        bool code_addr = (*p > 0x1400) && (*p < 0x80000) && (((*p) & 0x1) == 0x1);  // approximate address range of code .text region in ROM
-        painter.draw_string({x, y}, code_addr ? Styles::bg_white_small : Styles::white_small, " " + to_string_hex(*p, 8));
-        x += 9 * 5;
-
-        // new line?
-        if (n == 4) {
-            n = 0;
+            // NOTE: in situations like a hard fault it seems not possible to write strings longer than 16 characters.
+            painter.draw_string({x, y}, Styles::white_small, to_string_hex((uint32_t)&__process_stack_base__, 8));
+            x += 8 * 5;
+            painter.draw_string({x, y}, Styles::white_small, " M0 STACK free=");
+            x += 15 * 5;
+            painter.draw_string({x, y}, Styles::white_small, to_string_dec_uint(stack_space_left));
             x = border;
             y += 8;
 
-            // out of room on the screen - prompt for more
-            if ((y >= portapack::display.height() - border - 8) && (p + 1 < &__process_stack_end__)) {
-                while (swizzled_switches() & ((1 << (int)Switch::Up) | (1 << (int)Switch::Down)))
-                    ;
-                painter.draw_string({x, y}, Styles::white_small, "Use UP/DOWN key");
-                while (1) {
-                    if (swizzled_switches() & (1 << (int)Switch::Up)) {
-                        // back up pointer by 2 screens of 8 pixels per line & 4 words per line
-                        p -= 2 * (y - border) / (8 / 4);
-                        if (p <= &__process_stack_base__)
-                            p = &__process_stack_base__ - 1;  // -1 for p++ in for loop
-                        break;
-                    }
-                    if (swizzled_switches() & (1 << (int)Switch::Down))
-                        break;
-                }
-                clear_rect = true;
-            }
+            // align subsequent lines to start on 16-byte boundaries
+            p -= (stack_space_left & 3);
         }
-    }
 
-    painter.draw_string({border, portapack::display.height() - border - 8}, Styles::white_small, "End! DFU=repeat");
+        // print one page of stack dump
+        while ((p < &__process_stack_end__) && (y < portapack::display.height() - border - 8)) {
+            // show address if start of line
+            if (n++ == 0) {
+                painter.draw_string({x, y}, Styles::white_small, to_string_hex((uint32_t)p, 8) + ":");
+                x += 9 * 5 - 2;  // note: saving 2 pixels here to prevent reaching right border
+            }
+
+            // show stack word -- highlight if a possible code address (low bit will be set too for !thumb)
+            bool code_addr = (*p > 0x1400) && (*p < 0x80000) && (((*p) & 0x1) == 0x1);  // approximate address range of code .text region in ROM
+            painter.draw_string({x, y}, code_addr ? Styles::bg_white_small : Styles::white_small, " " + to_string_hex(*p, 8));
+            x += 9 * 5;
+
+            // new line?
+            if (n == 4) {
+                n = 0;
+                x = border;
+                y += 8;
+            }
+
+            // point to next stack word
+            p++;
+        }
+
+        // Out of room on the screen or end of stack - allow Up/Down paging.
+        // First wait for button release from previous press.
+        // NOTE: can't call swizzle_switches() with interrupted enabled!
+        while (swizzled_switches() & ((1 << (int)Switch::Right) | (1 << (int)Switch::Left) | (1 << (int)Switch::Down) | (1 << (int)Switch::Up) | (1 << (int)Switch::Sel) | (1 << (int)Switch::Dfu)))
+            ;
+
+        painter.draw_string({border, portapack::display.height() - border - 8}, Styles::white_small, "Use UP/DOWN key");
+
+        // Wait for button press.
+        while (1) {
+            auto switches = swizzled_switches();
+
+            // If LEFT button pressed, exit
+            if (switches & (1 << (int)Switch::Left))
+                return;
+
+            // If DOWN pressed; continue to show next page
+            if (switches & (1 << (int)Switch::Down))
+                break;
+
+            // If UP pressed, scroll back by one page
+            if (switches & (1 << (int)Switch::Up)) {
+                // Back up pointer by offset on this screen plus one full screen of 8 pixels per line & 4 words per line
+                // (underflow can't happen here due to stack address range in RAM)
+                p -= ((y - border) + (portapack::display.height() - (border * 2 + 1 * 8))) / (8 / 4);
+                if (p < &__process_stack_base__)
+                    p = &__process_stack_base__;
+                break;
+            }
+
+            // If SEL button pressed, try writing to file (likely to hang in fault condition but heh)
+            if (switches & (1 << (int)Switch::Sel))
+                stack_dump();
+        }
+
+        // clear screen to allow new range to be displayed, if we're not at the end
+        if (p < &__process_stack_end__)
+            clear_rect = true;
+    }
 }
 
 // Disk I/O in this function doesn't work after a fault

--- a/firmware/application/debug.cpp
+++ b/firmware/application/debug.cpp
@@ -199,7 +199,7 @@ void draw_stack_dump() {
 
             // out of room on the screen - prompt for more
             if ((y >= portapack::display.height() - border - 8) && (p + 1 < &__process_stack_end__)) {
-                while (swizzled_switches())
+                while (swizzled_switches() & (1 << (int)Switch::Down))
                     ;
                 painter.draw_string({x, y}, Styles::white_small, "DOWN for more");
                 while (!(swizzled_switches() & (1 << (int)Switch::Down)))

--- a/firmware/application/debug.cpp
+++ b/firmware/application/debug.cpp
@@ -198,7 +198,7 @@ void draw_stack_dump() {
             }
 
             // show stack word -- highlight if a possible code address (low bit will be set too for !thumb) or actual fault address
-            bool code_addr = (*p > 0x1400) && (*p < 0x80000) && (((*p) & 0x1) == 0x1);  // approximate address range of code .text region in ROM           
+            bool code_addr = (*p > 0x1400) && (*p < 0x80000) && (((*p) & 0x1) == 0x1);  // approximate address range of code .text region in ROM
             Style style = (fault_address && *p == fault_address) ? Styles::bg_yellow_small : (code_addr ? Styles::bg_white_small : Styles::white_small);
             painter.draw_string({x, y}, style, " " + to_string_hex(*p, 8));
             x += 9 * 5;

--- a/firmware/application/ui/ui_styles.cpp
+++ b/firmware/application/ui/ui_styles.cpp
@@ -50,6 +50,12 @@ const Style Styles::bg_white_small{
     .foreground = ui::Color::black(),
 };
 
+const Style Styles::bg_yellow_small{
+    .font = ui::font::fixed_5x8,
+    .background = ui::Color::yellow(),
+    .foreground = ui::Color::black(),
+};
+
 const Style Styles::yellow{
     .font = font::fixed_8x16,
     .background = Color::black(),

--- a/firmware/application/ui/ui_styles.cpp
+++ b/firmware/application/ui/ui_styles.cpp
@@ -44,6 +44,12 @@ const Style Styles::white_small{
     .foreground = Color::white(),
 };
 
+const Style Styles::bg_white_small{
+    .font = ui::font::fixed_5x8,
+    .background = ui::Color::white(),
+    .foreground = ui::Color::black(),
+};
+
 const Style Styles::yellow{
     .font = font::fixed_8x16,
     .background = Color::black(),

--- a/firmware/application/ui/ui_styles.hpp
+++ b/firmware/application/ui/ui_styles.hpp
@@ -37,6 +37,9 @@ class Styles {
     /* White foreground, small font. */
     static const Style white_small;
 
+    /* White background, small font. */
+    static const Style bg_white_small;
+
     /* Yellow foreground. */
     static const Style yellow;
 

--- a/firmware/application/ui/ui_styles.hpp
+++ b/firmware/application/ui/ui_styles.hpp
@@ -40,6 +40,9 @@ class Styles {
     /* White background, small font. */
     static const Style bg_white_small;
 
+    /* Red background, small font. */
+    static const Style bg_yellow_small;
+
     /* Yellow foreground. */
     static const Style yellow;
 


### PR DESCRIPTION
Writing a stack dump file didn't work after a fault, so I added a function to display the stack on the screen instead.  It usually takes multiple screens to display, so the UP & DOWN keys are supported to display additional pages.  Possible code addresses are highlighted in white, PC of fault is highlighted in yellow.

![IMG_0848](https://github.com/eried/portapack-mayhem/assets/129641948/43f9fdca-026e-4a3d-8c5e-46b171966466)
![IMG_0831](https://github.com/eried/portapack-mayhem/assets/129641948/a7555cdc-7416-45dc-aff6-da7d137041c5)
