### PR TITLE
Small fine tuning xOVS selection for BW 25k

### DIFF
--- a/firmware/common/oversample.hpp
+++ b/firmware/common/oversample.hpp
@@ -57,8 +57,8 @@
  * The oversample rate is used to increase the sample rate to improve SNR and quality.
  * This is also used as the interpolation rate when replaying captures. */
 inline OversampleRate get_oversample_rate(uint32_t sample_rate) {
-    if (sample_rate < 30'000) return OversampleRate::x64;    // 25k, 16k, 12k5.
-    if (sample_rate < 80'000) return OversampleRate::x32;    // 75k, 50k, 32k.
+    if (sample_rate < 25'000) return OversampleRate::x64;    // 16k, 12k5.
+    if (sample_rate < 80'000) return OversampleRate::x32;    // 75k, 50k, 32k,25k
     if (sample_rate < 250'000) return OversampleRate::x16;   // 100k, 150k.
     if (sample_rate < 1'250'000) return OversampleRate::x8;  // 250k, 500k, 600k, 650k, 750k, 1Mhz.
 

--- a/firmware/common/oversample.hpp
+++ b/firmware/common/oversample.hpp
@@ -57,10 +57,10 @@
  * The oversample rate is used to increase the sample rate to improve SNR and quality.
  * This is also used as the interpolation rate when replaying captures. */
 inline OversampleRate get_oversample_rate(uint32_t sample_rate) {
-    if (sample_rate < 25'000) return OversampleRate::x64;    // 16k, 12k5.
-    if (sample_rate < 80'000) return OversampleRate::x32;    // 75k, 50k, 32k,25k
+    if (sample_rate < 25'000) return OversampleRate::x64;    // 12k5, 16k.
+    if (sample_rate < 80'000) return OversampleRate::x32;    // 25k,  32k, 50k, 75k.
     if (sample_rate < 250'000) return OversampleRate::x16;   // 100k, 150k.
-    if (sample_rate < 1'250'000) return OversampleRate::x8;  // 250k, 500k, 600k, 650k, 750k, 1Mhz.
+    if (sample_rate < 1'250'000) return OversampleRate::x8;  // 250k, 500k, 600k, 750k, 1Mhz.
 
     return OversampleRate::x4;  // Top range (1.25Mhz ... 5.5Mhz).
 }


### PR DESCRIPTION
Just  minor  xOVS value change  to the only bandwith rate : 25k .

Ideally Hackrf is working better with higher sample rate  (advice from 2Mhz to 20 Mhz) , but experimentally our ADC seems working well from 200k min . Then , based on evaluation , all is a tradeoff related to Image reject / vertical stripe / anti-aliasing performances.

In that particular BW = 25k , with  OVS   x32  , sometimes we got  too much anoying "vertical stripes" . Those vertical stripes can be minimized with fine tunning adjustment +-10Hz till getting the vertical stripes convergence .
 But from all BW rates,  25k , clearly was the worse , and that PR,  changing OVS(25k)   from x32 -->x16 really reduces that effect,

I confirmed it checking it in both H1 and H2+ , with similar results .  
With the new settings, that random  "vertical stripe effect" in BW 25K is reduced , and at the same time , we got also better adjacent interference rejection .   

![image](https://github.com/eried/portapack-mayhem/assets/86470699/5ebd59e0-bd2f-4c64-898c-88d7adb360bf)
