### PR TITLE
App Settings w/out radio settings, Settings UI cleanup

### DIFF
--- a/firmware/application/app_settings.cpp
+++ b/firmware/application/app_settings.cpp
@@ -244,55 +244,64 @@ SettingsManager::SettingsManager(
     : app_name_{app_name},
       settings_{},
       bindings_{},
-      loaded_{false} {
+      loaded_{false},
+      radio_loaded_{false} {
     settings_.mode = mode;
     settings_.options = options;
-
-    if (!portapack::persistent_memory::load_app_settings())
-        return;
 
     // Pre-alloc enough for app settings and additional settings.
     additional_settings.reserve(17 + additional_settings.size());
     bindings_ = std::move(additional_settings);
 
-    // Transmitter model settings.
-    if (flags_enabled(mode, Mode::TX)) {
-        bindings_.emplace_back("tx_frequency"sv, &settings_.tx_frequency);
-        bindings_.emplace_back("tx_amp"sv, &settings_.tx_amp);
-        bindings_.emplace_back("tx_gain"sv, &settings_.tx_gain);
-        bindings_.emplace_back("channel_bandwidth"sv, &settings_.channel_bandwidth);
-    }
+    // Additional settings should always be loaded because apps now rely
+    // on being able to store UI settings, config, etc. The radio settings
+    // are only loaded if the global option has been enabled.
+    // Add the radio setting bindings if either load or save are enabled.
+    if (portapack::persistent_memory::load_app_settings() ||
+        portapack::persistent_memory::save_app_settings()) {
+        // Transmitter model settings.
+        if (flags_enabled(mode, Mode::TX)) {
+            bindings_.emplace_back("tx_frequency"sv, &settings_.tx_frequency);
+            bindings_.emplace_back("tx_amp"sv, &settings_.tx_amp);
+            bindings_.emplace_back("tx_gain"sv, &settings_.tx_gain);
+            bindings_.emplace_back("channel_bandwidth"sv, &settings_.channel_bandwidth);
+        }
 
-    // Receiver model settings.
-    if (flags_enabled(mode, Mode::RX)) {
-        bindings_.emplace_back("rx_frequency"sv, &settings_.rx_frequency);
-        bindings_.emplace_back("lna"sv, &settings_.lna);
-        bindings_.emplace_back("vga"sv, &settings_.vga);
-        bindings_.emplace_back("rx_amp"sv, &settings_.rx_amp);
-        bindings_.emplace_back("modulation"sv, &settings_.modulation);
-        bindings_.emplace_back("am_config_index"sv, &settings_.am_config_index);
-        bindings_.emplace_back("nbfm_config_index"sv, &settings_.nbfm_config_index);
-        bindings_.emplace_back("wfm_config_index"sv, &settings_.wfm_config_index);
-        bindings_.emplace_back("squelch"sv, &settings_.squelch);
-    }
+        // Receiver model settings.
+        if (flags_enabled(mode, Mode::RX)) {
+            bindings_.emplace_back("rx_frequency"sv, &settings_.rx_frequency);
+            bindings_.emplace_back("lna"sv, &settings_.lna);
+            bindings_.emplace_back("vga"sv, &settings_.vga);
+            bindings_.emplace_back("rx_amp"sv, &settings_.rx_amp);
+            bindings_.emplace_back("modulation"sv, &settings_.modulation);
+            bindings_.emplace_back("am_config_index"sv, &settings_.am_config_index);
+            bindings_.emplace_back("nbfm_config_index"sv, &settings_.nbfm_config_index);
+            bindings_.emplace_back("wfm_config_index"sv, &settings_.wfm_config_index);
+            bindings_.emplace_back("squelch"sv, &settings_.squelch);
+        }
 
-    // Common model settings.
-    bindings_.emplace_back("baseband_bandwidth"sv, &settings_.baseband_bandwidth);
-    bindings_.emplace_back("sampling_rate"sv, &settings_.sampling_rate);
-    bindings_.emplace_back("step"sv, &settings_.step);
-    bindings_.emplace_back("volume"sv, &settings_.volume);
+        // Common model settings.
+        bindings_.emplace_back("baseband_bandwidth"sv, &settings_.baseband_bandwidth);
+        bindings_.emplace_back("sampling_rate"sv, &settings_.sampling_rate);
+        bindings_.emplace_back("step"sv, &settings_.step);
+        bindings_.emplace_back("volume"sv, &settings_.volume);
+    }
 
     loaded_ = load_settings(app_name_, bindings_);
 
-    if (loaded_)
+    // Only copy to the radio if load was successful.
+    if (loaded_ && portapack::persistent_memory::load_app_settings()) {
+        radio_loaded_ = true;
         copy_to_radio_model(settings_);
+    }
 }
 
 SettingsManager::~SettingsManager() {
-    if (portapack::persistent_memory::save_app_settings()) {
+    // Only save radio settings when the option is enabled.
+    if (portapack::persistent_memory::save_app_settings())
         copy_from_radio_model(settings_);
-        save_settings(app_name_, bindings_);
-    }
+
+    save_settings(app_name_, bindings_);
 }
 
 }  // namespace app_settings

--- a/firmware/application/app_settings.hpp
+++ b/firmware/application/app_settings.hpp
@@ -150,7 +150,9 @@ void copy_to_radio_model(const AppSettings& settings);
 /* Copies common values from the receiver/transmitter models. */
 void copy_from_radio_model(AppSettings& settings);
 
-/* RAII wrapper for automatically loading and saving radio settings for an app.
+/* RAII wrapper for automatically loading and saving settings for an app.
+ * "Additional" settings are always loaded, but radio settings are conditionally
+ * saved/loaded if the global app settings options are enabled.
  * NB: This should be added to a class before any LNA/VGA controls so that
  * the receiver/transmitter models are set before the control ctors run. */
 class SettingsManager {
@@ -167,6 +169,9 @@ class SettingsManager {
 
     /* True if settings were successfully loaded from file. */
     bool loaded() const { return loaded_; }
+
+    /* True if radio settings were successfully loaded from file. */
+    bool radio_loaded() const { return radio_loaded_; }
     Mode mode() const { return settings_.mode; }
 
     AppSettings& raw() { return settings_; }
@@ -176,6 +181,7 @@ class SettingsManager {
     AppSettings settings_;
     SettingBindings bindings_;
     bool loaded_;
+    bool radio_loaded_;
 };
 
 }  // namespace app_settings

--- a/firmware/application/apps/ais_app.cpp
+++ b/firmware/application/apps/ais_app.cpp
@@ -382,7 +382,7 @@ AISAppView::AISAppView(NavigationView& nav)
 
     recent_entry_detail_view.hidden(true);
 
-    if (!settings_.loaded())
+    if (!settings_.radio_loaded())
         receiver_model.set_target_frequency(initial_target_frequency);
 
     receiver_model.enable();

--- a/firmware/application/apps/ert_app.cpp
+++ b/firmware/application/apps/ert_app.cpp
@@ -110,7 +110,7 @@ ERTAppView::ERTAppView(NavigationView&) {
         &recent_entries_view,
     });
 
-    if (!settings_.loaded())
+    if (!settings_.radio_loaded())
         receiver_model.set_target_frequency(initial_target_frequency);
 
     receiver_model.enable();

--- a/firmware/application/apps/gps_sim_app.cpp
+++ b/firmware/application/apps/gps_sim_app.cpp
@@ -173,7 +173,7 @@ GpsSimAppView::GpsSimAppView(
         &waterfall,
     });
 
