### PR TITLE
POCSAG Processor Rewrite

### DIFF
--- a/firmware/application/apps/pocsag_app.cpp
+++ b/firmware/application/apps/pocsag_app.cpp
@@ -105,6 +105,7 @@ POCSAGAppView::POCSAGAppView(NavigationView& nav)
          &field_volume,
          &image_status,
          &text_packet_count,
+         &widget_baud,
          &widget_bits,
          &widget_frames,
          &button_ignore_last,
@@ -274,9 +275,25 @@ void POCSAGAppView::on_packet(const POCSAGPacketMessage* message) {
 }
 
 void POCSAGAppView::on_stats(const POCSAGStatsMessage* stats) {
+    widget_baud.set_rate(stats->baud_rate);
     widget_bits.set_bits(stats->current_bits);
     widget_frames.set_frames(stats->current_frames);
     widget_frames.set_sync(stats->has_sync);
+}
+
+void BaudIndicator::paint(Painter& painter) {
+    auto p = screen_pos();
+    char top = '-';
+    char bot = '-';
+
+    if (rate_ > 0) {
+        auto r = rate_ / 100;
+        top = (r / 10) + '0';
+        bot = (r % 10) + '0';
+    }
+
+    painter.draw_char(p, Styles::white_small, top);
+    painter.draw_char({p.x(), p.y() + 8}, Styles::white_small, bot);
 }
 
 void BitsIndicator::paint(Painter&) {
@@ -295,7 +312,7 @@ void FrameIndicator::paint(Painter& painter) {
     painter.draw_rectangle({p, {2, height}}, has_sync_ ? Color::green() : Color::grey());
 
     for (size_t i = 0; i < height; ++i) {
-        auto p2 = p + Point{2, 16 - (int)i};
+        auto p2 = p + Point{2, 15 - (int)i};
         painter.draw_hline(p2, 2, i < frame_count_ ? Color::white() : Color::black());
     }
 }

--- a/firmware/application/apps/pocsag_app.hpp
+++ b/firmware/application/apps/pocsag_app.hpp
@@ -52,6 +52,24 @@ class POCSAGLogger {
 
 namespace ui {
 
+class BaudIndicator : public Widget {
+   public:
+    BaudIndicator(Point position)
+        : Widget{{position, {5, height}}} {}
+
+    void paint(Painter& painter) override;
+    void set_rate(uint16_t rate) {
+        if (rate != rate_) {
+            rate_ = rate;
+            set_dirty();
+        }
+    }
+
+   private:
+    static constexpr uint8_t height = 16;
+    uint16_t rate_ = 0;
+};
+
 class BitsIndicator : public Widget {
    public:
     BitsIndicator(Point position)
@@ -247,10 +265,13 @@ class POCSAGAppView : public View {
         "0"};
 
     BitsIndicator widget_bits{
-        {9 * 7 + 6, 1 * 16 + 2}};
+        {8 * 8 + 1, 1 * 16 + 2}};
 
     FrameIndicator widget_frames{
-        {9 * 8, 1 * 16 + 2}};
+        {8 * 8 + 4, 1 * 16 + 2}};
+
+    BaudIndicator widget_baud{
+        {8 * 9 + 1, 1 * 16 + 2}};
 
     Button button_ignore_last{
         {10 * 8, 1 * 16, 12 * 8, 20},

--- a/firmware/application/apps/ui_settings.hpp
+++ b/firmware/application/apps/ui_settings.hpp
@@ -370,7 +370,7 @@ class SetConverterSettingsView : public View {
 
     Button button_return{
         {16 * 8, 16 * 16, 12 * 8, 32},
-        "return",
+        "Return",
     };
 };
 

--- a/firmware/baseband/dsp_squelch.cpp
+++ b/firmware/baseband/dsp_squelch.cpp
@@ -29,20 +29,19 @@ bool FMSquelch::execute(const buffer_f32_t& audio) {
         return true;
     }
 
-    // TODO: No hard-coded array size.
-    std::array<float, N> squelch_energy_buffer;
-    const buffer_f32_t squelch_energy{
-        squelch_energy_buffer.data(),
-        squelch_energy_buffer.size()};
+    // TODO: alloca temp buffer, assert audio.count
+    std::array<float, 32> squelch_energy_buffer;
+    const buffer_f32_t squelch_energy{squelch_energy_buffer.data(), audio.count};
     non_audio_hpf.execute(audio, squelch_energy);
 
     // "Non-audio" implies "noise" here. Find the loudest noise sample.
     float non_audio_max_squared = 0;
-    for (const auto sample : squelch_energy_buffer) {
-        const float sample_squared = sample * sample;
-        if (sample_squared > non_audio_max_squared) {
+    for (size_t i = 0; i < squelch_energy.count; ++i) {
+        auto sample = squelch_energy.p[i];
+        float sample_squared = sample * sample;
+
+        if (sample_squared > non_audio_max_squared)
             non_audio_max_squared = sample_squared;
-        }
     }
 
     // Is the noise less than the threshold?

--- a/firmware/baseband/dsp_squelch.hpp
+++ b/firmware/baseband/dsp_squelch.hpp
@@ -39,7 +39,6 @@ class FMSquelch {
     bool enabled() const;
 
    private:
-    static constexpr size_t N = 32;
     float threshold_squared{0.0f};
 
     IIRBiquadFilter non_audio_hpf{non_audio_hpf_config};

--- a/firmware/baseband/proc_pocsag.cpp
+++ b/firmware/baseband/proc_pocsag.cpp
@@ -144,7 +144,7 @@ void POCSAGProcessor::configure() {
 }
 
 void POCSAGProcessor::send_stats() const {
-    POCSAGStatsMessage message(m_fifo.codeword, m_numCode, m_gotSync);
+    POCSAGStatsMessage message(m_fifo.codeword, m_numCode, m_gotSync, getRate());
     shared_memory.application_queue.push(message);
 }
 
@@ -522,7 +522,7 @@ int POCSAGProcessor::getNoOfBits() {
 // ====================================================================
 //
 // ====================================================================
-uint32_t POCSAGProcessor::getRate() {
+uint32_t POCSAGProcessor::getRate() const {
     return ((m_samplesPerSec << 10) + 512) / m_lastStableSymbolLen_1024;
 }
 

--- a/firmware/baseband/proc_pocsag.hpp
+++ b/firmware/baseband/proc_pocsag.hpp
@@ -187,7 +187,7 @@ class POCSAGProcessor : public BasebandProcessor {
     short getBit();
 
     int getNoOfBits();
-    uint32_t getRate();
+    uint32_t getRate() const;
 
     uint32_t m_averageSymbolLen_1024{0};
     uint32_t m_lastStableSymbolLen_1024{0};

--- a/firmware/baseband/proc_pocsag2.cpp
+++ b/firmware/baseband/proc_pocsag2.cpp
@@ -169,8 +169,8 @@ void BitExtractor::configure(uint32_t sample_rate) {
         info.bit_length = sample_rate / info.baud_rate;
 
         // Allow for 20% deviation.
-        info.min_bit_length -= 0.20 * info.bit_length;
-        info.max_bit_length += 0.20 * info.bit_length;
+        info.min_bit_length = 0.80 * info.bit_length;
+        info.max_bit_length = 1.20 * info.bit_length;
 
         if (info.min_bit_length < min_valid_length_)
             min_valid_length_ = info.min_bit_length;

--- a/firmware/baseband/proc_pocsag2.cpp
+++ b/firmware/baseband/proc_pocsag2.cpp
@@ -148,7 +148,7 @@ void BitExtractor::extract_bits(const buffer_f32_t& audio) {
 
         // Time to push the next bit?
         if (sample_index_ >= next_bit_center_) {
-            // Use the two more recent samples for the bit value.
+            // Use the two most recent samples for the bit value.
             auto val = (sample_ + last_sample_) / 2.0;
             bits_.push(val < 0);  // NB: '1' is negative.
 
@@ -254,11 +254,11 @@ bool BitExtractor::count_bits(uint32_t length, uint16_t& bit_count) {
     // Round to the nearest # of bits and determine how
     // well the current rate fits the data.
     float round_bits = std::round(exact_bits);
-    float error = std::abs(exact_bits - round_bits);
+    float error = std::abs(exact_bits - round_bits) / exact_bits;
 
-    // Good transition are w/in 20% of current rate estimate.
+    // Good transition are w/in 15% of current rate estimate.
     bit_count = round_bits;
-    return error <= 0.20;
+    return error < 0.15;
 }
 
 const BitExtractor::BaudInfo* BitExtractor::get_baud_info(float bit_length) const {

--- a/firmware/baseband/proc_pocsag2.cpp
+++ b/firmware/baseband/proc_pocsag2.cpp
@@ -169,8 +169,8 @@ void BitExtractor::configure(uint32_t sample_rate) {
         info.bit_length = sample_rate / info.baud_rate;
 
         // Allow for 20% deviation.
-        info.min_bit_length = 0.8 * info.bit_length;
-        info.max_bit_length = 1.2 * info.bit_length;
+        info.min_bit_length -= 0.20 * info.bit_length;
+        info.max_bit_length += 0.20 * info.bit_length;
 
         if (info.min_bit_length < min_valid_length_)
             min_valid_length_ = info.min_bit_length;
@@ -283,9 +283,9 @@ void CodewordExtractor::process_bits() {
         // Wait for the sync frame.
         if (!has_sync_) {
             if (differ_bit_count(data_, sync_codeword) <= 2)
-                handle_sync(false);
+                handle_sync(/*inverted=*/false);
             else if (differ_bit_count(data_, ~sync_codeword) <= 2)
-                handle_sync(true);
+                handle_sync(/*inverted=*/true);
             continue;
         }
 

--- a/firmware/baseband/proc_pocsag2.cpp
+++ b/firmware/baseband/proc_pocsag2.cpp
@@ -213,6 +213,10 @@ bool BitExtractor::handle_transition() {
     auto rate = get_baud_info(bit_length);
     if (!rate) return false;
 
+    // Set current rate if it hasn't been set yet.
+    if (!current_rate_)
+        current_rate_ = rate;
+
     // Maybe current rate isn't the best rate?
     auto rate_miss = rate != current_rate_;
     if (rate_miss) {

--- a/firmware/baseband/proc_pocsag2.cpp
+++ b/firmware/baseband/proc_pocsag2.cpp
@@ -258,6 +258,7 @@ bool BitExtractor::count_bits(uint32_t length, uint16_t& bit_count) {
 }
 
 const BitExtractor::BaudInfo* BitExtractor::get_baud_info(float bit_length) const {
+    // NB: This assumes known_rates_ are ordered slowest first.
     for (const auto& info : known_rates_) {
         if (bit_length >= info.min_bit_length &&
             bit_length <= info.max_bit_length) {

--- a/firmware/baseband/proc_pocsag2.hpp
+++ b/firmware/baseband/proc_pocsag2.hpp
@@ -26,6 +26,8 @@
 #ifndef __PROC_POCSAG2_H__
 #define __PROC_POCSAG2_H__
 
+/* https://www.aaroncake.net/schoolpage/pocsag.htm */
+
 #include "audio_output.hpp"
 #include "baseband_processor.hpp"
 #include "baseband_thread.hpp"
@@ -39,8 +41,9 @@
 #include "rssi_thread.hpp"
 
 #include <cstdint>
+#include <functional>
 
-/* Takes audio stream and automatically normalizes it to +/-1.0f */
+/* Processes audio stream to normalizes it to +/-1.0f */
 class AudioNormalizer {
    public:
     void execute_in_place(const buffer_f32_t& audio) {
@@ -97,15 +100,96 @@ class AudioNormalizer {
     float t_lo_ = 1.0;
 };
 
-// How to detect clock signal across baud rates?
-// Maybe have a bit extraction state machine that reset
-// then watches for the clocks, but there are multiple
-// clock and the last one is the right one.
-// So keep updating clock until a sync?
+/* FIFO wrapper over a uin32_t's bits. */
+class BitQueue {
+   public:
+    void push(bool bit) {
+        data_ = (data_ << 1) | (bit ? 1 : 0);
+        if (count_ < max_size_) ++count_;
+    }
 
-class BitExtractor {};
+    bool pop() {
+        if (count_ == 0) return false;
 
-class WordExtractor {};
+        --count_;
+        return (data_ & (1 << count_)) != 0;
+    }
+
+    void reset() {
+        data_ = 0;
+        count_ = 0;
+    }
+
+    uint8_t size() const {
+        return count_;
+    }
+
+    uint32_t data() const {
+        return data_;
+    }
+
+   private:
+    uint32_t data_ = 0;
+    uint8_t count_ = 0;
+
+    static constexpr uint8_t max_size_ = sizeof(data_) * 8;
+};
+
+// TODO: better clock sync.
+/* Extracts bits and bitrate from audio stream. */
+class BitExtractor {
+   public:
+   private:
+};
+
+class CodewordExtractor {
+   public:
+    /* Number of codewords in a batch. */
+    static constexpr uint8_t batch_size = 16;
+    using batch_t = std::array<uint32_t, batch_size>;
+
+    CodewordExtractor(BitExtractor& bits)
+        : bits_{bits}, code {}
+    
+    void process_bits();
+    void flush();
+    void reset();
+
+    const batch_t& batch() const { return batch_; }
+    uint8_t count() const { return word_count_; }
+
+   private:
+    /* Sync frame codeword. */
+    static constexpr uint32_t sync_codeword = 0x7cd215d8;
+
+    /* Idle codeword used to pad a 16 codeword "batch". */
+    static constexpr uint32_t idle_codeword = 0x7a89c197;
+
+    /* Number of bits in 'data_' member. */
+    static constexpr uint8_t data_bit_count = sizeof(uint32_t) * 8;
+
+    void clear_data_bits();
+
+    /* Pop a bit off the queue and add it to data. */
+    void take_one_bit();
+    void handle_sync(bool inverted);
+    void save_current_codeword();
+    void handle_batch_complete();
+
+    /* Fill the rest of the batch with 'idle' codewords. */
+    void pad_idle();
+
+    BitQueue& bits_;
+
+    bool has_sync_ = false;
+    /* When true, bit meanings are flipped in the words. */
+    bool inverted_ = false;
+    uint32_t data_ = 0;
+    uint8_t bit_count_ = 0;
+    uint8_t word_count_ = 0;
+
+    batch_t batch_{}:
+};
 
 class POCSAGProcessor : public BasebandProcessor {
    public:
@@ -122,17 +206,20 @@ class POCSAGProcessor : public BasebandProcessor {
         baseband_fs / stat_update_interval;
 
     void configure();
+    void flush();
+    void reset();
     void send_stats() const;
+    void send_packet() const;
 
     // Set once app is ready to receive messages.
     bool configured = false;
 
     // Buffer for decimated IQ data.
-    std::array<complex16_t, 512> dst{};
+    std::array<complex16_t, 256> dst{};
     const buffer_c16_t dst_buffer{dst.data(), dst.size()};
 
     // Buffer for demodulated audio.
-    std::array<float, 32> audio{};
+    std::array<float, 16> audio{};
     const buffer_f32_t audio_buffer{audio.data(), audio.size()};
 
     // Decimate to 48kHz.
@@ -143,16 +230,17 @@ class POCSAGProcessor : public BasebandProcessor {
     dsp::decimate::FIRAndDecimateComplex channel_filter{};
     dsp::demodulate::FM demod{};
 
-    // LPF to reduce noise.
-    // scipy.signal.butter(2, 1800, "lowpass", fs=24000, analog=False)
-    IIRBiquadFilter lpf{{{0.04125354f, 0.082507070f, 0.04125354f},
-                         {1.00000000f, -1.34896775f, 0.51398189f}}};
-
     // Squelch to ignore noise.
     FMSquelch squelch{};
     uint64_t squelch_history = 0;
 
-    // Attempts to de-noise signal and normalize to +/- 1.0f.
+    // LPF to reduce noise. POCSAG supports 2400 baud, but that falls
+    // nicely into the transition band of this 1800Hz filter.
+    // scipy.signal.butter(2, 1800, "lowpass", fs=24000, analog=False)
+    IIRBiquadFilter lpf{{{0.04125354f, 0.082507070f, 0.04125354f},
+                         {1.00000000f, -1.34896775f, 0.51398189f}}};
+
+    // Attempts to de-noise and normalize signal.
     AudioNormalizer normalizer{};
 
     // Handles writing audio stream to hardware.
@@ -161,30 +249,33 @@ class POCSAGProcessor : public BasebandProcessor {
     // Holds the data sent to the app.
     pocsag::POCSAGPacket packet{};
 
-    bool has_been_reset = true;
+    // Used to keep track of how many samples were processed
+    // between status update messages.
     uint32_t samples_processed = 0;
 
+    BitQueue bits{};
+    CodewordContainer words{};
+
+    // Processes bits into codewords.
+    BitExtractor bit_extractor{};
+
+    // Processes bits into codewords.
+    CodewordExtractor word_extractor{bits, words};
+
     //--------------------------------------------------
+    // Transitional code
+
+    bool has_been_reset = true;
 
     // ----------------------------------------
     // Frame extractraction methods and members
     // ----------------------------------------
     void initFrameExtraction();
-    struct FIFOStruct {
-        unsigned long codeword;
-        int numBits;
-    };
-
     void resetVals();
     void setFrameExtractParams(long a_samplesPerSec, long a_maxBaud = 8000, long a_minBaud = 200, long maxRunOfSameValue = 32);
-
     int processDemodulatedSamples(float* sampleBuff, int noOfSamples);
     int extractFrames();
 
-    void storeBit();
-    short getBit();
-
-    int getNoOfBits();
     uint32_t getRate();
 
     uint32_t m_averageSymbolLen_1024{0};
@@ -210,11 +301,6 @@ class POCSAGProcessor : public BasebandProcessor {
     uint32_t m_minSymSamples_1024{0};
     uint32_t m_maxSymSamples_1024{0};
     uint32_t m_maxRunOfSameValue{0};
-
-    static constexpr long BIT_BUF_SIZE = 64;
-    std::bitset<64> m_bits{0};
-    long m_bitsStart{0};
-    long m_bitsEnd{0};
 
     FIFOStruct m_fifo{0, 0};
     bool m_gotSync{false};

--- a/firmware/baseband/proc_pocsag2.hpp
+++ b/firmware/baseband/proc_pocsag2.hpp
@@ -89,7 +89,7 @@ class BitExtractor {
 
    private:
     /* Number of rate misses that would cause a rate update. */
-    static constexpr uint8_t rate_miss_reset_threshold = 10;
+    static constexpr uint8_t rate_miss_reset_threshold = 5;
 
     /* Number of rate misses that would cause a rate update. */
     static constexpr uint8_t bad_transition_reset_threshold = 10;

--- a/firmware/baseband/proc_pocsag2.hpp
+++ b/firmware/baseband/proc_pocsag2.hpp
@@ -100,7 +100,7 @@ class AudioNormalizer {
     float t_lo_ = 1.0;
 };
 
-/* FIFO wrapper over a uin32_t's bits. */
+/* FIFO wrapper over a uint32_t's bits. */
 class BitQueue {
    public:
     void push(bool bit) {
@@ -285,8 +285,6 @@ class POCSAGProcessor : public BasebandProcessor {
     //--------------------------------------------------
     // Transitional code
 
-    bool has_been_reset = true;
-
     // ----------------------------------------
     // Frame extractraction methods and members
     // ----------------------------------------
@@ -294,7 +292,6 @@ class POCSAGProcessor : public BasebandProcessor {
     void resetVals();
     void setFrameExtractParams(long a_samplesPerSec, long a_maxBaud = 8000, long a_minBaud = 200, long maxRunOfSameValue = 32);
     int processDemodulatedSamples(float* sampleBuff, int noOfSamples);
-    int extractFrames();
 
     uint32_t getRate();
 
@@ -321,11 +318,6 @@ class POCSAGProcessor : public BasebandProcessor {
     uint32_t m_minSymSamples_1024{0};
     uint32_t m_maxSymSamples_1024{0};
     uint32_t m_maxRunOfSameValue{0};
-
-    // FIFOStruct m_fifo{0, 0};
-    // bool m_gotSync{false};
-    // int m_numCode{0};
-    // bool m_inverted{false};
 
     //--------------------------------------------------
 

--- a/firmware/baseband/proc_pocsag2.hpp
+++ b/firmware/baseband/proc_pocsag2.hpp
@@ -88,6 +88,12 @@ class BitExtractor {
     uint16_t baud_rate() const;
 
    private:
+    /* Number of rate misses that would cause a rate update. */
+    static constexpr uint8_t rate_miss_reset_threshold = 5;
+
+    /* Number of rate misses that would cause a rate update. */
+    static constexpr uint8_t bad_transition_reset_threshold = 10;
+
     struct BaudInfo {
         uint16_t baud_rate = 0;
         float bit_length = 0.0;
@@ -102,16 +108,8 @@ class BitExtractor {
      * Returns true if valid given the current baud rate. */
     bool count_bits(uint32_t length, uint16_t& bit_count);
 
-    /* Gets the baud info associated with the specified bit length. */
+    /* Gets the best baud info associated with the specified bit length. */
     const BaudInfo* get_baud_info(float bit_length) const;
-
-    bool is_stable() const {
-        return good_transitions_ > 20;
-    }
-
-    bool is_failed() const {
-        return bad_transitions_ > 10;
-    }
 
     std::array<BaudInfo, 3> known_rates_{
         BaudInfo{512},
@@ -121,16 +119,16 @@ class BitExtractor {
     BitQueue& bits_;
 
     uint32_t sample_rate_ = 0;
+    uint16_t min_valid_length_ = 0;
     const BaudInfo* current_rate_ = nullptr;
+    uint8_t rate_misses_ = 0;
 
     float sample_ = 0.0;
     float last_sample_ = 0.0;
+    float next_bit_center_ = 0.0;
 
     uint32_t sample_index_ = 0;
     uint32_t last_transition_index_ = 0;
-    uint32_t last_send_index_ = 0;
-
-    uint32_t good_transitions_ = 0;
     uint32_t bad_transitions_ = 0;
 };
 

--- a/firmware/baseband/proc_pocsag2.hpp
+++ b/firmware/baseband/proc_pocsag2.hpp
@@ -44,7 +44,7 @@
 #include <cstdint>
 #include <functional>
 
-/* Processes audio stream to normalizes it to +/-1.0f */
+/* Normalizes audio stream to +/-1.0f */
 class AudioNormalizer {
    public:
     void execute_in_place(const buffer_f32_t& audio);

--- a/firmware/common/message.hpp
+++ b/firmware/common/message.hpp
@@ -346,16 +346,19 @@ class POCSAGStatsMessage : public Message {
     constexpr POCSAGStatsMessage(
         uint32_t current_bits,
         uint8_t current_frames,
-        bool has_sync)
+        bool has_sync,
+        uint16_t baud_rate)
         : Message{ID::POCSAGStats},
           current_bits{current_bits},
           current_frames{current_frames},
-          has_sync{has_sync} {
+          has_sync{has_sync},
+          baud_rate{baud_rate} {
     }
 
     uint32_t current_bits = 0;
     uint8_t current_frames = 0;
     bool has_sync = false;
+    uint16_t baud_rate = 0;
 };
 
 class ACARSPacketMessage : public Message {

--- a/firmware/common/pocsag.cpp
+++ b/firmware/common/pocsag.cpp
@@ -412,7 +412,7 @@ bool pocsag_decode_batch(const POCSAGPacket& batch, POCSAGState& state) {
                     state.ascii_idx -= 7;
                     char ascii_char = (state.ascii_data >> state.ascii_idx) & 0x7F;
 
-                    // Reverse the bits.
+                    // Reverse the bits. (TODO: __RBIT?)
                     ascii_char = (ascii_char & 0xF0) >> 4 | (ascii_char & 0x0F) << 4;  // 01234567 -> 45670123
                     ascii_char = (ascii_char & 0xCC) >> 2 | (ascii_char & 0x33) << 2;  // 45670123 -> 67452301
                     ascii_char = (ascii_char & 0xAA) >> 2 | (ascii_char & 0x55);       // 67452301 -> 76543210

--- a/firmware/common/pocsag.cpp
+++ b/firmware/common/pocsag.cpp
@@ -412,7 +412,7 @@ bool pocsag_decode_batch(const POCSAGPacket& batch, POCSAGState& state) {
                     state.ascii_idx -= 7;
                     char ascii_char = (state.ascii_data >> state.ascii_idx) & 0x7F;
 
-                    // Bottom's up (reverse the bits).
+                    // Reverse the bits.
                     ascii_char = (ascii_char & 0xF0) >> 4 | (ascii_char & 0x0F) << 4;  // 01234567 -> 45670123
                     ascii_char = (ascii_char & 0xCC) >> 2 | (ascii_char & 0x33) << 2;  // 45670123 -> 67452301
                     ascii_char = (ascii_char & 0xAA) >> 2 | (ascii_char & 0x55);       // 67452301 -> 76543210

--- a/firmware/common/pocsag.hpp
+++ b/firmware/common/pocsag.hpp
@@ -90,11 +90,10 @@ struct POCSAGState {
     std::string output{};
 };
 
-const pocsag::BitRate pocsag_bitrates[4] = {
+const pocsag::BitRate pocsag_bitrates[3] = {
     pocsag::BitRate::FSK512,
     pocsag::BitRate::FSK1200,
     pocsag::BitRate::FSK2400,
-    pocsag::BitRate::FSK3200,
 };
 
 std::string bitrate_str(BitRate bitrate);

--- a/firmware/common/pocsag.hpp
+++ b/firmware/common/pocsag.hpp
@@ -90,10 +90,11 @@ struct POCSAGState {
     std::string output{};
 };
 
-const pocsag::BitRate pocsag_bitrates[3] = {
+const pocsag::BitRate pocsag_bitrates[4] = {
     pocsag::BitRate::FSK512,
     pocsag::BitRate::FSK1200,
     pocsag::BitRate::FSK2400,
+    pocsag::BitRate::FSK3200,
 };
 
 std::string bitrate_str(BitRate bitrate);

--- a/firmware/common/pocsag_packet.hpp
+++ b/firmware/common/pocsag_packet.hpp
@@ -45,6 +45,10 @@ enum PacketFlag : uint32_t {
     TOO_LONG
 };
 
+/* Number of codewords in a batch. */
+constexpr uint8_t batch_size = 16;
+using batch_t = std::array<uint32_t, batch_size>;
+
 class POCSAGPacket {
    public:
     void set_timestamp(const Timestamp& value) {
@@ -55,16 +59,20 @@ class POCSAGPacket {
         return timestamp_;
     }
 
-    void set(const size_t index, const uint32_t data) {
-        if (index < 16)
+    void set(size_t index, uint32_t data) {
+        if (index < batch_size)
             codewords[index] = data;
     }
 
-    uint32_t operator[](const size_t index) const {
-        return (index < 16) ? codewords[index] : 0;
+    void set(const batch_t& batch) {
+        codewords = batch;
     }
 
-    void set_bitrate(const uint16_t bitrate) {
+    uint32_t operator[](size_t index) const {
+        return (index < batch_size) ? codewords[index] : 0;
+    }
+
+    void set_bitrate(uint16_t bitrate) {
         bitrate_ = bitrate;
     }
 
@@ -72,7 +80,7 @@ class POCSAGPacket {
         return bitrate_;
     }
 
-    void set_flag(const PacketFlag flag) {
+    void set_flag(PacketFlag flag) {
         flag_ = flag;
     }
 
@@ -89,7 +97,7 @@ class POCSAGPacket {
    private:
     uint16_t bitrate_{0};
     PacketFlag flag_{NORMAL};
-    std::array<uint32_t, 16> codewords{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+    batch_t codewords{};
     Timestamp timestamp_{};
 };
 

--- a/firmware/test/baseband/dsp_fft_test.cpp
+++ b/firmware/test/baseband/dsp_fft_test.cpp
@@ -50,8 +50,46 @@ TEST_CASE("ifft successfully calculates dc on zero frequency") {
     for (uint32_t i = 0; i < fft_width; i++)
         CHECK(v[i].imag() == 0);
 
-    free(v);
-    free(tmp);
+    delete[] v;
+    delete[] tmp;
+}
+
+TEST_CASE("ifft successfully calculates sine of quarter the sample rate") {
+    uint32_t fft_width = 8;
+    complex16_t* v = new complex16_t[fft_width];
+    complex16_t* tmp = new complex16_t[fft_width];
+
+    v[0] = {0, 0};
+    v[1] = {0, 0};
+    v[2] = {1024, 0};  // sample rate /4 bin
+    v[3] = {0, 0};
+    v[4] = {0, 0};
+    v[5] = {0, 0};
+    v[6] = {0, 0};
+    v[7] = {0, 0};
+
+    ifft<complex16_t>(v, fft_width, tmp);
+
+    CHECK(v[0].real() == 1024);
+    CHECK(v[1].real() == 0);
+    CHECK(v[2].real() == -1024);
+    CHECK(v[3].real() == 0);
+    CHECK(v[4].real() == 1024);
+    CHECK(v[5].real() == 0);
+    CHECK(v[6].real() == -1024);
+    CHECK(v[7].real() == 0);
+
+    CHECK(v[0].imag() == 0);
+    CHECK(v[1].imag() == 1024);
+    CHECK(v[2].imag() == 0);
+    CHECK(v[3].imag() == -1024);
+    CHECK(v[4].imag() == 0);
+    CHECK(v[5].imag() == 1024);
+    CHECK(v[6].imag() == 0);
+    CHECK(v[7].imag() == -1024);
+
+    delete[] v;
+    delete[] tmp;
 }
 
 TEST_CASE("ifft successfully calculates pure sine of half the sample rate") {
@@ -82,6 +120,6 @@ TEST_CASE("ifft successfully calculates pure sine of half the sample rate") {
     for (uint32_t i = 0; i < fft_width; i++)
         CHECK(v[i].imag() == 0);
 
-    free(v);
-    free(tmp);
+    delete[] v;
+    delete[] tmp;
 }


### PR DESCRIPTION
This is a total rewrite of proc_pocsag. The intention of this work was the following.
- Support squelching noise between signals
- Increase decode success rate
- Reduce code complexity
- Better diagnostics for why decoding fails

There's one major difference, this version doesn't support 3200 baud -- but that's not really a valid rate as far as I can tell from the docs I found online.

Currently this processor is only used when "Beta" is checked on the POCSAG app config page.
The app MUST be restarted for the new processor to take effect.

Once we get some test coverage in the wild and feel confident this works at least as well as the previous implementation, we can delete the old implementation and reclaim the firmware space.