### PR TITLE
Kludge fix for null parent() in GPS Sim app

### DIFF
--- a/firmware/application/apps/gps_sim_app.cpp
+++ b/firmware/application/apps/gps_sim_app.cpp
@@ -74,7 +74,10 @@ void GpsSimAppView::on_file_changed(const fs::path& new_file_path) {
     auto duration = ms_duration(file_size, transmitter_model.sampling_rate(), 2);
     text_duration.set(to_string_time_ms(duration));
 
-    button_play.focus();
+    // TODO: fix in UI framework with 'try_focus()'?
+    // Hack around focus getting called by ctor before parent is set.
+    if (parent())
+        button_play.focus();
 }
 
 void GpsSimAppView::on_tx_progress(const uint32_t progress) {


### PR DESCRIPTION
Fixes #1472 using the same kludge fix as in the PlayList app.  Not sure how #1460 triggered this issue to show up.

Caveat:  Focus doesn't get changed to the "Play" button automatically, so user will need to move focus manually.

@kallanreed, FYI