### PR TITLE
Fix RSSI for apps using proc_capture

### DIFF
--- a/firmware/application/ui/ui_spectrum.cpp
+++ b/firmware/application/ui/ui_spectrum.cpp
@@ -382,7 +382,8 @@ void WaterfallView::on_audio_spectrum() {
 
 uint32_t filter_bandwidth_for_sampling_rate(int32_t sampling_rate) {
     switch (sampling_rate) {   // Use the var fs (sampling_rate) to set up BPF aprox < fs_max / 2 by Nyquist theorem.
-        case 0 ... 3'500'000:  // BW Captured range (0 <= 250kHz max) fs = 8x250k = 2000, 16x150k = 2400, 32x100k = 3200, 32x75k = 2400, 64x40k = 2400.
+        case 0 ... 3'500'000:  // BW Captured range BW (<=250K) : fs = 8x250k = 2000k, 16x150k = 2400k, 16x100k=1600k,
+                               // 32x75k = 2400k, 32x50k=1600, 32x32k=1024, 64x25k = 1600k, 64x16k = 1024k, 64x12k5 = 800k.
             return 1'750'000;  // Minimum BPF MAX2837 for all those lower BW options.
 
         case 4'000'000 ... 7'000'000:  // OVS x8, BW capture range (500k...750kHz max) fs_max = 8 x 750k = 6Mhz

--- a/firmware/application/ui/ui_spectrum.cpp
+++ b/firmware/application/ui/ui_spectrum.cpp
@@ -380,10 +380,9 @@ void WaterfallView::on_audio_spectrum() {
 
 } /* namespace spectrum */
 
-// TODO: Comments below refer to a fixed oversample rate (8x), cleanup.
 uint32_t filter_bandwidth_for_sampling_rate(int32_t sampling_rate) {
     switch (sampling_rate) {   // Use the var fs (sampling_rate) to set up BPF aprox < fs_max / 2 by Nyquist theorem.
-        case 0 ... 3'500'000:  // BW Captured range (0 <= 250kHz max) fs = 8x250k = 2000, 16x150k = 2400, 32x100k = 3200, 32x75k = 2400, (future 64x40 khz = 2400)
+        case 0 ... 3'500'000:  // BW Captured range (0 <= 250kHz max) fs = 8x250k = 2000, 16x150k = 2400, 32x100k = 3200, 32x75k = 2400, 64x40k = 2400.
             return 1'750'000;  // Minimum BPF MAX2837 for all those lower BW options.
 
         case 4'000'000 ... 7'000'000:  // OVS x8, BW capture range (500k...750kHz max) fs_max = 8 x 750k = 6Mhz


### PR DESCRIPTION
@gullradriel @Brumi-2021 This fixes the slow/choppy RSSI spectrum updating for Level and Recon.
There were 2 issues.
1) These apps need to configure the baseband with the sample rate/oversample and then set the radio to the actual sampling rate (desired rate * oversample).
2) These apps weren't running their Bandwidth "on change" handlers when the modulation was changed so the code to fix up the bandwidths was not running until (if) someone updated the bandwidth.

I tested both and they seem to work as expected now.
[portapack-h1_h2-mayhem.bin.zip](https://github.com/eried/portapack-mayhem/files/12471784/portapack-h1_h2-mayhem.bin.zip)
