### PR TITLE
Cpld update must be done before i2c0.stop(); in init() 

### DIFF
--- a/firmware/application/portapack.cpp
+++ b/firmware/application/portapack.cpp
@@ -407,23 +407,6 @@ bool init() {
     configure_pins_portapack();
 
     portapack::io.init();
-    
-    chThdSleepMilliseconds(10);
-
-    portapack::cpld::CpldUpdateStatus result = portapack::cpld::update_if_necessary(portapack_cpld_config());
-    if (result == portapack::cpld::CpldUpdateStatus::Program_failed) {
-        chThdSleepMilliseconds(10);
-        // Mode left (R1) and right (R2,H2,H2+) bypass going into hackrf mode after failing CPLD update
-        // Mode center (autodetect), up (R1) and down (R2,H2,H2+) will go into hackrf mode after failing CPLD update
-        if (load_config() != 3 /* left */ && load_config() != 4 /* right */) {
-            shutdown_base();
-            return false;
-        }
-    }
-
-    if (!hackrf::cpld::load_sram()) {
-        chSysHalt();
-    }
 
     /* Cache some configuration data from persistent memory. */
     persistent_memory::cache::init();
@@ -495,6 +478,23 @@ bool init() {
 
     sdcStart(&SDCD1, nullptr);
     sd_card::poll_inserted();
+
+    chThdSleepMilliseconds(10);
+
+    portapack::cpld::CpldUpdateStatus result = portapack::cpld::update_if_necessary(portapack_cpld_config());
+    if (result == portapack::cpld::CpldUpdateStatus::Program_failed) {
+        chThdSleepMilliseconds(10);
+        // Mode left (R1) and right (R2,H2,H2+) bypass going into hackrf mode after failing CPLD update
+        // Mode center (autodetect), up (R1) and down (R2,H2,H2+) will go into hackrf mode after failing CPLD update
+        if (load_config() != 3 /* left */ && load_config() != 4 /* right */) {
+            shutdown_base();
+            return false;
+        }
+    }
+
+    if (!hackrf::cpld::load_sram()) {
+        chSysHalt();
+    }
 
     chThdSleepMilliseconds(10);  // This delay seems to solve white noise audio issues
 

--- a/firmware/application/portapack.cpp
+++ b/firmware/application/portapack.cpp
@@ -407,6 +407,23 @@ bool init() {
     configure_pins_portapack();
 
     portapack::io.init();
+    
+    chThdSleepMilliseconds(10);
+
+    portapack::cpld::CpldUpdateStatus result = portapack::cpld::update_if_necessary(portapack_cpld_config());
+    if (result == portapack::cpld::CpldUpdateStatus::Program_failed) {
+        chThdSleepMilliseconds(10);
+        // Mode left (R1) and right (R2,H2,H2+) bypass going into hackrf mode after failing CPLD update
+        // Mode center (autodetect), up (R1) and down (R2,H2,H2+) will go into hackrf mode after failing CPLD update
+        if (load_config() != 3 /* left */ && load_config() != 4 /* right */) {
+            shutdown_base();
+            return false;
+        }
+    }
+
+    if (!hackrf::cpld::load_sram()) {
+        chSysHalt();
+    }
 
     /* Cache some configuration data from persistent memory. */
     persistent_memory::cache::init();
@@ -478,23 +495,6 @@ bool init() {
 
     sdcStart(&SDCD1, nullptr);
     sd_card::poll_inserted();
-
-    chThdSleepMilliseconds(10);
-
-    portapack::cpld::CpldUpdateStatus result = portapack::cpld::update_if_necessary(portapack_cpld_config());
-    if (result == portapack::cpld::CpldUpdateStatus::Program_failed) {
-        chThdSleepMilliseconds(10);
-        // Mode left (R1) and right (R2,H2,H2+) bypass going into hackrf mode after failing CPLD update
-        // Mode center (autodetect), up (R1) and down (R2,H2,H2+) will go into hackrf mode after failing CPLD update
-        if (load_config() != 3 /* left */ && load_config() != 4 /* right */) {
-            shutdown_base();
-            return false;
-        }
-    }
-
-    if (!hackrf::cpld::load_sram()) {
-        chSysHalt();
-    }
 
     chThdSleepMilliseconds(10);  // This delay seems to solve white noise audio issues
 


### PR DESCRIPTION
On portapack H1 (20181029).

Boot process broken by commit 43e9ce47049372c3fbe049d899542770df9bb609.

Related to issue : https://github.com/eried/portapack-mayhem/issues/1447#issue-1896140725

Ok for this hardware on last next version.