### PR TITLE
Add Remote App & UI updates.

### DIFF
--- a/firmware/application/apps/gps_sim_app.hpp
+++ b/firmware/application/apps/gps_sim_app.hpp
@@ -24,9 +24,6 @@
 #ifndef __GPS_SIM_APP_HPP__
 #define __GPS_SIM_APP_HPP__
 
-#define SHORT_UI true
-#define NORMAL_UI false
-
 #include "app_settings.hpp"
 #include "radio_state.hpp"
 #include "ui_widget.hpp"
@@ -109,10 +106,8 @@ class GpsSimAppView : public View {
         nav_};
 
     TransmitterView2 tx_view{
-        // new handling of NumberField field_rfgain, NumberField field_rfamp
-        74, 1 * 8, SHORT_UI  // x(columns), y (line) position. (Used in Replay / GPS Simul / Playlist App)
-                             //		10*8, 2*8, NORMAL_UI				// x(columns), y (line) position. (Used in Mic App)
-    };
+        {11 * 8, 2 * 16},
+        /*short_ui*/ true};
 
     Checkbox check_loop{
         {21 * 8, 2 * 16},

--- a/firmware/application/apps/replay_app.cpp
+++ b/firmware/application/apps/replay_app.cpp
@@ -203,9 +203,6 @@ ReplayAppView::ReplayAppView(
 
 ReplayAppView::~ReplayAppView() {
     transmitter_model.disable();
-
-    display.fill_rectangle({0, 0, 240, 320}, Color::black());  // Solving sometimes visible bottom waterfall artifacts, clearing all LCD  pixels.
-    chThdSleepMilliseconds(40);                                // (that happened sometimes if we interrupt the waterfall play at the beggining of the play  around 25% and exit )
     baseband::shutdown();
 }
 

--- a/firmware/application/apps/replay_app.hpp
+++ b/firmware/application/apps/replay_app.hpp
@@ -23,9 +23,6 @@
 #ifndef __REPLAY_APP_HPP__
 #define __REPLAY_APP_HPP__
 
-#define SHORT_UI true
-#define NORMAL_UI false
-
 #include "app_settings.hpp"
 #include "radio_state.hpp"
 #include "ui_widget.hpp"
@@ -99,16 +96,13 @@ class ReplayAppView : public View {
     ProgressBar progressbar{
         {18 * 8, 1 * 16, 12 * 8, 16}};
 
-    // TODO: Does this need to be a frequency field at all?
     TxFrequencyField field_frequency{
         {0 * 8, 2 * 16},
         nav_};
 
     TransmitterView2 tx_view{
-        // new handling of NumberField field_rfgain, NumberField field_rfamp
-        74, 1 * 8, SHORT_UI  // x(columns), y (line) position. (Uused in Repay / GPS Simul / Playlist App)
-                             //		10*8, 2*8, NORMAL_UI				// x(columns), y (line) position. (Used in Mic App)
-    };
+        {11 * 8, 2 * 16},
+        /*short_ui*/ true};
 
     Checkbox check_loop{
         {21 * 8, 2 * 16},

--- a/firmware/application/apps/ui_debug.cpp
+++ b/firmware/application/apps/ui_debug.cpp
@@ -398,17 +398,17 @@ DebugMenuView::DebugMenuView(NavigationView& nav) {
         add_items({{"..", ui::Color::light_grey(), &bitmap_icon_previous, [&nav]() { nav.pop(); }}});
     }
     add_items({
+        {"Buttons Test", ui::Color::dark_cyan(), &bitmap_icon_controls, [&nav]() { nav.push<DebugControlsView>(); }},
+        {"Debug Dump", ui::Color::dark_cyan(), &bitmap_icon_memory, [&nav]() { portapack::persistent_memory::debug_dump(); }},
+        //{"Fonts Viewer", ui::Color::dark_cyan(), &bitmap_icon_notepad, [&nav]() { nav.push<DebugFontsView>(); }},  // temporarily disabled to conserve ROM space
+        {"M0 Stack Dump", ui::Color::dark_cyan(), &bitmap_icon_memory, [&nav]() { stack_dump(); }},
         {"Memory", ui::Color::dark_cyan(), &bitmap_icon_memory, [&nav]() { nav.push<DebugMemoryView>(); }},
+        {"P.Memory", ui::Color::dark_cyan(), &bitmap_icon_memory, [&nav]() { nav.push<DebugPmemView>(); }},
+        {"Peripherals", ui::Color::dark_cyan(), &bitmap_icon_peripherals, [&nav]() { nav.push<DebugPeripheralsMenuView>(); }},
         //{ "Radio State",	ui::Color::white(),	nullptr,	[&nav](){ nav.push<NotImplementedView>(); } },
         {"SD Card", ui::Color::dark_cyan(), &bitmap_icon_sdcard, [&nav]() { nav.push<SDCardDebugView>(); }},
-        {"Peripherals", ui::Color::dark_cyan(), &bitmap_icon_peripherals, [&nav]() { nav.push<DebugPeripheralsMenuView>(); }},
         {"Temperature", ui::Color::dark_cyan(), &bitmap_icon_temperature, [&nav]() { nav.push<TemperatureView>(); }},
-        {"Buttons Test", ui::Color::dark_cyan(), &bitmap_icon_controls, [&nav]() { nav.push<DebugControlsView>(); }},
         {"Touch Test", ui::Color::dark_cyan(), &bitmap_icon_notepad, [&nav]() { nav.push<DebugScreenTest>(); }},
-        {"P.Memory", ui::Color::dark_cyan(), &bitmap_icon_memory, [&nav]() { nav.push<DebugPmemView>(); }},
-        {"Debug Dump", ui::Color::dark_cyan(), &bitmap_icon_memory, [&nav]() { portapack::persistent_memory::debug_dump(); }},
-        {"M0 Stack Dump", ui::Color::dark_cyan(), &bitmap_icon_memory, [&nav]() { stack_dump(); }},
-        //{"Fonts Viewer", ui::Color::dark_cyan(), &bitmap_icon_notepad, [&nav]() { nav.push<DebugFontsView>(); }},  // temporarily disabled to conserve ROM space
     });
     set_max_rows(2);  // allow wider buttons
 }

--- a/firmware/application/apps/ui_fileman.cpp
+++ b/firmware/application/apps/ui_fileman.cpp
@@ -27,6 +27,7 @@
 #include <algorithm>
 #include "ui_fileman.hpp"
 #include "ui_playlist.hpp"
+#include "ui_remote.hpp"
 #include "ui_ss_viewer.hpp"
 #include "ui_text_editor.hpp"
 #include "string_format.hpp"
@@ -44,6 +45,7 @@ static const fs::path c16_ext{u".C16"};
 static const fs::path cxx_ext{u".C*"};
 static const fs::path png_ext{u".PNG"};
 static const fs::path bmp_ext{u".BMP"};
+static const fs::path rem_ext{u".REM"};
 }  // namespace ui
 
 namespace {
@@ -524,6 +526,9 @@ bool FileManagerView::handle_file_open() {
     } else if (path_iequal(bmp_ext, ext)) {
         nav_.push<SplashViewer>(path);
         reload_current();
+        return true;
+    } else if (path_iequal(rem_ext, ext)) {
+        nav_.push<RemoteView>(path);
         return true;
     }
 

--- a/firmware/application/apps/ui_fileman.cpp
+++ b/firmware/application/apps/ui_fileman.cpp
@@ -634,7 +634,7 @@ FileManagerView::FileManagerView(
     button_open_notepad.on_select = [this]() {
         if (selected_is_valid() && !get_selected_entry().is_directory) {
             auto path = get_selected_full_path();
-            nav_.replace<TextEditorView>(path);
+            nav_.push<TextEditorView>(path);
         } else
             nav_.display_modal("Open in Notepad", "Can't open that in Notepad.");
     };

--- a/firmware/application/apps/ui_fileman.hpp
+++ b/firmware/application/apps/ui_fileman.hpp
@@ -77,7 +77,8 @@ class FileManBaseView : public View {
         {u".C8", &bitmap_icon_file_iq, ui::Color::dark_cyan()},
         {u".C16", &bitmap_icon_file_iq, ui::Color::dark_cyan()},
         {u".WAV", &bitmap_icon_file_wav, ui::Color::dark_magenta()},
-        {u".PPL", &bitmap_icon_file_iq, ui::Color::white()},  // PPL is the file extension for playlist app
+        {u".PPL", &bitmap_icon_file_iq, ui::Color::white()},  // Playlist/Replay
+        {u".REM", &bitmap_icon_remote, ui::Color::orange()},  // Remote
         {u"", &bitmap_icon_file, ui::Color::light_grey()}     // NB: Must be last.
     };
 

--- a/firmware/application/apps/ui_fileman.hpp
+++ b/firmware/application/apps/ui_fileman.hpp
@@ -269,7 +269,8 @@ class FileManagerView : public FileManBaseView {
         {4 * 8, 34 * 8, 4 * 8, 32},
         {},
         &bitmap_icon_options_datetime,
-        Color::orange()};
+        Color::orange(),
+        /*vcenter*/ true};
 };
 
 } /* namespace ui */

