### PR TITLE
Added Freq to Radio State, only update specified App Settings, always Load/Save Settings

### DIFF
--- a/firmware/application/app_settings.hpp
+++ b/firmware/application/app_settings.hpp
@@ -170,8 +170,6 @@ class SettingsManager {
     /* True if settings were successfully loaded from file. */
     bool loaded() const { return loaded_; }
 
-    /* True if radio settings were successfully loaded from file. */
-    bool radio_loaded() const { return radio_loaded_; }
     Mode mode() const { return settings_.mode; }
 
     AppSettings& raw() { return settings_; }
@@ -181,7 +179,6 @@ class SettingsManager {
     AppSettings settings_;
     SettingBindings bindings_;
     bool loaded_;
-    bool radio_loaded_;
 };
 
 }  // namespace app_settings

--- a/firmware/application/apps/acars_app.hpp
+++ b/firmware/application/apps/acars_app.hpp
@@ -60,11 +60,12 @@ class ACARSAppView : public View {
    private:
     NavigationView& nav_;
     RxRadioState radio_state_{
+        131550000 /* frequency */,
         1750000 /* bandwidth */,
         2457600 /* sampling rate */
     };
     app_settings::SettingsManager settings_{
-        "rx_acars.hpp", app_settings::Mode::RX};
+        "rx_acars", app_settings::Mode::RX};
 
     bool logging{false};
     uint32_t packet_counter{0};

--- a/firmware/application/apps/ais_app.cpp
+++ b/firmware/application/apps/ais_app.cpp
@@ -382,9 +382,6 @@ AISAppView::AISAppView(NavigationView& nav)
 
     recent_entry_detail_view.hidden(true);
 
