### PR TITLE
Prevent unnecessary CPLD SRAM load on first RX operation

### DIFF
--- a/firmware/application/radio.cpp
+++ b/firmware/application/radio.cpp
@@ -92,8 +92,8 @@ max2839::MAX2839 second_if_max2839{ssp1_target_max283x};
 static max5864::MAX5864 baseband_codec{ssp1_target_max5864};
 static baseband::CPLD baseband_cpld;
 
-// Set invalid to force the set_direction CPLD workaround to run.
-static rf::Direction direction{-1};
+// load_sram() is called at boot in portapack.cpp, including verify CPLD part, so default direction is Receive
+static rf::Direction direction{rf::Direction::Receive};
 static bool baseband_invert = false;
 static bool mixer_invert = false;
 


### PR DESCRIPTION
Not well understood, but this change seems to solve #1468.

More investigation is needed to understand why unnecessarily calling load_sram_no_verify() in set_direction() adversely affects RX reception.