### PR TITLE
Ignore empty App Settings files (avoid overwriting Radio State BW & sample rate)

### DIFF
--- a/firmware/application/app_settings.cpp
+++ b/firmware/application/app_settings.cpp
@@ -124,6 +124,7 @@ void SettingsStore::save() const {
 
 bool load_settings(std::string_view store_name, SettingBindings& bindings) {
     File f;
+    bool settings_loaded{false};
     auto path = get_settings_path(std::string{store_name});
 
     auto error = f.open(path);
@@ -145,15 +146,21 @@ bool load_settings(std::string_view store_name, SettingBindings& bindings) {
             });
 
         // If found, parse the value.
-        if (it != bindings.end())
+        if (it != bindings.end()) {
             it->parse(cols[1]);
+            settings_loaded = true;
+        }
     }
 
-    return true;
+    return settings_loaded;
 }
 
 bool save_settings(std::string_view store_name, const SettingBindings& bindings) {
     File f;
+
+    if (!portapack::persistent_memory::save_app_settings())
+        return false;
+
     auto path = get_settings_path(std::string{store_name});
 
     auto error = f.create(path);

--- a/firmware/application/app_settings.cpp
+++ b/firmware/application/app_settings.cpp
@@ -158,7 +158,7 @@ bool load_settings(std::string_view store_name, SettingBindings& bindings) {
 bool save_settings(std::string_view store_name, const SettingBindings& bindings) {
     File f;
 
-    if (!portapack::persistent_memory::save_app_settings())
+    if (!portapack::persistent_memory::save_app_settings() || bindings.empty())
         return false;
 
     auto path = get_settings_path(std::string{store_name});

--- a/firmware/application/apps/ui_adsb_rx.cpp
+++ b/firmware/application/apps/ui_adsb_rx.cpp
@@ -521,7 +521,9 @@ ADSBRxView::ADSBRxView(NavigationView& nav) {
 
     baseband::set_adsb();
 
-    receiver_model.set_target_frequency(1'090'000'000);
+    if (!settings_.radio_loaded())
+        receiver_model.set_target_frequency(1'090'000'000);
+    
     receiver_model.enable();
 }
 

--- a/firmware/application/apps/ui_adsb_rx.cpp
+++ b/firmware/application/apps/ui_adsb_rx.cpp
@@ -523,7 +523,7 @@ ADSBRxView::ADSBRxView(NavigationView& nav) {
 
     if (!settings_.radio_loaded())
         receiver_model.set_target_frequency(1'090'000'000);
-    
+
     receiver_model.enable();
 }
 


### PR DESCRIPTION
Proposed fix for issue #1487

1.  If an app settings .ini file has no settings lines in it, ignore the file.  Previously, the app-specific Bandwidth & Sample Rate values initialized in Radio State were being overwritten with non-app-specific default values when an empty .ini file was read.
2.  When "Save App Settings" is disabled, don't write out empty .ini files.

I've also updated ui_adsb_rx to allow rx_frequency to be modified via the App Settings .ini file.