### PR TITLE
Nav stack cleanup

### DIFF
--- a/firmware/application/apps/ui_fileman.cpp
+++ b/firmware/application/apps/ui_fileman.cpp
@@ -108,14 +108,17 @@ bool partner_file_prompt(
     if (partner.empty())
         return false;
 
-    nav.push_under_current<ModalMessageView>(
-        "Partner File",
-        partner.filename().string() + "\n" + action_name + " this file too?",
-        YESNO,
-        [&nav, partner, on_partner_action](bool choice) {
-            if (on_partner_action)
-                on_partner_action(partner, choice);
-        });
+    // Display the continuation UI once the current has been popped.
+    nav.set_on_pop([&nav, partner, action_name, on_partner_action] {
+        nav.display_modal(
+            "Partner File",
+            partner.filename().string() + "\n" + action_name + " this file too?",
+            YESNO,
+            [&nav, partner, on_partner_action](bool choice) {
+                if (on_partner_action)
+                    on_partner_action(partner, choice);
+            });
+    });
 
     return true;
 }

--- a/firmware/application/apps/ui_fileman.cpp
+++ b/firmware/application/apps/ui_fileman.cpp
@@ -189,8 +189,8 @@ FileManBaseView::FileManBaseView(
                   &text_current,
                   &button_exit});
 
