### PR TITLE
Improved trimming

### DIFF
--- a/firmware/application/CMakeLists.txt
+++ b/firmware/application/CMakeLists.txt
@@ -182,6 +182,7 @@ set(CPPSRC
 	io_convert.cpp
 	io_file.cpp
 	io_wave.cpp
+	iq_trim.cpp
 	irq_controls.cpp
 	irq_lcd_frame.cpp
 	irq_rtc.cpp

--- a/firmware/application/apps/ui_iq_trim.cpp
+++ b/firmware/application/apps/ui_iq_trim.cpp
@@ -198,7 +198,7 @@ bool IQTrimView::trim_capture() {
         }
 
         progress_ui.show_trimming();
-        trimmed = iq::trim_capture_with_cutoff(path_, power_cutoff_, nullptr);
+        trimmed = iq::trim_capture_with_cutoff(path_, power_cutoff_, progress_ui.get_callback());
         progress_ui.clear();
 
     } else {

--- a/firmware/application/apps/ui_iq_trim.cpp
+++ b/firmware/application/apps/ui_iq_trim.cpp
@@ -35,6 +35,7 @@ IQTrimView::IQTrimView(NavigationView& nav) {
         &labels,
         &field_path,
         &text_range,
+        &field_threshold,
         &button_trim,
     });
 
@@ -46,6 +47,11 @@ IQTrimView::IQTrimView(NavigationView& nav) {
             path_ = std::move(path);
             refresh_ui();
         };