-    if (!settings_.radio_loaded())
-        receiver_model.set_target_frequency(initial_target_frequency);
-
     receiver_model.enable();
 
     options_channel.on_change = [this](size_t, OptionsField::value_t v) {

--- a/firmware/application/apps/ais_app.hpp
+++ b/firmware/application/apps/ais_app.hpp
@@ -162,9 +162,8 @@ class AISAppView : public View {
     std::string title() const override { return "AIS RX"; };
 
    private:
-    static constexpr uint32_t initial_target_frequency = 162025000;
-
     RxRadioState radio_state_{
+        162025000 /* frequency*/,
         1750000 /* bandwidth */,
         2457600 /* sampling rate */
     };

--- a/firmware/application/apps/ert_app.cpp
+++ b/firmware/application/apps/ert_app.cpp
@@ -110,9 +110,6 @@ ERTAppView::ERTAppView(NavigationView&) {
         &recent_entries_view,
     });
 
-    if (!settings_.radio_loaded())
-        receiver_model.set_target_frequency(initial_target_frequency);
-
     receiver_model.enable();
 
     logger = std::make_unique<ERTLogger>();

--- a/firmware/application/apps/ert_app.hpp
+++ b/firmware/application/apps/ert_app.hpp
@@ -123,12 +123,11 @@ class ERTAppView : public View {
     std::string title() const override { return "ERT RX"; };
 
    private:
-    static constexpr uint32_t initial_target_frequency = 911600000;
-
     ERTRecentEntries recent{};
     std::unique_ptr<ERTLogger> logger{};
 
     RxRadioState radio_state_{
+        911600000 /* frequency */,
         2500000 /* bandwidth */,
         4194304 /* sampling rate */};
     app_settings::SettingsManager settings_{

--- a/firmware/application/apps/gps_sim_app.cpp
+++ b/firmware/application/apps/gps_sim_app.cpp
@@ -176,13 +176,7 @@ GpsSimAppView::GpsSimAppView(
         &waterfall,
     });
 
-    transmitter_model.set_baseband_bandwidth(15'000'000);  // GPS L1 signal use to have wide band spectrum, still with lobule energy -30dB's at + - 15 Mhz
-
-    if (!settings_.radio_loaded()) {
-        field_frequency.set_value(initial_target_frequency);
-        transmitter_model.set_sampling_rate(2600000);
-    }
-
+//    field_frequency.set_value(initial_target_frequency);
     field_frequency.set_step(5000);
 
     button_play.on_select = [this](ImageButton&) {

--- a/firmware/application/apps/gps_sim_app.cpp
+++ b/firmware/application/apps/gps_sim_app.cpp
@@ -176,7 +176,6 @@ GpsSimAppView::GpsSimAppView(
         &waterfall,
     });
 
-//    field_frequency.set_value(initial_target_frequency);
     field_frequency.set_step(5000);
 
     button_play.on_select = [this](ImageButton&) {

--- a/firmware/application/apps/gps_sim_app.hpp
+++ b/firmware/application/apps/gps_sim_app.hpp
@@ -51,12 +51,11 @@ class GpsSimAppView : public View {
     std::string title() const override { return "GPS Sim TX"; };
 
    private:
-    static constexpr uint32_t initial_target_frequency = 1575420000;
-
     NavigationView& nav_;
     RxRadioState radio_state_{
-        3000000 /* bandwidth */,
-        500000 /* sampling rate */
+        1575420000 /* frequency */,
+        15000000 /* bandwidth */,
+        2600000 /* sampling rate */
     };
     app_settings::SettingsManager settings_{
         "tx_gps", app_settings::Mode::TX};

--- a/firmware/application/apps/gps_sim_app.hpp
+++ b/firmware/application/apps/gps_sim_app.hpp
@@ -62,8 +62,6 @@ class GpsSimAppView : public View {
 
     static constexpr ui::Dim header_height = 3 * 16;
 
-    int32_t tx_gain{47};
-    bool rf_amp{true};                                       // aux private var to store temporal, same as Replay App rf_amp user selection.
     const size_t read_size{16384};
     const size_t buffer_count{3};
 

--- a/firmware/application/apps/gps_sim_app.hpp
+++ b/firmware/application/apps/gps_sim_app.hpp
@@ -52,7 +52,7 @@ class GpsSimAppView : public View {
 
    private:
     NavigationView& nav_;
-    RxRadioState radio_state_{
+    TxRadioState radio_state_{
         1575420000 /* frequency */,
         15000000 /* bandwidth */,
         2600000 /* sampling rate */
@@ -64,7 +64,6 @@ class GpsSimAppView : public View {
 
     int32_t tx_gain{47};
     bool rf_amp{true};                                       // aux private var to store temporal, same as Replay App rf_amp user selection.
-    static constexpr uint32_t baseband_bandwidth = 3000000;  // filter bandwidth
     const size_t read_size{16384};
     const size_t buffer_count{3};
 

--- a/firmware/application/apps/lge_app.hpp
+++ b/firmware/application/apps/lge_app.hpp
@@ -51,6 +51,7 @@ class LGEView : public View {
     };
 
     TxRadioState radio_state_{
+        868067000 /* frequency */,
         1750000 /* bandwidth */,
         2280000 /* sampling rate */
     };

--- a/firmware/application/apps/pocsag_app.cpp
+++ b/firmware/application/apps/pocsag_app.cpp
@@ -114,9 +114,6 @@ POCSAGAppView::POCSAGAppView(NavigationView& nav)
                                     ? FILTER_NONE
                                     : FILTER_DROP;
     }
-    if (!app_settings_.radio_loaded()) {
-        field_frequency.set_value(initial_target_frequency);
-    }
 
     logger.append(LOG_ROOT_DIR "/POCSAG.TXT");
 

--- a/firmware/application/apps/pocsag_app.hpp
+++ b/firmware/application/apps/pocsag_app.hpp
@@ -197,14 +197,17 @@ class POCSAGAppView : public View {
     void focus() override;
 
    private:
-    static constexpr uint32_t initial_target_frequency = 466'175'000;
     bool logging() const { return settings_.enable_logging; };
     bool logging_raw() const { return settings_.enable_raw_log; };
     bool hide_bad_data() const { return settings_.hide_bad_data; };
     bool hide_addr_only() const { return settings_.hide_addr_only; };
 
     NavigationView& nav_;
-    RxRadioState radio_state_{};
+    RxRadioState radio_state_{
+        466175000 /* frequency*/,
+        max283x::filter::bandwidth_minimum /* bandwidth */,
+        3072000 /* sampling rate */
+    };
 
     // Settings
     POCSAGSettings settings_{};

--- a/firmware/application/apps/soundboard_app.cpp
+++ b/firmware/application/apps/soundboard_app.cpp
@@ -120,7 +120,6 @@ void SoundBoardView::start_tx(const uint32_t id) {
     );
     baseband::set_sample_rate(sample_rate);
 
-    transmitter_model.set_baseband_bandwidth(1'750'000);  // the Minimum TX LPF  1M75 is fine.
     transmitter_model.enable();
 
     tx_view.set_transmitting(true);

--- a/firmware/application/apps/soundboard_app.hpp
+++ b/firmware/application/apps/soundboard_app.hpp
@@ -50,6 +50,7 @@ class SoundBoardView : public View {
 
    private:
     TxRadioState radio_state_{
+        0 /* frequency */,
         1750000 /* bandwidth */,
         1536000 /* sampling rate */
     };

--- a/firmware/application/apps/tpms_app.cpp
+++ b/firmware/application/apps/tpms_app.cpp
@@ -157,9 +157,6 @@ TPMSAppView::TPMSAppView(NavigationView&) {
                   &field_vga,
                   &recent_entries_view});
 
-    if (!settings_.radio_loaded())
-        receiver_model.set_target_frequency(initial_target_frequency);
-
     receiver_model.enable();
 
     options_band.on_change = [this](size_t, OptionsField::value_t v) {

--- a/firmware/application/apps/tpms_app.hpp
+++ b/firmware/application/apps/tpms_app.hpp
@@ -102,9 +102,8 @@ class TPMSAppView : public View {
     std::string title() const override { return "TPMS RX"; };
 
    private:
-    static constexpr uint32_t initial_target_frequency = 315000000;
-
     RxRadioState radio_state_{
+        315000000 /* frequency*/,
         1750000 /* bandwidth */,
         2457600 /* sampling rate */};
     app_settings::SettingsManager settings_{

--- a/firmware/application/apps/tpms_app.hpp
+++ b/firmware/application/apps/tpms_app.hpp
@@ -134,7 +134,7 @@ class TPMSAppView : public View {
         3,
         {
             {"315", 315000000},
-            {"433", 433920000},
+            {"434", 433920000},
         }};
 
     OptionsField options_pressure{

--- a/firmware/application/apps/ui_adsb_rx.cpp
+++ b/firmware/application/apps/ui_adsb_rx.cpp
@@ -521,7 +521,6 @@ ADSBRxView::ADSBRxView(NavigationView& nav) {
 
     baseband::set_adsb();
 
-    receiver_model.set_target_frequency(1'090'000'000);
     receiver_model.enable();
 }
 

--- a/firmware/application/apps/ui_adsb_rx.hpp
+++ b/firmware/application/apps/ui_adsb_rx.hpp
@@ -342,6 +342,7 @@ class ADSBRxView : public View {
 
    private:
     RxRadioState radio_state_{
+        1090000000 /* frequency */,
         2500000 /* bandwidth */,
         2000000 /* sampling rate */,
         ReceiverModel::Mode::SpectrumAnalysis};

--- a/firmware/application/apps/ui_adsb_tx.cpp
+++ b/firmware/application/apps/ui_adsb_tx.cpp
@@ -299,7 +299,6 @@ void ADSBTxView::start_tx() {
     /* Already tested , with SDR Angel + another Hackrf RX  and dump1090 + SDR RLT. Final conclusion is TX LPF 6 Mhz is
      * the best settings to fulfill ADSB transponder spectrum mask requirements (<=-20 dB's at +-7Mhz , <=-40 dB's at +-23Mhz )
      * and not showing any ADSB data decoding degradation.*/
-    transmitter_model.set_baseband_bandwidth(6'000'000);  // best settings for ADSB TX.
     transmitter_model.enable();
 
     baseband::set_adsb();

--- a/firmware/application/apps/ui_adsb_tx.hpp
+++ b/firmware/application/apps/ui_adsb_tx.hpp
@@ -203,7 +203,8 @@ class ADSBTxView : public View {
         };*/
 
     TxRadioState radio_state_{
-        10000000 /* bandwidth */,
+        1090000000 /* frequency */,
+        6000000 /* bandwidth */,
         4000000 /* sampling rate */
     };
     app_settings::SettingsManager settings_{

--- a/firmware/application/apps/ui_aprs_rx.hpp
+++ b/firmware/application/apps/ui_aprs_rx.hpp
@@ -190,7 +190,11 @@ class APRSRxView : public View {
     bool reset_console = false;
 
     NavigationView& nav_;
-    RxRadioState radio_state_{};
+    RxRadioState radio_state_{
+        144390000 /* frequency */,
+        1750000 /* bandwidth */,
+        3072000 /* sampling rate */
+    };
     app_settings::SettingsManager settings_{
         "rx_aprs", app_settings::Mode::RX};
 

--- a/firmware/application/apps/ui_aprs_tx.cpp
+++ b/firmware/application/apps/ui_aprs_tx.cpp
@@ -57,7 +57,6 @@ void APRSTXView::start_tx() {
     // uint8_t * bb_data_ptr = shared_memory.bb_data.data;
     // text_payload.set(to_string_hex_array(bb_data_ptr + 56, 15));
 
-    transmitter_model.set_baseband_bandwidth(1'750'000);  // APRS Automatic Packet Reporting System (APRS).AFSK with NBFM , max BW= 12k5 , then TX LPF min 1M75
     transmitter_model.enable();
 
     baseband::set_afsk_data(

--- a/firmware/application/apps/ui_aprs_tx.hpp
+++ b/firmware/application/apps/ui_aprs_tx.hpp
@@ -46,6 +46,7 @@ class APRSTXView : public View {
 
    private:
     TxRadioState radio_state_{
+        144390000 /* frequency */,
         1750000 /* bandwidth */,
         AFSK_TX_SAMPLERATE /* sampling rate */
     };

--- a/firmware/application/apps/ui_btle_rx.cpp
+++ b/firmware/application/apps/ui_btle_rx.cpp
@@ -54,7 +54,6 @@ BTLERxView::BTLERxView(NavigationView& nav)
                   &console});
 
     // Auto-configure modem for LCR RX (TODO: remove later)
-    field_frequency.set_value(2426000000);
     auto def_bell202 = &modem_defs[0];
     persistent_memory::set_modem_baudrate(def_bell202->baudrate);
     serial_format_t serial_format;

--- a/firmware/application/apps/ui_btle_rx.hpp
+++ b/firmware/application/apps/ui_btle_rx.hpp
@@ -50,6 +50,7 @@ class BTLERxView : public View {
 
     NavigationView& nav_;
     RxRadioState radio_state_{
+        2426000000 /* frequency */,
         4000000 /* bandwidth */,
         4000000 /* sampling rate */,
         ReceiverModel::Mode::WidebandFMAudio};

--- a/firmware/application/apps/ui_coasterp.cpp
+++ b/firmware/application/apps/ui_coasterp.cpp
@@ -67,7 +67,6 @@ void CoasterPagerView::generate_frame() {
 void CoasterPagerView::start_tx() {
     generate_frame();
 
-    transmitter_model.set_baseband_bandwidth(1'750'000);  // AFSK narrowband ,low baud,  max FM dev 150khz , std 10khz. TX LPF=1M75 the min.
     transmitter_model.enable();
 
     baseband::set_fsk_data(19 * 8, 2280000 / 1000, 5000, 32);

--- a/firmware/application/apps/ui_coasterp.hpp
+++ b/firmware/application/apps/ui_coasterp.hpp
@@ -52,6 +52,7 @@ class CoasterPagerView : public View {
     tx_modes tx_mode = IDLE;
 
     TxRadioState radio_state_{
+        911600000, /* frequency */
         1750000 /* bandwidth */,
         2280000 /* sampling rate */
     };

--- a/firmware/application/apps/ui_coasterp.hpp
+++ b/firmware/application/apps/ui_coasterp.hpp
@@ -52,7 +52,7 @@ class CoasterPagerView : public View {
     tx_modes tx_mode = IDLE;
 
     TxRadioState radio_state_{
-        911600000, /* frequency */
+        0, /* frequency */
         1750000 /* bandwidth */,
         2280000 /* sampling rate */
     };

--- a/firmware/application/apps/ui_coasterp.hpp
+++ b/firmware/application/apps/ui_coasterp.hpp
@@ -52,7 +52,7 @@ class CoasterPagerView : public View {
     tx_modes tx_mode = IDLE;
 
     TxRadioState radio_state_{
-        0, /* frequency */
+        433920000, /* frequency */
         1750000 /* bandwidth */,
         2280000 /* sampling rate */
     };

--- a/firmware/application/apps/ui_encoders.cpp
+++ b/firmware/application/apps/ui_encoders.cpp
@@ -272,7 +272,6 @@ void EncodersView::start_tx(const bool scan) {
     /* Setting TX LPF 1M75 in this TX OOK App  , We got same results as fw 1.7.4
      * Looking max BW of this app, we tested , Selecting OOK type 145026 with CLK 455K and max DEV. 150k,
      * and we got BW +-2Mhz , with that TX LPF 1M75, it is fine.*/
-    transmitter_model.set_baseband_bandwidth(1'750'000);  // Min. TX LPF value.
     transmitter_model.enable();
 
     baseband::set_ook_data(

--- a/firmware/application/apps/ui_encoders.hpp
+++ b/firmware/application/apps/ui_encoders.hpp
@@ -185,6 +185,7 @@ class EncodersView : public View {
     };
 
     TxRadioState radio_state_{
+        433920000 /* frequency */,
         1750000 /* bandwidth */,
         OOK_SAMPLERATE /* sampling rate */
     };

--- a/firmware/application/apps/ui_jammer.hpp
+++ b/firmware/application/apps/ui_jammer.hpp
@@ -101,6 +101,7 @@ class JammerView : public View {
    private:
     NavigationView& nav_;
     TxRadioState radio_state_{
+        0 /* frequency */,
         3500000 /* bandwidth */,
         3072000 /* sampling rate */
     };

--- a/firmware/application/apps/ui_keyfob.cpp
+++ b/firmware/application/apps/ui_keyfob.cpp
@@ -222,8 +222,6 @@ KeyfobView::KeyfobView(
 
     options_make.set_selected_index(0);
 
-    transmitter_model.set_target_frequency(433920000);  // Fixed 433.92MHz
-
     tx_view.on_edit_frequency = [this, &nav]() {
         auto new_view = nav.push<FrequencyKeypadView>(transmitter_model.target_frequency());
         new_view->on_changed = [this](rf::Frequency f) {

--- a/firmware/application/apps/ui_keyfob.hpp
+++ b/firmware/application/apps/ui_keyfob.hpp
@@ -44,6 +44,7 @@ class KeyfobView : public View {
     NavigationView& nav_;
 
     TxRadioState radio_state_{
+        433920000 /* frequency */,
         1750000 /* bandwidth */,
         OOK_SAMPLERATE /* sampling rate */
     };

--- a/firmware/application/apps/ui_lcr.hpp
+++ b/firmware/application/apps/ui_lcr.hpp
@@ -82,6 +82,7 @@ class LCRView : public View {
     };
 
     TxRadioState radio_state_{
+        0 /* frequency */,
         1750000 /* bandwidth */,
         AFSK_TX_SAMPLERATE /* sampling rate */
     };

--- a/firmware/application/apps/ui_mictx.hpp
+++ b/firmware/application/apps/ui_mictx.hpp
@@ -82,6 +82,7 @@ class MicTXView : public View {
 
     RxRadioState rx_radio_state_{};
     TxRadioState tx_radio_state_{
+        0 /* frequency */,
         1750000 /* bandwidth */,
         sampling_rate /* sampling rate */
     };

--- a/firmware/application/apps/ui_morse.hpp
+++ b/firmware/application/apps/ui_morse.hpp
@@ -70,6 +70,7 @@ class MorseView : public View {
     uint32_t time_units{0};
 
     TxRadioState radio_state_{
+        0 /* frequency */,
         1750000 /* bandwidth */,
         1536000 /* sampling rate */
     };

--- a/firmware/application/apps/ui_nrf_rx.cpp
+++ b/firmware/application/apps/ui_nrf_rx.cpp
@@ -54,7 +54,6 @@ NRFRxView::NRFRxView(NavigationView& nav)
                   &console});
 
     // Auto-configure modem for LCR RX (will be removed later)
-    field_frequency.set_value(2480000000);
     auto def_bell202 = &modem_defs[0];
     persistent_memory::set_modem_baudrate(def_bell202->baudrate);
     serial_format_t serial_format;

--- a/firmware/application/apps/ui_nrf_rx.hpp
+++ b/firmware/application/apps/ui_nrf_rx.hpp
@@ -50,6 +50,7 @@ class NRFRxView : public View {
 
     NavigationView& nav_;
     RxRadioState radio_state_{
+        2480000000 /* frequency */,
         4000000 /* bandwidth */,
         4000000 /* sampling rate */,
         ReceiverModel::Mode::WidebandFMAudio};

--- a/firmware/application/apps/ui_numbers.hpp
+++ b/firmware/application/apps/ui_numbers.hpp
@@ -56,6 +56,7 @@ class NumbersStationView : public View {
     NavigationView& nav_;
 
     TxRadioState radio_state_{
+        0 /* frequency */,
         1750000 /* bandwidth */,
         1536000 /* sampling rate */
     };

--- a/firmware/application/apps/ui_nuoptix.hpp
+++ b/firmware/application/apps/ui_nuoptix.hpp
@@ -56,6 +56,7 @@ class NuoptixView : public View {
     };
 
     TxRadioState radio_state_{
+        0 /* frequency */,
         1750000 /* bandwidth */,
         1536000 /* sampling rate */
     };

--- a/firmware/application/apps/ui_pocsag_tx.hpp
+++ b/firmware/application/apps/ui_pocsag_tx.hpp
@@ -60,6 +60,7 @@ class POCSAGTXView : public View {
     NavigationView& nav_;
 
     TxRadioState radio_state_{
+        0 /* frequency */,
         1750000 /* bandwidth */,
         2280000 /* sampling rate */
     };

--- a/firmware/application/apps/ui_rds.cpp
+++ b/firmware/application/apps/ui_rds.cpp
@@ -187,7 +187,6 @@ void RDSView::start_tx() {
     else
         frame_datetime.clear();
 
-    transmitter_model.set_baseband_bandwidth(1'750'000);  // Big Spectrum harmonics reduction, and now quicker decoding time.
     transmitter_model.enable();
 
     tx_thread = std::make_unique<RDSThread>(frames);

--- a/firmware/application/apps/ui_rds.hpp
+++ b/firmware/application/apps/ui_rds.hpp
@@ -142,6 +142,7 @@ class RDSView : public View {
     RDS_flags rds_flags{};
 
     TxRadioState radio_state_{
+        0 /* frequency */,
         1750000 /* bandwidth */,
         2280000 /* sampling rate */
     };

--- a/firmware/application/apps/ui_search.hpp
+++ b/firmware/application/apps/ui_search.hpp
@@ -90,6 +90,7 @@ class SearchView : public View {
    private:
     NavigationView& nav_;
     RxRadioState radio_state_{
+        100'000'000 /* frequency */,
         2500000 /* bandwidth */,
         SEARCH_SLICE_WIDTH /* sampling rate */,
         ReceiverModel::Mode::SpectrumAnalysis};

--- a/firmware/application/apps/ui_settings.cpp
+++ b/firmware/application/apps/ui_settings.cpp
@@ -343,34 +343,6 @@ void SetUIView::focus() {
     button_save.focus();
 }
 
-/* SetAppSettingsView ************************************/
-
-SetAppSettingsView::SetAppSettingsView(NavigationView& nav) {
-    add_children({
-        &labels,
-        &checkbox_load_app_settings,
-        &checkbox_save_app_settings,
-        &button_save,
-        &button_cancel,
-    });
-
-    checkbox_load_app_settings.set_value(pmem::load_app_settings());
-    checkbox_save_app_settings.set_value(pmem::save_app_settings());
-
-    button_save.on_select = [&nav, this](Button&) {
-        pmem::set_load_app_settings(checkbox_load_app_settings.value());
-        pmem::set_save_app_settings(checkbox_save_app_settings.value());
-        nav.pop();
-    };
-    button_cancel.on_select = [&nav, this](Button&) {
-        nav.pop();
-    };
-}
-
-void SetAppSettingsView::focus() {
-    button_save.focus();
-}
-
 /* SetConverterSettingsView ******************************/
 
 SetConverterSettingsView::SetConverterSettingsView(NavigationView& nav) {
@@ -654,7 +626,6 @@ SettingsMenuView::SettingsMenuView(NavigationView& nav) {
         add_items({{"..", ui::Color::light_grey(), &bitmap_icon_previous, [&nav]() { nav.pop(); }}});
     }
     add_items({
-        {"App Settings", ui::Color::dark_cyan(), &bitmap_icon_setup, [&nav]() { nav.push<SetAppSettingsView>(); }},
         {"Audio", ui::Color::dark_cyan(), &bitmap_icon_speaker, [&nav]() { nav.push<SetAudioView>(); }},
         {"Calibration", ui::Color::dark_cyan(), &bitmap_icon_options_touch, [&nav]() { nav.push<TouchCalibrationView>(); }},
         {"Converter", ui::Color::dark_cyan(), &bitmap_icon_options_radio, [&nav]() { nav.push<SetConverterSettingsView>(); }},

--- a/firmware/application/apps/ui_settings.hpp
+++ b/firmware/application/apps/ui_settings.hpp
@@ -310,41 +310,6 @@ class SetUIView : public View {
     };
 };
 
-class SetAppSettingsView : public View {
-   public:
-    SetAppSettingsView(NavigationView& nav);
-
-    void focus() override;
-    std::string title() const override { return "App Settings"; };
-
-   private:
-    Labels labels{
-        {{1 * 8, 1 * 16}, "App settings are saved to", Color::light_grey()},
-        {{1 * 8, 2 * 16}, "the SD card in /SETTINGS.", Color::light_grey()},
-        {{1 * 8, 3 * 16}, "Radio settings may also be", Color::light_grey()},
-        {{1 * 8, 4 * 16}, "loaded or saved per app.", Color::light_grey()},
-    };
-
-    Checkbox checkbox_load_app_settings{
-        {3 * 8, 6 * 16},
-        25,
-        "Load radio settings"};
-
-    Checkbox checkbox_save_app_settings{
-        {3 * 8, 8 * 16},
-        25,
-        "Save radio settings"};
-
-    Button button_save{
-        {2 * 8, 16 * 16, 12 * 8, 32},
-        "Save"};
-
-    Button button_cancel{
-        {16 * 8, 16 * 16, 12 * 8, 32},
-        "Cancel",
-    };
-};
-
 class SetConverterSettingsView : public View {
    public:
     SetConverterSettingsView(NavigationView& nav);

--- a/firmware/application/apps/ui_siggen.hpp
+++ b/firmware/application/apps/ui_siggen.hpp
@@ -51,6 +51,7 @@ class SigGenView : public View {
     void on_tx_progress(const uint32_t progress, const bool done);
 
     TxRadioState radio_state_{
+        0 /* frequency */,
         1750000 /* bandwidth */,
         1536000 /* sampling rate */
     };

--- a/firmware/application/apps/ui_sonde.cpp
+++ b/firmware/application/apps/ui_sonde.cpp
@@ -66,9 +66,6 @@ SondeView::SondeView(NavigationView& nav)
                   &button_see_qr,
                   &button_see_map});
 
-    if (!settings_.radio_loaded())
-        field_frequency.set_value(initial_target_frequency);
-
     field_frequency.set_step(500);  // euquiq: was 10000, but we are using this for fine-tunning
 
     geopos.set_read_only(true);

--- a/firmware/application/apps/ui_sonde.hpp
+++ b/firmware/application/apps/ui_sonde.hpp
@@ -68,6 +68,7 @@ class SondeView : public View {
    private:
     NavigationView& nav_;
     RxRadioState radio_state_{
+        402700000 /* frequency */,
         1750000 /* bandwidth */,
         2457600 /* sampling rate */
     };
@@ -75,7 +76,6 @@ class SondeView : public View {
         "rx_sonde", app_settings::Mode::RX};
 
     std::unique_ptr<SondeLogger> logger{};
-    uint32_t target_frequency_{402700000};
     bool logging{false};
     bool use_crc{false};
     bool beep{false};

--- a/firmware/application/apps/ui_test.hpp
+++ b/firmware/application/apps/ui_test.hpp
@@ -62,7 +62,7 @@ class TestView : public View {
    private:
     NavigationView& nav_;
     RxRadioState radio_state_{
-        ? /* frequency */,
+        0 /* frequency */,
         1750000 /* bandwidth */,
         2457600 * 2 /* sampling rate */
     };

--- a/firmware/application/apps/ui_test.hpp
+++ b/firmware/application/apps/ui_test.hpp
@@ -62,6 +62,7 @@ class TestView : public View {
    private:
     NavigationView& nav_;
     RxRadioState radio_state_{
+        ? /* frequency */,
         1750000 /* bandwidth */,
         2457600 * 2 /* sampling rate */
     };

--- a/firmware/application/apps/ui_touchtunes.cpp
+++ b/firmware/application/apps/ui_touchtunes.cpp
@@ -85,7 +85,6 @@ void TouchTunesView::on_tx_progress(const uint32_t progress, const bool done) {
 // transmission events.
 void TouchTunesView::start_ew() {
     // Radio
-    transmitter_model.set_target_frequency(433920000);
     transmitter_model.set_rf_amp(true);
     transmitter_model.set_tx_gain(47);
     transmitter_model.enable();
@@ -151,10 +150,7 @@ void TouchTunesView::start_tx(const uint32_t button_index) {
 
     size_t bitstream_length = make_bitstream(fragments);
 
-    transmitter_model.set_target_frequency(433920000);
-    transmitter_model.set_sampling_rate(OOK_SAMPLERATE);
     transmitter_model.set_rf_amp(true);
-    transmitter_model.set_baseband_bandwidth(1750000);
     transmitter_model.enable();
 
     baseband::set_ook_data(

--- a/firmware/application/apps/ui_touchtunes.hpp
+++ b/firmware/application/apps/ui_touchtunes.hpp
@@ -25,6 +25,7 @@
 #include "ui_transmitter.hpp"
 #include "transmitter_model.hpp"
 #include "radio_state.hpp"
+#include "encoders.hpp"
 
 // The coding in notpike's script is quite complex, using multiple LUTs to form the data sent to the YSO.
 // The format is actually very simple if it is rather seen as short and long gaps between pulses (as seen in many OOK remotes).
@@ -115,8 +116,9 @@ class TouchTunesView : public View {
 
    private:
     TxRadioState radio_state_{
-        3500000 /* bandwidth */,
-        3072000 /* sampling rate */
+        433920000 /* frequency */,
+        1750000 /* bandwidth */,
+        OOK_SAMPLERATE /* sampling rate */
     };
 
     uint32_t scan_button_index{};

--- a/firmware/application/radio_state.hpp
+++ b/firmware/application/radio_state.hpp
@@ -41,8 +41,10 @@ class RadioState {
         model->initialize();
     }
 
-    RadioState(uint32_t new_bandwidth, uint32_t new_sampling_rate) {
+    RadioState(uint32_t new_frequency, uint32_t new_bandwidth, uint32_t new_sampling_rate) {
         model->initialize();
+        if (new_frequency != 0)
+            model->set_target_frequency(new_frequency);
         model->set_sampling_rate(new_sampling_rate);
         model->set_baseband_bandwidth(new_bandwidth);
     }
@@ -61,10 +63,13 @@ class RadioState {
         typename U = TModel,
         typename Mode = std::enable_if_t<sizeof(typename U::Mode), typename U::Mode> >
     RadioState(
+        uint32_t new_frequency,
         uint32_t new_bandwidth,
         uint32_t new_sampling_rate,
         Mode new_mode) {
         model->initialize();
+        if (new_frequency != 0)
+            model->set_target_frequency(new_frequency);
         model->set_sampling_rate(new_sampling_rate);
         model->set_baseband_bandwidth(new_bandwidth);
         model->settings().mode = new_mode;

--- a/firmware/common/portapack_persistent_memory.cpp
+++ b/firmware/common/portapack_persistent_memory.cpp
@@ -524,14 +524,6 @@ bool show_gui_return_icon() {  // add return icon in touchscreen menu
     return data->ui_config.show_gui_return_icon != 0;
 }
 
-bool load_app_settings() {  // load (last saved) app settings on startup of app
-    return data->ui_config.load_app_settings != 0;
-}
-
-bool save_app_settings() {  // save app settings when closing app
-    return data->ui_config.save_app_settings != 0;
-}
-
 bool show_bigger_qr_code() {  // show bigger QR code
     return data->ui_config.show_large_qr_code != 0;
 }

--- a/firmware/common/portapack_persistent_memory.hpp
+++ b/firmware/common/portapack_persistent_memory.hpp
@@ -179,8 +179,6 @@ bool config_converter();
 bool config_updown_converter();
 int64_t config_converter_freq();
 bool show_gui_return_icon();
-bool load_app_settings();
-bool save_app_settings();
 bool show_bigger_qr_code();
 bool hide_clock();
 bool clock_with_date();


### PR DESCRIPTION
This PR is an alternative solution to issue #1487, taking into consideration the feedback on PR #1490 (which I have now closed).

Changes in this PR are as follows:
1.  Added Frequency to the Radio State defaults specified in each App's header file, in lieu of checking in each app whether radio settings were loaded.  Note:  value==0 means "don't change the freq value in the TX/RX".
2.  Always load and store Radio Settings from/to the .ini file, similar to the non-radio app settings.  If the user doesn't want to load the values from the .ini file, they can rename the .ini file, or can now delete specific line(s) containing setting(s) they don't want to load from the file.  If a Radio Setting is not found in the .ini file, the default setting is used from the app's header file, as noted above.
3. Deleted unnecessary Settings -> App Settings configuration screen.