-    button_exit.on_select = [this, &nav](Button&) {
-        nav.pop();
+    button_exit.on_select = [this](Button&) {
+        nav_.pop();
     };
 
     if (!sdcIsCardInserted(&SDCD1)) {
@@ -325,9 +325,9 @@ FileLoadView::FileLoadView(
         if (get_selected_entry().is_directory) {
             push_dir(get_selected_entry().path);
         } else {
-            nav_.pop();
             if (on_changed)
                 on_changed(get_selected_full_path());
+            nav_.pop();
         }
     };
 }

--- a/firmware/application/apps/ui_freqman.cpp
+++ b/firmware/application/apps/ui_freqman.cpp
@@ -92,9 +92,9 @@ void FreqManBaseView::focus() {
 
     // TODO: Shouldn't be on focus.
     if (error_ == ERROR_ACCESS) {
-        nav_.display_modal("Error", "File access error", ABORT, nullptr);
+        nav_.display_modal("Error", "File access error", ABORT);
     } else if (error_ == ERROR_NOFILES) {
-        nav_.display_modal("Error", "No database files\nin /FREQMAN", ABORT, nullptr);
+        nav_.display_modal("Error", "No database files\nin /FREQMAN", ABORT);
     } else {
         options_category.focus();
     }

--- a/firmware/application/apps/ui_numbers.cpp
+++ b/firmware/application/apps/ui_numbers.cpp
@@ -39,7 +39,7 @@ namespace ui {
 
 void NumbersStationView::focus() {
     if (file_error)
-        nav_.display_modal("No voices", "No valid voices found in\nthe /numbers directory.", ABORT, nullptr);
+        nav_.display_modal("No voices", "No valid voices found in\nthe /numbers directory.", ABORT);
     else
         button_exit.focus();
 }

--- a/firmware/application/apps/ui_recon.cpp
+++ b/firmware/application/apps/ui_recon.cpp
@@ -459,8 +459,7 @@ ReconView::ReconView(NavigationView& nav)
     rssi.set_focusable(true);
     rssi.set_peak(true, 500);
     rssi.on_select = [this](RSSI&) {
-        nav_.pop();
-        nav_.push<LevelView>();
+        nav_.replace<LevelView>();
     };
 
     // TODO: *BUG* Both transmitter_model and receiver_model share the same pmem setting for target_frequency.

--- a/firmware/application/apps/ui_remote.cpp
+++ b/firmware/application/apps/ui_remote.cpp
@@ -555,7 +555,6 @@ void RemoteView::open_remote() {
         save_remote();
         load_remote(std::move(path));
         refresh_ui();
-        ;
     };
 }
 

--- a/firmware/application/apps/ui_sd_wipe.cpp
+++ b/firmware/application/apps/ui_sd_wipe.cpp
@@ -44,15 +44,21 @@ void WipeSDView::focus() {
     dummy.focus();
 
     if (!confirmed) {
-        nav_.push<ModalMessageView>("Warning !", "Wipe FAT of SD card?", YESCANCEL, [this](bool choice) {
-            if (choice)
-                confirmed = true;
-        });
+        nav_.push<ModalMessageView>(
+            "Warning !",
+            "Wipe FAT of SD card?",
+            YESNO,
+            [this](bool choice) {
+                if (choice)
+                    confirmed = true;
+                else
+                    nav_.pop(false);  // Pop w/o update so the modal will pop off the app.
+            });
     } else {
         if (sdcGetInfo(&SDCD1, &block_device_info) == CH_SUCCESS) {
             thread = chThdCreateFromHeap(NULL, 2048, NORMALPRIO, WipeSDView::static_fn, this);
         } else {
-            nav_.pop();  // Just silently abort for now
+            nav_.pop();  // Just silently abort for now.
         }
     }
 }

--- a/firmware/application/apps/ui_sd_wipe.hpp
+++ b/firmware/application/apps/ui_sd_wipe.hpp
@@ -38,7 +38,7 @@ class WipeSDView : public View {
     ~WipeSDView();
     void focus() override;
 
-    std::string title() const override { return "Wipe sdcard"; };
+    std::string title() const override { return "Wipe SD Card"; };
 
    private:
     NavigationView& nav_;

--- a/firmware/application/apps/ui_spectrum_painter_image.cpp
+++ b/firmware/application/apps/ui_spectrum_painter_image.cpp
@@ -40,17 +40,13 @@ SpectrumInputImageView::SpectrumInputImageView(NavigationView& nav) {
         auto open_view = nav.push<FileLoadView>(".bmp");
 
         constexpr auto data_directory = u"SPECTRUM";
-        if (std::filesystem::is_directory(data_directory) == false) {
-            if (make_new_directory(data_directory).ok())
-                open_view->push_dir(data_directory);
-        } else
-            open_view->push_dir(data_directory);
+        ensure_directory(data_directory);
+        open_view->push_dir(data_directory);
 
         open_view->on_changed = [this](std::filesystem::path new_file_path) {
             this->file = new_file_path.string();
             painted = false;
             this->set_dirty();
-
             this->on_input_avaliable();
         };
     };

--- a/firmware/application/apps/ui_sstvtx.cpp
+++ b/firmware/application/apps/ui_sstvtx.cpp
@@ -35,7 +35,7 @@ namespace ui {
 
 void SSTVTXView::focus() {
     if (file_error)
-        nav_.display_modal("No files", "No valid bitmaps\nin /sstv directory.", ABORT, nullptr);
+        nav_.display_modal("No files", "No valid bitmaps\nin /sstv directory.", ABORT);
     else
         options_bitmaps.focus();
 }

--- a/firmware/application/apps/ui_text_editor.cpp
+++ b/firmware/application/apps/ui_text_editor.cpp
@@ -413,16 +413,9 @@ TextEditorView::TextEditorView(NavigationView& nav)
     };
 
     menu.on_open() = [this]() {
-        /*show_save_prompt([this]() {
+        show_save_prompt([this]() {
             show_file_picker();
-        });*/
-        // HACK: above should work but it's faulting.
-        if (!file_dirty_) {
-            show_file_picker();
-        } else {
-            show_save_prompt(nullptr);
-            show_file_picker(false);
-        }
+        });
     };
 
     menu.on_save() = [this]() {
@@ -530,16 +523,12 @@ void TextEditorView::hide_menu(bool hidden) {
     set_dirty();
 }
 
-void TextEditorView::show_file_picker(bool immediate) {
-    // TODO: immediate is a hack until nav_.on_pop is fixed.
-    auto open_view = immediate ? nav_.push<FileLoadView>("") : nav_.push_under_current<FileLoadView>("");
-
-    if (open_view) {
-        open_view->on_changed = [this](std::filesystem::path path) {
-            open_file(path);
-            hide_menu();
-        };
-    }
+void TextEditorView::show_file_picker() {
+    auto open_view = nav_.push<FileLoadView>("");
+    open_view->on_changed = [this](std::filesystem::path path) {
+        open_file(path);
+        hide_menu();
+    };
 }
 
 void TextEditorView::show_edit_line() {

--- a/firmware/application/apps/ui_text_editor.cpp
+++ b/firmware/application/apps/ui_text_editor.cpp
@@ -29,14 +29,6 @@
 using namespace portapack;
 namespace fs = std::filesystem;
 
-namespace {
-/*void log(const std::string& msg) {
-    LogFile log{};
-    log.append("LOGS/Notepad.txt");
-    log.write_entry(msg);
-}*/
-}  // namespace
-
 namespace ui {
 
 /* TextViewer *******************************************************/
@@ -526,8 +518,12 @@ void TextEditorView::hide_menu(bool hidden) {
 void TextEditorView::show_file_picker() {
     auto open_view = nav_.push<FileLoadView>("");
     open_view->on_changed = [this](std::filesystem::path path) {
-        open_file(path);
-        hide_menu();
+        // Can't update the UI focus while the FileLoadView is still up.
+        // Do this on a continuation instead of in on_changed.
+        nav_.set_on_pop([this, p = std::move(path)]() {
+            open_file(p);
+            hide_menu();
+        });
     };
 }
 

--- a/firmware/application/apps/ui_text_editor.hpp
+++ b/firmware/application/apps/ui_text_editor.hpp
@@ -19,10 +19,6 @@
  * Boston, MA 02110-1301, USA.
  */
 
-/* TODO:
- * - Busy indicator while reading files.
- */
-
 #ifndef __UI_TEXT_EDITOR_H__
 #define __UI_TEXT_EDITOR_H__
 

--- a/firmware/application/apps/ui_text_editor.hpp
+++ b/firmware/application/apps/ui_text_editor.hpp
@@ -238,7 +238,7 @@ class TextEditorView : public View {
     void refresh_ui();
     void update_position();
     void hide_menu(bool hidden = true);
-    void show_file_picker(bool immediate = true);
+    void show_file_picker();
     void show_edit_line();
     void show_save_prompt(std::function<void()> continuation);
 

--- a/firmware/application/apps/ui_text_editor.hpp
+++ b/firmware/application/apps/ui_text_editor.hpp
@@ -252,8 +252,8 @@ class TextEditorView : public View {
     bool has_temp_file_{false};
 
     TextViewer viewer{
-        /* 272 = 320 - 16 (top bar) - 32 (bottom controls) */
-        {0, 0, 240, 272}};
+        /* 272 = screen_height - 16 (top bar) - 32 (bottom controls) */
+        {0, 0, screen_width, 272}};
 
     TextEditorMenu menu{};
 

--- a/firmware/application/apps/ui_view_wav.cpp
+++ b/firmware/application/apps/ui_view_wav.cpp
@@ -138,17 +138,20 @@ ViewWavView::ViewWavView(
     reset_controls();
     button_open.on_select = [this, &nav](Button&) {
         auto open_view = nav.push<FileLoadView>(".WAV");
-        open_view->on_changed = [this](std::filesystem::path file_path) {
-            if (!wav_reader->open(file_path)) {
-                nav_.display_modal("Error", "Couldn't open file.");
-                return;
-            }
-            if ((wav_reader->channels() != 1) || (wav_reader->bits_per_sample() != 16)) {
-                nav_.display_modal("Error", "Wrong format.\nWav viewer only accepts\n16-bit mono files.");
-                return;
-            }
-            load_wav(file_path);
-            field_pos_seconds.focus();
+        open_view->on_changed = [this, &nav](std::filesystem::path file_path) {
+            // Can't show new dialogs in an on_changed handler, so use continuation.
+            nav.set_on_pop([this, &nav, file_path]() {
+                if (!wav_reader->open(file_path)) {
+                    nav_.display_modal("Error", "Couldn't open file.");
+                    return;
+                }
+                if ((wav_reader->channels() != 1) || (wav_reader->bits_per_sample() != 16)) {
+                    nav_.display_modal("Error", "Wrong format.\nWav viewer only accepts\n16-bit mono files.");
+                    return;
+                }
+                load_wav(file_path);
+                field_pos_seconds.focus();
+            });
         };
     };
 

--- a/firmware/application/ui/ui_geomap.cpp
+++ b/firmware/application/ui/ui_geomap.cpp
@@ -413,7 +413,7 @@ void GeoMapView::focus() {
     geopos.focus();
 
     if (!map_opened)
-        nav_.display_modal("No map", "No world_map.bin file in\n/ADSB/ directory", ABORT, nullptr);
+        nav_.display_modal("No map", "No world_map.bin file in\n/ADSB/ directory", ABORT);
 }
 
 void GeoMapView::update_position(float lat, float lon, uint16_t angle, int32_t altitude) {

--- a/firmware/application/ui/ui_receiver.cpp
+++ b/firmware/application/ui/ui_receiver.cpp
@@ -273,9 +273,8 @@ FrequencyKeypadView::FrequencyKeypadView(
     };
 
     button_close.on_select = [this, &nav](Button&) {
-        if (on_changed) {
+        if (on_changed)
             on_changed(this->value());
-        }
         nav.pop();
     };
 

--- a/firmware/application/ui/ui_textentry.cpp
+++ b/firmware/application/ui/ui_textentry.cpp
@@ -41,20 +41,12 @@ void text_prompt(
     uint32_t cursor_pos,
     size_t max_length,
     std::function<void(std::string&)> on_done) {
-    // if (persistent_memory::ui_config_textentry() == 0) {
     auto te_view = nav.push<AlphanumView>(str, max_length);
     te_view->set_cursor(cursor_pos);
     te_view->on_changed = [on_done](std::string& value) {
         if (on_done)
             on_done(value);
     };
-    /*} else {
-                auto te_view = nav.push<HandWriteView>(str, max_length);
-                te_view->on_changed = [on_done](std::string * value) {
-                        if (on_done)
-                                on_done(value);
-                };
-        }*/
 }
 
 /* TextEntryView ***********************************************************/

--- a/firmware/application/ui_navigation.cpp
+++ b/firmware/application/ui_navigation.cpp
@@ -775,7 +775,7 @@ ModalMessageView::ModalMessageView(
         button_ok.on_select = [this, &nav](Button&) {
             if (on_choice_) on_choice_(true);
             nav.pop(false);  // Pop the modal.
-            nav.pop();  // Pop the underlying view.
+            nav.pop();       // Pop the underlying view.
         };
     }
 }

--- a/firmware/application/ui_navigation.cpp
+++ b/firmware/application/ui_navigation.cpp
@@ -430,8 +430,8 @@ void NavigationView::display_modal(
 void NavigationView::display_modal(
     const std::string& title,
     const std::string& message,
-    const modal_t type,
-    const std::function<void(bool)> on_choice) {
+    modal_t type,
+    std::function<void(bool)> on_choice) {
     push<ModalMessageView>(title, message, type, on_choice);
 }
 

--- a/firmware/application/ui_navigation.hpp
+++ b/firmware/application/ui_navigation.hpp
@@ -84,7 +84,11 @@ class NavigationView : public View {
     void pop();
 
     void display_modal(const std::string& title, const std::string& message);
-    void display_modal(const std::string& title, const std::string& message, const modal_t type, const std::function<void(bool)> on_choice = nullptr);
+    void display_modal(
+        const std::string& title,
+        const std::string& message,
+        modal_t type,
+        std::function<void(bool)> on_choice = nullptr);
 
     void focus() override;
 

--- a/firmware/application/ui_navigation.hpp
+++ b/firmware/application/ui_navigation.hpp
@@ -51,7 +51,6 @@ namespace ui {
 enum modal_t {
     INFO = 0,
     YESNO,
-    YESCANCEL,
     ABORT
 };
 
@@ -81,7 +80,7 @@ class NavigationView : public View {
 
     void push(View* v);
     void replace(View* v);
-    void pop();
+    void pop(bool trigger_update = true);
 
     void display_modal(const std::string& title, const std::string& message);
     void display_modal(
@@ -353,8 +352,8 @@ class ModalMessageView : public View {
         NavigationView& nav,
         const std::string& title,
         const std::string& message,
-        const modal_t type,
-        const std::function<void(bool)> on_choice);
+        modal_t type,
+        std::function<void(bool)> on_choice);
 
     void paint(Painter& painter) override;
     void focus() override;

--- a/firmware/application/ui_navigation.hpp
+++ b/firmware/application/ui_navigation.hpp
@@ -73,15 +73,6 @@ class NavigationView : public View {
         return reinterpret_cast<T*>(push_view(std::unique_ptr<View>(new T(*this, std::forward<Args>(args)...))));
     }
 
-    // Pushes a new view under the current on the stack so the current view returns into this new one.
-    template <class T, class... Args>
-    T* push_under_current(Args&&... args) {
-        auto new_view = std::unique_ptr<View>(new T(*this, std::forward<Args>(args)...));
-        auto new_view_ptr = new_view.get();
-        view_stack.insert(view_stack.end() - 1, ViewState{std::move(new_view), {}});
-        return reinterpret_cast<T*>(new_view_ptr);
-    }
-
     template <class T, class... Args>
     T* replace(Args&&... args) {
         pop();
@@ -90,9 +81,7 @@ class NavigationView : public View {
 
     void push(View* v);
     void replace(View* v);
-
     void pop();
-    void pop_modal();
 
     void display_modal(const std::string& title, const std::string& message);
     void display_modal(const std::string& title, const std::string& message, const modal_t type, const std::function<void(bool)> on_choice = nullptr);
@@ -110,11 +99,9 @@ class NavigationView : public View {
     };
 
     std::vector<ViewState> view_stack{};
-    Widget* modal_view{nullptr};
 
     Widget* view() const;
 
-    void pop(bool update);
     void free_view();
     void update_view();
     View* push_view(std::unique_ptr<View> new_view);

--- a/firmware/common/ui_focus.cpp
+++ b/firmware/common/ui_focus.cpp
@@ -43,18 +43,12 @@ void FocusManager::set_focus_widget(Widget* const new_focus_widget) {
     }
 
     if (new_focus_widget) {
-        // if( !new_focus_widget->visible() ) {
-        // if( new_focus_widget->hidden() ) {
-        // 	// New widget is not visible. Do nothing.
-        // 	// TODO: Should this be a debug assertion?
-        // 	return;
-        // }
-        if (!new_focus_widget->focusable()) {
+        if (!new_focus_widget->focusable())
             return;
-        }
     }
 
     // Blur old widget.
+    // NB: This will crash if the focus_widget is a destroyed instance.
     if (focus_widget()) {
         focus_widget()->on_blur();
         focus_widget()->set_dirty();

--- a/firmware/common/ui_widget.cpp
+++ b/firmware/common/ui_widget.cpp
@@ -134,7 +134,6 @@ void Widget::focus() {
 }
 
 void Widget::on_focus() {
-    // set_dirty();
 }
 
 void Widget::blur() {
@@ -142,7 +141,6 @@ void Widget::blur() {
 }
 
 void Widget::on_blur() {
-    // set_dirty();
 }
 
 bool Widget::focusable() const {


### PR DESCRIPTION
Simplify navigation stack related code by removing concepts like pop_modal, etc.
If you need to do UI continuations (e.g. a modal in a file open callback) use the `set_on_pop` to set up a continuation.
General nav-stack related cleanup in the calling apps.

Also fixes annoying lifetime bugs caused by the focus_manager trying to call blur() on deleted instances.
Ideally the focus manager would be updated whenever a Widget is destroyed, but when I tried that, the device didn't boot. 