+    };
+
+    field_threshold.set_value(amp_threshold);
+    field_threshold.on_change = [this](uint32_t v) {
+        amp_threshold = v;
     };
 
     button_trim.on_select = [this, &nav](Button&) {
@@ -92,7 +98,7 @@ void IQTrimView::focus() {
 
 void IQTrimView::refresh_ui() {
     field_path.set_text(path_.filename().string());
-    text_range.set(to_string_dec_uint(trim_range_.start) + "-" + to_string_dec_uint(trim_range_.end));
+    text_range.set(to_string_dec_uint(trim_range_.start) + "-" + to_string_dec_uint(trim_range_.end) + "  " + to_string_dec_uint(trim_range_.max_value));
     set_dirty();
 }
 

--- a/firmware/application/apps/ui_iq_trim.hpp
+++ b/firmware/application/apps/ui_iq_trim.hpp
@@ -80,28 +80,21 @@ class IQTrimView : public View {
     /* Update the start/end controls with capture info. */
     void update_range_controls();
 
-    /* Determine the start and end buckets based on the cutoff. */
-    void compute_range();
-
     /* Collect capture info and samples to draw the UI. */
     void profile_capture();
 
+    /* Determine the start and end buckets based on the cutoff. */
+    void compute_range();
+
     /* Trims the capture file based on the settings. */
     bool trim_capture();
-
-    enum class TrimMode : uint8_t {
-        Cutoff,
-        Range,
-    };
 
     NavigationView& nav_;
 
     std::filesystem::path path_{};
     Optional<iq::CaptureInfo> info_{};
     std::array<iq::PowerBuckets::Bucket, screen_width> power_buckets_{};
-    uint32_t power_cutoff_ = 0;
     TrimProgressUI progress_ui{};
-    TrimMode mode_ = TrimMode::Cutoff;
 
     Labels labels{
         {{0 * 8, 0 * 16}, "Capture File:", Color::light_grey()},

--- a/firmware/application/apps/ui_iq_trim.hpp
+++ b/firmware/application/apps/ui_iq_trim.hpp
@@ -38,11 +38,6 @@ namespace ui {
 /* TODO: Ideally this would all be done on second thread. */
 class TrimProgressUI {
    public:
-    void show_profiling() {
-        clear();
-        p.draw_string({5 * 8, 5 * 16}, Styles::yellow, "Profiling Capture...");
-    }
-
     void show_reading() {
         clear();
         p.draw_string({6 * 8, 5 * 16}, Styles::yellow, "Reading Capture...");
@@ -79,23 +74,41 @@ class IQTrimView : public View {
     void focus() override;
 
    private:
+    /* Update controls with latest values. */
     void refresh_ui();
+
+    /* Update the start/end controls with capture info. */
+    void update_range_controls();
+
+    /* Determine the start and end buckets based on the cutoff. */
     void compute_range();
-    void read_capture(const std::filesystem::path& path);
+
+    /* Collect capture info and samples to draw the UI. */
+    void profile_capture();
+
+    /* Trims the capture file based on the settings. */
+    bool trim_capture();
+
+    enum class TrimMode : uint8_t {
+        Cutoff,
+        Range,
+    };
+
+    NavigationView& nav_;
 
     std::filesystem::path path_{};
-    TrimRange trim_range_{};
     Optional<CaptureInfo> info_{};
     std::array<PowerBuckets::Bucket, screen_width> power_buckets_{};
     uint32_t power_cutoff = 0;
     TrimProgressUI progress_ui{};
+    TrimMode mode_ = TrimMode::Cutoff;
 
     Labels labels{
         {{0 * 8, 0 * 16}, "Capture File:", Color::light_grey()},
         {{0 * 8, 6 * 16}, "Start  :", Color::light_grey()},
         {{0 * 8, 7 * 16}, "End    :", Color::light_grey()},
         {{0 * 8, 8 * 16}, "Max Pwr:", Color::light_grey()},
-        {{0 * 8, 9 * 16}, "Cutoff :", Color::light_grey()},
+        {{0 * 8, 9 * 16}, "Cutoff%:", Color::light_grey()},
     };
 
     TextField field_path{
@@ -105,24 +118,33 @@ class IQTrimView : public View {
     Point pos_lines{0 * 8, 4 * 16};
     Dim height_lines{2 * 16};
 
-    Text text_start{
-        {9 * 8, 6 * 16, 20 * 8, 1 * 16},
-        {}};
+    NumberField field_start{
+        {9 * 8, 6 * 16},
+        10,
+        {0, 0},
+        1,
+        ' '};
 
-    Text text_end{
-        {9 * 8, 7 * 16, 20 * 8, 1 * 16},
-        {}};
-    
+    NumberField field_end{
+        {9 * 8, 7 * 16},
+        10,
+        {0, 0},
+        1,
+        ' '};
+
     Text text_max{
         {9 * 8, 8 * 16, 20 * 8, 1 * 16},
-        {}};
+        "0"};
 
-    SymField field_cutoff{
+    NumberField field_cutoff{
         {9 * 8, 9 * 16},
-        8};
+        3,
+        {1, 100},
+        1,
+        ' '};
 
     Button button_trim{
-        {11 * 8, 12 * 16, 8 * 8, 3 * 16},
+        {20 * 8, 16 * 16, 8 * 8, 2 * 16},
         "Trim"};
 };
 

--- a/firmware/application/apps/ui_iq_trim.hpp
+++ b/firmware/application/apps/ui_iq_trim.hpp
@@ -79,12 +79,13 @@ class IQTrimView : public View {
     std::filesystem::path path_{};
     TrimRange trim_range_{};
     std::array<PowerBuckets::Bucket, screen_width> power_buckets_{};
-    uint8_t amp_threshold = 5;
+    uint32_t amp_threshold = 512;
     TrimProgressUI progress_ui{};
 
     Labels labels{
         {{0 * 8, 0 * 16}, "Capture File:", Color::light_grey()},
         {{0 * 8, 6 * 16}, "Range:", Color::light_grey()},
+        {{0 * 8, 7 * 16}, "Threshold:", Color::light_grey()},
     };
 
     TextField field_path{
@@ -98,8 +99,15 @@ class IQTrimView : public View {
         {7 * 8, 6 * 16, 20 * 8, 1 * 16},
         {}};
 
+    NumberField field_threshold{
+        {11 * 8, 7 * 16},
+        3,
+        {1, 256 * 256},
+        1,
+        ' '};
+
     Button button_trim{
-        {11 * 8, 9 * 16, 8 * 8, 3 * 16},
+        {11 * 8, 10 * 16, 8 * 8, 3 * 16},
         "Trim"};
 };
 

--- a/firmware/application/apps/ui_iq_trim.hpp
+++ b/firmware/application/apps/ui_iq_trim.hpp
@@ -77,8 +77,8 @@ class IQTrimView : public View {
     /* Update controls with latest values. */
     void refresh_ui();
 
-    /* Update the start/end controls with capture info. */
-    void update_range_controls();
+    /* Update the start/end controls with trim range info. */
+    void update_range_controls(iq::TrimRange trim_range);
 
     /* Collect capture info and samples to draw the UI. */
     void profile_capture();

--- a/firmware/application/apps/ui_iq_trim.hpp
+++ b/firmware/application/apps/ui_iq_trim.hpp
@@ -97,9 +97,9 @@ class IQTrimView : public View {
     NavigationView& nav_;
 
     std::filesystem::path path_{};
-    Optional<CaptureInfo> info_{};
-    std::array<PowerBuckets::Bucket, screen_width> power_buckets_{};
-    uint32_t power_cutoff = 0;
+    Optional<iq::CaptureInfo> info_{};
+    std::array<iq::PowerBuckets::Bucket, screen_width> power_buckets_{};
+    uint32_t power_cutoff_ = 0;
     TrimProgressUI progress_ui{};
     TrimMode mode_ = TrimMode::Cutoff;
 
@@ -107,8 +107,10 @@ class IQTrimView : public View {
         {{0 * 8, 0 * 16}, "Capture File:", Color::light_grey()},
         {{0 * 8, 6 * 16}, "Start  :", Color::light_grey()},
         {{0 * 8, 7 * 16}, "End    :", Color::light_grey()},
-        {{0 * 8, 8 * 16}, "Max Pwr:", Color::light_grey()},
-        {{0 * 8, 9 * 16}, "Cutoff%:", Color::light_grey()},
+        {{0 * 8, 8 * 16}, "Samples:", Color::light_grey()},
+        {{0 * 8, 9 * 16}, "Max Pwr:", Color::light_grey()},
+        {{0 * 8, 10 * 16}, "Cutoff :", Color::light_grey()},
+        {{12 * 8, 10 * 16}, "%", Color::light_grey()},
     };
 
     TextField field_path{
@@ -132,12 +134,16 @@ class IQTrimView : public View {
         1,
         ' '};
 
+    Text text_samples{
+        {9 * 8, 8 * 16, 10 * 8, 1 * 16},
+        "0"};
+
     Text text_max{
-        {9 * 8, 8 * 16, 20 * 8, 1 * 16},
+        {9 * 8, 9 * 16, 10 * 8, 1 * 16},
         "0"};
 
     NumberField field_cutoff{
-        {9 * 8, 9 * 16},
+        {9 * 8, 10 * 16},
         3,
         {1, 100},
         1,

--- a/firmware/application/file.cpp
+++ b/firmware/application/file.cpp
@@ -280,6 +280,7 @@ std::vector<std::filesystem::path> scan_root_directories(const std::filesystem::
 }
 
 std::filesystem::filesystem_error trim_file(const std::filesystem::path& file_path, uint64_t start, uint64_t length) {
+    // NB: between this buffer and the two Files, this needs ~1.5kb RAM.
     constexpr size_t buffer_size = std::filesystem::max_file_block_size;
     uint8_t buffer[buffer_size];
     auto temp_path = file_path + u"-tmp";

--- a/firmware/application/file.hpp
+++ b/firmware/application/file.hpp
@@ -265,7 +265,6 @@ struct FATTimestamp {
     uint16_t FAT_time;
 };
 
-std::filesystem::filesystem_error trim_file(const std::filesystem::path& file_path, uint64_t start, uint64_t length);
 std::filesystem::filesystem_error delete_file(const std::filesystem::path& file_path);
 std::filesystem::filesystem_error rename_file(const std::filesystem::path& file_path, const std::filesystem::path& new_name);
 std::filesystem::filesystem_error copy_file(const std::filesystem::path& file_path, const std::filesystem::path& dest_path);

--- a/firmware/application/file.hpp
+++ b/firmware/application/file.hpp
@@ -302,6 +302,7 @@ static_assert(sizeof(FIL::err) == 1, "FatFs FIL::err size not expected.");
 #define FR_BAD_SEEK (0x102)
 #define FR_UNEXPECTED (0x103)
 
+/* NOTE: sizeof(File) == 556 bytes because of the FIL's buf member. */
 class File {
    public:
     using Size = uint64_t;

--- a/firmware/application/iq_trim.cpp
+++ b/firmware/application/iq_trim.cpp
@@ -22,7 +22,6 @@
 #include "iq_trim.hpp"
 
 #include <memory>
-#include "debug.hpp"
 #include "string_format.hpp"
 
 namespace fs = std::filesystem;
@@ -37,12 +36,12 @@ uint32_t power(T value) {
     return (real * real) + (imag * imag);
 }
 
-/* Collects capture file metadata and samples power buckets. */
+/* Collects capture file metadata and sample power buckets. */
 template <typename T>
 Optional<CaptureInfo> profile_capture(
     const std::filesystem::path& path,
-    uint16_t profile_samples,
-    PowerBuckets* buckets) {
+    PowerBuckets& buckets,
+    uint8_t samples_per_bucket) {
     File f;
     auto error = f.open(path);
     if (error)
@@ -54,13 +53,11 @@ Optional<CaptureInfo> profile_capture(
         .sample_size = sizeof(T),
         .max_power = 0};
 
+    auto profile_samples = buckets.size * samples_per_bucket;
     auto sample_interval = info.sample_count / profile_samples;
-    uint32_t samples_per_bucket = 1;
+    uint32_t bucket_width = std::max(1ULL, info.sample_count / buckets.size);
     uint64_t sample_index = 0;
     T value{};
-
-    if (buckets)
-        samples_per_bucket = std::max(1ULL, info.sample_count / buckets->size);
 
     while (true) {
         f.seek(sample_index * info.sample_size);
@@ -75,170 +72,115 @@ Optional<CaptureInfo> profile_capture(
         if (mag_squared > info.max_power)
             info.max_power = mag_squared;
 
-        // Fill in optional power buckets.
-        if (buckets) {
-            auto bucket_index = sample_index / samples_per_bucket;
-            buckets->add(bucket_index, mag_squared);
-        }
-
+        auto bucket_index = sample_index / bucket_width;
+        buckets.add(bucket_index, mag_squared);
         sample_index += sample_interval;
     }
 
     return info;
 }
 
-/* Trims the capture file with the specified power cutoff.
- * This trims in-place without needing a second pass. */
-template <typename T>
-bool trim_capture(
-    const std::filesystem::path& file_path,
-    uint32_t cutoff,
-    const std::function<void(uint8_t)>& on_progress) {
-    constexpr size_t buffer_size = std::filesystem::max_file_block_size;
-    uint8_t buffer[buffer_size]{};
-    auto temp_path = file_path + u"-tmp";
-
-    // These need to be heap allocated to avoid overflowing the stack.
-    auto src = std::make_unique<File>();
-    auto dst = std::make_unique<File>();
-
-    auto error = src->open(file_path);
-    if (error) return false;
-
-    error = dst->create(temp_path);
-    if (error) return false;
-
-    // For progress reporting.
-    uint32_t next_update = 0;
-    uint32_t update_interval = src->size() / 25;
-
-    File::Offset offset = 0;
-    uint32_t start_offset = 0;
-    bool found_start = false;
-    T value{};
-
-    // Find first sample above cutoff.
-    while (!found_start) {
-        auto result = src->read(buffer, buffer_size);
-        if (!result) return false;  // Bad read
-
-        for (size_t i = 0; i < *result; i += sizeof(T)) {
-            auto value = *reinterpret_cast<T*>(&buffer[i]);
-            auto mag_squared = power(value);
-
-            if (mag_squared >= cutoff) {
-                start_offset = offset + i;
-                found_start = true;
-                DEBUG_LOG("FOUND START AT " + to_string_dec_uint(start_offset));
-                DEBUG_LOG("START == " + to_string_dec_uint(mag_squared));
-                DEBUG_LOG("CUTOFF = " + to_string_dec_uint(cutoff));
-                break;
-            }
-        }
-
-        if (*result != buffer_size && !found_start)
-            return false;  // EOF without finding a sample.
-
-        offset += *result;
-
-        // Update progress.
-        if (on_progress && offset >= next_update) {
-            next_update += update_interval;
-            on_progress(100 * offset / src->size());
-        }
-    }
-
-    uint32_t end_offset = start_offset;
-    offset = start_offset;
-    src->seek(offset);
-
-    // Write out the rest of the file and look for last good sample.
-    while (true) {
-        auto result = src->read(buffer, buffer_size);
-        if (result.is_error()) return false;
-
-        result = dst->write(buffer, *result);
-        if (result.is_error()) return false;
-
-        // Look though all the samples to find the last one above cutoff.
-        for (size_t i = 0; i < *result; i += sizeof(T)) {
-            auto value = *reinterpret_cast<T*>(&buffer[i]);
-
-            // Still above cutoff?
-            if (power(value) >= cutoff)
-                end_offset = offset + i;
-        }
-
-        if (*result != buffer_size)
-            break;  // All done reading.
-
-        offset += *result;
-
-        // Update progress.
-        if (on_progress && offset >= next_update) {
-            next_update += update_interval;
-            on_progress(100 * offset / src->size());
-        }
-    }
-
-    // Now trim off the end of the output file.
-    // NB: end_offset should be included in trimmed file, so add sizeof(T).
-    auto length = (end_offset - start_offset) + sizeof(T);
-    DEBUG_LOG("FOUND END AT " + to_string_dec_uint(end_offset));
-    DEBUG_LOG("LENGTH " + to_string_dec_uint(length));
-
-    dst->seek(length);
-    dst->truncate();
-
-    // Close the files before renaming/deleting.
-    src.reset();
-    dst.reset();
-
-    // Delete original and overwrite with temp file.
-    delete_file(file_path);
-    return rename_file(temp_path, file_path).ok();
-}
-
 Optional<CaptureInfo> profile_capture(
     const fs::path& path,
-    uint16_t profile_samples,
-    PowerBuckets* buckets) {
+    PowerBuckets& buckets,
+    uint8_t samples_per_bucket) {
     auto sample_size = fs::capture_file_sample_size(path);
 
     switch (sample_size) {
         case sizeof(complex16_t):
-            return profile_capture<complex16_t>(path, profile_samples, buckets);
+            return profile_capture<complex16_t>(path, buckets, samples_per_bucket);
 
         case sizeof(complex8_t):
-            return profile_capture<complex8_t>(path, profile_samples, buckets);
+            return profile_capture<complex8_t>(path, buckets, samples_per_bucket);
 
         default:
             return {};
     };
 }
 
-bool trim_capture_with_range(const fs::path& path, TrimRange range) {
-    auto start_byte = range.start_sample * range.sample_size;
-    auto end_byte = (range.end_sample + 1) * range.sample_size;
-    auto result = trim_file(path, start_byte, end_byte - start_byte);
-    return result.ok();
+TrimRange compute_trim_range(
+    CaptureInfo info,
+    const PowerBuckets& buckets,
+    uint8_t cutoff_percent) {
+
+    bool has_start = false;
+    uint8_t start_bucket = 0;
+    uint8_t end_bucket = 0;
+
+    uint32_t power_cutoff = cutoff_percent * static_cast<uint64_t>(info.max_power) / 100;
+
+    for (size_t i = 0; i < buckets.size; ++i) {
+        auto power = buckets.p[i].power;
+
+        if (power > power_cutoff) {
+            if (has_start)
+                end_bucket = i;
+            else {
+                start_bucket = i;
+                end_bucket = i;
+                has_start = true;
+            }
+        }
+    }
+
+    auto samples_per_bucket = info.sample_count / buckets.size;
+    return {
+        start_bucket * samples_per_bucket,
+        end_bucket * samples_per_bucket,
+        info.sample_size
+    };
 }
 
-bool trim_capture_with_cutoff(
+bool trim_capture_with_range(
     const fs::path& path,
-    uint32_t cutoff,
+    TrimRange range,
     const std::function<void(uint8_t)>& on_progress) {
-    auto sample_size = fs::capture_file_sample_size(path);
-    switch (sample_size) {
-        case sizeof(complex16_t):
-            return trim_capture<complex16_t>(path, cutoff, on_progress);
+    constexpr size_t buffer_size = std::filesystem::max_file_block_size;
+    uint8_t buffer[buffer_size];
+    auto temp_path = path + u"-tmp";
 
-        case sizeof(complex8_t):
-            return trim_capture<complex8_t>(path, cutoff, on_progress);
+    auto start_byte = range.start_sample * range.sample_size;
+    auto end_byte = (range.end_sample + 1) * range.sample_size;
+    auto length = end_byte - start_byte;
 
-        default:
-            return false;
-    };
+    // 'File' is 556 bytes! Heap alloc to avoid overflowing the stack.
+    auto src = std::make_unique<File>();
+    auto dst = std::make_unique<File>();
+
+    auto error = src->open(path);
+    if (error) return false;
+
+    error = dst->create(temp_path);
+    if (error) return false;
+
+    src->seek(start_byte);
+    auto remaining = length;
+
+    while (true) {
+        auto result = src->read(buffer, buffer_size);
+        if (result.is_error()) return false;
+
+        auto to_write = std::min(remaining, *result);
+
+        result = dst->write(buffer, to_write);
+        if (result.is_error()) return false;
+
+        remaining -= *result;
+
+        if (*result < buffer_size || remaining == 0)
+            break;
+
+        on_progress(100 * (length - remaining) / length);
+    }
+
+    // Close files before renaming/deleting.
+    src.reset();
+    dst.reset();
+
+    // Delete original and overwrite with temp file.
+    delete_file(path);
+    rename_file(temp_path, path);
+    return true;
 }
 
 }  // namespace iq

--- a/firmware/application/iq_trim.cpp
+++ b/firmware/application/iq_trim.cpp
@@ -22,6 +22,8 @@
 #include "iq_trim.hpp"
 
 #include <memory>
+#include "debug.hpp"
+#include "string_format.hpp"
 
 namespace fs = std::filesystem;
 
@@ -93,7 +95,7 @@ bool trim_capture(
     uint32_t cutoff,
     const std::function<void(uint8_t)>& on_progress) {
     constexpr size_t buffer_size = std::filesystem::max_file_block_size;
-    uint8_t buffer[buffer_size];
+    uint8_t buffer[buffer_size]{};
     auto temp_path = file_path + u"-tmp";
 
     // These need to be heap allocated to avoid overflowing the stack.
@@ -127,6 +129,9 @@ bool trim_capture(
             if (mag_squared >= cutoff) {
                 start_offset = offset + i;
                 found_start = true;
+                DEBUG_LOG("FOUND START AT " + to_string_dec_uint(start_offset));
+                DEBUG_LOG("START == " + to_string_dec_uint(mag_squared));
+                DEBUG_LOG("CUTOFF = " + to_string_dec_uint(cutoff));
                 break;
             }
         }
@@ -179,6 +184,9 @@ bool trim_capture(
     // Now trim off the end of the output file.
     // NB: end_offset should be included in trimmed file, so add sizeof(T).
     auto length = (end_offset - start_offset) + sizeof(T);
+    DEBUG_LOG("FOUND END AT " + to_string_dec_uint(end_offset));
+    DEBUG_LOG("LENGTH " + to_string_dec_uint(length));
+
     dst->seek(length);
     dst->truncate();
 

--- a/firmware/application/iq_trim.cpp
+++ b/firmware/application/iq_trim.cpp
@@ -1,0 +1,236 @@
+/*
+ * Copyright (C) 2023 Kyle Reed
+ *
+ * This file is part of PortaPack.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#include "iq_trim.hpp"
+
+#include <memory>
+
+namespace fs = std::filesystem;
+
+namespace iq {
+
+/* Trimming helpers based on the sample type (complex8 or complex16). */
+template <typename T>
+uint32_t power(T value) {
+    auto real = value.real();
+    auto imag = value.imag();
+    return (real * real) + (imag * imag);
+}
+
+/* Collects capture file metadata and samples power buckets. */
+template <typename T>
+Optional<CaptureInfo> profile_capture(
+    const std::filesystem::path& path,
+    uint16_t profile_samples,
+    PowerBuckets* buckets) {
+    File f;
+    auto error = f.open(path);
+    if (error)
+        return {};
+
+    CaptureInfo info{
+        .file_size = f.size(),
+        .sample_count = f.size() / sizeof(T),
+        .sample_size = sizeof(T),
+        .max_power = 0};
+
+    auto sample_interval = info.sample_count / profile_samples;
+    uint32_t samples_per_bucket = 1;
+    uint64_t sample_index = 0;
+    T value{};
+
+    if (buckets)
+        samples_per_bucket = std::max(1ULL, info.sample_count / buckets->size);
+
+    while (true) {
+        f.seek(sample_index * info.sample_size);
+        auto result = f.read(&value, info.sample_size);
+        if (!result) return {};  // Read failed.
+
+        if (*result != info.sample_size)
+            break;  // EOF
+
+        auto mag_squared = power(value);
+
+        if (mag_squared > info.max_power)
+            info.max_power = mag_squared;
+
+        // Fill in optional power buckets.
+        if (buckets) {
+            auto bucket_index = sample_index / samples_per_bucket;
+            buckets->add(bucket_index, mag_squared);
+        }
+
+        sample_index += sample_interval;
+    }
+
+    return info;
+}
+
+/* Trims the capture file with the specified power cutoff.
+ * This trims in-place without needing a second pass. */
+template <typename T>
+bool trim_capture(
+    const std::filesystem::path& file_path,
+    uint32_t cutoff,
+    const std::function<void(uint8_t)>& on_progress) {
+    constexpr size_t buffer_size = std::filesystem::max_file_block_size;
+    uint8_t buffer[buffer_size];
+    auto temp_path = file_path + u"-tmp";
+
+    // These need to be heap allocated to avoid overflowing the stack.
+    auto src = std::make_unique<File>();
+    auto dst = std::make_unique<File>();
+
+    auto error = src->open(file_path);
+    if (error) return false;
+
+    error = dst->create(temp_path);
+    if (error) return false;
+
+    // For progress reporting.
+    uint32_t next_update = 0;
+    uint32_t update_interval = src->size() / 25;
+
+    File::Offset offset = 0;
+    uint32_t start_offset = 0;
+    bool found_start = false;
+    T value{};
+
+    // Find first sample above cutoff.
+    while (!found_start) {
+        auto result = src->read(buffer, buffer_size);
+        if (!result) return false;  // Bad read
+
+        for (size_t i = 0; i < *result; i += sizeof(T)) {
+            auto value = *reinterpret_cast<T*>(&buffer[i]);
+            auto mag_squared = power(value);
+
+            if (mag_squared >= cutoff) {
+                start_offset = offset + i;
+                found_start = true;
+                break;
+            }
+        }
+
+        if (*result != buffer_size && !found_start)
+            return false;  // EOF without finding a sample.
+
+        offset += *result;
+
+        // Update progress.
+        if (on_progress && offset >= next_update) {
+            next_update += update_interval;
+            on_progress(100 * offset / src->size());
+        }
+    }
+
+    uint32_t end_offset = start_offset;
+    offset = start_offset;
+    src->seek(offset);
+
+    // Write out the rest of the file and look for last good sample.
+    while (true) {
+        auto result = src->read(buffer, buffer_size);
+        if (result.is_error()) return false;
+
+        result = dst->write(buffer, *result);
+        if (result.is_error()) return false;
+
+        // Look though all the samples to find the last one above cutoff.
+        for (size_t i = 0; i < *result; i += sizeof(T)) {
+            auto value = *reinterpret_cast<T*>(&buffer[i]);
+
+            // Still above cutoff?
+            if (power(value) >= cutoff)
+                end_offset = offset + i;
+        }
+
+        if (*result != buffer_size)
+            break;  // All done reading.
+
+        offset += *result;
+
+        // Update progress.
+        if (on_progress && offset >= next_update) {
+            next_update += update_interval;
+            on_progress(100 * offset / src->size());
+        }
+    }
+
+    // Now trim off the end of the output file.
+    // NB: end_offset should be included in trimmed file, so add sizeof(T).
+    auto length = (end_offset - start_offset) + sizeof(T);
+    dst->seek(length);
+    dst->truncate();
+
+    // Close the files before renaming/deleting.
+    src.reset();
+    dst.reset();
+
+    // Delete original and overwrite with temp file.
+    delete_file(file_path);
+    return rename_file(temp_path, file_path).ok();
+}
+
+Optional<CaptureInfo> profile_capture(
+    const fs::path& path,
+    uint16_t profile_samples,
+    PowerBuckets* buckets) {
+    auto sample_size = fs::capture_file_sample_size(path);
+
+    switch (sample_size) {
+        case sizeof(complex16_t):
+            return profile_capture<complex16_t>(path, profile_samples, buckets);
+
+        case sizeof(complex8_t):
+            return profile_capture<complex8_t>(path, profile_samples, buckets);
+
+        default:
+            return {};
+    };
+}
+
+bool trim_capture_with_range(const fs::path& path, TrimRange range) {
+    auto start_byte = range.start_sample * range.sample_size;
+    auto end_byte = (range.end_sample + 1) * range.sample_size;
+    auto result = trim_file(path, start_byte, end_byte - start_byte);
+    return result.ok();
+}
+
+bool trim_capture_with_cutoff(
+    const fs::path& path,
+    uint32_t cutoff,
+    const std::function<void(uint8_t)>& on_progress) {
+    auto sample_size = fs::capture_file_sample_size(path);
+    switch (sample_size) {
+        case sizeof(complex16_t):
+            return trim_capture<complex16_t>(path, cutoff, on_progress);
+
+        case sizeof(complex8_t):
+            return trim_capture<complex8_t>(path, cutoff, on_progress);
+
+        default:
+            return false;
+    };
+}
+
+}  // namespace iq

--- a/firmware/application/iq_trim.hpp
+++ b/firmware/application/iq_trim.hpp
@@ -29,6 +29,8 @@
 #include <functional>
 #include <limits>
 
+namespace iq {
+
 /* Data needed to trim a capture by sample range. */
 struct TrimRange {
     uint64_t start_sample;
@@ -66,219 +68,21 @@ struct PowerBuckets {
     }
 };
 
-/* Trims the capture file with the specified range. */
-inline bool TrimCapture(const std::filesystem::path& path, TrimRange range) {
-    auto start_byte = range.start_sample * range.sample_size;
-    auto end_byte = (range.end_sample + 1) * range.sample_size;
-    auto result = trim_file(path, start_byte, end_byte - start_byte);
-    return result.ok();
-}
-
-/* Trimming helper based on the sample type (complex8 or complex16). */
-template <typename T>
-class IQTrimmer {
-    static constexpr uint8_t max_amp = 0xFF;
-    static constexpr typename T::value_type max_value = std::numeric_limits<typename T::value_type>::max();
-    static constexpr uint32_t max_mag_squared{2 * (max_value * max_value)};  // NB: Braces to detect narrowing.
-
-   public:
-    /* Collects capture file metadata and samples power buckets. */
-    static Optional<CaptureInfo> ProfileCapture(
-        const std::filesystem::path& path,
-        uint16_t profile_samples,
-        PowerBuckets* buckets) {
-        File f;
-        auto error = f.open(path);
-        if (error)
-            return {};
-
-        CaptureInfo info{
-            .file_size = f.size(),
-            .sample_count = f.size() / sizeof(T),
-            .sample_size = sizeof(T),
-            .max_power = 0};
-
-        auto sample_interval = info.sample_count / profile_samples;
-        uint32_t samples_per_bucket = 1;
-        uint64_t sample_index = 0;
-        T value{};
-
-        if (buckets)
-            samples_per_bucket = std::max(1ULL, info.sample_count / buckets->size);
-
-        while (true) {
-            f.seek(sample_index * info.sample_size);
-            auto result = f.read(&value, info.sample_size);
-            if (!result) return {};  // Read failed.
-
-            if (*result != info.sample_size)
-                break;  // EOF
-
-            auto mag_squared = power(value);
-
-            if (mag_squared > info.max_power)
-                info.max_power = mag_squared;
-
-            // Fill in optional power buckets.
-            if (buckets) {
-                auto bucket_index = sample_index / samples_per_bucket;
-                buckets->add(bucket_index, mag_squared);
-            }
-
-            sample_index += sample_interval;
-        }
-
-        return info;
-    }
-
-    /* Trims the capture file with the specified power cutoff.
-     * This trims in-place without needing a second pass. */
-    static bool TrimCapture(
-        const std::filesystem::path& path,
-        uint32_t cutoff,
-        std::function<void(uint8_t)> on_progress) {
-        constexpr size_t buffer_size = std::filesystem::max_file_block_size;
-        uint8_t buffer[buffer_size];
-        auto temp_path = path + u"-tmp";
-
-        /* Scope for File instances. */
-        {
-            File src;
-            File dst;
-
-            auto error = src.open(path);
-            if (error) return false;
-
-            error = dst.create(temp_path);
-            if (error) return false;
-
-            // For progress reporting.
-            uint32_t update_interval = src.size() / 25;
-            uint32_t next_update = 0;
-
-            File::Offset offset = 0;
-            uint32_t start_offset = 0;
-            bool found_start = false;
-            T value{};
-
-            // Find first sample above cutoff.
-            while (!found_start) {
-                auto result = src.read(buffer, buffer_size);
-                if (!result) return false;  // Bad read
-
-                for (size_t i = 0; i < *result; i += sizeof(T)) {
-                    auto value = *reinterpret_cast<T*>(&buffer[i]);
-                    auto mag_squared = power(value);
-
-                    if (mag_squared >= cutoff) {
-                        start_offset = offset + i;
-                        found_start = true;
-                        break;
-                    }
-                }
-
-                if (*result != buffer_size && !found_start)
-                    return false;  // EOF without finding a sample.
-
-                offset += *result;
-
-                // Update progress.
-                if (on_progress && offset >= next_update) {
-                    next_update += update_interval;
-                    on_progress(100 * offset / src.size());
-                }
-            }
-
-            uint32_t end_offset = start_offset;
-            offset = start_offset;
-            src.seek(offset);
-
-            // Write out the rest of the file and look for last good sample.
-            while (true) {
-                auto result = src.read(buffer, buffer_size);
-                if (result.is_error()) return false;
-
-                result = dst.write(buffer, *result);
-                if (result.is_error()) return false;
-
-                // Look though all the samples to find the last one above cutoff.
-                for (size_t i = 0; i < *result; i += sizeof(T)) {
-                    auto value = *reinterpret_cast<T*>(&buffer[i]);
-                    auto mag_squared = power(value);
-
-                    // Still above cutoff?
-                    if (mag_squared >= cutoff)
-                        end_offset = offset + i;
-                }
-
-                if (*result != buffer_size)
-                    break;  // All done reading.
-
-                offset += *result;
-
-                // Update progress.
-                if (on_progress && offset >= next_update) {
-                    next_update += update_interval;
-                    on_progress(100 * offset / src.size());
-                }
-            }
-
-            // Now trim off the end of the output file.
-            // NB: end_offset should be included in trimmed file, so add sizeof(T).
-            auto length = (end_offset - start_offset) + sizeof(T);
-            dst.seek(length);
-            dst.truncate();
-        }
-
-        // Delete original and overwrite with temp file.
-        delete_file(path);
-        return rename_file(temp_path, path).ok();
-    }
-
-   private:
-    static uint32_t power(T value) {
-        auto real = value.real();
-        auto imag = value.imag();
-        return (real * real) + (imag * imag);
-    }
-};
-
 /* Collects capture file metadata and samples power buckets. */
-inline Optional<CaptureInfo> ProfileCapture(
+Optional<CaptureInfo> profile_capture(
     const std::filesystem::path& path,
     uint16_t profile_samples = 2'400,
-    PowerBuckets* buckets = nullptr) {
-    auto sample_size = std::filesystem::capture_file_sample_size(path);
+    PowerBuckets* buckets = nullptr);
 
-    switch (sample_size) {
-        case sizeof(complex16_t):
-            return IQTrimmer<complex16_t>::ProfileCapture(path, profile_samples, buckets);
-
-        case sizeof(complex8_t):
-            return IQTrimmer<complex8_t>::ProfileCapture(path, profile_samples, buckets);
-
-        default:
-            return {};
-    };
-}
+/* Trims the capture file with the specified range. */
+bool trim_capture_with_range(const std::filesystem::path& path, TrimRange range);
 
 /* Trims the capture file with the specified power cutoff. */
-inline bool TrimCapture(
+bool trim_capture_with_cutoff(
     const std::filesystem::path& path,
     uint32_t cutoff,
-    std::function<void(uint8_t)> on_progress = nullptr) {
-    auto sample_size = std::filesystem::capture_file_sample_size(path);
+    const std::function<void(uint8_t)>& on_progress);
 
-    switch (sample_size) {
-        case sizeof(complex16_t):
-            return IQTrimmer<complex16_t>::TrimCapture(path, cutoff, on_progress);
-
-        case sizeof(complex8_t):
-            return IQTrimmer<complex8_t>::TrimCapture(path, cutoff, on_progress);
-
-        default:
-            return false;
-    };
-}
+}  // namespace iq
 
 #endif /*__IQ_TRIM_H__*/

--- a/firmware/application/iq_trim.hpp
+++ b/firmware/application/iq_trim.hpp
@@ -49,8 +49,8 @@ struct CaptureInfo {
 /* Holds sample average power by bucket. */
 struct PowerBuckets {
     struct Bucket {
-        uint32_t power;
-        uint8_t count;
+        uint32_t power = 0;
+        uint8_t count = 0;
     };
 
     Bucket* p = nullptr;

--- a/firmware/application/iq_trim.hpp
+++ b/firmware/application/iq_trim.hpp
@@ -61,7 +61,8 @@ struct PowerBuckets {
     }
 };
 
-/* Data needed to trim a capture by sample range. */
+/* Data needed to trim a capture by sample range.
+ * end_sample is the sample *after* the last to keep. */
 struct TrimRange {
     uint64_t start_sample;
     uint64_t end_sample;

--- a/firmware/application/iq_trim.hpp
+++ b/firmware/application/iq_trim.hpp
@@ -31,13 +31,6 @@
 
 namespace iq {
 
-/* Data needed to trim a capture by sample range. */
-struct TrimRange {
-    uint64_t start_sample;
-    uint64_t end_sample;
-    uint8_t sample_size;
-};
-
 /* Information about a capture. */
 struct CaptureInfo {
     uint64_t file_size;
@@ -54,9 +47,9 @@ struct PowerBuckets {
     };
 
     Bucket* p = nullptr;
-    size_t size = 0;
+    const size_t size = 0;
 
-    /* Add the power to the bucket at index. */
+    /* Add the power to the bucket average at index. */
     void add(size_t index, uint32_t power) {
         if (index < size) {
             auto& b = p[index];
@@ -68,19 +61,30 @@ struct PowerBuckets {
     }
 };
 
+/* Data needed to trim a capture by sample range. */
+struct TrimRange {
+    uint64_t start_sample;
+    uint64_t end_sample;
+    uint8_t sample_size;
+};
+
 /* Collects capture file metadata and samples power buckets. */
 Optional<CaptureInfo> profile_capture(
     const std::filesystem::path& path,
-    uint16_t profile_samples = 2'400,
-    PowerBuckets* buckets = nullptr);
+    PowerBuckets& buckets,
+    uint8_t samples_per_bucket = 10);
+
+/* Computes the trimming range given profiling info.
+ * Cutoff percent is a number 1-100. */
+TrimRange compute_trim_range(
+    CaptureInfo info,
+    const PowerBuckets& buckets,
+    uint8_t cutoff_percent);
 
 /* Trims the capture file with the specified range. */
-bool trim_capture_with_range(const std::filesystem::path& path, TrimRange range);
-
-/* Trims the capture file with the specified power cutoff. */
-bool trim_capture_with_cutoff(
+bool trim_capture_with_range(
     const std::filesystem::path& path,
-    uint32_t cutoff,
+    TrimRange range,
     const std::function<void(uint8_t)>& on_progress);
 
 }  // namespace iq

--- a/firmware/application/ui_record_view.cpp
+++ b/firmware/application/ui_record_view.cpp
@@ -305,15 +305,12 @@ void RecordView::update_status_display() {
 void RecordView::trim_capture() {
     if (file_type != FileType::WAV && auto_trim && !trim_path.empty()) {
         trim_ui.show_reading();
-        auto range = ComputeTrimRange(
-            trim_path,
-            /*threshold*/ 5,
-            /*power array*/ nullptr,
-            trim_ui.get_callback());
+        auto info = ProfileCapture(trim_path);
 
-        if (range) {
+        if (info) {
+            auto cutoff = info->max_power / 16ULL;  // ~6.25% max.
             trim_ui.show_trimming();
-            TrimFile(trim_path, *range);
+            TrimCapture(trim_path, cutoff, trim_ui.get_callback());
         }
 
         trim_ui.clear();

--- a/firmware/application/ui_record_view.cpp
+++ b/firmware/application/ui_record_view.cpp
@@ -304,8 +304,12 @@ void RecordView::update_status_display() {
 }
 
 void RecordView::trim_capture() {
+    using bucket_t = iq::PowerBuckets::Bucket;
+
     if (file_type != FileType::WAV && auto_trim && !trim_path.empty()) {
-        std::vector<iq::PowerBuckets::Bucket> buckets(size_t(255), iq::PowerBuckets::Bucket{});;
+        // Need to heap alloc the buckets in this case. The large static buffer overflows the stack.
+        std::vector<bucket_t> buckets(size_t(255), bucket_t{});
+        ;
         iq::PowerBuckets power_buckets{
             .p = &buckets[0],
             .size = buckets.size()};

--- a/firmware/application/ui_record_view.cpp
+++ b/firmware/application/ui_record_view.cpp
@@ -305,12 +305,12 @@ void RecordView::update_status_display() {
 void RecordView::trim_capture() {
     if (file_type != FileType::WAV && auto_trim && !trim_path.empty()) {
         trim_ui.show_reading();
-        auto info = ProfileCapture(trim_path);
+        auto info = iq::profile_capture(trim_path);
 
         if (info) {
             auto cutoff = info->max_power / 16ULL;  // ~6.25% max.
             trim_ui.show_trimming();
-            TrimCapture(trim_path, cutoff, trim_ui.get_callback());
+            iq::trim_capture_with_cutoff(trim_path, cutoff, trim_ui.get_callback());
         }
 
         trim_ui.clear();

--- a/firmware/common/ui_widget.cpp
+++ b/firmware/common/ui_widget.cpp
@@ -1987,6 +1987,9 @@ void SymField::set_value(uint64_t value) {
         value_[i] = uint_to_char(temp, radix);
         v /= radix;
     }
+
+    if (on_change)
+        on_change(*this);
 }
 
 void SymField::set_value(std::string_view value) {


### PR DESCRIPTION
Previous implementation didn't work correctly for C16. This is rewrite with a new approach.
Now there's a profiling pass that determines power in N buckets. These buckets are used to determine the edges of the signal.

Implications:
- Resolution might be too coarse for long captures - especially when auto capturing.
- Some signal right at the edges may be clipped if it pushed into the adjacent "quiet" bucket.

From my tests it seems to work reliably and produces good trims.

But Wait! There's More!
I reworked the trim tool UI to allow for the threshold and start/end trim range to be adjusted. This allows you to refine the trim range if the auto detection isn't working well.