--- a/firmware/application/apps/ui_mictx.cpp
+++ b/firmware/application/apps/ui_mictx.cpp
@@ -633,7 +633,7 @@ MicTXView::MicTXView(
 
 MicTXView::~MicTXView() {
     audio::input::stop();
-    transmitter_model.set_target_frequency(tx_frequency);  // Save Tx frequency instead of Rx. Or maybe we need some "System Wide" changes to seperate Tx and Rx frequency.
+    transmitter_model.set_target_frequency(tx_frequency);
     transmitter_model.disable();
     if (rx_enabled)  // Also turn off audio rx if enabled
         rxaudio(false);

--- a/firmware/application/apps/ui_mictx.hpp
+++ b/firmware/application/apps/ui_mictx.hpp
@@ -25,9 +25,6 @@
 #ifndef __UI_MICTX_H__
 #define __UI_MICTX_H__
 
-#define SHORT_UI true
-#define NORMAL_UI false
-
 #include "app_settings.hpp"
 #include "radio_state.hpp"
 #include "ui.hpp"
@@ -219,10 +216,8 @@ class MicTXView : public View {
         ' '};
 
     TransmitterView2 tx_view{
-        // new handling of NumberField field_rfgain, NumberField field_rfamp
-        //	3*8, 2*8, SHORT_UI					// x(columns), y (line) position. (used in Replay / GPS Simul / Playlist App's)
-        3 * 8, 2 * 8, NORMAL_UI  // x(columns), y (line) position. (used in Mic App)
-    };
+        {3 * 8, 5 * 8},
+        /*short_ui*/ false};
 
     OptionsField options_mode{
         {24 * 8, 5 * 8},

--- a/firmware/application/apps/ui_playlist.cpp
+++ b/firmware/application/apps/ui_playlist.cpp
@@ -386,6 +386,7 @@ PlaylistView::PlaylistView(
         &waterfall,
     });
 
+    ensure_directory(u"PLAYLIST");
     waterfall.show_audio_spectrum_view(false);
 
     field_frequency.set_value(100'000'000);

--- a/firmware/application/apps/ui_playlist.hpp
+++ b/firmware/application/apps/ui_playlist.hpp
@@ -21,9 +21,6 @@
  * Boston, MA 02110-1301, USA.
  */
 
-#define SHORT_UI true
-#define NORMAL_UI false
-
 #include "app_settings.hpp"
 #include "bitmap.hpp"
 #include "file.hpp"
@@ -135,7 +132,8 @@ class PlaylistView : public View {
     // TODO: delay duration field.
 
     TransmitterView2 tx_view{
-        9 * 8, 1 * 8, SHORT_UI};
+        {11 * 8, 2 * 16},
+        /*short_ui*/ true};
 
     Checkbox check_loop{
         {21 * 8, 2 * 16},

--- a/firmware/application/apps/ui_playlist.hpp
+++ b/firmware/application/apps/ui_playlist.hpp
@@ -60,7 +60,7 @@ class PlaylistView : public View {
 
     // More header == less spectrum view.
     static constexpr ui::Dim header_height = 6 * 16;
-    static constexpr uint32_t baseband_bandwidth = 2500000;
+    static constexpr uint32_t baseband_bandwidth = 2'500'000;
 
     struct playlist_entry {
         std::filesystem::path path{};
@@ -115,14 +115,11 @@ class PlaylistView : public View {
     Text text_sample_rate{
         {10 * 8, 1 * 16, 7 * 8, 16}};
 
-    /*v making there's 1px line (instead of two) between two progress bars,
-     * by letting 1px overlapped.
-     * So, since they overlapped 1px, they are visually same, and looks better.
-     */
-
     ProgressBar progressbar_track{
         {18 * 8, 1 * 16, 12 * 8, 8 + 1}};
 
+    // (-1) to overlap with progressbar_track so there's
+    // only 1 pixel between them instead of 2.
     ProgressBar progressbar_transmit{
         {18 * 8, 3 * 8 - 1, 12 * 8, 8}};
 

--- a/firmware/application/apps/ui_remote.cpp
+++ b/firmware/application/apps/ui_remote.cpp
@@ -25,6 +25,26 @@ using namespace portapack;
 
 namespace ui {
 
+/* RemoteButton *******************************************/
+
+RemoteButton(Rect parent_rect, RemoteEntryModel& model)
+    : NewButton{rect, model.name, RemoteIcons::get(icon), RemoteColors::get(fg_color)},
+    model_{model} {
+}
+
+void RemoteButton::on_focus() {
+    // Set long press
+}
+
+void RemoteButton::on_focus() {
+    // Set long press
+}
+
+bool RemoteButton::on_key(KeyEvent key) {
+}
+
+/* RemoteView *********************************************/
+
 RemoteView::RemoteView(
     NavigationView& nav)
     : nav_{nav} {
@@ -35,6 +55,8 @@ RemoteView::RemoteView(
         &button_open,
         &button_save,
     });
+
+    
 }
 
 RemoteView::~RemoteView() {

--- a/firmware/application/apps/ui_remote.cpp
+++ b/firmware/application/apps/ui_remote.cpp
@@ -546,14 +546,15 @@ void RemoteView::open_remote() {
     open_view->on_changed = [this](fs::path path) {
         save_remote();
         load_remote(std::move(path));
-        refresh_ui();;
+        refresh_ui();
+        ;
     };
 }
 
 void RemoteView::init_remote() {
     model_ = {"<Unnamed Remote>", {}};
     reset_buttons();
-    set_remote_path(next_filename_matching_pattern(u"/REMOTE/REMOTE_????.REM"));
+    set_remote_path(next_filename_matching_pattern(u"/REMOTES/REMOTE_????.REM"));
     set_needs_save(false);
 
     if (remote_path_.empty()) {
@@ -572,7 +573,7 @@ void RemoteView::save_remote() {
     if (!needs_save_)
         return;
 
-    model_.save(remote_path_);
+    model_.save(remote_path_);  // TODO: indicate when save fails?
     set_needs_save(false);
 }
 

--- a/firmware/application/apps/ui_remote.cpp
+++ b/firmware/application/apps/ui_remote.cpp
@@ -21,27 +21,151 @@
 
 #include "ui_remote.hpp"
 
+#include "irq_controls.hpp"
+#include "string_format.hpp"
+#include "ui_textentry.hpp"
+
 using namespace portapack;
 
 namespace ui {
 
 /* RemoteButton *******************************************/
 
-RemoteButton::RemoteButton(Rect parent_rect, RemoteEntryModel& model)
-    : NewButton{parent_rect, model.name, RemoteIcons::get(model.icon), RemoteColors::get(model.fg_color)},
-    model_{model} {
+RemoteButton::RemoteButton(Rect parent_rect, RemoteEntryModel& entry)
+    : NewButton{
+          parent_rect,
+          entry.name,
+          RemoteIcons::get(entry.icon),
+          RemoteColors::get(entry.fg_color)},
+      entry_{entry} {
 }
 
 void RemoteButton::on_focus() {
-    // Setup long press
+    // Enable long press on "Select".
+    SwitchesState config;
+    config[toUType(Switch::Sel)] = true;
+    set_switches_long_press_config(config);
 }
 
 void RemoteButton::on_blur() {
     // Reset long press
+    SwitchesState config{};
+    set_switches_long_press_config(config);
 }
 
 bool RemoteButton::on_key(KeyEvent key) {
-  return NewButton::on_key(key);
+    if (key == KeyEvent::Select) {
+        if (key_is_long_pressed(key) && on_long_select) {
+            on_long_select(*this);
+            return true;
+        }
+
+        if (on_select2) {
+            on_select2(*this);
+            return true;
+        }
+    }
+
+    return false;
+}
+
+RemoteEntryModel& RemoteButton::entry() {
+    return entry_;
+}
+
+Style RemoteButton::paint_style() {
+    MutableStyle s{style()};
+    s.foreground = RemoteColors::get(entry_.fg_color);
+    s.background = RemoteColors::get(entry_.bg_color);
+
+    if (has_focus() || highlighted())
+        s.invert();
+
+    // It's kind of a hack to set 'color_' here, but the base
+    // class' paint logic is kind of convoluted but isn't worth
+    // the extra bytes to copy and paste a paint override.
+    color_ = s.foreground;
+
+    return s;
+}
+
+/* RemoteEntryEditView ************************************/
+
+RemoteEntryEditView::RemoteEntryEditView(
+    NavigationView& nav,
+    RemoteEntryModel& entry)
+    : entry_{entry} {
+    add_children({
+        &labels,
+        &field_name,
+        &field_path,
+        &field_freq,
+        &text_rate,
+        &field_icon_index,
+        &field_fg_color_index,
+        &field_bg_color_index,
+        &button_preview,
+        &button_delete,
+        &button_done,
+    });
+
+    // TODO: It's time to make field bindings and clean this mess up.
+    field_name.on_change = [this](TextField& tf) {
+        entry_.name = tf.get_text();
+        button_preview.set_text(entry_.name);
+    };
+    field_name.on_select = [this, &nav](TextField& tf) {
+        temp_buffer_ = tf.get_text();
+        text_prompt(nav, temp_buffer_, text_edit_max,
+                    [this, &tf](std::string& str) {
+                        tf.set_text(str);
+                    });
+    };
+    field_name.set_text(entry_.name);
+
+    field_path.set_text(entry_.path.string());
+    field_freq.set_value(entry_.metadata.center_frequency);
+    text_rate.set(unit_auto_scale(entry_.metadata.sample_rate, 3, 0) + "Hz");
+
+    field_icon_index.on_change = [this](int32_t v) {
+        entry_.icon = v;
+        button_preview.set_bitmap(RemoteIcons::get(v));
+    };
+    field_icon_index.set_value(entry.icon);
+
+    field_fg_color_index.on_change = [this](int32_t v) {
+        entry_.fg_color = v;
+        button_preview.set_color(RemoteColors::get(v));
+    };
+    field_fg_color_index.set_value(entry_.fg_color);
+
+    field_bg_color_index.on_change = [this](int32_t v) {
+        entry_.bg_color = v;
+        button_preview.set_dirty();
+    };
+    field_bg_color_index.set_value(entry_.bg_color);
+
+    button_delete.on_select = [this, &nav](Button&) {
+        nav.display_modal(
+            "Delete?", "    Delete this button?", YESNO,
+            [this, &nav](bool choice) {
+                if (choice) {
+                    if (on_delete)
+                        on_delete(entry_);
+
+                    // Exit the edit view upon delete.
+                    nav.set_on_pop([&nav]() { nav.pop(); });
+                }
+            });
+    };
+
+    button_done.on_select = [&nav](Button&) {
+        nav.pop();
+    };
+}
+
+void RemoteEntryEditView::focus() {
+    button_done.focus();
 }
 
 /* RemoteView *********************************************/
@@ -57,21 +181,62 @@ RemoteView::RemoteView(
         &button_save,
     });
 
-    
+    load_test();
+    refresh_ui();
 }
 
 RemoteView::~RemoteView() {
 }
 
 void RemoteView::focus() {
+    if (buttons_.empty())
+        button_add.focus();
+    else
+        buttons_[0]->focus();
+}
+
+void RemoteView::refresh_ui() {
+    // Delete exising buttons.
+    for (auto& btn : buttons_)
+        remove_child(btn.get());
+
+    buttons_.clear();
+
+    auto handle_send = [this](RemoteButton&) {
+        nav_.display_modal("Send", "Sending");
+    };
+
+    auto handle_edit = [this](RemoteButton& btn) {
+        auto edit_view = nav_.push<RemoteEntryEditView>(btn.entry());
+        nav_.set_on_pop([this]() { refresh_ui(); });
+
+        edit_view->on_delete = [this](RemoteEntryModel& to_delete) {
+            model_.delete_entry(&to_delete);
+        };
+    };
+
+    // Add new buttons from model.
+    for (auto& entry : model_.entries) {
+        Coord x = buttons_.size() % button_cols;
+        Coord y = buttons_.size() / button_cols;
+
+        auto btn = std::make_unique<RemoteButton>(
+            Rect{x * button_width, y * button_height, button_width, button_height},
+            entry);
+        btn->on_select2 = handle_send;
+        btn->on_long_select = handle_edit;
+
+        add_child(btn.get());
+        buttons_.push_back(std::move(btn));
+    }
 }
 
 void RemoteView::load_test() {
     model_.name = "Cool Remote!";
     model_.entries = {
-        RemoteEntryModel{{}, "Lamp On", 3, 6, 2},
-        RemoteEntryModel{{}, "Lamp On", 8, 9, 1},
-        RemoteEntryModel{{}, "Fan Hi", 10, 0, 12},
+        RemoteEntryModel{{}, "Lamp On", 3, 1, 2},
+        RemoteEntryModel{{}, "Lamp Off", 8, 9, 1},
+        RemoteEntryModel{{}, "Fan Hi", 10, 2, 12},
     };
 }
 

--- a/firmware/application/apps/ui_remote.cpp
+++ b/firmware/application/apps/ui_remote.cpp
@@ -69,6 +69,20 @@ bool RemoteButton::on_key(KeyEvent key) {
     return false;
 }
 
+void RemoteButton::paint(Painter& painter) {
+    NewButton::paint(painter);
+    
+    // Add a border on the highlighted button.
+    if (has_focus() || highlighted()) {
+        auto r = screen_rect();
+        painter.draw_rectangle(r, Color::white());
+
+        auto p = r.location() + Point{1, 1};
+        auto s = Size{r.size().width() - 2, r.size().height() - 2};
+        painter.draw_rectangle({p, s}, Color::light_grey());
+    }
+};
+
 RemoteEntryModel& RemoteButton::entry() {
     return entry_;
 }

--- a/firmware/application/apps/ui_remote.cpp
+++ b/firmware/application/apps/ui_remote.cpp
@@ -27,20 +27,21 @@ namespace ui {
 
 /* RemoteButton *******************************************/
 
-RemoteButton(Rect parent_rect, RemoteEntryModel& model)
-    : NewButton{rect, model.name, RemoteIcons::get(icon), RemoteColors::get(fg_color)},
+RemoteButton::RemoteButton(Rect parent_rect, RemoteEntryModel& model)
+    : NewButton{parent_rect, model.name, RemoteIcons::get(model.icon), RemoteColors::get(model.fg_color)},
     model_{model} {
 }
 
 void RemoteButton::on_focus() {
-    // Set long press
+    // Setup long press
 }
 
-void RemoteButton::on_focus() {
-    // Set long press
+void RemoteButton::on_blur() {
+    // Reset long press
 }
 
 bool RemoteButton::on_key(KeyEvent key) {
+  return NewButton::on_key(key);
 }
 
 /* RemoteView *********************************************/

--- a/firmware/application/apps/ui_remote.cpp
+++ b/firmware/application/apps/ui_remote.cpp
@@ -1,6 +1,5 @@
 /*
- * Copyright (C) 2015 Jared Boone, ShareBrained Technology, Inc.
- * Copyright (C) 2018 Furrtek
+ * Copyright (C) 2023 Kyle Reed
  *
  * This file is part of PortaPack.
  *
@@ -22,30 +21,16 @@
 
 #include "ui_remote.hpp"
 
-#include "baseband_api.hpp"
-#include "string_format.hpp"
-
 using namespace portapack;
 
 namespace ui {
 
-void RemoteView::focus() {
-    button.focus();
-}
-
-RemoteView::~RemoteView() {
-    // transmitter_model.disable();
-    // baseband::shutdown();
-}
-
 RemoteView::RemoteView(
-    NavigationView& nav) {
-    add_children({&labels,
-                  &button});
+    NavigationView& nav)
+    : nav_{nav} {
+}
 
-    button.on_select = [this, &nav](Button&) {
-        nav.pop();
-    };
+void RemoteView::focus() {
 }
 
 } /* namespace ui */

--- a/firmware/application/apps/ui_remote.cpp
+++ b/firmware/application/apps/ui_remote.cpp
@@ -28,9 +28,28 @@ namespace ui {
 RemoteView::RemoteView(
     NavigationView& nav)
     : nav_{nav} {
+    add_children({
+        &button_edit,
+        &button_add,
+        &button_delete,
+        &button_open,
+        &button_save,
+    });
+}
+
+RemoteView::~RemoteView() {
 }
 
 void RemoteView::focus() {
+}
+
+void RemoteView::load_test() {
+    model_.name = "Cool Remote!";
+    model_.entries = {
+        RemoteEntryModel{{}, "Lamp On", 3, 6, 2},
+        RemoteEntryModel{{}, "Lamp On", 8, 9, 1},
+        RemoteEntryModel{{}, "Fan Hi", 10, 0, 12},
+    };
 }
 
 } /* namespace ui */

--- a/firmware/application/apps/ui_remote.hpp
+++ b/firmware/application/apps/ui_remote.hpp
@@ -21,6 +21,7 @@
 
 #include "ui.hpp"
 #include "ui_navigation.hpp"
+#include "ui_receiver.hpp"
 
 #include "app_settings.hpp"
 #include "bitmap.hpp"
@@ -28,7 +29,9 @@
 #include "metadata_file.hpp"
 #include "radio_state.hpp"
 
+#include <algorithm>
 #include <functional>
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -37,12 +40,17 @@ namespace ui {
 /* Maps icon index to bitmap. */
 class RemoteIcons {
    public:
-    static const Bitmap* get(uint8_t index) {
+    static constexpr const Bitmap* get(uint8_t index) {
         if (index >= std::size(bitmaps_))
             return bitmaps_[0];
 
         return bitmaps_[index];
     }
+
+    static constexpr size_t size() {
+        return std::size(bitmaps_);
+    }
+
    private:
     static constexpr std::array<const Bitmap*, 24> bitmaps_{
         &bitmap_icon_adsb,
@@ -68,19 +76,23 @@ class RemoteIcons {
         &bitmap_icon_sonde,
         &bitmap_icon_stealth,
         &bitmap_icon_tetra,
-        &bitmap_icon_temperature
-    };
+        &bitmap_icon_temperature};
 };
 
 /* Maps color index to color. */
 class RemoteColors {
    public:
-    static Color get(uint8_t index) {
+    static constexpr Color get(uint8_t index) {
         if (index >= std::size(colors_))
             return colors_[0];
 
         return colors_[index];
     }
+
+    static constexpr size_t size() {
+        return std::size(colors_);
+    }
+
    private:
     static constexpr std::array<Color, 18> colors_{
         Color::black(),
@@ -100,8 +112,7 @@ class RemoteColors {
         Color::dark_blue(),
         Color::dark_cyan(),
         Color::dark_magenta(),
-        Color::dark_grey()
-    };
+        Color::dark_grey()};
 };
 
 /* Data model for a remote entry. */
@@ -120,6 +131,19 @@ struct RemoteEntryModel {
 struct RemoteModel {
     std::string name{};
     std::vector<RemoteEntryModel> entries{};
+
+    bool delete_entry(const RemoteEntryModel* entry) {
+        // NB: expecting 'entry' to be a pointer to an entry in vector.
+        // I hate implementing operator==, so using this hack instead.
+        auto it = std::find_if(
+            entries.begin(), entries.end(),
+            [entry](auto& item) { return entry == &item; });
+        if (it == entries.end())
+            return false;
+
+        entries.erase(it);
+        return true;
+    }
 };
 
 /* Button for the remote UI. */
@@ -128,15 +152,21 @@ class RemoteButton : public NewButton {
     std::function<void(RemoteButton&)> on_select2{};
     std::function<void(RemoteButton&)> on_long_select{};
 
-    RemoteButton(Rect parent_rect, RemoteEntryModel& model);
+    RemoteButton(Rect parent_rect, RemoteEntryModel& entry);
 
     void on_focus() override;
     void on_blur() override;
     bool on_key(KeyEvent key) override;
 
+    RemoteEntryModel& entry();
+
+   protected:
+    Style paint_style() override;
+
    private:
+    // Hide because it's not used.
     using NewButton::on_select;
-    RemoteEntryModel& model_;
+    RemoteEntryModel& entry_;
 };
 
 /* Settings container for remote. */
@@ -144,10 +174,75 @@ struct RemoteSettings {
     std::string remote_path{};
 };
 
+class RemoteEntryEditView : public View {
+   public:
+    std::function<void(RemoteEntryModel&)> on_delete{};
+
+    RemoteEntryEditView(NavigationView& nav, RemoteEntryModel& entry);
+
+    std::string title() const override { return "Edit Item"; };
+    void focus() override;
+
+   private:
+    RemoteEntryModel& entry_;
+    std::string temp_buffer_{};
+    static constexpr uint8_t text_edit_max = 30;
+
+    Labels labels{
+        {{1 * 8, 1 * 16}, "Name:", Color::light_grey()},
+        {{1 * 8, 2 * 16}, "Path:", Color::light_grey()},
+        {{1 * 8, 3 * 16}, "Freq:", Color::light_grey()},
+        {{1 * 8, 4 * 16}, "Rate:", Color::light_grey()},
+        {{1 * 8, 5 * 16}, "Icon:", Color::light_grey()},
+        {{1 * 8, 6 * 16}, "FG Color:", Color::light_grey()},
+        {{1 * 8, 7 * 16}, "BG Color:", Color::light_grey()},
+        {{8 * 8, 9 * 16}, "Button preview", Color::light_grey()},
+    };
+
+    TextField field_name{{7 * 8, 1 * 16, 20 * 8, 1 * 16}, {}};
+
+    TextField field_path{{7 * 8, 2 * 16, 20 * 8, 1 * 16}, {}};
+
+    FrequencyField field_freq{{7 * 8, 3 * 16}};
+
+    Text text_rate{{7 * 8, 4 * 16, 20 * 8, 1 * 16}, {}};
+
+    NumberField field_icon_index{
+        {7 * 8, 5 * 16},
+        2,
+        {0, RemoteIcons::size() - 1},
+        /*step*/ 1,
+        /*fill*/ ' ',
+        /*loop*/ true};
+
+    NumberField field_fg_color_index{
+        {11 * 8, 6 * 16},
+        2,
+        {0, RemoteColors::size() - 1},
+        /*step*/ 1,
+        /*fill*/ ' ',
+        /*loop*/ true};
+
+    NumberField field_bg_color_index{
+        {11 * 8, 7 * 16},
+        2,
+        {0, RemoteColors::size() - 1},
+        /*step*/ 1,
+        /*fill*/ ' ',
+        /*loop*/ true};
+
+    RemoteButton button_preview{
+        {10 * 8, 11 * 16, 10 * 8, 50},
+        entry_};
+
+    Button button_delete{{5 * 8, 16 * 16, 10 * 8, 2 * 16}, "Delete"};
+    Button button_done{{16 * 8, 16 * 16, 8 * 8, 2 * 16}, "Done"};
+};
+
 class RemoteView : public View {
    public:
     RemoteView(NavigationView& nav);
-    //RemoteView(NavigationView& nav, const std::filesystem::path& path);
+    // RemoteView(NavigationView& nav, const std::filesystem::path& path);
     ~RemoteView();
 
     std::string title() const override { return "Remote"; };
@@ -156,6 +251,12 @@ class RemoteView : public View {
    private:
     void refresh_ui();
     void load_test();
+
+    static constexpr Dim button_rows = 4;
+    static constexpr Dim button_cols = 3;
+    static constexpr uint8_t max_buttons = button_rows * button_cols;
+    static constexpr Dim button_width = 240 / button_cols;
+    static constexpr Dim button_height = 200 / button_rows;
 
     NavigationView& nav_;
     RxRadioState radio_state_{};
@@ -170,7 +271,6 @@ class RemoteView : public View {
         }};
 
     RemoteModel model_{};
-
     std::vector<std::unique_ptr<RemoteButton>> buttons_{};
 
     NewButton button_edit{

--- a/firmware/application/apps/ui_remote.hpp
+++ b/firmware/application/apps/ui_remote.hpp
@@ -157,6 +157,7 @@ class RemoteButton : public NewButton {
     void on_focus() override;
     void on_blur() override;
     bool on_key(KeyEvent key) override;
+    void paint(Painter& painter) override;
 
     RemoteEntryModel& entry();
 

--- a/firmware/application/apps/ui_remote.hpp
+++ b/firmware/application/apps/ui_remote.hpp
@@ -196,6 +196,9 @@ class RemoteEntryEditView : public View {
     RemoteEntryModel& entry_;
     std::string temp_buffer_{};
 
+    void refresh_ui();
+    void load_path(std::filesystem::path&& path);
+
     Labels labels{
         {{2 * 8, 1 * 16}, "Name:", Color::light_grey()},
         {{2 * 8, 2 * 16}, "Path:", Color::light_grey()},

--- a/firmware/application/apps/ui_remote.hpp
+++ b/firmware/application/apps/ui_remote.hpp
@@ -285,12 +285,13 @@ class RemoteView : public View {
     void open_remote();
     void init_remote();
     bool load_remote(std::filesystem::path&& path);
-    void save_remote();
+    void save_remote(bool show_errors = true);
     void rename_remote(const std::string& new_name);
     void handle_replay_thread_done(uint32_t return_code);
     void set_needs_save(bool v = true) { needs_save_ = v; }
     void set_remote_path(std::filesystem::path&& path);
     bool is_sending() const { return replay_thread_ != nullptr; }
+    void show_error(const std::string& msg) const;
 
     static constexpr Dim button_rows = 4;
     static constexpr Dim button_cols = 3;
@@ -325,7 +326,7 @@ class RemoteView : public View {
     std::vector<std::unique_ptr<RemoteButton>> buttons_{};
 
     std::unique_ptr<ReplayThread> replay_thread_{};
-    bool ready_signal_{};  // Used to signal the ReplayThread.
+    bool ready_signal_{};  // Used to signal ReplayThread ready.
 
     TextField field_title{
         {0 * 8, 0 * 16 + 2, 30 * 8, 1 * 16},

--- a/firmware/application/apps/ui_remote.hpp
+++ b/firmware/application/apps/ui_remote.hpp
@@ -1,6 +1,5 @@
 /*
- * Copyright (C) 2015 Jared Boone, ShareBrained Technology, Inc.
- * Copyright (C) 2018 Furrtek
+ * Copyright (C) 2023 Kyle Reed
  *
  * This file is part of PortaPack.
  *
@@ -21,42 +20,52 @@
  */
 
 #include "ui.hpp"
-#include "ui_transmitter.hpp"
-#include "transmitter_model.hpp"
+#include "ui_navigation.hpp"
+
+#include "app_settings.hpp"
+#include "radio_state.hpp"
+
+#include <string>
+#include <vector>
 
 namespace ui {
+
+/* Data model for a remote entry. */
+class RemoteEntryModel {
+};
+
+/* Data model for a remote. */
+class RemoteModel {
+   public:
+   private:
+    std::string name_;
+    std::vector<RemoteEntryModel> entries_;
+};
+
+/* Settings container for remote. */
+struct RemoteSettings {
+    std::string remote_path{};
+};
 
 class RemoteView : public View {
    public:
     RemoteView(NavigationView& nav);
-    ~RemoteView();
 
+    std::string title() const override { return "Remote"; };
     void focus() override;
 
-    std::string title() const override { return "Custom remote"; };
-
    private:
-    /*enum tx_modes {
-                IDLE = 0,
-                SINGLE,
-                SCAN
-        };
+    NavigationView& nav_;
+    RxRadioState radio_state_{};
 
-        tx_modes tx_mode = IDLE;
-
-        struct remote_layout_t {
-                Point position;
-                std::string text;
-        };
-
-        const std::array<remote_layout_t, 32> remote_layout { };*/
-
-    Labels labels{
-        {{1 * 8, 0}, "Work in progress...", Color::light_grey()}};
-
-    Button button{
-        {60, 64, 120, 32},
-        "Exit"};
+    // Settings
+    RemoteSettings settings_{};
+    app_settings::SettingsManager app_settings_{
+        "tx_remote"sv,
+        app_settings::Mode::TX,
+        {
+            {"remote_path"sv, &settings_.remote_path},
+        }};
 };
 
 } /* namespace ui */

--- a/firmware/application/apps/ui_remote.hpp
+++ b/firmware/application/apps/ui_remote.hpp
@@ -28,6 +28,7 @@
 #include "metadata_file.hpp"
 #include "radio_state.hpp"
 
+#include <functional>
 #include <string>
 #include <vector>
 
@@ -124,8 +125,8 @@ struct RemoteModel {
 /* Button for the remote UI. */
 class RemoteButton : public NewButton {
    public:
-    public std::function<void(RemoteButton&)> on_select;
-    public std::function<void(RemoteButton&)> on_long_select;
+    std::function<void(RemoteButton&)> on_select2{};
+    std::function<void(RemoteButton&)> on_long_select{};
 
     RemoteButton(Rect parent_rect, RemoteEntryModel& model);
 
@@ -134,7 +135,7 @@ class RemoteButton : public NewButton {
     bool on_key(KeyEvent key) override;
 
    private:
-    NewButton::on_select;
+    using NewButton::on_select;
     RemoteEntryModel& model_;
 };
 
@@ -170,7 +171,7 @@ class RemoteView : public View {
 
     RemoteModel model_{};
 
-    std::vector<std::unique_ptr<RemoteButton>> buttons_
+    std::vector<std::unique_ptr<RemoteButton>> buttons_{};
 
     NewButton button_edit{
         {7 * 8, 4 * 16, 4 * 8, 2 * 16},

--- a/firmware/application/apps/ui_remote.hpp
+++ b/firmware/application/apps/ui_remote.hpp
@@ -71,6 +71,7 @@ class RemoteIcons {
     };
 };
 
+/* Maps color index to color. */
 class RemoteColors {
    public:
     static Color get(uint8_t index) {
@@ -120,6 +121,23 @@ struct RemoteModel {
     std::vector<RemoteEntryModel> entries{};
 };
 
+/* Button for the remote UI. */
+class RemoteButton : public NewButton {
+   public:
+    public std::function<void(RemoteButton&)> on_select;
+    public std::function<void(RemoteButton&)> on_long_select;
+
+    RemoteButton(Rect parent_rect, RemoteEntryModel& model);
+
+    void on_focus() override;
+    void on_blur() override;
+    bool on_key(KeyEvent key) override;
+
+   private:
+    NewButton::on_select;
+    RemoteEntryModel& model_;
+};
+
 /* Settings container for remote. */
 struct RemoteSettings {
     std::string remote_path{};
@@ -135,6 +153,7 @@ class RemoteView : public View {
     void focus() override;
 
    private:
+    void refresh_ui();
     void load_test();
 
     NavigationView& nav_;
@@ -150,6 +169,8 @@ class RemoteView : public View {
         }};
 
     RemoteModel model_{};
+
+    std::vector<std::unique_ptr<RemoteButton>> buttons_
 
     NewButton button_edit{
         {7 * 8, 4 * 16, 4 * 8, 2 * 16},

--- a/firmware/application/apps/ui_remote.hpp
+++ b/firmware/application/apps/ui_remote.hpp
@@ -156,14 +156,17 @@ class RemoteButton : public NewButton {
     std::function<void(RemoteButton&)> on_select2{};
     std::function<void(RemoteButton&)> on_long_select{};
 
-    RemoteButton(Rect parent_rect, RemoteEntryModel& entry);
+    RemoteButton(Rect parent_rect, RemoteEntryModel* entry);
+    RemoteButton(const RemoteButton&) = default;
+    RemoteButton& operator=(const RemoteButton&) = default;
 
     void on_focus() override;
     void on_blur() override;
     bool on_key(KeyEvent key) override;
     void paint(Painter& painter) override;
 
-    RemoteEntryModel& entry();
+    RemoteEntryModel* entry();
+    void set_entry(RemoteEntryModel* entry);
 
    protected:
     Style paint_style() override;
@@ -171,7 +174,7 @@ class RemoteButton : public NewButton {
    private:
     // Hide because it's not used.
     using NewButton::on_select;
-    RemoteEntryModel& entry_;
+    RemoteEntryModel* entry_;
 };
 
 /* Settings container for remote. */
@@ -192,7 +195,6 @@ class RemoteEntryEditView : public View {
    private:
     RemoteEntryModel& entry_;
     std::string temp_buffer_{};
-    static constexpr uint8_t text_edit_max = 30;
 
     Labels labels{
         {{2 * 8, 1 * 16}, "Name:", Color::light_grey()},
@@ -240,7 +242,7 @@ class RemoteEntryEditView : public View {
 
     RemoteButton button_preview{
         {10 * 8, 11 * 16 - 8, 10 * 8, 50},
-        entry_};
+        &entry_};
 
     NewButton button_delete{
         {2 * 8, 16 * 16, 4 * 8, 2 * 16},
@@ -262,8 +264,9 @@ class RemoteView : public View {
     void focus() override;
 
    private:
+    /* Creates the dynamic buttons. */
+    void create_buttons();
     void refresh_ui();
-    void load_test();
 
     void add_button();
     void edit_button(RemoteButton& btn);
@@ -351,13 +354,6 @@ class RemoteView : public View {
                 ready_signal_ = true;
             }
         }};
-
-    // MessageHandlerRegistration message_handler_tx_progress{
-    //     Message::ID::TXProgress,
-    //     [this](const Message* p) {
-    //         auto message = *reinterpret_cast<const TXProgressMessage*>(p);
-    //         on_tx_progress(message.progress);
-    //     }};
 };
 
 } /* namespace ui */

--- a/firmware/application/apps/ui_remote.hpp
+++ b/firmware/application/apps/ui_remote.hpp
@@ -23,6 +23,9 @@
 #include "ui_navigation.hpp"
 
 #include "app_settings.hpp"
+#include "bitmap.hpp"
+#include "file.hpp"
+#include "metadata_file.hpp"
 #include "radio_state.hpp"
 
 #include <string>
@@ -30,16 +33,91 @@
 
 namespace ui {
 
+/* Maps icon index to bitmap. */
+class RemoteIcons {
+   public:
+    static const Bitmap* get(uint8_t index) {
+        if (index >= std::size(bitmaps_))
+            return bitmaps_[0];
+
+        return bitmaps_[index];
+    }
+   private:
+    static constexpr std::array<const Bitmap*, 24> bitmaps_{
+        &bitmap_icon_adsb,
+        &bitmap_icon_ais,
+        &bitmap_icon_aprs,
+        &bitmap_icon_btle,
+        &bitmap_icon_burger,
+        &bitmap_icon_camera,
+        &bitmap_icon_cwgen,
+        &bitmap_icon_dmr,
+        &bitmap_icon_file_image,
+        &bitmap_icon_fox,
+        &bitmap_icon_lge,
+        &bitmap_icon_looking,
+        &bitmap_icon_memory,
+        &bitmap_icon_morse,
+        &bitmap_icon_nrf,
+        &bitmap_icon_notepad,
+        &bitmap_icon_rds,
+        &bitmap_icon_remote,
+        &bitmap_icon_setup,
+        &bitmap_icon_sleep,
+        &bitmap_icon_sonde,
+        &bitmap_icon_stealth,
+        &bitmap_icon_tetra,
+        &bitmap_icon_temperature
+    };
+};
+
+class RemoteColors {
+   public:
+    static Color get(uint8_t index) {
+        if (index >= std::size(colors_))
+            return colors_[0];
+
+        return colors_[index];
+    }
+   private:
+    static constexpr std::array<Color, 18> colors_{
+        Color::black(),
+        Color::white(),
+        Color::red(),
+        Color::orange(),
+        Color::yellow(),
+        Color::green(),
+        Color::blue(),
+        Color::cyan(),
+        Color::magenta(),
+        Color::grey(),
+        Color::dark_red(),
+        Color::dark_orange(),
+        Color::dark_yellow(),
+        Color::dark_green(),
+        Color::dark_blue(),
+        Color::dark_cyan(),
+        Color::dark_magenta(),
+        Color::dark_grey()
+    };
+};
+
 /* Data model for a remote entry. */
-class RemoteEntryModel {
+struct RemoteEntryModel {
+    std::filesystem::path path{};
+    std::string name{};
+    uint8_t icon = 0;
+    uint8_t bg_color = 0;
+    uint8_t fg_color = 0;
+    capture_metadata metadata{};
+    File::Size file_size = 0;
+    // TODO: start/end position for trimming.
 };
 
 /* Data model for a remote. */
-class RemoteModel {
-   public:
-   private:
-    std::string name_;
-    std::vector<RemoteEntryModel> entries_;
+struct RemoteModel {
+    std::string name{};
+    std::vector<RemoteEntryModel> entries{};
 };
 
 /* Settings container for remote. */
@@ -50,11 +128,15 @@ struct RemoteSettings {
 class RemoteView : public View {
    public:
     RemoteView(NavigationView& nav);
+    //RemoteView(NavigationView& nav, const std::filesystem::path& path);
+    ~RemoteView();
 
     std::string title() const override { return "Remote"; };
     void focus() override;
 
    private:
+    void load_test();
+
     NavigationView& nav_;
     RxRadioState radio_state_{};
 
@@ -66,6 +148,40 @@ class RemoteView : public View {
         {
             {"remote_path"sv, &settings_.remote_path},
         }};
+
+    RemoteModel model_{};
+
+    NewButton button_edit{
+        {7 * 8, 4 * 16, 4 * 8, 2 * 16},
+        "",
+        &bitmap_icon_notepad,
+        Color::orange()};
+
+    NewButton button_add{
+        {11 * 8, 4 * 16, 4 * 8, 2 * 16},
+        "",
+        &bitmap_icon_new_file,
+        Color::orange()};
+
+    NewButton button_delete{
+        {15 * 8, 4 * 16, 4 * 8, 2 * 16},
+        "",
+        &bitmap_icon_delete,
+        Color::orange()};
+
+    NewButton button_open{
+        {20 * 8, 4 * 16, 4 * 8, 2 * 16},
+        "",
+        &bitmap_icon_load,
+        Color::dark_blue()};
+
+    NewButton button_save{
+        {24 * 8, 4 * 16, 4 * 8, 2 * 16},
+        "",
+        &bitmap_icon_save,
+        Color::dark_blue()};
+
+    // Waterfall?
 };
 
 } /* namespace ui */

--- a/firmware/application/apps/ui_settings.cpp
+++ b/firmware/application/apps/ui_settings.cpp
@@ -654,17 +654,17 @@ SettingsMenuView::SettingsMenuView(NavigationView& nav) {
         add_items({{"..", ui::Color::light_grey(), &bitmap_icon_previous, [&nav]() { nav.pop(); }}});
     }
     add_items({
+        {"App Settings", ui::Color::dark_cyan(), &bitmap_icon_setup, [&nav]() { nav.push<SetAppSettingsView>(); }},
         {"Audio", ui::Color::dark_cyan(), &bitmap_icon_speaker, [&nav]() { nav.push<SetAudioView>(); }},
+        {"Calibration", ui::Color::dark_cyan(), &bitmap_icon_options_touch, [&nav]() { nav.push<TouchCalibrationView>(); }},
+        {"Converter", ui::Color::dark_cyan(), &bitmap_icon_options_radio, [&nav]() { nav.push<SetConverterSettingsView>(); }},
+        {"Date/Time", ui::Color::dark_cyan(), &bitmap_icon_options_datetime, [&nav]() { nav.push<SetDateTimeView>(); }},
+        {"Encoder Dial", ui::Color::dark_cyan(), &bitmap_icon_setup, [&nav]() { nav.push<SetEncoderDialView>(); }},
+        {"Freq. Correct", ui::Color::dark_cyan(), &bitmap_icon_options_radio, [&nav]() { nav.push<SetFrequencyCorrectionView>(); }},
+        {"P.Memory Mgmt", ui::Color::dark_cyan(), &bitmap_icon_memory, [&nav]() { nav.push<SetPersistentMemoryView>(); }},
+        {"QR Code", ui::Color::dark_cyan(), &bitmap_icon_qr_code, [&nav]() { nav.push<SetQRCodeView>(); }},
         {"Radio", ui::Color::dark_cyan(), &bitmap_icon_options_radio, [&nav]() { nav.push<SetRadioView>(); }},
         {"User Interface", ui::Color::dark_cyan(), &bitmap_icon_options_ui, [&nav]() { nav.push<SetUIView>(); }},
-        {"Date/Time", ui::Color::dark_cyan(), &bitmap_icon_options_datetime, [&nav]() { nav.push<SetDateTimeView>(); }},
-        {"Calibration", ui::Color::dark_cyan(), &bitmap_icon_options_touch, [&nav]() { nav.push<TouchCalibrationView>(); }},
-        {"App Settings", ui::Color::dark_cyan(), &bitmap_icon_setup, [&nav]() { nav.push<SetAppSettingsView>(); }},
-        {"Converter", ui::Color::dark_cyan(), &bitmap_icon_options_radio, [&nav]() { nav.push<SetConverterSettingsView>(); }},
-        {"Freq. Correct", ui::Color::dark_cyan(), &bitmap_icon_options_radio, [&nav]() { nav.push<SetFrequencyCorrectionView>(); }},
-        {"QR Code", ui::Color::dark_cyan(), &bitmap_icon_qr_code, [&nav]() { nav.push<SetQRCodeView>(); }},
-        {"P.Memory Mgmt", ui::Color::dark_cyan(), &bitmap_icon_memory, [&nav]() { nav.push<SetPersistentMemoryView>(); }},
-        {"Encoder Dial", ui::Color::dark_cyan(), &bitmap_icon_setup, [&nav]() { nav.push<SetEncoderDialView>(); }},
     });
     set_max_rows(2);  // allow wider buttons
 }

--- a/firmware/application/apps/ui_text_editor.hpp
+++ b/firmware/application/apps/ui_text_editor.hpp
@@ -261,7 +261,8 @@ class TextEditorView : public View {
         {26 * 8, 34 * 8, 4 * 8, 4 * 8},
         {},
         &bitmap_icon_controls,
-        Color::dark_grey()};
+        Color::dark_grey(),
+        /*vcenter*/ true};
 
     Text text_position{
         {0 * 8, 34 * 8, 26 * 8, 2 * 8},

--- a/firmware/application/string_format.cpp
+++ b/firmware/application/string_format.cpp
@@ -311,10 +311,10 @@ std::string to_string_file_size(uint32_t file_size) {
     return to_string_dec_uint(file_size) + suffix[suffix_index];
 }
 
-std::string unit_auto_scale(double n, const uint32_t base_nano, uint32_t precision) {
+std::string unit_auto_scale(double n, const uint32_t base_unit, uint32_t precision) {
     const uint32_t powers_of_ten[5] = {1, 10, 100, 1000, 10000};
     std::string string{""};
-    uint32_t prefix_index = base_nano;
+    uint32_t prefix_index = base_unit;
     double integer_part;
     double fractional_part;
 

--- a/firmware/application/string_format.hpp
+++ b/firmware/application/string_format.hpp
@@ -76,7 +76,9 @@ std::string to_string_FAT_timestamp(const FATTimestamp& timestamp);
 // Gets a human readable file size string.
 std::string to_string_file_size(uint32_t file_size);
 
-std::string unit_auto_scale(double n, const uint32_t base_nano, uint32_t precision);
+/* Scales 'n' to be a value less than 1000. 'base_unit' is the index of the unit from
+ * 'unit_prefix' that 'n' is in initially. 3 is the index of the '1s' unit. */
+std::string unit_auto_scale(double n, const uint32_t base_unit, uint32_t precision);
 double get_decimals(double num, int16_t mult, bool round = false);
 
 std::string trim(std::string_view str);   // Remove whitespace at ends.

--- a/firmware/application/ui/ui_alphanum.hpp
+++ b/firmware/application/ui/ui_alphanum.hpp
@@ -82,7 +82,8 @@ class AlphanumView : public TextEntryView {
         {192, 214, screen_width / 5, 38},
         {},
         &bitmap_icon_shift,
-        Color::dark_grey()};
+        Color::dark_grey(),
+        /*vcenter*/ true};
 
     Labels labels{
         {{1 * 8, 33 * 8}, "Raw:", Color::light_grey()},

--- a/firmware/application/ui/ui_transmitter.hpp
+++ b/firmware/application/ui/ui_transmitter.hpp
@@ -26,9 +26,9 @@
 #include "ui.hpp"
 #include "ui_navigation.hpp"
 #include "ui_painter.hpp"
+#include "ui_receiver.hpp"
 #include "ui_styles.hpp"
 #include "ui_widget.hpp"
-#include "ui_receiver.hpp"
 
 #include "rf_path.hpp"
 
@@ -36,10 +36,6 @@
 #include <cstdint>
 #include <algorithm>
 #include <functional>
-
-#define POWER_THRESHOLD_HIGH 47
-#define POWER_THRESHOLD_MED 38
-#define POWER_THRESHOLD_LOW 17
 
 namespace ui {
 
@@ -74,11 +70,8 @@ class TransmitterView : public View {
 
    private:
     const Style& style_start = Styles::green;
-    const Style style_stop = Styles::red;
-    const Style style_locked = Styles::dark_grey;
-    const Style style_power_low = Styles::yellow;
-    const Style style_power_med = Styles::orange;
-    const Style style_power_high = Styles::red;
+    const Style& style_stop = Styles::red;
+    const Style& style_locked = Styles::dark_grey;
 
     bool lock_{false};
     bool transmitting_{false};
@@ -134,60 +127,32 @@ class TransmitterView : public View {
     void update_gainlevel_styles(void);
 };
 
+/* Simpler transmitter view that only renders TX Gain and Amp.
+ * When short_UI is set it abbreviates control labels. */
 class TransmitterView2 : public View {
    public:
-    TransmitterView2(const Coord x, const Coord y, bool short_UI);
-
-    ~TransmitterView2();
-
-    void on_show() override;
-    void paint(Painter& painter) override;
+    TransmitterView2(Point pos, bool short_ui);
 
    private:
-    const Style& style_power_low = Styles::yellow;
-    const Style& style_power_med = Styles::orange;
-    const Style& style_power_high = Styles::red;
-
-    Text text_gain_amp{
-        {0, 3 * 8, 5 * 8, 1 * 16},
-        "Gain:   Amp:"};
+    Text text_labels{
+        {},  // Set in ctor.
+        {}};
 
     NumberField field_gain{
-        {5 * 8, 3 * 8},
+        {},  // Set in ctor.
         2,
         {max2837::tx::gain_db_range.minimum, max2837::tx::gain_db_range.maximum},
         max2837::tx::gain_db_step,
         ' '};
 
     NumberField field_amp{
-        {12 * 8, 3 * 8},
+        {},  // Set in ctor.
         2,
         {0, 14},
         14,
         ' '};
 
-    Text text_gain_amp_short_UI{
-        {0, (3 * 8), 5 * 8, 1 * 16},
-        "Gain   A:"};
-
-    NumberField field_gain_short_UI{
-        {(4 * 8) + 2, 3 * 8},
-        2,
-        {max2837::tx::gain_db_range.minimum, max2837::tx::gain_db_range.maximum},
-        max2837::tx::gain_db_step,
-        ' '};
-
-    NumberField field_amp_short_UI{
-        {(9 * 8) - 2, 3 * 8},
-        2,
-        {0, 14},
-        14,
-        ' '};
-
-    void on_tx_gain_changed(int32_t tx_gain);
-    void on_tx_amp_changed(bool rf_amp);
-
-    void update_gainlevel_styles(void);
+    void update_gainlevel_styles();
 };
 
 } /* namespace ui */

--- a/firmware/application/ui_navigation.cpp
+++ b/firmware/application/ui_navigation.cpp
@@ -302,17 +302,18 @@ void SystemStatusView::on_converter() {
 
 void SystemStatusView::on_bias_tee() {
     if (!portapack::get_antenna_bias()) {
-        nav_.display_modal("Bias voltage",
-                           "Enable DC voltage on\nantenna connector?",
-                           YESNO,
-                           [this](bool v) {
-                               if (v) {
-                                   portapack::set_antenna_bias(true);
-                                   receiver_model.set_antenna_bias();
-                                   transmitter_model.set_antenna_bias();
-                                   refresh();
-                               }
-                           });
+        nav_.display_modal(
+            "Bias voltage",
+            "Enable DC voltage on\nantenna connector?",
+            YESNO,
+            [this](bool v) {
+                if (v) {
+                    portapack::set_antenna_bias(true);
+                    receiver_model.set_antenna_bias();
+                    transmitter_model.set_antenna_bias();
+                    refresh();
+                }
+            });
     } else {
         portapack::set_antenna_bias(false);
         receiver_model.set_antenna_bias();
@@ -498,30 +499,28 @@ ReceiversMenuView::ReceiversMenuView(NavigationView& nav) {
         add_items({{"..", Color::light_grey(), &bitmap_icon_previous, [&nav]() { nav.pop(); }}});
     }
     add_items({
+        // {"ACARS", Color::yellow(), &bitmap_icon_adsb, [&nav](){ nav.push<ACARSAppView>(); }},
         {"ADS-B", Color::green(), &bitmap_icon_adsb, [&nav]() { nav.push<ADSBRxView>(); }},
-        //{ "ACARS",	Color::yellow(),	&bitmap_icon_adsb,			[&nav](){ nav.push<ACARSAppView>(); }},
-        {"AIS Boats", Color::green(), &bitmap_icon_ais, [&nav]() { nav.push<AISAppView>(); }},
         {"AFSK", Color::yellow(), &bitmap_icon_modem, [&nav]() { nav.push<AFSKRxView>(); }},
-        {"BTLE", Color::yellow(), &bitmap_icon_btle, [&nav]() { nav.push<BTLERxView>(); }},
-        {"NRF", Color::yellow(), &bitmap_icon_nrf, [&nav]() { nav.push<NRFRxView>(); }},
-        {"Audio", Color::green(), &bitmap_icon_speaker, [&nav]() { nav.push<AnalogAudioView>(); }},
+        {"AIS Boats", Color::green(), &bitmap_icon_ais, [&nav]() { nav.push<AISAppView>(); }},
         {"Analog TV", Color::yellow(), &bitmap_icon_sstv, [&nav]() { nav.push<AnalogTvView>(); }},
+        {"APRS", Color::green(), &bitmap_icon_aprs, [&nav]() { nav.push<APRSRXView>(); }},
+        {"Audio", Color::green(), &bitmap_icon_speaker, [&nav]() { nav.push<AnalogAudioView>(); }},
+        {"BTLE", Color::yellow(), &bitmap_icon_btle, [&nav]() { nav.push<BTLERxView>(); }},
         {"ERT Meter", Color::green(), &bitmap_icon_ert, [&nav]() { nav.push<ERTAppView>(); }},
+        {"Level", Color::green(), &bitmap_icon_options_radio, [&nav]() { nav.push<LevelView>(); }},
+        {"NRF", Color::yellow(), &bitmap_icon_nrf, [&nav]() { nav.push<NRFRxView>(); }},
         {"POCSAG", Color::green(), &bitmap_icon_pocsag, [&nav]() { nav.push<POCSAGAppView>(); }},
         {"Radiosnde", Color::green(), &bitmap_icon_sonde, [&nav]() { nav.push<SondeView>(); }},
-        {"TPMS Cars", Color::green(), &bitmap_icon_tpms, [&nav]() { nav.push<TPMSAppView>(); }},
         {"Recon", Color::green(), &bitmap_icon_scanner, [&nav]() { nav.push<ReconView>(); }},
-        {"Level", Color::green(), &bitmap_icon_options_radio, [&nav]() { nav.push<LevelView>(); }},
-        {"APRS", Color::green(), &bitmap_icon_aprs, [&nav]() { nav.push<APRSRXView>(); }}
-        /*
-                { "DMR", 		Color::dark_grey(),	&bitmap_icon_dmr,		[&nav](){ nav.push<NotImplementedView>(); } },
-                { "SIGFOX", 	Color::dark_grey(),	&bitmap_icon_fox,		[&nav](){ nav.push<NotImplementedView>(); } }, // SIGFRXView
-                { "LoRa", 		Color::dark_grey(),	&bitmap_icon_lora,		[&nav](){ nav.push<NotImplementedView>(); } },
-                { "SSTV", 		Color::dark_grey(), &bitmap_icon_sstv,		[&nav](){ nav.push<NotImplementedView>(); } },
-                { "TETRA", 		Color::dark_grey(),	&bitmap_icon_tetra,		[&nav](){ nav.push<NotImplementedView>(); } },*/
+        {"Search", Color::yellow(), &bitmap_icon_search, [&nav]() { nav.push<SearchView>(); }},
+        {"TPMS Cars", Color::green(), &bitmap_icon_tpms, [&nav]() { nav.push<TPMSAppView>(); }},
+        // {"DMR", Color::dark_grey(), &bitmap_icon_dmr, [&nav](){ nav.push<NotImplementedView>(); }},
+        // {"SIGFOX", Color::dark_grey(), &bitmap_icon_fox, [&nav](){ nav.push<NotImplementedView>(); }},
+        // {"LoRa", Color::dark_grey(), &bitmap_icon_lora, [&nav](){ nav.push<NotImplementedView>(); }},
+        // {"SSTV", Color::dark_grey(), &bitmap_icon_sstv, [&nav](){ nav.push<NotImplementedView>(); }},
+        // {"TETRA", Color::dark_grey(), &bitmap_icon_tetra, [&nav](){ nav.push<NotImplementedView>(); }},
     });
-
-    // set_highlighted(0);		// Default selection is "Audio"
 }
 
 /* TransmittersMenuView **************************************************/
@@ -531,26 +530,24 @@ TransmittersMenuView::TransmittersMenuView(NavigationView& nav) {
         add_items({{"..", Color::light_grey(), &bitmap_icon_previous, [&nav]() { nav.pop(); }}});
     }
     add_items({
-        {"ADS-B [S]", ui::Color::green(), &bitmap_icon_adsb, [&nav]() { nav.push<ADSBTxView>(); }},
+        {"ADS-B", ui::Color::green(), &bitmap_icon_adsb, [&nav]() { nav.push<ADSBTxView>(); }},
         {"APRS", ui::Color::green(), &bitmap_icon_aprs, [&nav]() { nav.push<APRSTXView>(); }},
         {"BHT Xy/EP", ui::Color::green(), &bitmap_icon_bht, [&nav]() { nav.push<BHTView>(); }},
+        {"BurgerPgr", ui::Color::yellow(), &bitmap_icon_burger, [&nav]() { nav.push<CoasterPagerView>(); }},
         {"GPS Sim", ui::Color::green(), &bitmap_icon_gps_sim, [&nav]() { nav.push<GpsSimAppView>(); }},
         {"Jammer", ui::Color::green(), &bitmap_icon_jammer, [&nav]() { nav.push<JammerView>(); }},
-        //{ "Key fob",		ui::Color::orange(),	&bitmap_icon_keyfob,	[&nav](){ nav.push<KeyfobView>(); } },
-        {"LGE tool", ui::Color::yellow(), &bitmap_icon_lge, [&nav]() { nav.push<LGEView>(); }},
+        // { "Key fob", ui::Color::orange(), &bitmap_icon_keyfob, [&nav](){ nav.push<KeyfobView>(); }},
+        {"LGE", ui::Color::yellow(), &bitmap_icon_lge, [&nav]() { nav.push<LGEView>(); }},
         {"Morse", ui::Color::green(), &bitmap_icon_morse, [&nav]() { nav.push<MorseView>(); }},
-        {"BurgerPgr", ui::Color::yellow(), &bitmap_icon_burger, [&nav]() { nav.push<CoasterPagerView>(); }},
-        //{ "Nuoptix DTMF", 	ui::Color::green(),		&bitmap_icon_nuoptix,	[&nav](){ nav.push<NuoptixView>(); } },
+        // { "Nuoptix DTMF", ui::Color::green(), &bitmap_icon_nuoptix, [&nav](){ nav.push<NuoptixView>(); }},
         {"OOK", ui::Color::yellow(), &bitmap_icon_remote, [&nav]() { nav.push<EncodersView>(); }},
         {"POCSAG", ui::Color::green(), &bitmap_icon_pocsag, [&nav]() { nav.push<POCSAGTXView>(); }},
         {"RDS", ui::Color::green(), &bitmap_icon_rds, [&nav]() { nav.push<RDSView>(); }},
         {"Soundbrd", ui::Color::green(), &bitmap_icon_soundboard, [&nav]() { nav.push<SoundBoardView>(); }},
+        {"S.Painter", ui::Color::orange(), &bitmap_icon_paint, [&nav]() { nav.push<SpectrumPainterView>(); }},
         {"SSTV", ui::Color::green(), &bitmap_icon_sstv, [&nav]() { nav.push<SSTVTXView>(); }},
         {"TEDI/LCR", ui::Color::yellow(), &bitmap_icon_lcr, [&nav]() { nav.push<LCRView>(); }},
         {"TouchTune", ui::Color::green(), &bitmap_icon_touchtunes, [&nav]() { nav.push<TouchTunesView>(); }},
-        //{"Playlist", ui::Color::green(), &bitmap_icon_scanner, [&nav]() { nav.push<PlaylistView>(); }},
-        {"S.Painter", ui::Color::orange(), &bitmap_icon_paint, [&nav]() { nav.push<SpectrumPainterView>(); }},
-        //{ "Remote",			ui::Color::dark_grey(),	&bitmap_icon_remote,	[&nav](){ nav.push<RemoteView>(); } },
     });
 }
 
@@ -561,41 +558,47 @@ UtilitiesMenuView::UtilitiesMenuView(NavigationView& nav) {
         add_items({{"..", Color::light_grey(), &bitmap_icon_previous, [&nav]() { nav.pop(); }}});
     }
     add_items({
-        //{ "Test app", 		Color::dark_grey(),	nullptr,				[&nav](){ nav.push<TestView>(); } },
-        {"Freq. manager", Color::green(), &bitmap_icon_freqman, [&nav]() { nav.push<FrequencyManagerView>(); }},
-        {"File manager", Color::green(), &bitmap_icon_dir, [&nav]() { nav.push<FileManagerView>(); }},
+        {"Antenna Length", Color::green(), &bitmap_icon_tools_antenna, [&nav]() { nav.push<WhipCalcView>(); }},
+        {"File Manager", Color::green(), &bitmap_icon_dir, [&nav]() { nav.push<FileManagerView>(); }},
+        {"Freq. Manager", Color::green(), &bitmap_icon_freqman, [&nav]() { nav.push<FrequencyManagerView>(); }},
         {"Notepad", Color::dark_cyan(), &bitmap_icon_notepad, [&nav]() { nav.push<TextEditorView>(); }},
-        {"Signal gen", Color::green(), &bitmap_icon_cwgen, [&nav]() { nav.push<SigGenView>(); }},
-        //{ "Tone search",	Color::dark_grey(), nullptr,					[&nav](){ nav.push<ToneSearchView>(); } },
-        {"Wav viewer", Color::yellow(), &bitmap_icon_soundboard, [&nav]() { nav.push<ViewWavView>(); }},
-        {"Antenna length", Color::green(), &bitmap_icon_tools_antenna, [&nav]() { nav.push<WhipCalcView>(); }},
+        {"SD Over USB", Color::yellow(), &bitmap_icon_hackrf, [&nav]() { nav.push<SdOverUsbView>(); }},
+        {"Signal Gen", Color::green(), &bitmap_icon_cwgen, [&nav]() { nav.push<SigGenView>(); }},
+        // {"Test App", Color::dark_grey(), nullptr, [&nav](){ nav.push<TestView>(); }},
+        // {"Tone Search", Color::dark_grey(), nullptr, [&nav](){ nav.push<ToneSearchView>(); }},
+        {"Wav View", Color::yellow(), &bitmap_icon_soundboard, [&nav]() { nav.push<ViewWavView>(); }},
 
-        {"Wipe SD card", Color::red(), &bitmap_icon_tools_wipesd, [&nav]() { nav.push<WipeSDView>(); }},
+        // Dangerous apps.
         {"Flash Utility", Color::red(), &bitmap_icon_temperature, [&nav]() { nav.push<FlashUtilityView>(); }},
-        {"SD over USB", Color::yellow(), &bitmap_icon_hackrf, [&nav]() { nav.push<SdOverUsbView>(); }},
+        {"Wipe SD card", Color::red(), &bitmap_icon_tools_wipesd, [&nav]() { nav.push<WipeSDView>(); }},
     });
+
     set_max_rows(2);  // allow wider buttons
 }
 
 /* SystemMenuView ********************************************************/
 
 void SystemMenuView::hackrf_mode(NavigationView& nav) {
-    nav.push<ModalMessageView>("HackRF mode", " This mode enables HackRF\n functionality. To return,\n  press the reset button.\n\n  Switch to HackRF mode?", YESNO,
-                               [this](bool choice) {
-                                   if (choice) {
-                                       EventDispatcher::request_stop();
-                                   }
-                               });
+    nav.push<ModalMessageView>(
+        "HackRF mode",
+        " This mode enables HackRF\n functionality. To return,\n  press the reset button.\n\n  Switch to HackRF mode?",
+        YESNO,
+        [this](bool choice) {
+            if (choice) {
+                EventDispatcher::request_stop();
+            }
+        });
 }
 
 SystemMenuView::SystemMenuView(NavigationView& nav) {
     add_items({
-        //{ "Play dead",				Color::red(),		&bitmap_icon_playdead,	[&nav](){ nav.push<PlayDeadView>(); } },
+        // {"Play dead", Color::red(), &bitmap_icon_playdead, [&nav]() { nav.push<PlayDeadView>(); }},
         {"Receive", Color::cyan(), &bitmap_icon_receivers, [&nav]() { nav.push<ReceiversMenuView>(); }},
         {"Transmit", Color::cyan(), &bitmap_icon_transmit, [&nav]() { nav.push<TransmittersMenuView>(); }},
         {"Capture", Color::red(), &bitmap_icon_capture, [&nav]() { nav.push<CaptureAppView>(); }},
         {"Replay", Color::green(), &bitmap_icon_replay, [&nav]() { nav.push<PlaylistView>(); }},
-        {"Search", Color::yellow(), &bitmap_icon_search, [&nav]() { nav.push<SearchView>(); }},
+        // {"Search", Color::yellow(), &bitmap_icon_search, [&nav]() { nav.push<SearchView>(); }},
+        {"Remote", ui::Color::green(), &bitmap_icon_remote, [&nav]() { nav.push<RemoteView>(); }},
         {"Scanner", Color::green(), &bitmap_icon_scanner, [&nav]() { nav.push<ScannerView>(); }},
         {"Microphone", Color::green(), &bitmap_icon_microphone, [&nav]() { nav.push<MicTXView>(); }},
         {"Looking Glass", Color::green(), &bitmap_icon_looking, [&nav]() { nav.push<GlassView>(); }},
@@ -603,11 +606,11 @@ SystemMenuView::SystemMenuView(NavigationView& nav) {
         {"Settings", Color::cyan(), &bitmap_icon_setup, [&nav]() { nav.push<SettingsMenuView>(); }},
         {"Debug", Color::light_grey(), &bitmap_icon_debug, [&nav]() { nav.push<DebugMenuView>(); }},
         {"HackRF", Color::cyan(), &bitmap_icon_hackrf, [this, &nav]() { hackrf_mode(nav); }},
-        //{ "About", 		Color::cyan(),			nullptr,				[&nav](){ nav.push<AboutView>(); } }
+        // {"About", Color::cyan(), nullptr, [&nav]() { nav.push<AboutView>(); }},
     });
+
     set_max_rows(2);  // allow wider buttons
     set_arrow_enabled(false);
-    // set_highlighted(1);		// Startup selection
 }
 
 /* SystemView ************************************************************/
@@ -623,19 +626,22 @@ SystemView::SystemView(
     constexpr Dim info_view_height = 16;
 
     add_child(&status_view);
-    status_view.set_parent_rect({{0, 0},
-                                 {parent_rect.width(), status_view_height}});
+    status_view.set_parent_rect(
+        {{0, 0},
+         {parent_rect.width(), status_view_height}});
     status_view.on_back = [this]() {
         this->navigation_view.pop();
     };
 
     add_child(&navigation_view);
-    navigation_view.set_parent_rect({{0, status_view_height},
-                                     {parent_rect.width(), static_cast<Dim>(parent_rect.height() - status_view_height)}});
+    navigation_view.set_parent_rect(
+        {{0, status_view_height},
+         {parent_rect.width(), static_cast<Dim>(parent_rect.height() - status_view_height)}});
 
     add_child(&info_view);
-    info_view.set_parent_rect({{0, 19 * 16},
-                               {parent_rect.width(), info_view_height}});
+    info_view.set_parent_rect(
+        {{0, 19 * 16},
+         {parent_rect.width(), info_view_height}});
 
     navigation_view.on_view_changed = [this](const View& new_view) {
         if (!this->navigation_view.is_top()) {
@@ -651,14 +657,6 @@ SystemView::SystemView(
         this->status_view.set_dirty();
     };
 
-    // pmem::set_playdead_sequence(0x8D1);
-
-    // Initial view
-    /*if ((pmem::playing_dead() == 0x5920C1DF) ||		// Enable code
-                (pmem::ui_config() & 16)) {					// Login option
-                navigation_view.push<PlayDeadView>();
-        } else {*/
-
     navigation_view.push<SystemMenuView>();
 
     if (pmem::config_splash()) {
@@ -667,10 +665,6 @@ SystemView::SystemView(
     status_view.set_back_enabled(false);
     status_view.set_title_image_enabled(true);
     status_view.set_dirty();
-    // else
-    //	navigation_view.push<SystemMenuView>();
-
-    //}
 }
 
 Context& SystemView::context() const {
@@ -812,7 +806,7 @@ void ModalMessageView::paint(Painter& painter) {
 
     portapack::display.drawBMP({100, 48}, modal_warning_bmp, false);
 
-    // Terrible...
+    // Break on lines.
     while ((pos = message_.find("\n", start)) != std::string::npos) {
         painter.draw_string(
             {1 * 8, (Coord)(120 + (i * 16))},

--- a/firmware/common/ui.hpp
+++ b/firmware/common/ui.hpp
@@ -97,6 +97,14 @@ struct Color {
         return (v ^ 0xffff);
     }
 
+    /* Converts a 32-bit color into a 16-bit color.
+     * High byte is ignored. */
+    static constexpr Color RGB(uint32_t rgb) {
+        return {static_cast<uint8_t>((rgb >> 16) & 0xff),
+                static_cast<uint8_t>((rgb >> 8) & 0xff),
+                static_cast<uint8_t>(rgb & 0xff)};
+    }
+
     static constexpr Color black() {
         return {0, 0, 0};
     }

--- a/firmware/common/ui_widget.cpp
+++ b/firmware/common/ui_widget.cpp
@@ -1139,9 +1139,9 @@ NewButton::NewButton(
     Color color,
     bool vertical_center)
     : Widget{parent_rect},
+      color_{color},
       text_{text},
       bitmap_{bitmap},
-      color_{color},
       vertical_center_{vertical_center} {
     set_focusable(true);
 }
@@ -1182,18 +1182,8 @@ void NewButton::paint(Painter& painter) {
     if (!bitmap_ && text_.empty())
         return;
 
-    Color bg, fg;
     const auto r = screen_rect();
-
-    if (has_focus() || highlighted()) {
-        bg = style().foreground;
-        fg = Color::black();
-    } else {
-        bg = Color::grey();
-        fg = style().foreground;
-    }
-
-    const Style paint_style = {style().font, bg, fg};
+    const Style style = paint_style();
 
     painter.draw_rectangle({r.location(), {r.width(), 1}}, Color::light_grey());
     painter.draw_rectangle({r.left(), r.top() + r.height() - 1, r.width(), 1}, Color::dark_grey());
@@ -1201,7 +1191,7 @@ void NewButton::paint(Painter& painter) {
 
     painter.fill_rectangle(
         {r.left(), r.top() + 1, r.width() - 1, r.height() - 2},
-        paint_style.background);
+        style.background);
 
     int y = r.top();
     if (bitmap_) {
@@ -1213,16 +1203,30 @@ void NewButton::paint(Painter& painter) {
             bmp_pos,
             *bitmap_,
             color_,
-            bg);
+            style.background);
     }
 
     if (!text_.empty()) {
-        const auto label_r = paint_style.font.size_of(text_);
+        const auto label_r = style.font.size_of(text_);
         painter.draw_string(
             {r.left() + (r.width() - label_r.width()) / 2, y + (r.height() - label_r.height()) / 2},
-            paint_style,
+            style,
             text_);
     }
+}
+
+Style NewButton::paint_style() {
+    MutableStyle s{style()};
+
+    if (has_focus() || highlighted()) {
+        s.background = style().foreground;
+        s.foreground = Color::black();
+    } else {
+        s.background = Color::grey();
+        s.foreground = style().foreground;
+    }
+
+    return s;
 }
 
 void NewButton::on_focus() {

--- a/firmware/common/ui_widget.hpp
+++ b/firmware/common/ui_widget.hpp
@@ -479,10 +479,13 @@ class NewButton : public Widget {
 
     void paint(Painter& painter) override;
 
+   protected:
+    virtual Style paint_style();
+    Color color_;
+
    private:
     std::string text_;
     const Bitmap* bitmap_;
-    Color color_;
     bool vertical_center_{false};
 };
 

--- a/firmware/common/utility.cpp
+++ b/firmware/common/utility.cpp
@@ -213,3 +213,25 @@ static constexpr uint32_t gcd_top(const uint32_t u, const uint32_t v) {
 uint32_t gcd(const uint32_t u, const uint32_t v) {
     return gcd_top(u, v);
 }
+
+std::string join(char c, std::initializer_list<std::string_view> strings) {
+    std::string result;
+    size_t total_size = strings.size();
+
+    for (auto s : strings)
+        total_size += s.size();
+
+    result.reserve(total_size);
+    bool first = true;
+
+    for (auto s : strings) {
+        if (!first)
+            result += c;
+        else
+            first = false;
+
+        result += s;
+    }
+
+    return result;
+}

--- a/firmware/common/utility.hpp
+++ b/firmware/common/utility.hpp
@@ -27,7 +27,9 @@
 #include <complex>
 #include <cstdint>
 #include <cstddef>
+#include <initializer_list>
 #include <memory>
+#include <string_view>
 #include <type_traits>
 
 #define LOCATE_IN_RAM __attribute__((section(".ramtext")))
@@ -212,5 +214,7 @@ struct range_t {
         return !contains(value);
     }
 };
+
+std::string join(char c, std::initializer_list<std::string_view> strings);
 
 #endif /*__UTILITY_H__*/

--- a/firmware/test/application/CMakeLists.txt
+++ b/firmware/test/application/CMakeLists.txt
@@ -47,6 +47,7 @@ add_executable(application_test EXCLUDE_FROM_ALL
 
 	${PROJECT_SOURCE_DIR}/../../application/file_reader.cpp
 	${PROJECT_SOURCE_DIR}/../../application/freqman_db.cpp
+	${PROJECT_SOURCE_DIR}/../../common/utility.cpp
 	
 	# Dependencies
 	${PROJECT_SOURCE_DIR}/../../application/file.cpp

--- a/firmware/test/application/test_utility.cpp
+++ b/firmware/test/application/test_utility.cpp
@@ -90,3 +90,10 @@ TEST_CASE("to_byte_array returns correct size and values.") {
     CHECK_EQ(arr4[2], 0x12);
     CHECK_EQ(arr4[3], 0x34);
 }
+
+TEST_CASE("join will join strings") {
+    CHECK_EQ(join(',', {}), "");
+    CHECK_EQ(join(',', {"a"}), "a");
+    CHECK_EQ(join('-', {"a", "b"}), "a-b");
+    CHECK_EQ(join(',', {"a", "b", "c"}), "a,b,c");
+}


### PR DESCRIPTION
Adds Remote app which allows you to create a custom 12 button remote that assigns a capture file to each button.
Use "long press" select on an existing button to edit its parameters.

Features:
- Custom buttons icon/colors to make a remote that is easy to remember.
- Capture replay center frequency can be set per button.
- A friendly title for the remote (top field).
- Easily rename the remote file (bottom left field).
- Auto save when changes are made.
- Last used remote loaded on launch to make it easy to quickly use a remote.
- Support opening from Fileman.

Additional Changes:
I needed to touch quite a few things while making this change, but I've added comments in the review to indicate the point of the changes.
- Cleanup TxView2 - code cleanup and fix how the parent_rect was set. It was very odd, requiring apps to know about internal control offsets.
- Alphabetize all of the sub-pages. Just makes everything feel a little more consistent.
- Ensure directory in Playlist app to fix bug if playlist folder is missing.
- Add vertical centering flags on some NewButton instances
 to make them look correct.
- Add join utility
- Add some unit tests for new code

PR build [portapack-h1_h2-mayhem.bin.zip](https://github.com/eried/portapack-mayhem/files/12651384/portapack-h1_h2-mayhem.bin.zip)