### PR TITLE
Recon: timer logic update

### DIFF
--- a/firmware/application/apps/ui_recon.hpp
+++ b/firmware/application/apps/ui_recon.hpp
@@ -303,7 +303,7 @@ class ReconView : public View {
     NumberField field_lock_wait{
         {25 * 8, 24 * 8 + 4},
         4,
-        {0, RECON_MAX_LOCK_DURATION},
+        {STATS_UPDATE_INTERVAL, RECON_MAX_LOCK_DURATION},
         STATS_UPDATE_INTERVAL,
         ' ',
     };


### PR DESCRIPTION
This PR fix a broken timer logic that 'may' have had some sense times ago but not anymore.
Also reduce the screen blinking when changing mode, and hiding unused button in scanner mode.