### PR TITLE
POCSAG clock detection 🐋 improvement(?) 

### DIFF
--- a/firmware/baseband/proc_pocsag2.hpp
+++ b/firmware/baseband/proc_pocsag2.hpp
@@ -91,17 +91,25 @@ class BitExtractor {
     static constexpr uint32_t clock_magic_number = 0xAAAAAAAA;
 
     struct RateInfo {
+        enum class State : uint8_t {
+            WaitForSample,
+            ReadyToSend
+        };
+
         const int16_t baud_rate = 0;
         float sample_interval = 0.0;
 
+        State state = State::WaitForSample;
         float samples_until_next = 0.0;
-        float last_sample = 0.0;
+        bool prev_value = false;
+        bool is_stable = false;
         BitQueue bits{};
-    };
 
-    /* Updates a rate info with the given sample.
-     * Returns true if the rate info has a new bit in its queue. */
-    bool handle_sample(RateInfo& rate, float sample);
+        /* Updates a rate info with the given sample.
+         * Returns true if the rate info has a new bit in its queue. */
+        bool handle_sample(float sample);
+        void reset();
+    };
 
     std::array<RateInfo, 3> known_rates_{
         RateInfo{512},
@@ -112,10 +120,6 @@ class BitExtractor {
 
     uint32_t sample_rate_ = 0;
     RateInfo* current_rate_ = nullptr;
-
-    float samples_until_next_ = 0.0;
-    float prev_sample_ = 0.0;
-    bool ready_to_send_ = false;
 };
 
 /* Extracts codeword batches from the BitQueue. */


### PR DESCRIPTION
The descent into madness is apparent. I hear POCSAG tones in my sleep. I have nightmares about noisy digital data and wake up exhausted. Surely it can't be that hard? They implemented this thing with like sticks and twigs for processors in the 90s... why won't you just work!?

Anyway, this is the best of all my iterations on this thing so far...
Code is even more consolidated (and hopefully understandable). During clock detection, if a transition is found, the sampling window is nudged a bit to hopefully avoid sampling on the edges of pulses which makes everything sad.

There's still a potential improvement to take more samples for the actual bit value, but there's already so many layers of noise reduction and normalization that it might not be needed.

[portapack-h1_h2-mayhem.bin.zip](https://github.com/eried/portapack-mayhem/files/12566149/portapack-h1_h2-mayhem.bin.zip)

