### PR TITLE
POCSAG TX default freq

### DIFF
--- a/firmware/application/apps/ui_pocsag_tx.hpp
+++ b/firmware/application/apps/ui_pocsag_tx.hpp
@@ -60,7 +60,7 @@ class POCSAGTXView : public View {
     NavigationView& nav_;
 
     TxRadioState radio_state_{
-        0 /* frequency */,
+        466175000 /* frequency */,
         1750000 /* bandwidth */,
         2280000 /* sampling rate */
     };

--- a/firmware/application/ui_navigation.cpp
+++ b/firmware/application/ui_navigation.cpp
@@ -585,7 +585,7 @@ TransmittersMenuView::TransmittersMenuView(NavigationView& nav) {
         {"Morse", ui::Color::green(), &bitmap_icon_morse, [&nav]() { nav.push<MorseView>(); }},
         // { "Nuoptix DTMF", ui::Color::green(), &bitmap_icon_nuoptix, [&nav](){ nav.push<NuoptixView>(); }},
         {"OOK", ui::Color::yellow(), &bitmap_icon_remote, [&nav]() { nav.push<EncodersView>(); }},
-        {"POCSAG", ui::Color::green(), &bitmap_icon_pocsag, [&nav]() { nav.push<POCSAGTXView>(); }},
+        {"POCSAG TX", ui::Color::green(), &bitmap_icon_pocsag, [&nav]() { nav.push<POCSAGTXView>(); }},
         {"RDS", ui::Color::green(), &bitmap_icon_rds, [&nav]() { nav.push<RDSView>(); }},
         {"Soundbrd", ui::Color::green(), &bitmap_icon_soundboard, [&nav]() { nav.push<SoundBoardView>(); }},
         {"S.Painter", ui::Color::orange(), &bitmap_icon_paint, [&nav]() { nav.push<SpectrumPainterView>(); }},


### PR DESCRIPTION
Picking a default POCSAG TX frequency that matches the default freq specified in POCSAG RX.

Changed name shown for POCSAG TX button to include TX, thereby making it more unique in wanting to include only the TX version in "blacklist".