### PR TITLE
Support for 1.25MHz capture

### DIFF
--- a/firmware/application/freqman_db.cpp
+++ b/firmware/application/freqman_db.cpp
@@ -83,22 +83,22 @@ options_t freqman_bandwidths[4] = {
         {"100k", 100000},
         {"150k", 150000},
         {"250k", 250000},
-        {"500k", 500000}, /* Previous Limit bandwith Option with perfect micro SD write .C16 format operaton.*/
-        {"600k", 600000}, /* We doubled x2 previous REC BW limit , now extended BW from 600k to 1M with fast enough SD card in C16 or C8 format .*/
+        {"500k", 500000},
+        {"600k", 600000},
         {"750k", 750000},
-        {"1000k", 1000000}, /* Limit bandwith option for recording in C16 (in fast SD card) or in C8 */
-        {"1250k", 1250000}, /* We doubled x 2 again previous REC BW limit */
+        {"1000k", 1000000},  // Max bandwith for recording in C16 (with fast SD card).
+        {"1250k", 1250000},
         {"1500k", 1500000},
         {"1750k", 1750000},
         {"2000k", 2000000},
-        {"2250k", 2250000}, /*  Limit bandwith option for recording in C8 (in fast SD card) */
-        {"2500k", 2500000}, /* From this BW onwards, the LCD is ok, but M4 CPU is having periodical sample rec dropps, (not real file size, accelerated replay) */
+        {"2250k", 2250000},  // Max bandwith for recording in C8 (with fast SD card).
+        {"2500k", 2500000},  // Here and up, LCD is ok, but M4 CPU drops samples.
         {"3000k", 3000000},
         {"3500k", 3500000},
         {"4000k", 4000000},
         {"4500k", 4500000},
-        {"5100k", 5100000},  // we skip exact 5Mhz because it is another periodic M4 99-100% in Capture App with abnormal waterfall motion.
-        {"5500k", 5500000},  // That is our max Capture option, to keep using later / 4 decimation (22Mhz sampling  ADC)
+        {"5100k", 5100000},  // Skip exactly 5Mhz, M4 sample drops and abnormal spectrum.
+        {"5500k", 5500000},  // Max capture, needs /4 decimation, (22Mhz sampling ADC).
     },
 };
 

--- a/firmware/application/freqman_db.cpp
+++ b/firmware/application/freqman_db.cpp
@@ -97,7 +97,7 @@ options_t freqman_bandwidths[4] = {
         {"3500k", 3500000},
         {"4000k", 4000000},
         {"4500k", 4500000},
-        {"5000k", 5000000},
+        {"5100k", 5100000},  // we skip exact 5Mhz because it is another periodic M4 99-100% in Capture App with abnormal waterfall motion.
         {"5500k", 5500000},  // That is our max Capture option, to keep using later / 4 decimation (22Mhz sampling  ADC)
     },
 };

--- a/firmware/application/freqman_db.cpp
+++ b/firmware/application/freqman_db.cpp
@@ -97,7 +97,7 @@ options_t freqman_bandwidths[4] = {
         {"3500k", 3500000},
         {"4000k", 4000000},
         {"4500k", 4500000},
-        {"5100k", 5100000},  // Skip exactly 5Mhz, M4 sample drops and abnormal spectrum.
+        {"5000k", 5500000},
         {"5500k", 5500000},  // Max capture, needs /4 decimation, (22Mhz sampling ADC).
     },
 };

--- a/firmware/application/freqman_db.cpp
+++ b/firmware/application/freqman_db.cpp
@@ -88,11 +88,11 @@ options_t freqman_bandwidths[4] = {
         {"750k", 750000},
         {"1000k", 1000000}, /* Limit bandwith option for recording in C16 (in fast SD card) or in C8 */
         {"1250k", 1250000}, /* We doubled x 2 again previous REC BW limit */
-        {"1500k", 1500000}, 
+        {"1500k", 1500000},
         {"1750k", 1750000},
         {"2000k", 2000000},
-        {"2250k", 2250000},/*  Limit bandwith option for recording in C8 (in fast SD card) */
-        {"2500k", 2500000},/* From this BW onwards, the LCD is ok, but M4 CPU is having periodical sample rec dropps, (not real file size, accelerated replay) */
+        {"2250k", 2250000}, /*  Limit bandwith option for recording in C8 (in fast SD card) */
+        {"2500k", 2500000}, /* From this BW onwards, the LCD is ok, but M4 CPU is having periodical sample rec dropps, (not real file size, accelerated replay) */
         {"3000k", 3000000},
         {"3500k", 3500000},
         {"4000k", 4000000},

--- a/firmware/application/freqman_db.cpp
+++ b/firmware/application/freqman_db.cpp
@@ -85,14 +85,20 @@ options_t freqman_bandwidths[4] = {
         {"250k", 250000},
         {"500k", 500000}, /* Previous Limit bandwith Option with perfect micro SD write .C16 format operaton.*/
         {"600k", 600000}, /* We doubled x2 previous REC BW limit , now extended BW from 600k to 1M with fast enough SD card in C16 or C8 format .*/
-        {"650k", 650000},
         {"750k", 750000},
-        {"1000k", 1000000}, /* New limit bandwith option for recording in C16 (in fast SD card) or in C8 */
-        {"1500k", 1500000}, /* From this BW onwards, the LCD is ok, but M4 CPU is having periodical sample rec dropps, (not real file size, accelerated replay) */
+        {"1000k", 1000000}, /* Limit bandwith option for recording in C16 (in fast SD card) or in C8 */
+        {"1250k", 1250000}, /* We doubled x 2 again previous REC BW limit */
+        {"1500k", 1500000}, 
         {"1750k", 1750000},
         {"2000k", 2000000},
-        {"2500k", 2500000},
-        {"2750k", 2750000},  // That is our max Capture option, to keep using later / 8 decimation (22Mhz sampling  ADC)
+        {"2250k", 2250000},/*  Limit bandwith option for recording in C8 (in fast SD card) */
+        {"2500k", 2500000},/* From this BW onwards, the LCD is ok, but M4 CPU is having periodical sample rec dropps, (not real file size, accelerated replay) */
+        {"3000k", 3000000},
+        {"3500k", 3500000},
+        {"4000k", 4000000},
+        {"4500k", 4500000},
+        {"5000k", 5000000},
+        {"5500k", 5500000},  // That is our max Capture option, to keep using later / 4 decimation (22Mhz sampling  ADC)
     },
 };
 

--- a/firmware/application/ui/ui_spectrum.cpp
+++ b/firmware/application/ui/ui_spectrum.cpp
@@ -386,30 +386,30 @@ uint32_t filter_bandwidth_for_sampling_rate(int32_t sampling_rate) {
         case 0 ... 3'500'000:  // BW Captured range (0 <= 250kHz max)  fs = 8x250 kHz =2000., 16x150 khz =2400, 32x100 khz =3200, (32x75k = 2400), (future 64x40 khz =2400)
             return 1'750'000;  // Minimum BPF MAX2837 for all those lower BW options.
 
-        case 4'000'000 ... 6'000'000:  // BW capture range (500k...750kHz max)  fs_max = 8 x 750kHz = 6Mhz
+        case 4'000'000 ... 7'000'000:  // OVS x8 , BW capture range (500k...750kHz max)  fs_max = 8 x 750kHz = 6Mhz
                                        // BW 500k...750kHz, ex. 500kHz (fs = 8 x BW = 4Mhz), BW 600kHz (fs = 4,8Mhz), BW 750 kHz (fs = 6Mhz).
             return 2'500'000;          // In some IC, MAX2837 appears as 2250000, but both work similarly.
 
-        case 8'000'000:        // BW capture 1Mhz fs = 8 x 1Mhz = 8Mhz. (1Mhz showed slightly higher noise background).
+        case 7'000'001 ... 10'000'000:  // OVS x8 and x4 , BW capture 1Mhz fs = 8 x 1Mhz = 8Mhz. (1Mhz showed slightly higher noise background).
             return 3'500'000;  // some low SD cards, if not showing avg. writting speed >4MB/sec, they will produce sammples drop at REC with 1MB and C16 format.
 
-        case 12'000'000:  // BW capture 1,5Mhz, fs = 8 x 1,5Mhz = 12Mhz
+        case 12'000'000 ... 14'000'000:  // OVS x4, BW capture 3Mhz, fs = 4 x 3Mhz = 12Mhz
                           // Good BPF, good matching, we have some periodical M4 % samples drop.
             return 5'000'000;
 
-        case 14'000'000:  // BW capture 1,75Mhz, fs = 8 x 1,75Mhz = 14Mhz
+         case 16'000'000:  // OVS x4, BW capture 4Mhz, fs = 4 x 4Mhz = 16Mhz
                           // Good BPF, good matching, we have some periodical M4 % samples drop.
-            return 5'000'000;
+            return 5'500'000;
 
-        case 16'000'000:  // BW capture 2Mhz, fs = 8 x 2Mhz = 16Mhz
+        case 18'000'000:  // OVS x4, BW capture 4,5Mhz, fs = 4 x 4,5Mhz = 18Mhz
                           // Good BPF, good matching, we have some periodical M4 % samples drop.
             return 6'000'000;
 
-        case 20'000'000:  // BW capture 2,5Mhz, fs = 8 x 2,5 Mhz = 20Mhz
+        case 20'000'000:  // OVS x4, BW capture 5Mhz, fs = 4 x 5Mhz = 20Mhz
                           // Good BPF, good matching, we have some periodical M4 % samples drop.
             return 7'000'000;
 
-        default:  // BW capture 2,75Mhz, fs = 8 x 2,75Mhz = 22Mhz max ADC sampling and others.
+        default:  // BW capture 5,5Mhz, fs = 4 x 5,5Mhz = 22Mhz max ADC sampling and others.
                   // We tested also 9Mhz FPB slightly too much noise floor, better at 8Mhz.
             return 8'000'000;
     }

