### PR TITLE
Solve mic to hp small side effect

### DIFF
--- a/firmware/application/apps/ui_mictx.cpp
+++ b/firmware/application/apps/ui_mictx.cpp
@@ -101,8 +101,11 @@ void MicTXView::set_tx(bool enable) {
             transmitting = false;
             configure_baseband();
             transmitter_model.disable();
-            if (rx_enabled)     // If audio RX is enabled and we've been transmitting
-                rxaudio(true);  // Turn back on audio RX
+            if (rx_enabled) {          // If audio RX is enabled and we've been transmitting
+                rxaudio(true);         // Turn back on audio RX
+                vumeter.set_value(0);  // Reset  vumeter
+                vumeter.dirty();       // Force to refresh vumeter.
+            }
         }
     }
 }
@@ -517,8 +520,10 @@ MicTXView::MicTXView(
     check_rxactive.on_select = [this](Checkbox&, bool v) {
         //		vumeter.set_value(0);	//Start with a clean vumeter
         rx_enabled = v;
-        check_mic_to_HP.hidden(rx_enabled);  // Hide or show "Hear Mic" checkbox depending if we activate the receiver (we should better not activate both things)
-        check_mic_to_HP.set_value(false);    // If activate receiver sound , reset the possible activation of "Hear to Mic" .
+        check_mic_to_HP.hidden(rx_enabled);  // Togle Hide / show "Hear Mic" checkbox depending if we activate or not the receiver. (if RX on => no visible "Mic Hear" option)
+        if ((rx_enabled) && (transmitting))
+            check_mic_to_HP.set_value(transmitting);  // Once we activate the "Rx audio" in reception time we disable "Hear Mic", but we allow it again in TX time.
+
         //		check_va.hidden(v); 	//Hide or show voice activation
         rxaudio(v);   // Activate-Deactivate audio RX (receiver) accordingly
         set_dirty();  // Refresh interface

--- a/firmware/application/apps/ui_mictx.cpp
+++ b/firmware/application/apps/ui_mictx.cpp
@@ -662,8 +662,10 @@ MicTXView::~MicTXView() {
     audio::input::stop();
     transmitter_model.set_target_frequency(tx_frequency);
     transmitter_model.disable();
-    if (rx_enabled)  // Also turn off audio rx if enabled
+    if (rx_enabled) {  // Also turn off both (audio rx if enabled, and disable  mic_loop to HP)
         rxaudio(false);
+        audio::input::loopback_mic_to_hp_disable();  // Leave Mic audio off in the main menu (as original audio path, otherwise we had No audio in next "Audio App")
+    }
     baseband::shutdown();
 }
 


### PR DESCRIPTION
Sorry for too many separated PR's about same feature "Mic to HP".
But I found a new side effect, and better to clean and solve it .

This small PR is solving the case of no Audio in RX App , if we prior do the following steps :  
i-) Launch Mic App
ii-)Activate "Mic Hear"   (we start to hear audio Mic, it is OK)
iii-)Activate "Rx Audio"  (we override Mic with receiver demodulated sound , it is OK)

(*1) If we exit the Mic App here ,  (we are still hearing the Mic Sound in the main Menu == > NG.
(*2) if  we launch then Audio RX App , we got no Audio sound ==> NG .

This small PR , is solving both side effects ,  (*1) and (*2) .  I hope no more bugs there....

