### PR TITLE
Add "Hear Mic" feature to the Mic App

### DIFF
--- a/firmware/application/apps/ui_mictx.cpp
+++ b/firmware/application/apps/ui_mictx.cpp
@@ -184,7 +184,10 @@ void MicTXView::rxaudio(bool is_on) {
         baseband::run_image(portapack::spi_flash::image_tag_mic_tx);
         audio::output::stop();
         audio::input::start(ak4951_alc_and_wm8731_boost_GUI);  // When detected AK4951 => set up ALC mode; when detected WM8731 => set up mic_boost ON/OFF.
-        (mic_to_HP_enabled ? audio::input::loopback_mic_to_hp_enable() : audio::input::loopback_mic_to_hp_disable());
+        if (mic_to_HP_enabled)
+            audio::input::loopback_mic_to_hp_enable();
+        else
+            audio::input::loopback_mic_to_hp_disable();
         portapack::pin_i2s0_rx_sda.mode(3);
         configure_baseband();
     }
@@ -290,7 +293,10 @@ MicTXView::MicTXView(
             }
             ak4951_alc_and_wm8731_boost_GUI = v;                   // 0..4, WM8731_boost dB's options, (combination boost on/off, and effective gain in captured data >>x)
             audio::input::start(ak4951_alc_and_wm8731_boost_GUI);  // Detected (WM8731), set up the proper wm_boost on/off, 0..4 (0,1) boost_on, (2,3,4) boost_off
-            (mic_to_HP_enabled ? audio::input::loopback_mic_to_hp_enable() : audio::input::loopback_mic_to_hp_disable());
+            if (mic_to_HP_enabled)
+                audio::input::loopback_mic_to_hp_enable();
+            else
+                audio::input::loopback_mic_to_hp_disable();
             configure_baseband();  // to update in real time, sending msg, var-parameters >>shift_bits FM msg, to audio_tx from M0 to M4 Proc -
         };
         options_wm8731_boost_mode.set_selected_index(3);  // preset GUI index 3 as default WM -> -02 dB's.
@@ -299,7 +305,10 @@ MicTXView::MicTXView(
         options_ak4951_alc_mode.on_change = [this](size_t, int8_t v) {
             ak4951_alc_and_wm8731_boost_GUI = v;                   // 0..11, AK4951 Mic -Automatic volume Level Control options,
             audio::input::start(ak4951_alc_and_wm8731_boost_GUI);  // Detected (AK4951) ==> Set up proper ALC mode from 0..11 options
-            (mic_to_HP_enabled ? audio::input::loopback_mic_to_hp_enable() : audio::input::loopback_mic_to_hp_disable());
+            if (mic_to_HP_enabled)
+                audio::input::loopback_mic_to_hp_enable();
+            else
+                audio::input::loopback_mic_to_hp_disable();
             configure_baseband();  // sending fixed >>8_FM, var-parameters msg, to audiotx from this M0 to M4 process.
         };
     }
