### PR TITLE
Fixed 0.1Hz error in tone key frequencies 146.2, 156.7, and 162.2

### DIFF
--- a/firmware/application/tone_key.cpp
+++ b/firmware/application/tone_key.cpp
@@ -85,7 +85,7 @@ const tone_key_t tone_keys = {
     {"Senn. 32.768k", F2Ix100(32768.0)}};
 
 std::string fx100_string(uint32_t f) {
-    return to_string_dec_uint(f / 100) + "." + to_string_dec_uint((f / 10) % 10);
+    return to_string_dec_uint(f / 100) + "." + to_string_dec_uint(((f + 5) / 10) % 10);
 }
 
 float tone_key_frequency(tone_index index) {

--- a/firmware/application/tone_key.hpp
+++ b/firmware/application/tone_key.hpp
@@ -31,7 +31,7 @@ namespace tonekey {
 
 #define TONE_FREQ_TOLERANCE_CENTIHZ (4 * 100)
 #define TONE_DISPLAY_TOGGLE_COUNTER 3
-#define F2Ix100(x) (int32_t)(x * 100.0)
+#define F2Ix100(x) (int32_t)(x * 100.0 + 0.5)  // add 0.5f to round vs truncate during FP->int conversion
 
 using tone_index = int32_t;
 using tone_key_t = std::vector<std::pair<std::string, uint32_t>>;


### PR DESCRIPTION
Fixes #1425

Three values were stored incorrectly in the tone key table:  146.2, 156.7, and 162.2, each of which were 0.01Hz off when transmitted, and 0.1Hz off on the screen).

The code change in tone_key.hpp corrects the value stored in the tone key table.  14619 was incorrectly in the table where we were expecting 14620.  Floating point math imprecision resulted in 146.2f * 100.0f = ~14619.99999999f, which was truncated to 14619 integer, which is what was being stored in the table incorrectly.  Adding 0.5 before integer conversion fixes this. 

Actual tone frequency transmitted was 146.19 which was close enough for CTCSS, but displayed value on screen was a concern.

Secondly, the code change in tone_key.cpp adds missing rounding before division when displaying the tone frequency (which is stored as freq times 100).  The 14619 above was being displayed as 146.1 when it should have been rounded to 146.2 when displayed with one decimal place.  (Actually it's good that this rounding was missing initially or we wouldn't have noticed the other error above.)