--- a/firmware/application/ui/ui_spectrum.cpp
+++ b/firmware/application/ui/ui_spectrum.cpp
@@ -391,13 +391,13 @@ uint32_t filter_bandwidth_for_sampling_rate(int32_t sampling_rate) {
             return 2'500'000;          // In some IC, MAX2837 appears as 2250000, but both work similarly.
 
         case 7'000'001 ... 10'000'000:  // OVS x8 and x4 , BW capture 1Mhz fs = 8 x 1Mhz = 8Mhz. (1Mhz showed slightly higher noise background).
-            return 3'500'000;  // some low SD cards, if not showing avg. writting speed >4MB/sec, they will produce sammples drop at REC with 1MB and C16 format.
+            return 3'500'000;           // some low SD cards, if not showing avg. writting speed >4MB/sec, they will produce sammples drop at REC with 1MB and C16 format.
 
         case 12'000'000 ... 14'000'000:  // OVS x4, BW capture 3Mhz, fs = 4 x 3Mhz = 12Mhz
-                          // Good BPF, good matching, we have some periodical M4 % samples drop.
+                                         // Good BPF, good matching, we have some periodical M4 % samples drop.
             return 5'000'000;
 
-         case 16'000'000:  // OVS x4, BW capture 4Mhz, fs = 4 x 4Mhz = 16Mhz
+        case 16'000'000:  // OVS x4, BW capture 4Mhz, fs = 4 x 4Mhz = 16Mhz
                           // Good BPF, good matching, we have some periodical M4 % samples drop.
             return 5'500'000;
 

--- a/firmware/application/ui/ui_spectrum.cpp
+++ b/firmware/application/ui/ui_spectrum.cpp
@@ -383,15 +383,15 @@ void WaterfallView::on_audio_spectrum() {
 // TODO: Comments below refer to a fixed oversample rate (8x), cleanup.
 uint32_t filter_bandwidth_for_sampling_rate(int32_t sampling_rate) {
     switch (sampling_rate) {   // Use the var fs (sampling_rate) to set up BPF aprox < fs_max / 2 by Nyquist theorem.
-        case 0 ... 3'500'000:  // BW Captured range (0 <= 250kHz max)  fs = 8x250 kHz =2000., 16x150 khz =2400, 32x100 khz =3200, (32x75k = 2400), (future 64x40 khz =2400)
+        case 0 ... 3'500'000:  // BW Captured range (0 <= 250kHz max) fs = 8x250k = 2000, 16x150k = 2400, 32x100k = 3200, 32x75k = 2400, (future 64x40 khz = 2400)
             return 1'750'000;  // Minimum BPF MAX2837 for all those lower BW options.
 
-        case 4'000'000 ... 7'000'000:  // OVS x8 , BW capture range (500k...750kHz max)  fs_max = 8 x 750kHz = 6Mhz
+        case 4'000'000 ... 7'000'000:  // OVS x8, BW capture range (500k...750kHz max) fs_max = 8 x 750k = 6Mhz
                                        // BW 500k...750kHz, ex. 500kHz (fs = 8 x BW = 4Mhz), BW 600kHz (fs = 4,8Mhz), BW 750 kHz (fs = 6Mhz).
             return 2'500'000;          // In some IC, MAX2837 appears as 2250000, but both work similarly.
 
-        case 7'000'001 ... 10'000'000:  // OVS x8 and x4 , BW capture 1Mhz fs = 8 x 1Mhz = 8Mhz. (1Mhz showed slightly higher noise background).
-            return 3'500'000;           // some low SD cards, if not showing avg. writting speed >4MB/sec, they will produce sammples drop at REC with 1MB and C16 format.
+        case 7'000'001 ... 10'000'000:  // OVS x8 and x4, BW capture 1Mhz fs = 8 x 1Mhz = 8Mhz. (1Mhz showed slightly higher noise background).
+            return 3'500'000;           // some low SD cards, if not showing avg. writing speed >4MB/sec, they will produce sammples drop at REC with 1MB and C16 format.
 
         case 12'000'000 ... 14'000'000:  // OVS x4, BW capture 3Mhz, fs = 4 x 3Mhz = 12Mhz
                                          // Good BPF, good matching, we have some periodical M4 % samples drop.

--- a/firmware/application/ui_record_view.cpp
+++ b/firmware/application/ui_record_view.cpp
@@ -114,9 +114,9 @@ uint32_t RecordView::set_sampling_rate(uint32_t new_sampling_rate) {
 
      * We keep original black background in all the correct IQ .C16 files BW's Options. */
     if ((actual_sampling_rate > 8'000'000) && (oversample_rate == OversampleRate::x4)) {  // yellow REC button means not ok for REC, BW >1Mhz  (BW from 12k5 till 1Mhz OK for REC and Replay)
-        button_record.set_background(ui::Color::yellow());  // From >2M onwards.
+        button_record.set_background(ui::Color::yellow());                                // From >2M onwards.
     } else {
-        button_record.set_background(ui::Color::black());   // From 12k5 till 2M     
+        button_record.set_background(ui::Color::black());  // From 12k5 till 2M
     }
 
     if (sampling_rate != new_sampling_rate) {
@@ -144,10 +144,10 @@ OversampleRate RecordView::get_oversample_rate(uint32_t sample_rate) {
 
     auto rate = ::get_oversample_rate(sample_rate);
 
-    // Currently proc_capture only supports /4 , /8, /16, /32, /64 for decimation, just  clipping protection.
-    if (rate < OversampleRate::x4)  // clipping while /4 is not implemented yet  (it will be used >1Mhz onwards when available)
+    // Currently proc_capture only supports /4 , /8, /16, /32, /64 for decimation, just  clipping protection (but now not necessary).
+    if (rate < OversampleRate::x4)  // clipping  protection <=4 , TODO ,  but we can delete it when refactoring
         rate = OversampleRate::x4;
-    else if (rate > OversampleRate::x64)  // clipping while /128 is not implemented yet , (but it is not necessary for 12k5)
+    else if (rate > OversampleRate::x64)  // clipping protection <=x64, (but /128  it is not necessary for 12k5),we can delete it when refactoring
         rate = OversampleRate::x64;
 
     return rate;

--- a/firmware/application/ui_record_view.cpp
+++ b/firmware/application/ui_record_view.cpp
@@ -109,7 +109,7 @@ uint32_t RecordView::set_sampling_rate(uint32_t new_sampling_rate) {
 
     // Change the "REC" icon background to yellow when the selected rate exceeds hardware limits.
     // Above this threshold, samples will be dropped resulting incomplete capture files.
-    if (new_sampling_rate > 1'250'000) { 
+    if (new_sampling_rate > 1'250'000) {
         button_record.set_background(ui::Color::yellow());
     } else {
         button_record.set_background(ui::Color::black());

--- a/firmware/application/ui_record_view.cpp
+++ b/firmware/application/ui_record_view.cpp
@@ -107,16 +107,12 @@ uint32_t RecordView::set_sampling_rate(uint32_t new_sampling_rate) {
     auto oversample_rate = get_oversample_rate(new_sampling_rate);
     auto actual_sampling_rate = new_sampling_rate * toUType(oversample_rate);
 
-    /* We are changing "REC" icon background to yellow in BW rec Options >1Mhz
-     * > 1Mhz BW options , we are NOT recording full IQ .C16 files (those files has some periodical  missing dropped samples).
-     * Those recorded files, has not the full IQ samples information, looks like decimated in file size.
-     * They are ok as recorded spectrum indication, but they should not be used by Replay app. (the voice speed will be accelerated)
-
-     * We keep original black background in all the correct IQ .C16 files BW's Options. */
-    if ((actual_sampling_rate >= 6'000'000) && (oversample_rate == OversampleRate::x4)) {  // yellow REC button means not ok for REC, BW >1.25Mhz  (BW from 12k5 till 1.25Mhz OK for REC and Replay)
-        button_record.set_background(ui::Color::yellow());                                 // From >1.25M onwards yellow, because we will have missed half of the buffer samples or  M4 samples drops or mi .
+    // Change the "REC" icon background to yellow when the selected rate exceeds hardware limits.
+    // Above this threshold, samples will be dropped resulting incomplete capture files.
+    if (new_sampling_rate > 1'250'000) { 
+        button_record.set_background(ui::Color::yellow());
     } else {
-        button_record.set_background(ui::Color::black());  // From 12k5 till 1.25M  OK,
+        button_record.set_background(ui::Color::black());
     }
 
     if (sampling_rate != new_sampling_rate) {
@@ -142,15 +138,7 @@ OversampleRate RecordView::get_oversample_rate(uint32_t sample_rate) {
     if (file_type == FileType::WAV)
         return OversampleRate::None;
 
-    auto rate = ::get_oversample_rate(sample_rate);
-
-    // Currently proc_capture only supports /4 , /8, /16, /32, /64 for decimation, just  clipping protection (but now not necessary).
-    if (rate < OversampleRate::x4)  // clipping  protection <=4 , TODO ,  but we can delete it when refactoring
-        rate = OversampleRate::x4;
-    else if (rate > OversampleRate::x64)  // clipping protection <=x64, (but /128  it is not necessary for 12k5),we can delete it when refactoring
-        rate = OversampleRate::x64;
-
-    return rate;
+    return ::get_oversample_rate(sample_rate);
 }
 
 // Setter for datetime and frequency filename

--- a/firmware/application/ui_record_view.cpp
+++ b/firmware/application/ui_record_view.cpp
@@ -113,10 +113,10 @@ uint32_t RecordView::set_sampling_rate(uint32_t new_sampling_rate) {
      * They are ok as recorded spectrum indication, but they should not be used by Replay app. (the voice speed will be accelerated)
 
      * We keep original black background in all the correct IQ .C16 files BW's Options. */
-    if (actual_sampling_rate > 8'000'000) {  // yellow REC button means not ok for REC, BW >1Mhz  (BW from 12k5 till 1Mhz OK for REC and Replay)
-        button_record.set_background(ui::Color::yellow());
+    if ((actual_sampling_rate > 8'000'000) && (oversample_rate == OversampleRate::x4)) {  // yellow REC button means not ok for REC, BW >1Mhz  (BW from 12k5 till 1Mhz OK for REC and Replay)
+        button_record.set_background(ui::Color::yellow());  // From >2M onwards.
     } else {
-        button_record.set_background(ui::Color::black());
+        button_record.set_background(ui::Color::black());   // From 12k5 till 2M     
     }
 
     if (sampling_rate != new_sampling_rate) {
@@ -144,9 +144,9 @@ OversampleRate RecordView::get_oversample_rate(uint32_t sample_rate) {
 
     auto rate = ::get_oversample_rate(sample_rate);
 
-    // Currently proc_capture only supports /8, /16, /32 for decimation.
-    if (rate < OversampleRate::x8)  // clipping while /4 is not implemented yet  (it will be used >1Mhz onwards when available)
-        rate = OversampleRate::x8;
+    // Currently proc_capture only supports /4 , /8, /16, /32, /64 for decimation, just  clipping protection.
+    if (rate < OversampleRate::x4)  // clipping while /4 is not implemented yet  (it will be used >1Mhz onwards when available)
+        rate = OversampleRate::x4;
     else if (rate > OversampleRate::x64)  // clipping while /128 is not implemented yet , (but it is not necessary for 12k5)
         rate = OversampleRate::x64;
 

--- a/firmware/application/ui_record_view.cpp
+++ b/firmware/application/ui_record_view.cpp
@@ -113,10 +113,10 @@ uint32_t RecordView::set_sampling_rate(uint32_t new_sampling_rate) {
      * They are ok as recorded spectrum indication, but they should not be used by Replay app. (the voice speed will be accelerated)
 
      * We keep original black background in all the correct IQ .C16 files BW's Options. */
-    if ((actual_sampling_rate > 8'000'000) && (oversample_rate == OversampleRate::x4)) {  // yellow REC button means not ok for REC, BW >1Mhz  (BW from 12k5 till 1Mhz OK for REC and Replay)
-        button_record.set_background(ui::Color::yellow());                                // From >2M onwards.
+    if ((actual_sampling_rate >= 6'000'000) && (oversample_rate == OversampleRate::x4)) {  // yellow REC button means not ok for REC, BW >1.25Mhz  (BW from 12k5 till 1.25Mhz OK for REC and Replay)
+        button_record.set_background(ui::Color::yellow());                                 // From >1.25M onwards yellow, because we will have missed half of the buffer samples or  M4 samples drops or mi .
     } else {
-        button_record.set_background(ui::Color::black());  // From 12k5 till 2M
+        button_record.set_background(ui::Color::black());  // From 12k5 till 1.25M  OK , 
     }
 
     if (sampling_rate != new_sampling_rate) {

--- a/firmware/application/ui_record_view.cpp
+++ b/firmware/application/ui_record_view.cpp
@@ -116,7 +116,7 @@ uint32_t RecordView::set_sampling_rate(uint32_t new_sampling_rate) {
     if ((actual_sampling_rate >= 6'000'000) && (oversample_rate == OversampleRate::x4)) {  // yellow REC button means not ok for REC, BW >1.25Mhz  (BW from 12k5 till 1.25Mhz OK for REC and Replay)
         button_record.set_background(ui::Color::yellow());                                 // From >1.25M onwards yellow, because we will have missed half of the buffer samples or  M4 samples drops or mi .
     } else {
-        button_record.set_background(ui::Color::black());  // From 12k5 till 1.25M  OK , 
+        button_record.set_background(ui::Color::black());  // From 12k5 till 1.25M  OK,
     }
 
     if (sampling_rate != new_sampling_rate) {

--- a/firmware/baseband/block_decimator.hpp
+++ b/firmware/baseband/block_decimator.hpp
@@ -69,29 +69,22 @@ class BlockDecimator {
 
         set_input_sampling_rate(src.sampling_rate);
 
-        while (src_i < src.count) {
+        for (size_t src_i = 0; src_i < src.count; src_i += factor()) {
             buffer[dst_i++] = src.p[src_i];
             if (dst_i == buffer.size()) {
                 callback({buffer.data(), buffer.size(), output_sampling_rate()});
                 reset_state();
-                dst_i = 0;
             }
-
-            src_i += factor();
         }
-
-        src_i -= src.count;
     }
 
    private:
     std::array<T, N> buffer{};
     uint32_t input_sampling_rate_{0};
     size_t factor_{1};
-    size_t src_i{0};
     size_t dst_i{0};
 
     void reset_state() {
-        src_i = 0;
         dst_i = 0;
     }
 };

--- a/firmware/baseband/dsp_decimate.cpp
+++ b/firmware/baseband/dsp_decimate.cpp
@@ -265,8 +265,8 @@ buffer_c16_t FIRC8xR16x24FS4Decim4_256::execute(
 
     const auto k = output_scale;
 
-    // const size_t count = src.count / decimation_factor;  // Original code of the cloned FIRC8xR16x24FS4Decim4
-    const size_t count = 256;  // We limit the buffer output of decim0 /4 to 256 C16 Complex samples.
+    const size_t count = src.count / decimation_factor;  // Original code of the cloned FIRC8xR16x24FS4Decim4
+    // const size_t count = 256;  // We limit the buffer output of decim0 /4 to 256 C16 Complex samples.
 
     for (size_t i = 0; i < count; i++) {
         const vec4_s8* const in = static_cast<const vec4_s8*>(__builtin_assume_aligned(&src.p[i * decimation_factor], 4));
@@ -296,7 +296,7 @@ buffer_c16_t FIRC8xR16x24FS4Decim4_256::execute(
 
     return {
         dst.p,
-        count,
+        count / 2,  // we decimated all 2048 input_buffer to our dst 512_output, but we just indicate 256 to avoid Waterfall crash.
         src.sampling_rate / decimation_factor};
 }
 

--- a/firmware/baseband/dsp_decimate.cpp
+++ b/firmware/baseband/dsp_decimate.cpp
@@ -203,7 +203,7 @@ buffer_c16_t FIRC8xR16x24FS4Decim4::execute(
 
     const auto k = output_scale;
 
-    size_t count = src.count / decimation_factor;   // 2048 buffer_c8 input src samples / 4 = 512 buffer c16 output samples.
+    size_t count = src.count / decimation_factor;  // 2048 buffer_c8 input src samples / 4 = 512 buffer c16 output samples.
     /*
     if (count > 256) {                  // Just investigation test .
             count =256;
@@ -242,11 +242,9 @@ buffer_c16_t FIRC8xR16x24FS4Decim4::execute(
         src.sampling_rate / decimation_factor};
 }
 
-
-
 // FIRC8xR16x24FS4Decim4_256 //////////////////////////////////////////////////
 // Cloned from previous FIRC8xR16x24FS4Decim4 limiting the output buffer C16 samples to 256
-// Waterfall fft function was designed to handle as a max. 256 Complex samples , (2048 /8 = 256), 
+// Waterfall fft function was designed to handle as a max. 256 Complex samples , (2048 /8 = 256),
 // if we just use Decimation /4 , we got 2048 c8 src input  / 4 = 512 C16 Complex output  samples and Waterfall crashes.
 
 void FIRC8xR16x24FS4Decim4_256::configure(
@@ -268,7 +266,7 @@ buffer_c16_t FIRC8xR16x24FS4Decim4_256::execute(
     const auto k = output_scale;
 
     // const size_t count = src.count / decimation_factor;  // Original code of the cloned FIRC8xR16x24FS4Decim4
-    const size_t count = 256; // We limit the buffer output of decim0 /4 to 256 C16 Complex samples.
+    const size_t count = 256;  // We limit the buffer output of decim0 /4 to 256 C16 Complex samples.
 
     for (size_t i = 0; i < count; i++) {
         const vec4_s8* const in = static_cast<const vec4_s8*>(__builtin_assume_aligned(&src.p[i * decimation_factor], 4));

--- a/firmware/baseband/dsp_decimate.cpp
+++ b/firmware/baseband/dsp_decimate.cpp
@@ -203,7 +203,73 @@ buffer_c16_t FIRC8xR16x24FS4Decim4::execute(
 
     const auto k = output_scale;
 
-    const size_t count = src.count / decimation_factor;
+    size_t count = src.count / decimation_factor;   // 2048 buffer_c8 input src samples / 4 = 512 buffer c16 output samples.
+    /*
+    if (count > 256) {                  // Just investigation test .
+            count =256;
+    }
+    */
+
+    for (size_t i = 0; i < count; i++) {
+        const vec4_s8* const in = static_cast<const vec4_s8*>(__builtin_assume_aligned(&src.p[i * decimation_factor], 4));
+
+        complex32_t accum;
+
+        // Oldest samples are discarded.
+        accum = mac_fs4_shift(z, t, 0, accum);
+        accum = mac_fs4_shift(z, t, 1, accum);
+
+        // Middle samples are shifted earlier in the "z" delay buffer.
+        accum = mac_fs4_shift_and_store(z, t, decimation_factor, 0, accum);
+        accum = mac_fs4_shift_and_store(z, t, decimation_factor, 1, accum);
+        accum = mac_fs4_shift_and_store(z, t, decimation_factor, 2, accum);
+        accum = mac_fs4_shift_and_store(z, t, decimation_factor, 3, accum);
+        accum = mac_fs4_shift_and_store(z, t, decimation_factor, 4, accum);
+        accum = mac_fs4_shift_and_store(z, t, decimation_factor, 5, accum);
+        accum = mac_fs4_shift_and_store(z, t, decimation_factor, 6, accum);
+        accum = mac_fs4_shift_and_store(z, t, decimation_factor, 7, accum);
+
+        // Newest samples come from "in" buffer, are copied to "z" delay buffer.
+        accum = mac_fs4_shift_and_store_new_c8_samples(z, t, in, decimation_factor, 0, taps_count, accum);
+        accum = mac_fs4_shift_and_store_new_c8_samples(z, t, in, decimation_factor, 1, taps_count, accum);
+
+        d[i] = scale_round_and_pack(accum, k);
+    }
+
+    return {
+        dst.p,
+        count,
+        src.sampling_rate / decimation_factor};
+}
+
+
+
+// FIRC8xR16x24FS4Decim4_256 //////////////////////////////////////////////////
+// Cloned from previous FIRC8xR16x24FS4Decim4 limiting the output buffer C16 samples to 256
+// Waterfall fft function was designed to handle as a max. 256 Complex samples , (2048 /8 = 256), 
+// if we just use Decimation /4 , we got 2048 c8 src input  / 4 = 512 C16 Complex output  samples and Waterfall crashes.
+
+void FIRC8xR16x24FS4Decim4_256::configure(
+    const std::array<tap_t, taps_count>& taps,
+    const int32_t scale,
+    const Shift shift) {
+    taps_copy(taps.data(), taps_.data(), taps_.size(), shift == Shift::Up);
+    output_scale = scale;
+    z_.fill({});
+}
+
+buffer_c16_t FIRC8xR16x24FS4Decim4_256::execute(
+    const buffer_c8_t& src,
+    const buffer_c16_t& dst) {
+    vec2_s16* const z = static_cast<vec2_s16*>(__builtin_assume_aligned(z_.data(), 4));
+    const vec2_s16* const t = static_cast<vec2_s16*>(__builtin_assume_aligned(taps_.data(), 4));
+    uint32_t* const d = static_cast<uint32_t*>(__builtin_assume_aligned(dst.p, 4));
+
+    const auto k = output_scale;
+
+    // const size_t count = src.count / decimation_factor;  // Original code of the cloned FIRC8xR16x24FS4Decim4
+    const size_t count = 256; // We limit the buffer output of decim0 /4 to 256 C16 Complex samples.
+
     for (size_t i = 0; i < count; i++) {
         const vec4_s8* const in = static_cast<const vec4_s8*>(__builtin_assume_aligned(&src.p[i * decimation_factor], 4));
 

--- a/firmware/baseband/dsp_decimate.hpp
+++ b/firmware/baseband/dsp_decimate.hpp
@@ -113,6 +113,33 @@ class FIRC8xR16x24FS4Decim4 {
     int32_t output_scale = 0;
 };
 
+class FIRC8xR16x24FS4Decim4_256 {       // Cloned from FIRC8xR16x24FS4Decim4 + limiting output buffer C16 x 256 samples.
+   public:
+    static constexpr size_t taps_count = 24;
+    static constexpr size_t decimation_factor = 4;
+
+    using sample_t = complex8_t;
+    using tap_t = int16_t;
+
+    enum class Shift : bool {
+        Down = true,
+        Up = false
+    };
+
+    void configure(
+        const std::array<tap_t, taps_count>& taps,
+        const int32_t scale,
+        const Shift shift = Shift::Down);
+
+    buffer_c16_t execute(
+        const buffer_c8_t& src,
+        const buffer_c16_t& dst);
+
+   private:
+    std::array<vec2_s16, taps_count - decimation_factor> z_{};
+    std::array<tap_t, taps_count> taps_{};
+    int32_t output_scale = 0;
+};
 class FIRC8xR16x24FS4Decim8 {
    public:
     static constexpr size_t taps_count = 24;

--- a/firmware/baseband/dsp_decimate.hpp
+++ b/firmware/baseband/dsp_decimate.hpp
@@ -113,7 +113,7 @@ class FIRC8xR16x24FS4Decim4 {
     int32_t output_scale = 0;
 };
 
-class FIRC8xR16x24FS4Decim4_256 {       // Cloned from FIRC8xR16x24FS4Decim4 + limiting output buffer C16 x 256 samples.
+class FIRC8xR16x24FS4Decim4_256 {  // Cloned from FIRC8xR16x24FS4Decim4 + limiting output buffer C16 x 256 samples.
    public:
     static constexpr size_t taps_count = 24;
     static constexpr size_t decimation_factor = 4;

--- a/firmware/baseband/dsp_decimate.hpp
+++ b/firmware/baseband/dsp_decimate.hpp
@@ -113,33 +113,6 @@ class FIRC8xR16x24FS4Decim4 {
     int32_t output_scale = 0;
 };
 
-class FIRC8xR16x24FS4Decim4_256 {  // Cloned from FIRC8xR16x24FS4Decim4 + limiting output buffer C16 x 256 samples.
-   public:
-    static constexpr size_t taps_count = 24;
-    static constexpr size_t decimation_factor = 4;
-
-    using sample_t = complex8_t;
-    using tap_t = int16_t;
-
-    enum class Shift : bool {
-        Down = true,
-        Up = false
-    };
-
-    void configure(
-        const std::array<tap_t, taps_count>& taps,
-        const int32_t scale,
-        const Shift shift = Shift::Down);
-
-    buffer_c16_t execute(
-        const buffer_c8_t& src,
-        const buffer_c16_t& dst);
-
-   private:
-    std::array<vec2_s16, taps_count - decimation_factor> z_{};
-    std::array<tap_t, taps_count> taps_{};
-    int32_t output_scale = 0;
-};
 class FIRC8xR16x24FS4Decim8 {
    public:
     static constexpr size_t taps_count = 24;

--- a/firmware/baseband/proc_capture.cpp
+++ b/firmware/baseband/proc_capture.cpp
@@ -101,7 +101,7 @@ void CaptureProcessor::sample_rate_config(const SampleRateConfigMessage& message
     // For high sample rates, the M4 is busy collecting samples so the
     // waterfall runs slower. Reduce the update interval so it runs faster.
     // NB: Trade off: looks nicer, but more frequent updates == more CPU.
-    if (sample_rate > 1'500'000)
+    if (sample_rate >= 1'500'000)
         spectrum_interval_samples /= (sample_rate / 500'000);
 
     // Mystery scalars for decimator configuration.

--- a/firmware/baseband/proc_capture.cpp
+++ b/firmware/baseband/proc_capture.cpp
@@ -128,13 +128,14 @@ void CaptureProcessor::sample_rate_config(const SampleRateConfigMessage& message
             break;
     }
 
-    size_t decim_0_output_fs = baseband_fs / decim_0_factor;
-    size_t decim_1_output_fs = decim_0_output_fs / decim_1_factor;
+    size_t decim_0_output_fs = baseband_fs / decim_0.decimation_factor();
+    size_t decim_1_output_fs = decim_0_output_fs / decim_1.decimation_factor();
 
     // TODO: Use the right taps give the decimator?
-    channel_filter_low_f = taps_200k_decim_1.low_frequency_normalized * decim_1_input_fs;
-    channel_filter_high_f = taps_200k_decim_1.high_frequency_normalized * decim_1_input_fs;
-    channel_filter_transition = taps_200k_decim_1.transition_normalized * decim_1_input_fs;
+    // TODO: Why was this using decim_0's output fs?
+    channel_filter_low_f = taps_200k_decim_1.low_frequency_normalized * decim_1_output_fs;
+    channel_filter_high_f = taps_200k_decim_1.high_frequency_normalized * decim_1_output_fs;
+    channel_filter_transition = taps_200k_decim_1.transition_normalized * decim_1_output_fs;
 
     spectrum_interval_samples = decim_1_output_fs / spectrum_rate_hz;
     spectrum_samples = 0;

--- a/firmware/baseband/proc_capture.cpp
+++ b/firmware/baseband/proc_capture.cpp
@@ -112,7 +112,7 @@ void CaptureProcessor::sample_rate_config(const SampleRateConfigMessage& message
             decim_0_factor = decim_0_4.decimation_factor;  // /4 = /(4x1)
 
             if (baseband_fs < 7'000'000) {  // we are in ovs x4 ,  < 1.5 Mhz , M4 is not overrun 100% when fs < 1M5 x 4 = 6000
-                decim_1_factor = 2 * 1;      // decim1 is /1 because bypassed, (but just increased to adjust waterfall speed, it seems no effect to the write process or fft scale)
+                decim_1_factor = 2 * 1;     // decim1 is /1 because bypassed, (but just increased to adjust waterfall speed, it seems no effect to the write process or fft scale)
             } else {
                 decim_1_factor = 4 * 1;  // decim1 is /1 because bypassed ,(but just increased to adjust waterfall speed  when M4 has buffer drops )
             }

--- a/firmware/baseband/proc_capture.cpp
+++ b/firmware/baseband/proc_capture.cpp
@@ -107,12 +107,12 @@ void CaptureProcessor::sample_rate_config(const SampleRateConfigMessage& message
     */
 
     size_t decim_0_factor, decim_1_factor;
-    switch (oversample_rate) {  // we are using 3 decim_1 modes,  /1 , /2 ,  /8
+    switch (oversample_rate) {  // we are using 3 decim_0 modes (/4,  /8-200k, /8-180k) , and   3 decim_1 modes : (/1 bypassed, /2,  /8)
         case OversampleRate::x4:
             decim_0_factor = decim_0_4.decimation_factor;  // /4 = /(4x1)
 
-            if (baseband_fs < 14'000'000) {  // we are in ovs x4 ,  < 3.5 Mhz , M4 is not overrun 100% when fs < 3M5 x 4 = 15M
-                decim_1_factor = 2 * 1;      // decim1 is /1 because bypassed, (but just increased to adjust waterfall speed , it seems no effect to the write process or fft scale)
+            if (baseband_fs < 7'000'000) {  // we are in ovs x4 ,  < 1.5 Mhz , M4 is not overrun 100% when fs < 1M5 x 4 = 6000
+                decim_1_factor = 2 * 1;      // decim1 is /1 because bypassed, (but just increased to adjust waterfall speed, it seems no effect to the write process or fft scale)
             } else {
                 decim_1_factor = 4 * 1;  // decim1 is /1 because bypassed ,(but just increased to adjust waterfall speed  when M4 has buffer drops )
             }
@@ -130,20 +130,21 @@ void CaptureProcessor::sample_rate_config(const SampleRateConfigMessage& message
 
         case OversampleRate::x16:
             decim_0_factor = decim_0_8.decimation_factor;      // /16 = /(8x2)
-            decim_1_factor = 2 * decim_1_2.decimation_factor;  // /16 = /8x2 (we applied additional *2 correction to increase waterfall spped >=600k and smooth & avoid abnormal motion >1M5 )
+            decim_1_factor = 2 * decim_1_2.decimation_factor;  // /16 = /(8x2) (we applied additional *2 correction to increase waterfall spped and smooth & avoid abnormal motion )
             break;
 
         case OversampleRate::x32:
             decim_0_factor = decim_0_4.decimation_factor;      // /32 = /(4x8) (we applied additional *2 correction to speed up waterfall, no effect to scale spectrum)
-            decim_1_factor = 4 * decim_1_8.decimation_factor;  // /32 = /4x8 (we applied additional *2 correction to speed up waterfall, no effect to scale spectrum)
+            decim_1_factor = 4 * decim_1_8.decimation_factor;  // /32 = /(4x8) (we applied additional *2 correction to speed up waterfall, no effect to scale spectrum)
             break;
 
         case OversampleRate::x64:
             decim_0_factor = decim_0_8.decimation_factor;      // /64 = /(8x8) (we applied additional *8 correction to speed up waterfall, no effect to scale spectrum)
-            decim_1_factor = 8 * decim_1_8.decimation_factor;  // /64 = /8x8 (we applied additional *8 correction to speed up waterfall, no effect to scale spectrum)
+            decim_1_factor = 8 * decim_1_8.decimation_factor;  // /64 = /(8x8) (we applied additional *8 correction to speed up waterfall, no effect to scale spectrum)
             break;
 
         default:
+            decim_0_factor = 4;  // just default initial value to remove compile warning.
             decim_1_factor = 2;  // just default initial value to remove compile warning.
             break;
     }

--- a/firmware/baseband/proc_capture.cpp
+++ b/firmware/baseband/proc_capture.cpp
@@ -27,14 +27,14 @@
 #include "utility.hpp"
 
 CaptureProcessor::CaptureProcessor() {
-    decim_0_4.configure(taps_200k_decim_0.taps, 33554432);           // to be used with decim1 (/2), then total two decim stages decim (/8)
-    decim_0_8.configure(taps_200k_decim_0.taps, 33554432);           // to be used with decim1 (/2), then total two decim stages decim (/16)
+    decim_0_4.configure(taps_200k_decim_0.taps, 33554432);  // to be used with decim1 (/2), then total two decim stages decim (/8)
+    decim_0_8.configure(taps_200k_decim_0.taps, 33554432);  // to be used with decim1 (/2), then total two decim stages decim (/16)
 
     decim_0_8_180k.configure(taps_180k_wfm_decim_0.taps, 33554432);  // to be used alone - no additional decim1 (/2), then total single decim stage (/8)
     decim_0_4_256.configure(taps_200k_decim_0.taps, 33554432);       // to be used alone - no additional decim1 (/2), then total single decim stage (/4)
 
-    decim_1_2.configure(taps_200k_decim_1.taps, 131072);                
-    decim_1_8.configure(taps_16k0_decim_1.taps, 131072);             // tentative decim1 /8  and taps, pending to be optimized.
+    decim_1_2.configure(taps_200k_decim_1.taps, 131072);
+    decim_1_8.configure(taps_16k0_decim_1.taps, 131072);  // tentative decim1 /8  and taps, pending to be optimized.
 
     channel_spectrum.set_decimation_factor(1);
     baseband_thread.start();
@@ -110,13 +110,13 @@ void CaptureProcessor::sample_rate_config(const SampleRateConfigMessage& message
     size_t decim_1_factor;
     switch (oversample_rate) {  // we are using 3 decim_1 modes,  /1 , /2 ,  /8
         case OversampleRate::x4:
-            if (baseband_fs < 14'000'000) {    // < 3.5 Mhz , M4 is not overrun 100% when fs < 3M5 X 4 = 15M
-                decim_1_factor = 2 *1;  // decim1 is /1 ,     (but just increased to adjust waterfall speed , it seems no effect to the write process or fft scale)
+            if (baseband_fs < 14'000'000) {  // we are in ovs x4 ,  < 3.5 Mhz , M4 is not overrun 100% when fs < 3M5 x 4 = 15M
+                decim_1_factor = 2 * 1;      // decim1 is /1 because bypassed, (but just increased to adjust waterfall speed , it seems no effect to the write process or fft scale)
             } else {
-                decim_1_factor = 4 *1;  // decim1 is /1 ,     (but just increased to adjust waterfall speed  when M4 has buffer drops ) 
+                decim_1_factor = 4 * 1;  // decim1 is /1 because bypassed ,(but just increased to adjust waterfall speed  when M4 has buffer drops )
             }
             break;
-              
+
         case OversampleRate::x8:
             if (baseband_fs < 4800'000) {
                 decim_1_factor = decim_1_2.decimation_factor;  // /8 = /4x2
@@ -143,7 +143,7 @@ void CaptureProcessor::sample_rate_config(const SampleRateConfigMessage& message
     }
 
     /*    // that was ok,  when we had only 2 oversampling x8 , x16
-    auto decim_1_factor = oversample_rate == OversampleRate::x32   
+    auto decim_1_factor = oversample_rate == OversampleRate::x32
                               ? decim_1_8.decimation_factor
                               : decim_1_2.decimation_factor;
     */
@@ -195,13 +195,13 @@ buffer_c16_t CaptureProcessor::decim_0_execute(const buffer_c8_t& src, const buf
 buffer_c16_t CaptureProcessor::decim_1_execute(const buffer_c16_t& src, const buffer_c16_t& dst) {
     switch (oversample_rate) {
         case OversampleRate::x4:
-            return src;                    // just decim0_4 (/4)                
+            return src;  // just decim0_4 (/4)
 
         case OversampleRate::x8:           // we can get /8 by two means , decim0 (/4) + decim1 (/2) .  or just decim0 (/8)
             if (baseband_fs < 4800'000) {  // 600khz (600k x 8)
                 return decim_1_2.execute(src, dst);
             } else {
-                return src;                 // just decim0_8 (/8)
+                return src;  // just decim0_8 (/8)
             }
 
         case OversampleRate::x16:

--- a/firmware/baseband/proc_capture.cpp
+++ b/firmware/baseband/proc_capture.cpp
@@ -27,32 +27,28 @@
 #include "utility.hpp"
 
 CaptureProcessor::CaptureProcessor() {
-    decim_0_4.configure(taps_200k_decim_0.taps, 33554432);  // to be used with decim1 (/2), then total two decim stages decim (/8)
+    // What are these scale factors? Where did they come from?
+    decim_0_4.configure(taps_200k_decim_0.taps, 33'554'432);  // to be used with decim1 (/2), then total two decim stages decim (/8)
     decim_0_8.configure(taps_200k_decim_0.taps, 33554432);  // to be used with decim1 (/2), then total two decim stages decim (/16)
 
+    // Why using 180k taps?
     decim_0_8_180k.configure(taps_180k_wfm_decim_0.taps, 33554432);  // to be used alone - no additional decim1 (/2), then total single decim stage (/8)
     decim_0_4_256.configure(taps_200k_decim_0.taps, 33554432);       // to be used alone - no additional decim1 (/2), then total single decim stage (/4)
 
+    // Why using 16k taps?
     decim_1_2.configure(taps_200k_decim_1.taps, 131072);
-    decim_1_8.configure(taps_16k0_decim_1.taps, 131072);  // tentative decim1 /8  and taps, pending to be optimized.
+    decim_1_8.configure(taps_16k0_decim_1.taps, 131072);  // tentative decim1 /8 and taps, pending to be optimized.
 
-    channel_spectrum.set_decimation_factor(1);
+    channel_spectrum.set_decimation_factor(1);  // What does this do?
     baseband_thread.start();
 }
 
 void CaptureProcessor::execute(const buffer_c8_t& buffer) {
-    /* 2.4576MHz, 2048 samples */
-    const auto decim_0_out = decim_0_execute(buffer, dst_buffer);       // selectable 3 possible decim_0, (/4.  /8 200k soft filter , /8 180k sharp )
-    const auto decim_1_out = decim_1_execute(decim_0_out, dst_buffer);  // selectable 3 possible decim_1, (/8.  /2 200k or bypassed /1  )
+    // 2.4576MHz, 2048 samples -- ??? Where did these come from?
+    const auto decim_0_out = decim_0_execute(buffer, dst_buffer);
+    const auto decim_1_out = decim_1_execute(decim_0_out, dst_buffer);
 
-    /* this code was valid when we had only 2 decim1 cases.
-    const auto decim_1_out = baseband_fs < 4800'000
-                                  ? decim_1_2.execute(decim_0_out, dst_buffer)  // < 600khz double decim. stage , means 500khz and lower bit rates.
-                                 // ? decim_1_8.execute(decim_0_out, dst_buffer)  // < 600khz double decim. stage , means 500khz and lower bit rates.
-                                  : decim_0_out;                              // >= 600khz single decim. stage , means 600khz and upper bit rates.
-
-     } */
-
+    // ??? Why?
     const auto& decimator_out = decim_1_out;
     const auto& channel = decimator_out;
 
@@ -60,7 +56,7 @@ void CaptureProcessor::execute(const buffer_c8_t& buffer) {
         const size_t bytes_to_write = sizeof(*decimator_out.p) * decimator_out.count;
         const size_t written = stream->write(decimator_out.p, bytes_to_write);
         if (written != bytes_to_write) {
-            // TODO eventually report error somewhere
+            // TODO: Report error somewhere?
         }
     }
 
@@ -99,12 +95,7 @@ void CaptureProcessor::sample_rate_config(const SampleRateConfigMessage& message
 
     baseband_thread.set_sampling_rate(baseband_fs);
 
-    /*
-      // when we had only 2 decim_0 modes,  /4 , /8
-      auto decim_0_factor = (oversample_rate == OversampleRate::x8) || (oversample_rate == OversampleRate::x4)
-                                ? decim_0_4.decimation_factor
-                                : decim_0_8.decimation_factor;
-    */
+    // TODO: We should not need to be futzing around with the values to make the waterfall happy.
 
     size_t decim_0_factor, decim_1_factor;
     switch (oversample_rate) {  // we are using 3 decim_0 modes (/4,  /8-200k, /8-180k) , and   3 decim_1 modes : (/1 bypassed, /2,  /8)
@@ -149,7 +140,7 @@ void CaptureProcessor::sample_rate_config(const SampleRateConfigMessage& message
             break;
     }
 
-    /*    // that was ok,  when we had only 2 oversampling x8 , x16
+    /*    // that was ok,  when we had only 2 oversampling x8, x16
     auto decim_1_factor = oversample_rate == OversampleRate::x32
                               ? decim_1_8.decimation_factor
                               : decim_1_2.decimation_factor;
@@ -187,23 +178,23 @@ void CaptureProcessor::capture_config(const CaptureConfigMessage& message) {
 buffer_c16_t CaptureProcessor::decim_0_execute(const buffer_c8_t& src, const buffer_c16_t& dst) {
     switch (oversample_rate) {
         case OversampleRate::x4:
-            return decim_0_4_256.execute(src, dst);  // decim_0 , /4 with single  decim0 stage with limited output buffer c16 to 256 samples.
+            return decim_0_4_256.execute(src, dst);  // decim_0, /4 with single  decim0 stage with limited output buffer c16 to 256 samples.
 
         case OversampleRate::x8:                     // we can get /8 by two means , decim0 (/4) + decim1 (/2) .  or just decim0 (/8)
-            if (baseband_fs < 4800'000) {            // 600khz (600k x 8)
-                return decim_0_4.execute(src, dst);  // decim_0 , /4 with double decim stage
+            if (baseband_fs < 4'800'000) {            // 600khz (600k x 8)
+                return decim_0_4.execute(src, dst);  // decim_0, /4 with double decim stage
             } else {
-                return decim_0_8_180k.execute(src, dst);  // decim_0  /8 with single decim stage
+                return decim_0_8_180k.execute(src, dst);  // decim_0 /8 with single decim stage
             }
 
         case OversampleRate::x16:
-            return decim_0_8.execute(src, dst);  // decim_0 , /8 with double decim stage
+            return decim_0_8.execute(src, dst);  // decim_0, /8 with double decim stage
 
         case OversampleRate::x32:
-            return decim_0_4.execute(src, dst);  // decim_0 , /4 with double decim stage
+            return decim_0_4.execute(src, dst);  // decim_0, /4 with double decim stage
 
         case OversampleRate::x64:
-            return decim_0_8.execute(src, dst);  // decim_0 , /8 with double decim stage
+            return decim_0_8.execute(src, dst);  // decim_0, /8 with double decim stage
 
         default:
             chDbgPanic("Unhandled OversampleRate");

--- a/firmware/baseband/proc_capture.cpp
+++ b/firmware/baseband/proc_capture.cpp
@@ -29,19 +29,7 @@
 using namespace dsp::decimate;
 
 CaptureProcessor::CaptureProcessor() {
-    // // What are these scale factors? Where did they come from?
-    // decim_0_4.configure(taps_200k_decim_0.taps, 33'554'432);  // to be used with decim1 (/2), then total two decim stages decim (/8)
-    // decim_0_8.configure(taps_200k_decim_0.taps, 33554432);  // to be used with decim1 (/2), then total two decim stages decim (/16)
-
-    // // Why using 180k taps?
-    // decim_0_8_180k.configure(taps_180k_wfm_decim_0.taps, 33554432);  // to be used alone - no additional decim1 (/2), then total single decim stage (/8)
-    // decim_0_4_256.configure(taps_200k_decim_0.taps, 33554432);       // to be used alone - no additional decim1 (/2), then total single decim stage (/4)
-
-    // // Why using 16k taps?
-    // decim_1_2.configure(taps_200k_decim_1.taps, 131072);
-    // decim_1_8.configure(taps_16k0_decim_1.taps, 131072);  // tentative decim1 /8 and taps, pending to be optimized.
-
-    channel_spectrum.set_decimation_factor(1);  // What does this do?
+    channel_spectrum.set_decimation_factor(1);
     baseband_thread.start();
 }
 
@@ -49,29 +37,27 @@ void CaptureProcessor::execute(const buffer_c8_t& buffer) {
     auto decim_0_out = decim_0.execute(buffer, dst_buffer);
     auto out_buffer = decim_1.execute(decim_0_out, dst_buffer);
 
-    // // 2.4576MHz, 2048 samples -- ??? Where did these come from?
-    // const auto decim_0_out = decim_0_execute(buffer, dst_buffer);
-    // const auto decim_1_out = decim_1_execute(decim_0_out, dst_buffer);
+    if (stream) {
+        const size_t bytes_to_write = sizeof(*out_buffer.p) * out_buffer.count;
+        const size_t written = stream->write(out_buffer.p, bytes_to_write);
+        if (written != bytes_to_write) {
+            // TODO: Send an error message to the app?
+        }
+    }
 
-    // // ??? Why?
-    // const auto& decimator_out = decim_1_out;
-    // const auto& channel = decimator_out;
+    feed_channel_stats(out_buffer);
 
-    // if (stream) {
-    //     const size_t bytes_to_write = sizeof(*decimator_out.p) * decimator_out.count;
-    //     const size_t written = stream->write(decimator_out.p, bytes_to_write);
-    //     if (written != bytes_to_write) {
-    //         // TODO: Report error somewhere?
-    //     }
-    // }
-
-    // feed_channel_stats(channel);
-
-    // spectrum_samples += channel.count;
-    // if (spectrum_samples >= spectrum_interval_samples) {
-    //     spectrum_samples -= spectrum_interval_samples;
-    //     channel_spectrum.feed(channel, channel_filter_low_f, channel_filter_high_f, channel_filter_transition);
-    // }
+    // TODO: per Brumi spectrum seems to only want 256 samples?
+    // Just call twice in that case?
+    spectrum_samples += out_buffer.count;
+    if (spectrum_samples >= spectrum_interval_samples) {
+        spectrum_samples -= spectrum_interval_samples;
+        channel_spectrum.feed(
+            out_buffer,
+            channel_filter_low_f,
+            channel_filter_high_f,
+            channel_filter_transition);
+    }
 }
 
 void CaptureProcessor::on_message(const Message* const message) {
@@ -98,15 +84,10 @@ void CaptureProcessor::sample_rate_config(const SampleRateConfigMessage& message
     // The actual sample rate is the requested rate * the oversample rate.
     // See oversample.hpp for more details on oversampling.
     baseband_fs = message.sample_rate * toUType(message.oversample_rate);
-    oversample_rate = message.oversample_rate;
-
     baseband_thread.set_sampling_rate(baseband_fs);
 
-    // TODO: Explain?
-    constexpr int decim_0_scale = 33'554'432;
-    constexpr int decim_1_scale = 131'072;
-
-    // TODO: separate waterfall scalar to make it look nice?
+    constexpr int decim_0_scale = 0x2000000;
+    constexpr int decim_1_scale = 0x20000;
 
     switch (message.oversample_rate) {
         case OversampleRate::x4:
@@ -147,137 +128,24 @@ void CaptureProcessor::sample_rate_config(const SampleRateConfigMessage& message
             break;
     }
 
-    // // TODO: We should not need to be futzing around with the values to make the waterfall happy.
-
-    // size_t decim_0_factor, decim_1_factor;
-    // switch (oversample_rate) {  // we are using 3 decim_0 modes (/4,  /8-200k, /8-180k) , and   3 decim_1 modes : (/1 bypassed, /2,  /8)
-    //     case OversampleRate::x4:
-    //         decim_0_factor = decim_0_4.decimation_factor;  // /4 = /(4x1)
-
-    // if (baseband_fs < 7'000'000) {  // we are in ovs x4 ,  < 1.5 Mhz , M4 is not overrun 100% when fs < 1M5 x 4 = 6000
-    //     decim_1_factor = 2 * 1;     // decim1 is /1 because bypassed, (but just increased to adjust waterfall speed, it seems no effect to the write process or fft scale)
-    // } else {
-    //     decim_1_factor = 4 * 1;  // decim1 is /1 because bypassed ,(but just increased to adjust waterfall speed  when M4 has buffer drops )
-    // }
-    // break;
-
-    // case OversampleRate::x8:
-    //     if (baseband_fs < 4800'000) {
-    //         decim_0_factor = decim_0_4.decimation_factor;  // /8 = /(4x2)
-    //         decim_1_factor = decim_1_2.decimation_factor;  // /8 = /4x2,    factor 2 *  , it is just to speed up waterfall.
-    //     } else {
-    //         decim_0_factor = decim_0_8.decimation_factor;  // /8 = /(8x1),   600khz and onwards, single decim /8 = /8x1 (we applied additional *2 correction to speed up waterfall, no effect to scale spectrum)
-    //         decim_1_factor = 1;                            // 600khz and onwards, single decim /8 = /8x1 (we applied additional *2 correction to speed up waterfall, no effect to scale spectrum)
-    //     }
-    //     break;
-
-    // case OversampleRate::x16:
-    //     decim_0_factor = decim_0_8.decimation_factor;      // /16 = /(8x2)
-    //     decim_1_factor = 2 * decim_1_2.decimation_factor;  // /16 = /(8x2) (we applied additional *2 correction to increase waterfall spped and smooth & avoid abnormal motion )
-    //     break;
-
-    // case OversampleRate::x32:
-    //     decim_0_factor = decim_0_4.decimation_factor;      // /32 = /(4x8) (we applied additional *2 correction to speed up waterfall, no effect to scale spectrum)
-    //     decim_1_factor = 4 * decim_1_8.decimation_factor;  // /32 = /(4x8) (we applied additional *2 correction to speed up waterfall, no effect to scale spectrum)
-    //     break;
-
-    // case OversampleRate::x64:
-    //     decim_0_factor = decim_0_8.decimation_factor;      // /64 = /(8x8) (we applied additional *8 correction to speed up waterfall, no effect to scale spectrum)
-    //     decim_1_factor = 8 * decim_1_8.decimation_factor;  // /64 = /(8x8) (we applied additional *8 correction to speed up waterfall, no effect to scale spectrum)
-    //     break;
-
-    // default:
-    //     decim_0_factor = 4;  // just default initial value to remove compile warning.
-    //     decim_1_factor = 2;  // just default initial value to remove compile warning.
-    //     break;
-
-    // /*    // that was ok,  when we had only 2 oversampling x8, x16
-    // auto decim_1_factor = oversample_rate == OversampleRate::x32
-    //                           ? decim_1_8.decimation_factor
-    //                           : decim_1_2.decimation_factor;
-    // */
-
-    // /*
-    // // Test To limit to buffer dst 512 -> 256 samples to waterfall but it also changes wrongly the fft horiz. spectrum scale .
-    // if (oversample_rate == OversampleRate::x4) {
-    //     channel_spectrum.set_decimation_factor(2);
-    // } else {
-    //     channel_spectrum.set_decimation_factor(1);
-    // }
-    // */
-
-    /*
-    // TODO: Use the right taps per.
     size_t decim_0_output_fs = baseband_fs / decim_0_factor;
-    size_t decim_1_input_fs = decim_0_output_fs;
-    size_t decim_1_output_fs = decim_1_input_fs / decim_1_factor;
+    size_t decim_1_output_fs = decim_0_output_fs / decim_1_factor;
 
+    // TODO: Use the right taps give the decimator?
     channel_filter_low_f = taps_200k_decim_1.low_frequency_normalized * decim_1_input_fs;
     channel_filter_high_f = taps_200k_decim_1.high_frequency_normalized * decim_1_input_fs;
     channel_filter_transition = taps_200k_decim_1.transition_normalized * decim_1_input_fs;
 
     spectrum_interval_samples = decim_1_output_fs / spectrum_rate_hz;
     spectrum_samples = 0;
-    */
 }
 
 void CaptureProcessor::capture_config(const CaptureConfigMessage& message) {
-    if (message.config) {
+    if (message.config)
         stream = std::make_unique<StreamInput>(message.config);
-    } else {
+    else
         stream.reset();
-    }
 }
-
-// buffer_c16_t CaptureProcessor::decim_0_execute(const buffer_c8_t& src, const buffer_c16_t& dst) {
-//     switch (oversample_rate) {
-//         case OversampleRate::x4:
-//             return decim_0_4_256.execute(src, dst);  // decim_0, /4 with single  decim0 stage with limited output buffer c16 to 256 samples.
-
-// case OversampleRate::x8:                     // we can get /8 by two means , decim0 (/4) + decim1 (/2) .  or just decim0 (/8)
-//     if (baseband_fs < 4'800'000) {            // 600khz (600k x 8)
-//         return decim_0_4.execute(src, dst);  // decim_0, /4 with double decim stage
-//     } else {
-//         return decim_0_8_180k.execute(src, dst);  // decim_0 /8 with single decim stage
-//     }
-
-// case OversampleRate::x16:
-//     return decim_0_8.execute(src, dst);  // decim_0, /8 with double decim stage
-
-// case OversampleRate::x32:
-//     return decim_0_4.execute(src, dst);  // decim_0, /4 with double decim stage
-
-// case OversampleRate::x64:
-//     return decim_0_8.execute(src, dst);  // decim_0, /8 with double decim stage
-
-// default:
-//     chDbgPanic("Unhandled OversampleRate");
-//     return {};}
-
-// buffer_c16_t CaptureProcessor::decim_1_execute(const buffer_c16_t& src, const buffer_c16_t& dst) {
-//     switch (oversample_rate) {
-//         case OversampleRate::x4:
-//             return src;  // just decim0_4 (/4)
-
-// case OversampleRate::x8:           // we can get /8 by two means , decim0 (/4) + decim1 (/2) .  or just decim0 (/8)
-//     if (baseband_fs < 4800'000) {  // 600khz (600k x 8)
-//         return decim_1_2.execute(src, dst);
-//     } else {
-//         return src;  // just decim0_8 (/8)
-//     }
-
-// case OversampleRate::x16:
-//     return decim_1_2.execute(src, dst);  // total decim /16 = /8x2, applied to 100khz and 150khz
-
-// case OversampleRate::x32:
-//     return decim_1_8.execute(src, dst);  // total decim /32 = /4x8, appled to  75k , 50k, 32k
-
-// case OversampleRate::x64:
-//     return decim_1_8.execute(src, dst);  // total decim /64 = /8x8, appled to 16k and 12k5
-
-// default:
-//     chDbgPanic("Unhandled OversampleRate");
-//     return {};}
 
 int main() {
     EventDispatcher event_dispatcher{std::make_unique<CaptureProcessor>()};

--- a/firmware/baseband/proc_capture.cpp
+++ b/firmware/baseband/proc_capture.cpp
@@ -26,47 +26,52 @@
 #include "event_m4.hpp"
 #include "utility.hpp"
 
+using namespace dsp::decimate;
+
 CaptureProcessor::CaptureProcessor() {
-    // What are these scale factors? Where did they come from?
-    decim_0_4.configure(taps_200k_decim_0.taps, 33'554'432);  // to be used with decim1 (/2), then total two decim stages decim (/8)
-    decim_0_8.configure(taps_200k_decim_0.taps, 33554432);  // to be used with decim1 (/2), then total two decim stages decim (/16)
+    // // What are these scale factors? Where did they come from?
+    // decim_0_4.configure(taps_200k_decim_0.taps, 33'554'432);  // to be used with decim1 (/2), then total two decim stages decim (/8)
+    // decim_0_8.configure(taps_200k_decim_0.taps, 33554432);  // to be used with decim1 (/2), then total two decim stages decim (/16)
 
-    // Why using 180k taps?
-    decim_0_8_180k.configure(taps_180k_wfm_decim_0.taps, 33554432);  // to be used alone - no additional decim1 (/2), then total single decim stage (/8)
-    decim_0_4_256.configure(taps_200k_decim_0.taps, 33554432);       // to be used alone - no additional decim1 (/2), then total single decim stage (/4)
+    // // Why using 180k taps?
+    // decim_0_8_180k.configure(taps_180k_wfm_decim_0.taps, 33554432);  // to be used alone - no additional decim1 (/2), then total single decim stage (/8)
+    // decim_0_4_256.configure(taps_200k_decim_0.taps, 33554432);       // to be used alone - no additional decim1 (/2), then total single decim stage (/4)
 
-    // Why using 16k taps?
-    decim_1_2.configure(taps_200k_decim_1.taps, 131072);
-    decim_1_8.configure(taps_16k0_decim_1.taps, 131072);  // tentative decim1 /8 and taps, pending to be optimized.
+    // // Why using 16k taps?
+    // decim_1_2.configure(taps_200k_decim_1.taps, 131072);
+    // decim_1_8.configure(taps_16k0_decim_1.taps, 131072);  // tentative decim1 /8 and taps, pending to be optimized.
 
     channel_spectrum.set_decimation_factor(1);  // What does this do?
     baseband_thread.start();
 }
 
 void CaptureProcessor::execute(const buffer_c8_t& buffer) {
-    // 2.4576MHz, 2048 samples -- ??? Where did these come from?
-    const auto decim_0_out = decim_0_execute(buffer, dst_buffer);
-    const auto decim_1_out = decim_1_execute(decim_0_out, dst_buffer);
+    auto decim_0_out = decim_0.execute(buffer, dst_buffer);
+    // auto decim_1_out = decim_1_execute(decim_0_out, dst_buffer);
 
-    // ??? Why?
-    const auto& decimator_out = decim_1_out;
-    const auto& channel = decimator_out;
+    // // 2.4576MHz, 2048 samples -- ??? Where did these come from?
+    // const auto decim_0_out = decim_0_execute(buffer, dst_buffer);
+    // const auto decim_1_out = decim_1_execute(decim_0_out, dst_buffer);
 
-    if (stream) {
-        const size_t bytes_to_write = sizeof(*decimator_out.p) * decimator_out.count;
-        const size_t written = stream->write(decimator_out.p, bytes_to_write);
-        if (written != bytes_to_write) {
-            // TODO: Report error somewhere?
-        }
-    }
+    // // ??? Why?
+    // const auto& decimator_out = decim_1_out;
+    // const auto& channel = decimator_out;
 
-    feed_channel_stats(channel);
+    // if (stream) {
+    //     const size_t bytes_to_write = sizeof(*decimator_out.p) * decimator_out.count;
+    //     const size_t written = stream->write(decimator_out.p, bytes_to_write);
+    //     if (written != bytes_to_write) {
+    //         // TODO: Report error somewhere?
+    //     }
+    // }
 
-    spectrum_samples += channel.count;
-    if (spectrum_samples >= spectrum_interval_samples) {
-        spectrum_samples -= spectrum_interval_samples;
-        channel_spectrum.feed(channel, channel_filter_low_f, channel_filter_high_f, channel_filter_transition);
-    }
+    // feed_channel_stats(channel);
+
+    // spectrum_samples += channel.count;
+    // if (spectrum_samples >= spectrum_interval_samples) {
+    //     spectrum_samples -= spectrum_interval_samples;
+    //     channel_spectrum.feed(channel, channel_filter_low_f, channel_filter_high_f, channel_filter_transition);
+    // }
 }
 
 void CaptureProcessor::on_message(const Message* const message) {
@@ -90,71 +95,150 @@ void CaptureProcessor::on_message(const Message* const message) {
 }
 
 void CaptureProcessor::sample_rate_config(const SampleRateConfigMessage& message) {
+    // The actual sample rate is the requested rate * the oversample rate.
+    // See oversample.hpp for more details on oversampling.
     baseband_fs = message.sample_rate * toUType(message.oversample_rate);
     oversample_rate = message.oversample_rate;
 
     baseband_thread.set_sampling_rate(baseband_fs);
 
-    // TODO: We should not need to be futzing around with the values to make the waterfall happy.
+    // TODO: Explain?
+    constexpr int decim_0_scale = 33'554'432;
+    constexpr int decim_1_scale = 131'072;
 
-    size_t decim_0_factor, decim_1_factor;
-    switch (oversample_rate) {  // we are using 3 decim_0 modes (/4,  /8-200k, /8-180k) , and   3 decim_1 modes : (/1 bypassed, /2,  /8)
-        case OversampleRate::x4:
-            decim_0_factor = decim_0_4.decimation_factor;  // /4 = /(4x1)
+    // TODO: separate waterfall scalar to make it look nice.
 
-            if (baseband_fs < 7'000'000) {  // we are in ovs x4 ,  < 1.5 Mhz , M4 is not overrun 100% when fs < 1M5 x 4 = 6000
-                decim_1_factor = 2 * 1;     // decim1 is /1 because bypassed, (but just increased to adjust waterfall speed, it seems no effect to the write process or fft scale)
+    switch (message.oversample_rate) {
+        case OversampleRate::None:
+            chDbgPanic("Unhandled OversampleRate");
+            break;
+
+        case OversampleRate::x4: {
+            FIRC8xR16x24FS4Decim4 d0;
+            d0.configure(taps_200k_decim_0.taps, decim_0_scale);
+            decim_0.set(d0);
+
+            decim_1.set(NoopDecim{});
+            break;
+        }
+
+        case OversampleRate::x8: {
+            // M4 can't handle 2 decimation passes for sample rates at or above 600k.
+            if (message.sample_rate < 600'00) {
+                FIRC8xR16x24FS4Decim4 d0;
+                d0.configure(taps_200k_decim_0.taps, decim_0_scale);
+                decim_0.set(d0);
+
+                FIRC16xR16x16Decim2 d1;
+                d1.configure(taps_200k_decim_1.taps, decim_1_scale);
+                decim_1.set(d1);
+
             } else {
-                decim_1_factor = 4 * 1;  // decim1 is /1 because bypassed ,(but just increased to adjust waterfall speed  when M4 has buffer drops )
+                // Using the 180k taps to provide better filtering with a single pass.
+                FIRC8xR16x24FS4Decim8 d0;
+                d0.configure(taps_180k_wfm_decim_0.taps, decim_0_scale);
+                decim_0.set(d0);
+
+                decim_1.set(NoopDecim{});
             }
             break;
+        }
 
-        case OversampleRate::x8:
-            if (baseband_fs < 4800'000) {
-                decim_0_factor = decim_0_4.decimation_factor;  // /8 = /(4x2)
-                decim_1_factor = decim_1_2.decimation_factor;  // /8 = /4x2,    factor 2 *  , it is just to speed up waterfall.
-            } else {
-                decim_0_factor = decim_0_8.decimation_factor;  // /8 = /(8x1),   600khz and onwards, single decim /8 = /8x1 (we applied additional *2 correction to speed up waterfall, no effect to scale spectrum)
-                decim_1_factor = 1;                            // 600khz and onwards, single decim /8 = /8x1 (we applied additional *2 correction to speed up waterfall, no effect to scale spectrum)
-            }
-            break;
+        case OversampleRate::x16: {
+            FIRC8xR16x24FS4Decim8 d0;
+            d0.configure(taps_200k_decim_0.taps, decim_0_scale);
+            decim_0.set(d0);
 
-        case OversampleRate::x16:
-            decim_0_factor = decim_0_8.decimation_factor;      // /16 = /(8x2)
-            decim_1_factor = 2 * decim_1_2.decimation_factor;  // /16 = /(8x2) (we applied additional *2 correction to increase waterfall spped and smooth & avoid abnormal motion )
+            FIRC16xR16x16Decim2 d1;
+            d1.configure(taps_200k_decim_1.taps, decim_1_scale);
+            decim_1.set(d1);
             break;
+        }
 
-        case OversampleRate::x32:
-            decim_0_factor = decim_0_4.decimation_factor;      // /32 = /(4x8) (we applied additional *2 correction to speed up waterfall, no effect to scale spectrum)
-            decim_1_factor = 4 * decim_1_8.decimation_factor;  // /32 = /(4x8) (we applied additional *2 correction to speed up waterfall, no effect to scale spectrum)
-            break;
+        case OversampleRate::x32: {
+            FIRC8xR16x24FS4Decim4 d0;
+            d0.configure(taps_200k_decim_0.taps, decim_0_scale);
+            decim_0.set(d0);
 
-        case OversampleRate::x64:
-            decim_0_factor = decim_0_8.decimation_factor;      // /64 = /(8x8) (we applied additional *8 correction to speed up waterfall, no effect to scale spectrum)
-            decim_1_factor = 8 * decim_1_8.decimation_factor;  // /64 = /(8x8) (we applied additional *8 correction to speed up waterfall, no effect to scale spectrum)
+            FIRC16xR16x32Decim8 d1;
+            d1.configure(taps_16k0_decim_1.taps, decim_1_scale);
+            decim_1.set(d1);
             break;
+        }
 
-        default:
-            decim_0_factor = 4;  // just default initial value to remove compile warning.
-            decim_1_factor = 2;  // just default initial value to remove compile warning.
+        case OversampleRate::x64: {
+            FIRC8xR16x24FS4Decim8 d0;
+            d0.configure(taps_200k_decim_0.taps, decim_0_scale);
+            decim_0.set(d0);
+
+            FIRC16xR16x32Decim8 d1;
+            d1.configure(taps_16k0_decim_1.taps, decim_1_scale);
+            decim_1.set(d1);
             break;
+        }
     }
 
-    /*    // that was ok,  when we had only 2 oversampling x8, x16
-    auto decim_1_factor = oversample_rate == OversampleRate::x32
-                              ? decim_1_8.decimation_factor
-                              : decim_1_2.decimation_factor;
-    */
+    // // TODO: We should not need to be futzing around with the values to make the waterfall happy.
+
+    // size_t decim_0_factor, decim_1_factor;
+    // switch (oversample_rate) {  // we are using 3 decim_0 modes (/4,  /8-200k, /8-180k) , and   3 decim_1 modes : (/1 bypassed, /2,  /8)
+    //     case OversampleRate::x4:
+    //         decim_0_factor = decim_0_4.decimation_factor;  // /4 = /(4x1)
+
+    // if (baseband_fs < 7'000'000) {  // we are in ovs x4 ,  < 1.5 Mhz , M4 is not overrun 100% when fs < 1M5 x 4 = 6000
+    //     decim_1_factor = 2 * 1;     // decim1 is /1 because bypassed, (but just increased to adjust waterfall speed, it seems no effect to the write process or fft scale)
+    // } else {
+    //     decim_1_factor = 4 * 1;  // decim1 is /1 because bypassed ,(but just increased to adjust waterfall speed  when M4 has buffer drops )
+    // }
+    // break;
+
+    // case OversampleRate::x8:
+    //     if (baseband_fs < 4800'000) {
+    //         decim_0_factor = decim_0_4.decimation_factor;  // /8 = /(4x2)
+    //         decim_1_factor = decim_1_2.decimation_factor;  // /8 = /4x2,    factor 2 *  , it is just to speed up waterfall.
+    //     } else {
+    //         decim_0_factor = decim_0_8.decimation_factor;  // /8 = /(8x1),   600khz and onwards, single decim /8 = /8x1 (we applied additional *2 correction to speed up waterfall, no effect to scale spectrum)
+    //         decim_1_factor = 1;                            // 600khz and onwards, single decim /8 = /8x1 (we applied additional *2 correction to speed up waterfall, no effect to scale spectrum)
+    //     }
+    //     break;
+
+    // case OversampleRate::x16:
+    //     decim_0_factor = decim_0_8.decimation_factor;      // /16 = /(8x2)
+    //     decim_1_factor = 2 * decim_1_2.decimation_factor;  // /16 = /(8x2) (we applied additional *2 correction to increase waterfall spped and smooth & avoid abnormal motion )
+    //     break;
+
+    // case OversampleRate::x32:
+    //     decim_0_factor = decim_0_4.decimation_factor;      // /32 = /(4x8) (we applied additional *2 correction to speed up waterfall, no effect to scale spectrum)
+    //     decim_1_factor = 4 * decim_1_8.decimation_factor;  // /32 = /(4x8) (we applied additional *2 correction to speed up waterfall, no effect to scale spectrum)
+    //     break;
+
+    // case OversampleRate::x64:
+    //     decim_0_factor = decim_0_8.decimation_factor;      // /64 = /(8x8) (we applied additional *8 correction to speed up waterfall, no effect to scale spectrum)
+    //     decim_1_factor = 8 * decim_1_8.decimation_factor;  // /64 = /(8x8) (we applied additional *8 correction to speed up waterfall, no effect to scale spectrum)
+    //     break;
+
+    // default:
+    //     decim_0_factor = 4;  // just default initial value to remove compile warning.
+    //     decim_1_factor = 2;  // just default initial value to remove compile warning.
+    //     break;
+
+    // /*    // that was ok,  when we had only 2 oversampling x8, x16
+    // auto decim_1_factor = oversample_rate == OversampleRate::x32
+    //                           ? decim_1_8.decimation_factor
+    //                           : decim_1_2.decimation_factor;
+    // */
+
+    // /*
+    // // Test To limit to buffer dst 512 -> 256 samples to waterfall but it also changes wrongly the fft horiz. spectrum scale .
+    // if (oversample_rate == OversampleRate::x4) {
+    //     channel_spectrum.set_decimation_factor(2);
+    // } else {
+    //     channel_spectrum.set_decimation_factor(1);
+    // }
+    // */
 
     /*
-    // Test To limit to buffer dst 512 -> 256 samples to waterfall but it also changes wrongly the fft horiz. spectrum scale .
-    if (oversample_rate == OversampleRate::x4) {
-        channel_spectrum.set_decimation_factor(2);
-    } else {
-        channel_spectrum.set_decimation_factor(1);
-    }
-    */
-
+    // TODO: Use the right taps per.
     size_t decim_0_output_fs = baseband_fs / decim_0_factor;
     size_t decim_1_input_fs = decim_0_output_fs;
     size_t decim_1_output_fs = decim_1_input_fs / decim_1_factor;
@@ -165,6 +249,7 @@ void CaptureProcessor::sample_rate_config(const SampleRateConfigMessage& message
 
     spectrum_interval_samples = decim_1_output_fs / spectrum_rate_hz;
     spectrum_samples = 0;
+    */
 }
 
 void CaptureProcessor::capture_config(const CaptureConfigMessage& message) {
@@ -175,59 +260,55 @@ void CaptureProcessor::capture_config(const CaptureConfigMessage& message) {
     }
 }
 
-buffer_c16_t CaptureProcessor::decim_0_execute(const buffer_c8_t& src, const buffer_c16_t& dst) {
-    switch (oversample_rate) {
-        case OversampleRate::x4:
-            return decim_0_4_256.execute(src, dst);  // decim_0, /4 with single  decim0 stage with limited output buffer c16 to 256 samples.
+// buffer_c16_t CaptureProcessor::decim_0_execute(const buffer_c8_t& src, const buffer_c16_t& dst) {
+//     switch (oversample_rate) {
+//         case OversampleRate::x4:
+//             return decim_0_4_256.execute(src, dst);  // decim_0, /4 with single  decim0 stage with limited output buffer c16 to 256 samples.
 
-        case OversampleRate::x8:                     // we can get /8 by two means , decim0 (/4) + decim1 (/2) .  or just decim0 (/8)
-            if (baseband_fs < 4'800'000) {            // 600khz (600k x 8)
-                return decim_0_4.execute(src, dst);  // decim_0, /4 with double decim stage
-            } else {
-                return decim_0_8_180k.execute(src, dst);  // decim_0 /8 with single decim stage
-            }
+// case OversampleRate::x8:                     // we can get /8 by two means , decim0 (/4) + decim1 (/2) .  or just decim0 (/8)
+//     if (baseband_fs < 4'800'000) {            // 600khz (600k x 8)
+//         return decim_0_4.execute(src, dst);  // decim_0, /4 with double decim stage
+//     } else {
+//         return decim_0_8_180k.execute(src, dst);  // decim_0 /8 with single decim stage
+//     }
 
-        case OversampleRate::x16:
-            return decim_0_8.execute(src, dst);  // decim_0, /8 with double decim stage
+// case OversampleRate::x16:
+//     return decim_0_8.execute(src, dst);  // decim_0, /8 with double decim stage
 
-        case OversampleRate::x32:
-            return decim_0_4.execute(src, dst);  // decim_0, /4 with double decim stage
+// case OversampleRate::x32:
+//     return decim_0_4.execute(src, dst);  // decim_0, /4 with double decim stage
 
-        case OversampleRate::x64:
-            return decim_0_8.execute(src, dst);  // decim_0, /8 with double decim stage
+// case OversampleRate::x64:
+//     return decim_0_8.execute(src, dst);  // decim_0, /8 with double decim stage
 
-        default:
-            chDbgPanic("Unhandled OversampleRate");
-            return {};
-    }
-}
+// default:
+//     chDbgPanic("Unhandled OversampleRate");
+//     return {};}
 
-buffer_c16_t CaptureProcessor::decim_1_execute(const buffer_c16_t& src, const buffer_c16_t& dst) {
-    switch (oversample_rate) {
-        case OversampleRate::x4:
-            return src;  // just decim0_4 (/4)
+// buffer_c16_t CaptureProcessor::decim_1_execute(const buffer_c16_t& src, const buffer_c16_t& dst) {
+//     switch (oversample_rate) {
+//         case OversampleRate::x4:
+//             return src;  // just decim0_4 (/4)
 
-        case OversampleRate::x8:           // we can get /8 by two means , decim0 (/4) + decim1 (/2) .  or just decim0 (/8)
-            if (baseband_fs < 4800'000) {  // 600khz (600k x 8)
-                return decim_1_2.execute(src, dst);
-            } else {
-                return src;  // just decim0_8 (/8)
-            }
+// case OversampleRate::x8:           // we can get /8 by two means , decim0 (/4) + decim1 (/2) .  or just decim0 (/8)
+//     if (baseband_fs < 4800'000) {  // 600khz (600k x 8)
+//         return decim_1_2.execute(src, dst);
+//     } else {
+//         return src;  // just decim0_8 (/8)
+//     }
 
-        case OversampleRate::x16:
-            return decim_1_2.execute(src, dst);  // total decim /16 = /8x2, applied to 100khz and 150khz
+// case OversampleRate::x16:
+//     return decim_1_2.execute(src, dst);  // total decim /16 = /8x2, applied to 100khz and 150khz
 
-        case OversampleRate::x32:
-            return decim_1_8.execute(src, dst);  // total decim /32 = /4x8, appled to  75k , 50k, 32k
+// case OversampleRate::x32:
+//     return decim_1_8.execute(src, dst);  // total decim /32 = /4x8, appled to  75k , 50k, 32k
 
-        case OversampleRate::x64:
-            return decim_1_8.execute(src, dst);  // total decim /64 = /8x8, appled to 16k and 12k5
+// case OversampleRate::x64:
+//     return decim_1_8.execute(src, dst);  // total decim /64 = /8x8, appled to 16k and 12k5
 
-        default:
-            chDbgPanic("Unhandled OversampleRate");
-            return {};
-    }
-}
+// default:
+//     chDbgPanic("Unhandled OversampleRate");
+//     return {};}
 
 int main() {
     EventDispatcher event_dispatcher{std::make_unique<CaptureProcessor>()};

--- a/firmware/baseband/proc_capture.hpp
+++ b/firmware/baseband/proc_capture.hpp
@@ -55,6 +55,7 @@ class CaptureProcessor : public BasebandProcessor {
      * use decim_0_4 for an overall decimation factor of 8.
      * use decim_0_8 for an overall decimation factor of 16. */
     dsp::decimate::FIRC8xR16x24FS4Decim4 decim_0_4{};
+    dsp::decimate::FIRC8xR16x24FS4Decim4_256 decim_0_4_256{};
     dsp::decimate::FIRC8xR16x24FS4Decim8 decim_0_8{};
     dsp::decimate::FIRC8xR16x24FS4Decim8 decim_0_8_180k{};
     dsp::decimate::FIRC16xR16x16Decim2 decim_1_2{};

--- a/firmware/baseband/proc_capture.hpp
+++ b/firmware/baseband/proc_capture.hpp
@@ -58,7 +58,7 @@ class MultiDecimator {
         const Source& src,
         const Destination& dst) {
         return std::visit(
-            [&src, &dst](auto&& arg) {
+            [&src, &dst](auto&& arg) -> Destination {
                 return arg.execute(src, dst);
             },
             decimator_);
@@ -66,7 +66,7 @@ class MultiDecimator {
 
     size_t decimation_factor() const {
         return std::visit(
-            [](auto&& arg) {
+            [](auto&& arg) -> size_t {
                 return arg.decimation_factor;
             },
             decimator_);

--- a/firmware/baseband/proc_capture.hpp
+++ b/firmware/baseband/proc_capture.hpp
@@ -93,7 +93,6 @@ class CaptureProcessor : public BasebandProcessor {
 
    private:
     size_t baseband_fs = 3072000;  // aka: sample_rate
-    static constexpr auto spectrum_rate_hz = 50.0f;
 
     std::array<complex16_t, 512> dst{};
     const buffer_c16_t dst_buffer{

--- a/firmware/baseband/proc_capture.hpp
+++ b/firmware/baseband/proc_capture.hpp
@@ -93,6 +93,7 @@ class CaptureProcessor : public BasebandProcessor {
 
    private:
     size_t baseband_fs = 3072000;  // aka: sample_rate
+    static constexpr auto spectrum_rate_hz = 50.0f;
 
     std::array<complex16_t, 512> dst{};
     const buffer_c16_t dst_buffer{

--- a/firmware/baseband/proc_capture.hpp
+++ b/firmware/baseband/proc_capture.hpp
@@ -33,6 +33,8 @@
 
 #include <array>
 #include <memory>
+#include <tuple>
+#include <variant>
 
 
 // Need to be able to configure "path" for each rate
@@ -43,7 +45,7 @@ template <typename T>
 class D {
 };
 
-// A decimator that just copies the source.
+// A decimator that just copies the source to the destination.
 class NoopDecim {
     template <typename Buffer>
     Buffer execute(const Buffer& src, const Buffer& dst) {
@@ -54,6 +56,34 @@ class NoopDecim {
         return {dst.p, src.count, src.sampling_rate};
     }
 };
+
+// All decimators must use same types.
+template <typename... Args>
+class MultiDecimator {
+
+    static constexpr size_t taps_count = 16;
+    static constexpr size_t decimation_factor = 2;
+
+    using sample_t = complex16_t;
+    using tap_t = int16_t;
+
+    void configure(
+        const std::array<tap_t, taps_count>& taps,
+        const int32_t scale);
+
+    buffer_c16_t execute(
+        const buffer_c16_t& src,
+        const buffer_c16_t& dst);
+
+   private:
+    std::variant<Args...> decimators_;
+};
+
+template <typename Decim0, typename Decim1>
+class DecimatorPath {
+};
+
+
 
 
 class CaptureProcessor : public BasebandProcessor {

--- a/firmware/baseband/proc_capture.hpp
+++ b/firmware/baseband/proc_capture.hpp
@@ -34,6 +34,28 @@
 #include <array>
 #include <memory>
 
+
+// Need to be able to configure "path" for each rate
+// Need to be able to get decimation factor
+// What about single layer decimation
+
+template <typename T>
+class D {
+};
+
+// A decimator that just copies the source.
+class NoopDecim {
+    template <typename Buffer>
+    Buffer execute(const Buffer& src, const Buffer& dst) {
+        // TODO: memcpy?
+        for (size_t i = 0; i < src.count; ++i)
+            dst.p[i] = src.p[i];
+
+        return {dst.p, src.count, src.sampling_rate};
+    }
+};
+
+
 class CaptureProcessor : public BasebandProcessor {
    public:
     CaptureProcessor();
@@ -55,7 +77,7 @@ class CaptureProcessor : public BasebandProcessor {
      * use decim_0_4 for an overall decimation factor of 8.
      * use decim_0_8 for an overall decimation factor of 16. */
     dsp::decimate::FIRC8xR16x24FS4Decim4 decim_0_4{};
-    dsp::decimate::FIRC8xR16x24FS4Decim4_256 decim_0_4_256{};
+    //dsp::decimate::FIRC8xR16x24FS4Decim4_256 decim_0_4_256{};
     dsp::decimate::FIRC8xR16x24FS4Decim8 decim_0_8{};
     dsp::decimate::FIRC8xR16x24FS4Decim8 decim_0_8_180k{};
     dsp::decimate::FIRC16xR16x16Decim2 decim_1_2{};

--- a/firmware/baseband/proc_capture.hpp
+++ b/firmware/baseband/proc_capture.hpp
@@ -36,9 +36,11 @@
 #include <tuple>
 #include <variant>
 
-// A decimator that just returns the source buffer.
+/* A decimator that just returns the source buffer. */
 class NoopDecim {
    public:
+    static constexpr int decimation_factor = 1;
+
     template <typename Buffer>
     Buffer execute(const Buffer& src, const Buffer&) {
         // TODO: should this copy to 'dst'?
@@ -46,7 +48,7 @@ class NoopDecim {
     }
 };
 
-// TODO: Does std::visit still add a lot of code bloat?
+/* Decimator wrapper that can hold one of a set of decimators and dispatch at runtime. */
 template <typename... Args>
 class MultiDecimator {
    public:
@@ -71,7 +73,7 @@ class MultiDecimator {
     }
 
     /* Sets this decimator to a new instance of the specified decimator type.
-     * NB: The instance is returned by-ref so configure can easily be called. */
+     * NB: The instance is returned by-ref so 'configure' can easily be called. */
     template <typename Decimator>
     Decimator& set() {
         decimator_ = Decimator{};
@@ -98,7 +100,7 @@ class CaptureProcessor : public BasebandProcessor {
         dst.data(),
         dst.size()};
 
-    // The actual type will be configured depending on the sample rate.
+    /* The actual type will be configured depending on the sample rate. */
     MultiDecimator<
         dsp::decimate::FIRC8xR16x24FS4Decim4,
         dsp::decimate::FIRC8xR16x24FS4Decim8>
@@ -118,7 +120,6 @@ class CaptureProcessor : public BasebandProcessor {
     SpectrumCollector channel_spectrum{};
     size_t spectrum_interval_samples = 0;
     size_t spectrum_samples = 0;
-    OversampleRate oversample_rate{OversampleRate::None};
 
     /* NB: Threads should be the last members in the class definition. */
     BasebandThread baseband_thread{
@@ -127,12 +128,6 @@ class CaptureProcessor : public BasebandProcessor {
 
     void sample_rate_config(const SampleRateConfigMessage& message);
     void capture_config(const CaptureConfigMessage& message);
-
-    // /* Dispatch to the correct decim_0 based on oversample rate. */
-    // buffer_c16_t decim_0_execute(const buffer_c8_t& src, const buffer_c16_t& dst);
-
-    // /* Dispatch to the correct decim_1 based on oversample rate. */
-    // buffer_c16_t decim_1_execute(const buffer_c16_t& src, const buffer_c16_t& dst);
 };
 
 #endif /*__PROC_CAPTURE_HPP__*/

--- a/firmware/baseband/proc_replay.cpp
+++ b/firmware/baseband/proc_replay.cpp
@@ -69,7 +69,7 @@ void ReplayProcessor::execute(const buffer_c8_t& buffer) {
         chDbgPanic("Output not div.");
 
     // Is the input smaple buffer big enough?
-    if (samples_to_read > iq_buffer.size())
+    if (samples_to_read > iq_buffer.count)
         chDbgPanic("IQ buf ovf.");
 #endif
 

--- a/firmware/baseband/proc_replay.hpp
+++ b/firmware/baseband/proc_replay.hpp
@@ -45,7 +45,7 @@ class ReplayProcessor : public BasebandProcessor {
     static constexpr auto spectrum_rate_hz = 50.0f;
 
     // Holds the read IQ data chunk from the file to send.
-    std::array<complex16_t, 256> iq{};
+    std::array<complex16_t, 512> iq{};
 
     int32_t channel_filter_low_f = 0;
     int32_t channel_filter_high_f = 0;

--- a/firmware/common/message.hpp
+++ b/firmware/common/message.hpp
@@ -820,6 +820,9 @@ enum class OversampleRate : uint8_t {
     // overrun the IQ read buffer in proc_replay.
 
     /* Oversample rate of 8 times the sample rate. */
+    x4 = 4,
+
+    /* Oversample rate of 8 times the sample rate. */
     x8 = 8,
 
     /* Oversample rate of 16 times the sample rate. */

--- a/firmware/common/message.hpp
+++ b/firmware/common/message.hpp
@@ -819,7 +819,7 @@ enum class OversampleRate : uint8_t {
     // 4x would make sense to have, but need to ensure it doesn't
     // overrun the IQ read buffer in proc_replay.
 
-    /* Oversample rate of 8 times the sample rate. */
+    /* Oversample rate of 4 times the sample rate. */
     x4 = 4,
 
     /* Oversample rate of 8 times the sample rate. */
@@ -833,9 +833,6 @@ enum class OversampleRate : uint8_t {
 
     /* Oversample rate of 64 times the sample rate. */
     x64 = 64,
-
-    /* Oversample rate of 128 times the sample rate. */
-    x128 = 128,
 };
 
 class SampleRateConfigMessage : public Message {

--- a/firmware/common/message.hpp
+++ b/firmware/common/message.hpp
@@ -816,9 +816,6 @@ enum class OversampleRate : uint8_t {
     None = 1,
     x1 = None,
 
-    // 4x would make sense to have, but need to ensure it doesn't
-    // overrun the IQ read buffer in proc_replay.
-
     /* Oversample rate of 4 times the sample rate. */
     x4 = 4,
 

--- a/firmware/common/oversample.hpp
+++ b/firmware/common/oversample.hpp
@@ -60,8 +60,9 @@ inline OversampleRate get_oversample_rate(uint32_t sample_rate) {
     if (sample_rate < 30'000) return OversampleRate::x64;   // 25k, 16k, 12k5.
     if (sample_rate < 80'000) return OversampleRate::x32;   // 75k, 50k, 32k.
     if (sample_rate < 250'000) return OversampleRate::x16;  // 100k and 150k.
-
-    return OversampleRate::x8;  // 250k .. 1Mhz, that decim x8 , is already applied.(OVerSampling and decim OK)
+    if (sample_rate < 1'250'000) return OversampleRate::x8;  // 250k,500k,600k,650k.750k.1Mhz.
+    
+    return OversampleRate::x4;  // 1.25Mhz ... 5.5Mhz, that decim x4  , it will allow us to REC 1M5,2M in C8 , from 2M onwards YELLOW icon.
 }
 
 /* Gets the actual sample rate for a given sample rate.

--- a/firmware/common/oversample.hpp
+++ b/firmware/common/oversample.hpp
@@ -57,11 +57,11 @@
  * The oversample rate is used to increase the sample rate to improve SNR and quality.
  * This is also used as the interpolation rate when replaying captures. */
 inline OversampleRate get_oversample_rate(uint32_t sample_rate) {
-    if (sample_rate < 30'000) return OversampleRate::x64;   // 25k, 16k, 12k5.
-    if (sample_rate < 80'000) return OversampleRate::x32;   // 75k, 50k, 32k.
-    if (sample_rate < 250'000) return OversampleRate::x16;  // 100k and 150k.
+    if (sample_rate < 30'000) return OversampleRate::x64;    // 25k, 16k, 12k5.
+    if (sample_rate < 80'000) return OversampleRate::x32;    // 75k, 50k, 32k.
+    if (sample_rate < 250'000) return OversampleRate::x16;   // 100k and 150k.
     if (sample_rate < 1'250'000) return OversampleRate::x8;  // 250k,500k,600k,650k.750k.1Mhz.
-    
+
     return OversampleRate::x4;  // 1.25Mhz ... 5.5Mhz, that decim x4  , it will allow us to REC 1M5,2M in C8 , from 2M onwards YELLOW icon.
 }
 

--- a/firmware/common/oversample.hpp
+++ b/firmware/common/oversample.hpp
@@ -62,7 +62,7 @@ inline OversampleRate get_oversample_rate(uint32_t sample_rate) {
     if (sample_rate < 250'000) return OversampleRate::x16;   // 100k and 150k.
     if (sample_rate < 1'250'000) return OversampleRate::x8;  // 250k,500k,600k,650k.750k.1Mhz.
 
-    return OversampleRate::x4;  // 1.25Mhz ... 5.5Mhz, that decim x4  , it will allow us to REC 1M5,2M in C8 , from 2M onwards YELLOW icon.
+    return OversampleRate::x4;  // top range (1.25Mhz ... 5.5Mhz),  we can REC (12k5 ... 1.25Mhz) c16/c8, and from (1.5Mhz ... 5.5Mhz) YELLOW icon.
 }
 
 /* Gets the actual sample rate for a given sample rate.

--- a/firmware/common/oversample.hpp
+++ b/firmware/common/oversample.hpp
@@ -42,15 +42,15 @@
  * In testing, a minimum rate of 400kHz seems to the functional minimum.
  *
  * There are several different concepts or terms related to Capture and Replay,
- * (1) oversampling (x8, x16 ,...) / decimation (/8, /16...)
- * In Capture App , when ADC can not handle directly a requiered low sample rates ,
- * we need to apply oversampling (x8. x16 ex) , getting more real samples than needed) by "x_number" ,
- * and later to write it to SD card with the proper needed real sample rate , we apply Decimation  , "/ number" .
+ * (1) Oversampling (x8, x16, ...) and Decimation (/8, /16...)
+ * In Capture App, the ADC can not directly handle low sample rates.
+ * We need to apply oversampling (x8, x16, ...), collecting more "x number" additional real samples.
+ * To write it to SD card with the desired sample rate, we apply Decimation ("/ number").
  *
- * (2) up-sampling or re-escale or interpolation. (x8, x16, ...)
- * In Replay-list App, when we got too low bit rate data for Hackrf ,
- * we need to upsampling or interpolate or resampling to increase those low bit rates
- * to a proper sample rate higher than the min. to be able to be transmitted by Hackrf.
+ * (2) Up-sampling or re-scale or interpolation. (x8, x16, ...).
+ * In Replay-list App, when the bit rate data is too low for HackRF.
+ * We need to upsample or interpolate to increase those low bit rates
+ * to a rate higher than the hardware nminimum to be transmitted by Hackrf.
  */
 
 /* Gets the oversample rate for a given sample rate.
@@ -59,10 +59,10 @@
 inline OversampleRate get_oversample_rate(uint32_t sample_rate) {
     if (sample_rate < 30'000) return OversampleRate::x64;    // 25k, 16k, 12k5.
     if (sample_rate < 80'000) return OversampleRate::x32;    // 75k, 50k, 32k.
-    if (sample_rate < 250'000) return OversampleRate::x16;   // 100k and 150k.
-    if (sample_rate < 1'250'000) return OversampleRate::x8;  // 250k,500k,600k,650k.750k.1Mhz.
+    if (sample_rate < 250'000) return OversampleRate::x16;   // 100k, 150k.
+    if (sample_rate < 1'250'000) return OversampleRate::x8;  // 250k, 500k, 600k, 650k, 750k, 1Mhz.
 
-    return OversampleRate::x4;  // top range (1.25Mhz ... 5.5Mhz),  we can REC (12k5 ... 1.25Mhz) c16/c8, and from (1.5Mhz ... 5.5Mhz) YELLOW icon.
+    return OversampleRate::x4;  // Top range (1.25Mhz ... 5.5Mhz).
 }
 
 /* Gets the actual sample rate for a given sample rate.


### PR DESCRIPTION
This PR is a collaboration with @Brumi-2021.

There are a few goals for this PR:
1) Support x4 oversampling rate for higher bandwidths in Capture and Replay.
2) Clean up existing code to reduce complexity.
3) Make BlockDecimator work when src.count > dst.count.