-    if (!settings_.loaded()) {
+    if (!settings_.radio_loaded()) {
         field_frequency.set_value(initial_target_frequency);
         transmitter_model.set_sampling_rate(2600000);
     }

--- a/firmware/application/apps/pocsag_app.cpp
+++ b/firmware/application/apps/pocsag_app.cpp
@@ -112,11 +112,13 @@ POCSAGAppView::POCSAGAppView(NavigationView& nav)
          &button_config,
          &console});
 
-    // No app settings, use fallbacks.
+    // No app settings, use fallbacks from pmem.
     if (!app_settings_.loaded()) {
-        field_frequency.set_value(initial_target_frequency);
         settings_.address_to_ignore = pmem::pocsag_ignore_address();
         settings_.enable_ignore = settings_.address_to_ignore > 0;
+    }
+    if (!app_settings_.radio_loaded()) {
+        field_frequency.set_value(initial_target_frequency);
     }
 
     logger.append(LOG_ROOT_DIR "/POCSAG.TXT");
@@ -151,7 +153,7 @@ POCSAGAppView::~POCSAGAppView() {
     receiver_model.disable();
     baseband::shutdown();
 
-    // Save pmem settings. TODO: Even needed anymore?
+    // Save pmem settings.
     pmem::set_pocsag_ignore_address(settings_.address_to_ignore);
     pmem::set_pocsag_last_address(pocsag_state.address);  // For POCSAG TX.
 }

--- a/firmware/application/apps/tpms_app.cpp
+++ b/firmware/application/apps/tpms_app.cpp
@@ -157,7 +157,7 @@ TPMSAppView::TPMSAppView(NavigationView&) {
                   &field_vga,
                   &recent_entries_view});
 
-    if (!settings_.loaded())
+    if (!settings_.radio_loaded())
         receiver_model.set_target_frequency(initial_target_frequency);
 
     receiver_model.enable();

--- a/firmware/application/apps/ui_sonde.cpp
+++ b/firmware/application/apps/ui_sonde.cpp
@@ -66,7 +66,7 @@ SondeView::SondeView(NavigationView& nav)
                   &button_see_qr,
                   &button_see_map});
 
-    if (!settings_.loaded())
+    if (!settings_.radio_loaded())
         field_frequency.set_value(initial_target_frequency);
 
     field_frequency.set_step(500);  // euquiq: was 10000, but we are using this for fine-tunning

--- a/firmware/application/baseband_api.cpp
+++ b/firmware/application/baseband_api.cpp
@@ -189,7 +189,16 @@ void kill_afsk() {
     send_message(&message);
 }
 
-void set_audiotx_config(const uint32_t divider, const float deviation_hz, const float audio_gain, uint8_t audio_shift_bits_s16, const uint32_t tone_key_delta, const bool am_enabled, const bool dsb_enabled, const bool usb_enabled, const bool lsb_enabled) {
+void set_audiotx_config(
+    const uint32_t divider,
+    const float deviation_hz,
+    const float audio_gain,
+    uint8_t audio_shift_bits_s16,
+    const uint32_t tone_key_delta,
+    const bool am_enabled,
+    const bool dsb_enabled,
+    const bool usb_enabled,
+    const bool lsb_enabled) {
     const AudioTXConfigMessage message{
         divider,
         deviation_hz,


### PR DESCRIPTION
Two changes here
1) App Settings option in UI only controls whether radio settings are saved/loaded per app.
This allows apps to rely on app settings for additional persistence (e.g. settings) regardless of the weather per-app radio settings are saved. This makes it easier for app dev to persist state without needing to think about that setting.

2) Setting UI cleanup
* Added help text to most pages to describe the settings.
* Used more consistent controls across pages (e.g. used FrequencyField instead of buttons)
* Tried for consistent capitalization and style