### PR TITLE
Hide unwanted apps by naming them in SETTINGS/blacklist file

### DIFF
--- a/firmware/application/ui/ui_btngrid.cpp
+++ b/firmware/application/ui/ui_btngrid.cpp
@@ -251,7 +251,7 @@ void load_blacklist() {
         blacklist_len = f.size();
 }
 
-bool blacklisted_app(GridItem new_item) {
+bool BtnGridView::blacklisted_app(GridItem new_item) {
     std::string app_name = new_item.text;
 
     if (blacklist_len < app_name.size())

--- a/firmware/application/ui/ui_btngrid.cpp
+++ b/firmware/application/ui/ui_btngrid.cpp
@@ -110,16 +110,18 @@ void BtnGridView::clear() {
 
 void BtnGridView::add_items(std::initializer_list<GridItem> new_items) {
     for (auto item : new_items) {
-        menu_items.push_back(item);
+        if (!blacklisted_app(item))
+            menu_items.push_back(item);
     }
 
     update_items();
 }
 
 void BtnGridView::add_item(GridItem new_item) {
-    menu_items.push_back(new_item);
-
-    update_items();
+    if (!blacklisted_app(new_item)) {
+        menu_items.push_back(new_item);
+        update_items();
+    }
 }
 
 void BtnGridView::update_items() {
@@ -230,6 +232,32 @@ bool BtnGridView::on_key(const KeyEvent key) {
 
 bool BtnGridView::on_encoder(const EncoderEvent event) {
     return set_highlighted(highlighted_item + event);
+}
+
+/* BlackList ******************************************************/
+
+std::unique_ptr<char> blacklist_ptr{};
+size_t blacklist_len{};
+
+void load_blacklist() {
+    File f;
+
+    auto error = f.open(BLACKLIST);
+    if (error)
+        return;
+
+    blacklist_ptr = std::unique_ptr<char>(new char[f.size()]);
+    if (f.read(blacklist_ptr.get(), f.size()))
+        blacklist_len = f.size();
+}
+
+bool blacklisted_app(GridItem new_item) {
+    std::string app_name = new_item.text;
+
+    if (blacklist_len < app_name.size())
+        return false;
+
+    return std::search(blacklist_ptr.get(), blacklist_ptr.get() + blacklist_len, app_name.begin(), app_name.end()) < blacklist_ptr.get() + blacklist_len;
 }
 
 } /* namespace ui */

--- a/firmware/application/ui/ui_btngrid.hpp
+++ b/firmware/application/ui/ui_btngrid.hpp
@@ -51,7 +51,6 @@ struct GridItem {
 };
 
 void load_blacklist();
-bool blacklisted_app(GridItem new_item);
 
 class BtnGridView : public View {
    public:
@@ -76,6 +75,7 @@ class BtnGridView : public View {
     void on_blur() override;
     bool on_key(const KeyEvent event) override;
     bool on_encoder(const EncoderEvent event) override;
+    bool blacklisted_app(GridItem new_item);
 
    private:
     int rows_{3};

--- a/firmware/application/ui/ui_btngrid.hpp
+++ b/firmware/application/ui/ui_btngrid.hpp
@@ -36,6 +36,9 @@
 #include <string>
 #include <vector>
 
+// file used for listing apps to hide from menu
+#define BLACKLIST u"/SETTINGS/blacklist"
+
 namespace ui {
 
 struct GridItem {
@@ -46,6 +49,9 @@ struct GridItem {
 
     // TODO: Prevent default-constructed GridItems.
 };
+
+void load_blacklist();
+bool blacklisted_app(GridItem new_item);
 
 class BtnGridView : public View {
    public:

--- a/firmware/application/ui_navigation.cpp
+++ b/firmware/application/ui_navigation.cpp
@@ -161,6 +161,8 @@ SystemStatusView::SystemStatusView(
 
     rtc_battery_workaround();
 
+    ui::load_blacklist();
+
     if (pmem::should_use_sdcard_for_pmem()) {
         pmem::load_persistent_settings_from_file();
     }
@@ -535,7 +537,7 @@ bool NavigationView::set_on_pop(std::function<void()> on_pop) {
 
 ReceiversMenuView::ReceiversMenuView(NavigationView& nav) {
     if (pmem::show_gui_return_icon()) {
-        add_items({{"..", Color::light_grey(), &bitmap_icon_previous, [&nav]() { nav.pop(); }}});
+        add_item({"..", Color::light_grey(), &bitmap_icon_previous, [&nav]() { nav.pop(); }});
     }
     add_items({
         // {"ACARS", Color::yellow(), &bitmap_icon_adsb, [&nav](){ nav.push<ACARSAppView>(); }},
@@ -569,7 +571,7 @@ ReceiversMenuView::ReceiversMenuView(NavigationView& nav) {
 
 TransmittersMenuView::TransmittersMenuView(NavigationView& nav) {
     if (pmem::show_gui_return_icon()) {
-        add_items({{"..", Color::light_grey(), &bitmap_icon_previous, [&nav]() { nav.pop(); }}});
+        add_item({"..", Color::light_grey(), &bitmap_icon_previous, [&nav]() { nav.pop(); }});
     }
     add_items({
         {"ADS-B", ui::Color::green(), &bitmap_icon_adsb, [&nav]() { nav.push<ADSBTxView>(); }},
@@ -601,7 +603,7 @@ TransmittersMenuView::TransmittersMenuView(NavigationView& nav) {
 
 UtilitiesMenuView::UtilitiesMenuView(NavigationView& nav) {
     if (pmem::show_gui_return_icon()) {
-        add_items({{"..", Color::light_grey(), &bitmap_icon_previous, [&nav]() { nav.pop(); }}});
+        add_item({"..", Color::light_grey(), &bitmap_icon_previous, [&nav]() { nav.pop(); }});
     }
     add_items({
         {"Antenna Length", Color::green(), &bitmap_icon_tools_antenna, [&nav]() { nav.push<WhipCalcView>(); }},

--- a/firmware/application/ui_navigation.cpp
+++ b/firmware/application/ui_navigation.cpp
@@ -574,8 +574,8 @@ TransmittersMenuView::TransmittersMenuView(NavigationView& nav) {
         add_items({{"..", Color::light_grey(), &bitmap_icon_previous, [&nav]() { nav.pop(); }}});
     }
     add_items({
-        {"ADS-B", ui::Color::green(), &bitmap_icon_adsb, [&nav]() { nav.push<ADSBTxView>(); }},
-        {"APRS", ui::Color::green(), &bitmap_icon_aprs, [&nav]() { nav.push<APRSTXView>(); }},
+        {"ADS-B TX", ui::Color::green(), &bitmap_icon_adsb, [&nav]() { nav.push<ADSBTxView>(); }},
+        {"APRS TX", ui::Color::green(), &bitmap_icon_aprs, [&nav]() { nav.push<APRSTXView>(); }},
         {"BHT Xy/EP", ui::Color::green(), &bitmap_icon_bht, [&nav]() { nav.push<BHTView>(); }},
         {"BurgerPgr", ui::Color::yellow(), &bitmap_icon_burger, [&nav]() { nav.push<CoasterPagerView>(); }},
         {"GPS Sim", ui::Color::green(), &bitmap_icon_gps_sim, [&nav]() { nav.push<GpsSimAppView>(); }},

--- a/firmware/application/ui_navigation.cpp
+++ b/firmware/application/ui_navigation.cpp
@@ -537,7 +537,7 @@ bool NavigationView::set_on_pop(std::function<void()> on_pop) {
 
 ReceiversMenuView::ReceiversMenuView(NavigationView& nav) {
     if (pmem::show_gui_return_icon()) {
-        add_item({"..", Color::light_grey(), &bitmap_icon_previous, [&nav]() { nav.pop(); }});
+        add_items({{"..", Color::light_grey(), &bitmap_icon_previous, [&nav]() { nav.pop(); }}});
     }
     add_items({
         // {"ACARS", Color::yellow(), &bitmap_icon_adsb, [&nav](){ nav.push<ACARSAppView>(); }},
@@ -571,7 +571,7 @@ ReceiversMenuView::ReceiversMenuView(NavigationView& nav) {
 
 TransmittersMenuView::TransmittersMenuView(NavigationView& nav) {
     if (pmem::show_gui_return_icon()) {
-        add_item({"..", Color::light_grey(), &bitmap_icon_previous, [&nav]() { nav.pop(); }});
+        add_items({{"..", Color::light_grey(), &bitmap_icon_previous, [&nav]() { nav.pop(); }}});
     }
     add_items({
         {"ADS-B", ui::Color::green(), &bitmap_icon_adsb, [&nav]() { nav.push<ADSBTxView>(); }},
@@ -603,7 +603,7 @@ TransmittersMenuView::TransmittersMenuView(NavigationView& nav) {
 
 UtilitiesMenuView::UtilitiesMenuView(NavigationView& nav) {
     if (pmem::show_gui_return_icon()) {
-        add_item({"..", Color::light_grey(), &bitmap_icon_previous, [&nav]() { nav.pop(); }});
+        add_items({{"..", Color::light_grey(), &bitmap_icon_previous, [&nav]() { nav.pop(); }}});
     }
     add_items({
         {"Antenna Length", Color::green(), &bitmap_icon_tools_antenna, [&nav]() { nav.push<WhipCalcView>(); }},


### PR DESCRIPTION
Simple support for reading and checking a SETTINGS/blacklist file before showing app icons.  Apps can be hidden by listing them in the file using their exact name as it appears on the menu screen.  Changes take effect on the NEXT boot.

This may fully resolve #1205, and partially help with #1492.

The blacklist file must be edited manually -- there is no fancy settings screen.

WARNING:  Don't get carried away and create some massive blacklist file or you'll run out of memory during power-up and will then need to delete the file off the SD card using a computer.