### PR TITLE
Minor issue : Slow down scrolling speed in BW 1.5Mhz onwards , and adding some TODO comments.

### DIFF
--- a/firmware/baseband/proc_capture.cpp
+++ b/firmware/baseband/proc_capture.cpp
@@ -104,10 +104,8 @@ void CaptureProcessor::sample_rate_config(const SampleRateConfigMessage& message
     if (sample_rate >= 1'500'000)
         spectrum_interval_samples /= (sample_rate / 750'000);
 
-    // Those two below "mystery" scalars are widely used in many App's, for decimator (decim0, decim1)  configuration.
-    // 0x2000000 = 335554432 dec = 2 exp 25 . Used in decim0,  to scale and shift the filtered with gain and decimated samples, using  int 64 that was using the bottom 38 bits.
-    // With that scale , we are shifting up  25 bits, and then ,  we can pick up the top 2 bytes with sign in the signed c16 conversion
-    // 0x20000   = 131072 dec = 2 exp 18 , same explanation , used in decim 1 ,to scale and shift the ,filtered + gain and decimated samples using int 32, in the signed c16 convertion.
+    // Mystery scalars for decimator configuration.
+    // TODO: figure these out and add a real comment.
     constexpr int decim_0_scale = 0x2000000;
     constexpr int decim_1_scale = 0x20000;
 

--- a/firmware/baseband/proc_capture.cpp
+++ b/firmware/baseband/proc_capture.cpp
@@ -102,10 +102,12 @@ void CaptureProcessor::sample_rate_config(const SampleRateConfigMessage& message
     // waterfall runs slower. Reduce the update interval so it runs faster.
     // NB: Trade off: looks nicer, but more frequent updates == more CPU.
     if (sample_rate >= 1'500'000)
-        spectrum_interval_samples /= (sample_rate / 500'000);
+        spectrum_interval_samples /= (sample_rate / 750'000);
 
-    // Mystery scalars for decimator configuration.
-    // TODO: figure these out and add a real comment.
+    // Those two below "mystery" scalars are widely used in many App's, for decimator (decim0, decim1)  configuration.
+    // 0x2000000 = 335554432 dec = 2 exp 25 . Used in decim0,  to scale and shift the filtered with gain and decimated samples, using  int 64 that was using the bottom 38 bits.
+    // With that scale , we are shifting up  25 bits, and then ,  we can pick up the top 2 bytes with sign in the signed c16 conversion
+    // 0x20000   = 131072 dec = 2 exp 18 , same explanation , used in decim 1 ,to scale and shift the ,filtered + gain and decimated samples using int 32, in the signed c16 convertion.
     constexpr int decim_0_scale = 0x2000000;
     constexpr int decim_1_scale = 0x20000;
 


### PR DESCRIPTION
Very Minor issue PR for Capture App . 
After checking more carefully  in different LCD's  ( H1R1 ,  H2+R4 ) the previous PR #1418 , 
I could see too much flickering artifacts in one type of slow  LCD H2+ , specially in freq. BW , 1.5 Mhz, 3Mhz, 4.5Mhz .

This PR makes the fine tuning , just slowing down slightly the waterfall scrolling in the BW from 1.5Mhz onwards.
and it also adds the pending TODO comments hints about two different "mystery" scalars used in the decimator configuration. 