@@ -482,7 +491,10 @@ MicTXView::MicTXView(
 
     check_mic_to_HP.on_select = [this](Checkbox&, bool v) {
         mic_to_HP_enabled = v;
-        (mic_to_HP_enabled ? audio::input::loopback_mic_to_hp_enable() : audio::input::loopback_mic_to_hp_disable());
+        if (mic_to_HP_enabled)
+            audio::input::loopback_mic_to_hp_enable();
+        else
+            audio::input::loopback_mic_to_hp_disable();
         if (mic_to_HP_enabled) {  // When user click to "hear mic to HP", we will select the higher acoustic sound Option MODE  ALC or BOOST-
             if (audio::debug::codec_name() == "WM8731") {
                 options_wm8731_boost_mode.set_selected_index(0);  // In WM we always go to Boost +12 dB’s respect reference level
@@ -621,7 +633,10 @@ MicTXView::MicTXView(
 
     audio::set_rate(audio::Rate::Hz_24000);
     audio::input::start(ak4951_alc_and_wm8731_boost_GUI);  // When detected AK4951 => set up ALC mode; when detected WM8731 => set up mic_boost ON/OFF.
-    (mic_to_HP_enabled ? audio::input::loopback_mic_to_hp_enable() : audio::input::loopback_mic_to_hp_disable());
+    if (mic_to_HP_enabled)
+        audio::input::loopback_mic_to_hp_enable();
+    else
+        audio::input::loopback_mic_to_hp_disable();
 }
 
 MicTXView::MicTXView(

--- a/firmware/application/apps/ui_mictx.cpp
+++ b/firmware/application/apps/ui_mictx.cpp
@@ -184,6 +184,7 @@ void MicTXView::rxaudio(bool is_on) {
         baseband::run_image(portapack::spi_flash::image_tag_mic_tx);
         audio::output::stop();
         audio::input::start(ak4951_alc_and_wm8731_boost_GUI);  // When detected AK4951 => set up ALC mode; when detected WM8731 => set up mic_boost ON/OFF.
+        (mic_to_HP_enabled ? audio::input::loopback_mic_to_hp_enable() : audio::input::loopback_mic_to_hp_disable());
         portapack::pin_i2s0_rx_sda.mode(3);
         configure_baseband();
     }
@@ -215,6 +216,7 @@ MicTXView::MicTXView(
                       &field_frequency,
                       &options_tone_key,
                       &check_rogerbeep,
+                      &check_mic_to_HP,          // check box to activate "hear mic"
                       &check_common_freq_tx_rx,  // added to handle common or separate freq- TX/RX
                       &check_rxactive,
                       &field_volume,
@@ -242,6 +244,7 @@ MicTXView::MicTXView(
                       &field_frequency,
                       &options_tone_key,
                       &check_rogerbeep,
+                      &check_mic_to_HP,          // check box to activate "hear mic"
                       &check_common_freq_tx_rx,  // added to handle common or separate freq- TX/RX
                       &check_rxactive,
                       &field_volume,
@@ -287,7 +290,8 @@ MicTXView::MicTXView(
             }
             ak4951_alc_and_wm8731_boost_GUI = v;                   // 0..4, WM8731_boost dB's options, (combination boost on/off, and effective gain in captured data >>x)
             audio::input::start(ak4951_alc_and_wm8731_boost_GUI);  // Detected (WM8731), set up the proper wm_boost on/off, 0..4 (0,1) boost_on, (2,3,4) boost_off
-            configure_baseband();                                  // to update in real time, sending msg, var-parameters >>shift_bits FM msg, to audio_tx from M0 to M4 Proc -
+            (mic_to_HP_enabled ? audio::input::loopback_mic_to_hp_enable() : audio::input::loopback_mic_to_hp_disable());
+            configure_baseband();  // to update in real time, sending msg, var-parameters >>shift_bits FM msg, to audio_tx from M0 to M4 Proc -
         };
         options_wm8731_boost_mode.set_selected_index(3);  // preset GUI index 3 as default WM -> -02 dB's.
     } else {
@@ -295,7 +299,8 @@ MicTXView::MicTXView(
         options_ak4951_alc_mode.on_change = [this](size_t, int8_t v) {
             ak4951_alc_and_wm8731_boost_GUI = v;                   // 0..11, AK4951 Mic -Automatic volume Level Control options,
             audio::input::start(ak4951_alc_and_wm8731_boost_GUI);  // Detected (AK4951) ==> Set up proper ALC mode from 0..11 options
-            configure_baseband();                                  // sending fixed >>8_FM, var-parameters msg, to audiotx from this M0 to M4 process.
+            (mic_to_HP_enabled ? audio::input::loopback_mic_to_hp_enable() : audio::input::loopback_mic_to_hp_disable());
+            configure_baseband();  // sending fixed >>8_FM, var-parameters msg, to audiotx from this M0 to M4 process.
         };
     }
 
@@ -475,6 +480,17 @@ MicTXView::MicTXView(
         rogerbeep_enabled = v;
     };
 
+    check_mic_to_HP.on_select = [this](Checkbox&, bool v) {
+        mic_to_HP_enabled = v;
+        (mic_to_HP_enabled ? audio::input::loopback_mic_to_hp_enable() : audio::input::loopback_mic_to_hp_disable());
+        if (mic_to_HP_enabled) {  // When user click to "hear mic to HP", we will select the higher acoustic sound Option MODE  ALC or BOOST-
+            if (audio::debug::codec_name() == "WM8731") {
+                options_wm8731_boost_mode.set_selected_index(0);  // In WM we always go to Boost +12 dB’s respect reference level
+            } else if (ak4951_alc_and_wm8731_boost_GUI == 0)      // In AK we are changing only that ALC index =0, because in that option, there is no sound.
+                options_ak4951_alc_mode.set_selected_index(1);    // alc_mode =0 , means no ALC,no DIGITAL filter block (by passed), and that mode has no loopback mode.
+        }
+    };
+
     check_common_freq_tx_rx.on_select = [this](Checkbox&, bool v) {
         bool_same_F_tx_rx_enabled = v;
         field_rxfrequency.hidden(v);                                           // Hide or show separated freq RX field. (When no hide user can enter down indep. freq for RX)
@@ -501,8 +517,10 @@ MicTXView::MicTXView(
     check_rxactive.on_select = [this](Checkbox&, bool v) {
         //		vumeter.set_value(0);	//Start with a clean vumeter
         rx_enabled = v;
+        check_mic_to_HP.hidden(rx_enabled);  // Hide or show "Hear Mic" checkbox depending if we activate the receiver (we should better not activate both things)
+        check_mic_to_HP.set_value(false);    // If activate receiver sound , reset the possible activation of "Hear to Mic" .
         //		check_va.hidden(v); 	//Hide or show voice activation
-        rxaudio(v);   // Activate-Deactivate audio rx accordingly
+        rxaudio(v);   // Activate-Deactivate audio RX (receiver) accordingly
         set_dirty();  // Refresh interface
     };
 
@@ -603,6 +621,7 @@ MicTXView::MicTXView(
 
     audio::set_rate(audio::Rate::Hz_24000);
     audio::input::start(ak4951_alc_and_wm8731_boost_GUI);  // When detected AK4951 => set up ALC mode; when detected WM8731 => set up mic_boost ON/OFF.
+    (mic_to_HP_enabled ? audio::input::loopback_mic_to_hp_enable() : audio::input::loopback_mic_to_hp_disable());
 }
 
 MicTXView::MicTXView(

--- a/firmware/application/apps/ui_mictx.hpp
+++ b/firmware/application/apps/ui_mictx.hpp
@@ -93,6 +93,7 @@ class MicTXView : public View {
     bool va_enabled{false};
     bool ptt_enabled{true};
     bool rogerbeep_enabled{false};
+    bool mic_to_HP_enabled{false};
     bool bool_same_F_tx_rx_enabled{false};
     bool rx_enabled{false};
     uint32_t tone_key_index{};
@@ -274,6 +275,12 @@ class MicTXView : public View {
         {3 * 8, (14 * 8) + 4},
         10,
         "Roger beep",
+        false};
+
+    Checkbox check_mic_to_HP{
+        {18 * 8, (14 * 8) + 4},
+        10,
+        "Hear Mic",
         false};
 
     Checkbox check_rxactive{

--- a/firmware/application/audio.cpp
+++ b/firmware/application/audio.cpp
@@ -208,6 +208,14 @@ void stop() {
     audio_codec->microphone_disable();
 }
 
+void loopback_mic_to_hp_enable() {
+    audio_codec->microphone_to_HP_enable();
+}
+
+void loopback_mic_to_hp_disable() {
+    audio_codec->microphone_to_HP_disable();
+}
+
 } /* namespace input */
 
 namespace headphone {

--- a/firmware/application/audio.hpp
+++ b/firmware/application/audio.hpp
@@ -53,6 +53,9 @@ class Codec {
     virtual void microphone_enable(int8_t alc_mode) = 0;  // added user-GUI  AK4951 ,selected ALC mode.
     virtual void microphone_disable() = 0;
 
+    virtual void microphone_to_HP_enable() = 0;
+    virtual void microphone_to_HP_disable() = 0;
+
     virtual size_t reg_count() const = 0;
     virtual size_t reg_bits() const = 0;
     virtual uint32_t reg_read(const size_t register_number) = 0;
@@ -78,6 +81,9 @@ namespace input {
 
 void start(int8_t alc_mode);  // added parameter user-GUI select AK4951-ALC mode for config mic path,(recording mode in datasheet),
 void stop();
+
+void loopback_mic_to_hp_enable();
+void loopback_mic_to_hp_disable();
 
 } /* namespace input */
 

--- a/firmware/common/ak4951.hpp
+++ b/firmware/common/ak4951.hpp
@@ -847,6 +847,9 @@ class AK4951 : public audio::Codec {
     void microphone_enable(int8_t alc_mode);  // added user GUI parameter , to set up AK4951 ALC mode.
     void microphone_disable();
 
+    void microphone_to_HP_enable();
+    void microphone_to_HP_disable();
+
     size_t reg_count() const override {
         return asahi_kasei::ak4951::reg_count;
     }

--- a/firmware/common/wm8731.hpp
+++ b/firmware/common/wm8731.hpp
@@ -359,7 +359,21 @@ class WM8731 : public audio::Codec {
     }
 
     void microphone_disable() override {
-        // TODO: Implement
+        microphone_mute(true);
+        microphone_to_HP_disable();
+    }
+
+    void microphone_to_HP_enable() override {
+        map.r.analog_audio_path_control.sidetone = 1;    // Side Tone Switch (Analogue) 1 = Enable Side Tone
+        map.r.analog_audio_path_control.sideatt = 0b00;  // Side Tone Attenuation 00 = -6dB
+        write(Register::AnalogAudioPathControl);
+        headphone_enable();
+    }
+
+    void microphone_to_HP_disable() override {
+        map.r.analog_audio_path_control.sidetone = 0;    // Side Tone Switch (Analogue) 0 = Disable Side Tone
+        map.r.analog_audio_path_control.sideatt = 0b11;  // Side Tone Attenuation 11 = -15dB
+        write(Register::AnalogAudioPathControl);
     }
 
     void microphone_boost(const bool boost) {


### PR DESCRIPTION
This PR, will allow to the user to  check its  Mic through the combined headphone and mic  headset , without  the need to use an additional receiver.

It works for both Portapack audio codec platforms : AK4951  / WM8731 . 

Notes 
to avoid user confusions, that audio sound feature is disabled when  user select to hear the receiver demodulated sound  .

In both platforms, when clicking that “Hear Mic” ,  we are changing the default pre-setting to the  ALC or BOOST option that has maximum audio codec gain sound …

Other minor limitations : 
In some ALC (AK) / BOOST (WM) options, we will not feel any acoustic  sound difference. This is correct , not any audio codec fault or bug . It is due to the  the fact , that activating the “audio codec IC loopback function” ,  we can only hear the effect of the audio codec register setting change , not the digital sample  post gain / post attenuation, that we are also applying to the transmitted audio path. 

in AK , we can hear the effect of all ALC option modes , except the OFF-ALC option), because that mode , is not using the digital filter block , and the IC does not allow in that mode audio loopback function. )

![image](https://github.com/eried/portapack-mayhem/assets/86470699/1ea39c16-4002-49cc-9289-a5a84629cadf)

