### PR TITLE
Applying a proper TX_LPF to all remaining TX App

### DIFF
--- a/firmware/application/apps/lge_app.cpp
+++ b/firmware/application/apps/lge_app.cpp
@@ -238,6 +238,10 @@ void LGEView::start_tx() {
         tx_view.set_dirty();
     }
 
+    /* By experimental test, previous fw 1.7.4 seems to have setting , tx LPF = 5Mhz
+    This LGE - seems to be for controlling a "laser tag equipment" (Havoc app) , modulated  FSK , low bauds,
+    and using max GUI fm dev 150k , we are still in NBFM, let's reduce slightly original TX LPF 5M ->2M5*/
+    transmitter_model.set_baseband_bandwidth(2'500'000);
     transmitter_model.enable();
 
     chThdSleep(100);

--- a/firmware/application/apps/ui_encoders.cpp
+++ b/firmware/application/apps/ui_encoders.cpp
@@ -269,6 +269,10 @@ void EncodersView::start_tx(const bool scan) {
     repeat_index = 1;
     update_progress();
 
+    /* Setting TX LPF 1M75 in this TX OOK App  , We got same results as fw 1.7.4
+     * Looking max BW of this app, we tested , Selecting OOK type 145026 with CLK 455K and max DEV. 150k,
+     * and we got BW +-2Mhz , with that TX LPF 1M75, it is fine.*/
+    transmitter_model.set_baseband_bandwidth(1'750'000);  // Min. TX LPF value.
     transmitter_model.enable();
 
     baseband::set_ook_data(

--- a/firmware/application/apps/ui_lcr.cpp
+++ b/firmware/application/apps/ui_lcr.cpp
@@ -127,6 +127,8 @@ void LCRView::start_tx(const bool scan) {
 
     modems::generate_data(lcr::generate_message(rgsb, litterals_list, options_ec.selected_index()), lcr_message_data);
 
+    /* It is AFSK modulation , measuring original fw 1.7.4 spectrum BW is just around 30khz , NBFM */
+    transmitter_model.set_baseband_bandwidth(1'750'000);  // Min TX LPF 1M75, same spectrum as previous fw 1.7.4
     transmitter_model.enable();
 
     memcpy(shared_memory.bb_data.data, lcr_message_data, sizeof(lcr_message_data));

--- a/firmware/application/apps/ui_morse.cpp
+++ b/firmware/application/apps/ui_morse.cpp
@@ -117,6 +117,8 @@ bool MorseView::start_tx() {
     }
 
     progressbar.set_max(symbol_count);
+    // By experimental spectrum measurment, we left exactly same TX LPF settings as previous fw 1.7.4,  TX LPF= 1M75 (min).
+    transmitter_model.set_baseband_bandwidth(1'750'000);  // Min TX LPF .already tested in FM morse max tone 9,999k , max dev 150khz
     transmitter_model.enable();
 
     if (modulation == CW) {

--- a/firmware/application/apps/ui_pocsag_tx.cpp
+++ b/firmware/application/apps/ui_pocsag_tx.cpp
@@ -81,6 +81,8 @@ bool POCSAGTXView::start_tx() {
 
     transmitter_model.set_rf_amp(true);
     transmitter_model.set_tx_gain(40);
+    // We left exactly same TX LPF settings as previous fw 1.7.4,  TX LPF= 1M75 (min). It is fine even in max FM dev. 150khz and 2400 bauds.
+    transmitter_model.set_baseband_bandwidth(5'000'000);  // Min TX LPF . Pocsag is NBFM , using BW channel 25khz or 12khz
     transmitter_model.enable();
 
     uint8_t* data_ptr = shared_memory.bb_data.data;

--- a/firmware/application/apps/ui_spectrum_painter.cpp
+++ b/firmware/application/apps/ui_spectrum_painter.cpp
@@ -85,7 +85,11 @@ SpectrumPainterView::SpectrumPainterView(
 
             if (tx_mode == 0 && image_input_avaliable == false)
                 return;
-
+            /* By experimental test measurement, we got a good painted spectrum quality when selecting
+            a BW GUI App range from 100k ... 2M aprox. In that range , the best TX LPF filter = 1M75 (the min)
+            With this min TX LPF filter , we minimized the harmonics aliasing multipicture overlapped.
+            So original fw 1.7.4., was already selecting the best setting (1M75)  */
+            transmitter_model.set_baseband_bandwidth(1'750'000);  // Already tested, is the best setting for this App.
             transmitter_model.enable();
 
             if (persistent_memory::stealth_mode()) {

--- a/firmware/application/apps/ui_sstvtx.cpp
+++ b/firmware/application/apps/ui_sstvtx.cpp
@@ -160,6 +160,7 @@ void SSTVTXView::start_tx() {
     scanline_counter = 0;
     prepare_scanline();  // Preload one scanline
 
+    transmitter_model.set_baseband_bandwidth(1'750'000);  // Min TX LPF 1M75, same spectrum as previous fw 1.7.4
     transmitter_model.enable();
 
     baseband::set_sstv_data(


### PR DESCRIPTION
This PR , finalize the previous PR #1470 . It is not adding any new user feature , just trying to reduce Tx harmonics .

I have checked , all the remaining  7 x TX Transmitter App, and adding the best  TX Low Pass filter setting .
(LGE, Morse, OOK, Pocsag, S.Painter,SSTV, TEDI/LCR ).  
In fact ,  TouchTune (no need , I confirmed that, it was already applied in his original code , TX LPF = 1M75, that is fine) 

![image](https://github.com/eried/portapack-mayhem/assets/86470699/df7e2840-b628-4da6-b060-fca95380bb78)

Then , with both PR's (#1470 and this one ) ,  I think we covered all TX App's .
Now we can be sure, that regarding that TX LPF reg. settings , every TX App has his own needed LPF settings, 
and it  does not depend on any previous usage of other Tx App's.

Cheers. 
