### PR TITLE
Search cleanup, more binder support

### DIFF
--- a/firmware/application/apps/ui_freqman.cpp
+++ b/firmware/application/apps/ui_freqman.cpp
@@ -153,28 +153,14 @@ FrequencySaveView::FrequencySaveView(
     add_children(
         {&labels,
          &big_display,
-         &button_clear,
-         &button_edit,
          &button_save,
-         &text_description});
+         &field_description});
 
     entry_.type = freqman_type::Single;
     entry_.frequency_a = value;
     entry_.description = to_string_timestamp(rtc_time::now());
-    refresh_ui();
 
-    button_clear.on_select = [this, &nav](Button&) {
-        entry_.description = "";
-        refresh_ui();
-    };
-
-    button_edit.on_select = [this, &nav](Button&) {
-        temp_buffer_ = entry_.description;
-        text_prompt(nav_, temp_buffer_, desc_edit_max, [this](std::string& new_desc) {
-            entry_.description = new_desc;
-            refresh_ui();
-        });
-    };
+    bind(field_description, entry_.description, nav);
 
     button_save.on_select = [this, &nav](Button&) {
         db_.insert_entry(db_.entry_count(), entry_);
@@ -182,9 +168,13 @@ FrequencySaveView::FrequencySaveView(
     };
 }
 
+void FrequencySaveView::focus() {
+    refresh_ui();
+    FreqManBaseView::focus();
+}
+
 void FrequencySaveView::refresh_ui() {
     big_display.set(entry_.frequency_a);
-    text_description.set(entry_.description);
 }
 
 /* FrequencyLoadView *************************************/

--- a/firmware/application/apps/ui_freqman.hpp
+++ b/firmware/application/apps/ui_freqman.hpp
@@ -87,9 +87,9 @@ class FrequencySaveView : public FreqManBaseView {
    public:
     FrequencySaveView(NavigationView& nav, const rf::Frequency value);
     std::string title() const override { return "Save freq"; }
+    void focus() override;
 
    private:
-    std::string temp_buffer_{};
     freqman_entry entry_{};
 
     void refresh_ui();
@@ -101,15 +101,9 @@ class FrequencySaveView : public FreqManBaseView {
     Labels labels{
         {{0 * 8, 6 * 16}, "Description:", Color::white()}};
 
-    Text text_description{{0 * 8, 7 * 16, 30 * 8, 1 * 16}};
-
-    Button button_clear{
-        {4 * 8, 10 * 16, 10 * 8, 2 * 16},
-        "Clear"};
-
-    Button button_edit{
-        {16 * 8, 10 * 16, 10 * 8, 2 * 16},
-        "Edit"};
+    TextField field_description{
+        {0 * 8, 7 * 16, 30 * 8, 1 * 16},
+        ""};
 
     Button button_save{
         {0 * 8, 17 * 16, 15 * 8, 2 * 16},

--- a/firmware/application/binder.hpp
+++ b/firmware/application/binder.hpp
@@ -53,6 +53,15 @@ struct NoOp {
  */
 
 template <typename T, typename Fn = NoOp>
+void bind(Checkbox& check, T& value, Fn fn = Fn{}) {
+    check.set_value(value);
+    check.on_select = [&value, fn](Checkbox&, bool b) {
+        value = b;
+        fn(value);
+    };
+}
+
+template <typename T, typename Fn = NoOp>
 void bind(NumberField& field, T& value, Fn fn = Fn{}) {
     field.set_value(value);
     field.on_change = [&value, fn](int32_t v) {

--- a/firmware/common/ui_widget.cpp
+++ b/firmware/common/ui_widget.cpp
@@ -28,6 +28,7 @@
 #include <cstddef>
 #include <algorithm>
 
+#include "irq_controls.hpp"
 #include "string_format.hpp"
 
 using namespace portapack;
@@ -1730,9 +1731,15 @@ bool TextEdit::on_key(const KeyEvent key) {
         cursor_pos_--;
     else if (key == KeyEvent::Right && cursor_pos_ < text_.length())
         cursor_pos_++;
-    else if (key == KeyEvent::Select)
-        insert_mode_ = !insert_mode_;
-    else
+    else if (key == KeyEvent::Select) {
+        if (key_is_long_pressed(key)) {
+            // Delete text to the cursor.
+            text_ = text_.substr(cursor_pos_);
+            set_cursor(0);
+        } else {
+            insert_mode_ = !insert_mode_;
+        }
+    } else
         return false;
 
     set_dirty();
@@ -1758,6 +1765,19 @@ bool TextEdit::on_touch(const TouchEvent event) {
 
     set_dirty();
     return true;
+}
+
+void TextEdit::on_focus() {
+    // Enable long press on "Select".
+    SwitchesState config;
+    config[toUType(Switch::Sel)] = true;
+    set_switches_long_press_config(config);
+}
+
+void TextEdit::on_blur() {
+    // Reset long press.
+    SwitchesState config{};
+    set_switches_long_press_config(config);
 }
 
 /* TextField *************************************************************/

--- a/firmware/common/ui_widget.hpp
+++ b/firmware/common/ui_widget.hpp
@@ -689,6 +689,9 @@ class TextEdit : public Widget {
     bool on_encoder(const EncoderEvent delta) override;
     bool on_touch(const TouchEvent event) override;
 
+    void on_focus() override;
+    void on_blur() override;
+
    protected:
     std::string& text_;
     size_t max_length_;


### PR DESCRIPTION
A little bit of code cleanup on Search app.
* Some settings are persisted
  * Freq range
  * Power threshold
  * Snap and snap value

Clean up the Freq Save view -- buttons aren't needed now with bound TextField and new TextEntry clear support.

TextEntry -- long press select will now delete all the text _up to_ the cursor. This makes it really simple to clear default text and rename files.

Support binding Checkbox.