### PR TITLE
Incrementing date workaround for dead RTC battery

### DIFF
--- a/firmware/application/file.cpp
+++ b/firmware/application/file.cpp
@@ -325,6 +325,14 @@ FATTimestamp file_created_date(const std::filesystem::path& file_path) {
     return {filinfo.fdate, filinfo.ftime};
 }
 
+std::filesystem::filesystem_error file_update_date(const std::filesystem::path& file_path, FATTimestamp timestamp) {
+    FILINFO filinfo{};
+
+    filinfo.fdate = timestamp.FAT_date;
+    filinfo.ftime = timestamp.FAT_time;
+    return f_utime(reinterpret_cast<const TCHAR*>(file_path.c_str()), &filinfo);
+}
+
 std::filesystem::filesystem_error make_new_file(
     const std::filesystem::path& file_path) {
     File f;

--- a/firmware/application/file.hpp
+++ b/firmware/application/file.hpp
@@ -270,6 +270,7 @@ std::filesystem::filesystem_error rename_file(const std::filesystem::path& file_
 std::filesystem::filesystem_error copy_file(const std::filesystem::path& file_path, const std::filesystem::path& dest_path);
 
 FATTimestamp file_created_date(const std::filesystem::path& file_path);
+std::filesystem::filesystem_error file_update_date(const std::filesystem::path& file_path, FATTimestamp timestamp);
 std::filesystem::filesystem_error make_new_file(const std::filesystem::path& file_path);
 std::filesystem::filesystem_error make_new_directory(const std::filesystem::path& dir_path);
 std::filesystem::filesystem_error ensure_directory(const std::filesystem::path& dir_path);

--- a/firmware/application/ui_navigation.cpp
+++ b/firmware/application/ui_navigation.cpp
@@ -405,7 +405,7 @@ void SystemStatusView::rtc_battery_workaround() {
         rtcSetTime(&RTCD1, &new_datetime);
 
         // update file date
-        timestamp.FAT_date = (uint16_t)(((year - 1980) << 9) | ((uint16_t)month << 5) | day);
+        timestamp.FAT_date = ((year - 1980) << 9) | ((uint16_t)month << 5) | day;
         timestamp.FAT_time = 0;
         file_update_date(DATE_FILEFLAG, timestamp);
     }

--- a/firmware/application/ui_navigation.cpp
+++ b/firmware/application/ui_navigation.cpp
@@ -366,17 +366,16 @@ void SystemStatusView::rtc_battery_workaround() {
     if (sd_card::status() != sd_card::Status::Mounted)
         return;
 
+    uint16_t year;
+    uint8_t month;
+    uint8_t day;
     FATTimestamp timestamp;
-
     rtc::RTC datetime;
+
     rtcGetTime(&RTCD1, &datetime);
 
-    uint16_t year = datetime.year();
-    uint8_t month = datetime.month();
-    uint8_t day = datetime.day();
-
     // if year is 0000, assume RTC battery is dead
-    if (year == 0) {
+    if (datetime.year() == 0) {
         // if timestamp file is present, use it's date and add 1 day
         if (std::filesystem::file_exists(DATE_FILEFLAG)) {
             timestamp = file_created_date(DATE_FILEFLAG);
@@ -406,7 +405,7 @@ void SystemStatusView::rtc_battery_workaround() {
         rtcSetTime(&RTCD1, &new_datetime);
 
         // update file date
-        timestamp.FAT_date = (uint16_t)(((new_datetime.year() - 1980) << 9) | ((uint16_t)new_datetime.month() << 5) | new_datetime.day());
+        timestamp.FAT_date = (uint16_t)(((year - 1980) << 9) | ((uint16_t)month << 5) | day);
         timestamp.FAT_time = 0;
         file_update_date(DATE_FILEFLAG, timestamp);
     }

--- a/firmware/application/ui_navigation.hpp
+++ b/firmware/application/ui_navigation.hpp
@@ -44,6 +44,9 @@
 #include <vector>
 #include <utility>
 
+// for incrementing fake date when RTC battery is dead
+#define DATE_FILEFLAG u"/SETTINGS/DATE_FILEFLAG"
+
 using namespace sd_card;
 
 namespace ui {
@@ -235,6 +238,7 @@ class SystemStatusView : public View {
     void on_title();
     void refresh();
     void on_clk();
+    void rtc_battery_workaround();
 
     MessageHandlerRegistration message_handler_refresh{
         Message::ID::StatusRefresh,

--- a/firmware/common/ffconf.h
+++ b/firmware/common/ffconf.h
@@ -47,7 +47,7 @@
 #define _USE_EXPAND 0
 /* This option switches f_expand function. (0:Disable or 1:Enable) */
 
-#define _USE_CHMOD 0
+#define _USE_CHMOD 1
 /* This option switches attribute manipulation functions, f_chmod() and f_utime().
 /  (0:Disable or 1:Enable) Also _FS_READONLY needs to be 0 to enable this option. */
 


### PR DESCRIPTION
For issue #1478,  only when the RTC battery is dead, increment the date by 1 every power cycle (starting from 1 January 1980), using the timestamp of a file on the SD card.

(The RTC battery does often go dead per issue #1297.)

The purpose is so that time stamps (in debug data, log files, etc) are in increasing chronological order.  Even though the date & time are bogus, at least they won't all be the SAME date.