### PR TITLE
Mic app enhancements - "Transmitting" icon, PTT TX button always enabled, and persistent settings

### DIFF
--- a/firmware/application/apps/ui_mictx.cpp
+++ b/firmware/application/apps/ui_mictx.cpp
@@ -296,12 +296,10 @@ MicTXView::MicTXView(
     field_frequency.set_step(receiver_model.frequency_step());
     field_frequency.on_change = [this](rf::Frequency f) {
         tx_frequency = f;
-        if (!rx_enabled) {                               // not activated receiver. just update freq TX
+        if (!rx_enabled)
             transmitter_model.set_target_frequency(f);
-        } else {                                         // activated receiver.
-            if (bool_same_F_tx_rx_enabled)               // user selected common freq- TX = RX
-                this->field_rxfrequency.set_value(f);
-        }
+        if (bool_same_F_tx_rx_enabled)
+            this->field_rxfrequency.set_value(f);
     };
     field_frequency.on_edit = [this, &nav]() {
         focused_ui = 0;

--- a/firmware/application/apps/ui_mictx.cpp
+++ b/firmware/application/apps/ui_mictx.cpp
@@ -472,7 +472,7 @@ MicTXView::MicTXView(
             check_mic_to_HP.set_value(transmitting);  // Once we activate the "Rx audio" in reception time we disable "Hear Mic", but we allow it again in TX time.
 
         if (rx_enabled)
-            check_va.set_value(false); 	// Disallow voice activation during RX audio (for now) - Future TODO: Should allow VOX during RX audio
+            check_va.set_value(false);  // Disallow voice activation during RX audio (for now) - Future TODO: Should allow VOX during RX audio
 
         rxaudio(v);   // Activate-Deactivate audio RX (receiver) accordingly
         set_dirty();  // Refresh interface

--- a/firmware/application/apps/ui_mictx.cpp
+++ b/firmware/application/apps/ui_mictx.cpp
@@ -61,7 +61,7 @@ void MicTXView::update_vumeter() {
 }
 
 void MicTXView::update_tx_icon() {
-    tx_icon.set_foreground(transmitting? Color::red() : Color::black());
+    tx_icon.set_foreground(transmitting ? Color::red() : Color::black());
 }
 
 void MicTXView::on_tx_progress(const bool done) {
@@ -210,10 +210,10 @@ MicTXView::MicTXView(
 
     bool wm = (audio::debug::codec_name() == "WM8731");
     add_children({&labels_both,
-                  wm? &labels_WM8731 : &labels_AK4951,  // enable ALC if AK4951
+                  wm ? &labels_WM8731 : &labels_AK4951,  // enable ALC if AK4951
                   &vumeter,
                   &options_gain,  // MIC GAIN float factor on the GUI.
-                  wm? &options_wm8731_boost_mode : &options_ak4951_alc_mode,
+                  wm ? &options_wm8731_boost_mode : &options_ak4951_alc_mode,
                   &check_va,
                   &field_va_level,
                   &field_va_attack,
@@ -420,7 +420,7 @@ MicTXView::MicTXView(
     check_va.on_select = [this](Checkbox&, bool v) {
         va_enabled = v;
         if (va_enabled)
-            check_rxactive.set_value(false);  // Disallow RX-audio in VOX mode (for now) - Future TODO: Should allow voice activation during RX
+            check_rxactive.set_value(false);  // Disallow RX-audio in VOX mode (for now) - Future TODO: Should allow VOX during RX audio
     };
 
     check_rogerbeep.on_select = [this](Checkbox&, bool v) {
@@ -467,12 +467,12 @@ MicTXView::MicTXView(
     check_rxactive.on_select = [this](Checkbox&, bool v) {
         //		vumeter.set_value(0);	//Start with a clean vumeter
         rx_enabled = v;
-        check_mic_to_HP.hidden(rx_enabled);  // Togle Hide / show "Hear Mic" checkbox depending if we activate or not the receiver. (if RX on => no visible "Mic Hear" option)
+        check_mic_to_HP.hidden(rx_enabled);  // Toggle Hide / show "Hear Mic" checkbox depending if we activate or not the receiver. (if RX on => no visible "Mic Hear" option)
         if ((rx_enabled) && (transmitting))
             check_mic_to_HP.set_value(transmitting);  // Once we activate the "Rx audio" in reception time we disable "Hear Mic", but we allow it again in TX time.
 
         if (rx_enabled)
-            check_va.set_value(false); 	//Disable voice activation during RX audio (for now) - Future TODO: Should allow voice activation during RX
+            check_va.set_value(false); 	// Disallow voice activation during RX audio (for now) - Future TODO: Should allow VOX during RX audio
 
         rxaudio(v);   // Activate-Deactivate audio RX (receiver) accordingly
         set_dirty();  // Refresh interface

--- a/firmware/application/apps/ui_mictx.cpp
+++ b/firmware/application/apps/ui_mictx.cpp
@@ -296,7 +296,7 @@ MicTXView::MicTXView(
     field_frequency.set_step(receiver_model.frequency_step());
     field_frequency.on_change = [this](rf::Frequency f) {
         tx_frequency = f;
-        if (!rx_enabled) {  // not activated receiver. just update freq TX
+        if (!rx_enabled) {                               // not activated receiver. just update freq TX
             transmitter_model.set_target_frequency(f);
         } else {                                         // activated receiver.
             if (bool_same_F_tx_rx_enabled)               // user selected common freq- TX = RX
@@ -320,8 +320,8 @@ MicTXView::MicTXView(
     // now, no need direct update, field_rfgain, field_rfamp (it is done in ui_transmitter.cpp)
 
     options_mode.on_change = [this](size_t, int32_t v) {  // { "NFM/FM", 0 }, { " WFM  ", 1 }, { "AM", 2 }, { "USB", 3 }, { "LSB", 4 }, { "DSB", 5 }
-        mic_mode_index = v;
-    
+        mode_index = v;
+
         enable_am = false;
         enable_usb = false;
         enable_lsb = false;
@@ -421,7 +421,7 @@ MicTXView::MicTXView(
         }
         // configure_baseband();
     };
-    options_mode.set_selected_index(mic_mode_index);
+    options_mode.set_selected_index(mode_index);
 
     check_va.on_select = [this](Checkbox&, bool v) {
         va_enabled = v;

--- a/firmware/application/apps/ui_mictx.cpp
+++ b/firmware/application/apps/ui_mictx.cpp
@@ -133,7 +133,8 @@ void MicTXView::set_tx(bool enable) {
             transmitting = false;
             configure_baseband();
             transmitter_model.disable();
-            if (rx_enabled) { 
+
+            if (rx_enabled) {
                 rxaudio(true);  // Turn back on audio RX
 
                 // TODO FIXME: this isn't working: vu meter isn't going to 0:
@@ -198,7 +199,7 @@ void MicTXView::rxaudio(bool enable) {
                 receiver_model.set_modulation(ReceiverModel::Mode::NarrowbandFMAudio);
                 // receiver_model.set_nbfm_configuration(n); is called above, depending user's selection (8k5, 11k, 16k).
                 break;
-             case MIC_MOD_WFM:  // WFM, BW 200Khz aprox, or the two new addional BW filters (180k, 40k)
+            case MIC_MOD_WFM:  // WFM, BW 200Khz aprox, or the two new addional BW filters (180k, 40k)
                 baseband::run_image(portapack::spi_flash::image_tag_wfm_audio);
                 receiver_model.set_modulation(ReceiverModel::Mode::WidebandFMAudio);
                 // receiver_model.set_wfm_configuration(n); is called above, depending user's selection (200k, 180k, 0k).
@@ -466,7 +467,7 @@ MicTXView::MicTXView(
 
         // update bw & tone key visibility - only visible in NFM/WFM modes
         if ((mic_mod_index == MIC_MOD_NFM) || (mic_mod_index == MIC_MOD_WFM)) {
-            field_bw.hidden(false); 
+            field_bw.hidden(false);
             options_tone_key.hidden(false);
         } else {
             field_bw.hidden(true);
@@ -489,9 +490,9 @@ MicTXView::MicTXView(
         set_rxbw_options();
         set_rxbw_defaults(false);
         field_rxbw.hidden(false);
-        set_dirty();                // Refresh display
+        set_dirty();  // Refresh display
 
-        rxaudio(rx_enabled);        // Update now if we have RX audio on
+        rxaudio(rx_enabled);  // Update now if we have RX audio on
         // configure_baseband();
     };
     options_mode.set_selected_index(mic_mod_index);

--- a/firmware/application/apps/ui_mictx.cpp
+++ b/firmware/application/apps/ui_mictx.cpp
@@ -472,7 +472,7 @@ MicTXView::MicTXView(
         } else {
             field_bw.hidden(true);
             options_tone_key.set_selected_index(0);
-            options_tone_key.hidden(true);       
+            options_tone_key.hidden(true);
         }
 
         // update rogerbeep visibility - disable in USB/LSB modes

--- a/firmware/application/apps/ui_mictx.hpp
+++ b/firmware/application/apps/ui_mictx.hpp
@@ -344,7 +344,7 @@ class MicTXView : public View {
         true};
 
     Image tx_icon{
-        {6 * 8, 31 * 8, 16, 16},
+        {6 * 8, (31 * 8) + 4, 16, 16},
         &bitmap_icon_microphone,
         Color::black(),
         Color::black()};

--- a/firmware/application/apps/ui_mictx.hpp
+++ b/firmware/application/apps/ui_mictx.hpp
@@ -286,7 +286,7 @@ class MicTXView : public View {
     Checkbox check_common_freq_tx_rx{
         {18 * 8, (21 * 8) - 7},
         8,
-        "F  TX=RX",
+        "F  RX=TX",
         false};
 
     AudioVolumeField field_volume{

--- a/firmware/application/apps/ui_mictx.hpp
+++ b/firmware/application/apps/ui_mictx.hpp
@@ -86,23 +86,39 @@ class MicTXView : public View {
         1750000 /* bandwidth */,
         sampling_rate /* sampling rate */
     };
-    app_settings::SettingsManager settings_{
-        "tx_mic", app_settings::Mode::RX_TX,
-        app_settings::Options::UseGlobalTargetFrequency};
 
-    bool transmitting{false};
+    // Settings
     bool va_enabled{false};
     bool rogerbeep_enabled{false};
     bool mic_to_HP_enabled{false};
     bool bool_same_F_tx_rx_enabled{false};
     bool rx_enabled{false};
-    uint32_t tone_key_index{};
-    float mic_gain{1.0};
+    uint32_t tone_key_index{0};
+    uint32_t mic_gain_x10{1};
     uint8_t ak4951_alc_and_wm8731_boost_GUI{0};
+    uint32_t va_level{40};
+    uint32_t attack_ms{500};
+    uint32_t decay_ms{1000};
+    app_settings::SettingsManager settings_{
+        "tx_mic",
+        app_settings::Mode::RX_TX,
+        app_settings::Options::UseGlobalTargetFrequency,
+        {
+            {"va_enabled"sv, &va_enabled},
+            {"rogerbeep_enabled"sv, &rogerbeep_enabled},
+            {"mic_to_HP_enabled"sv, &mic_to_HP_enabled},
+            {"bool_same_F_tx_rx_enabled"sv, &bool_same_F_tx_rx_enabled},
+            {"rx_enabled"sv, &rx_enabled},
+            {"tone_key_index"sv, &tone_key_index},
+            {"mic_gain_x10"sv, &mic_gain_x10},
+            {"ak4951_alc_and_wm8731_boost_GUI"sv, &ak4951_alc_and_wm8731_boost_GUI},
+            {"va_level"sv, &va_level},
+            {"attack_ms"sv, &attack_ms},
+            {"decay_ms"sv, &decay_ms},
+        }};
+
+    bool transmitting{false};
     uint32_t audio_level{0};
-    uint32_t va_level{};
-    uint32_t attack_ms{};
-    uint32_t decay_ms{};
     uint32_t attack_timer{0};
     uint32_t decay_timer{0};
     int32_t tx_gain{47};

--- a/firmware/application/apps/ui_mictx.hpp
+++ b/firmware/application/apps/ui_mictx.hpp
@@ -89,7 +89,7 @@ class MicTXView : public View {
         sampling_rate /* sampling rate */
     };
 
-    enum Mic_Modulation:uint32_t {
+    enum Mic_Modulation : uint32_t {
         MIC_MOD_NFM = 0,
         MIC_MOD_WFM,
         MIC_MOD_AM,

--- a/firmware/application/apps/ui_mictx.hpp
+++ b/firmware/application/apps/ui_mictx.hpp
@@ -88,6 +88,8 @@ class MicTXView : public View {
     };
 
     // Settings
+    uint32_t mic_mode_index{0};
+    uint32_t rxbw_index{0};
     bool va_enabled{false};
     bool rogerbeep_enabled{false};
     bool mic_to_HP_enabled{false};
@@ -104,6 +106,8 @@ class MicTXView : public View {
         app_settings::Mode::RX_TX,
         app_settings::Options::UseGlobalTargetFrequency,
         {
+            {"mic_mode_index"sv, &mic_mode_index},
+            {"rxbw_index"sv, &rxbw_index},
             {"va_enabled"sv, &va_enabled},
             {"rogerbeep_enabled"sv, &rogerbeep_enabled},
             {"mic_to_HP_enabled"sv, &mic_to_HP_enabled},
@@ -117,6 +121,7 @@ class MicTXView : public View {
             {"decay_ms"sv, &decay_ms},
         }};
 
+    bool use_app_settings{false};
     bool transmitting{false};
     uint32_t audio_level{0};
     uint32_t attack_timer{0};

--- a/firmware/application/apps/ui_mictx.hpp
+++ b/firmware/application/apps/ui_mictx.hpp
@@ -91,11 +91,11 @@ class MicTXView : public View {
 
     enum Mic_Modulation : uint32_t {
         MIC_MOD_NFM = 0,
-        MIC_MOD_WFM,
-        MIC_MOD_AM,
-        MIC_MOD_DSB,
-        MIC_MOD_USB,
-        MIC_MOD_LSB
+        MIC_MOD_WFM = 1,
+        MIC_MOD_AM = 2,
+        MIC_MOD_USB = 3,
+        MIC_MOD_LSB = 4,
+        MIC_MOD_DSB = 5,
     };
 
     // Settings
@@ -227,12 +227,12 @@ class MicTXView : public View {
         {24 * 8, 5 * 8},
         6,
         {
-            {"NFM/FM", 0},
-            {" WFM  ", 1},
-            {"  AM  ", 2},  // in fact that TX mode = AM -DSB with carrier.
-            {" USB  ", 3},
-            {" LSB  ", 4},
-            {"DSB-SC", 5}  // We are TX Double Side AM Band with suppressed carrier, and allowing in RX both indep SSB lateral band (USB/LSB).
+            {"NFM/FM", MIC_MOD_NFM},
+            {" WFM  ", MIC_MOD_WFM},
+            {"  AM  ", MIC_MOD_AM},  // in fact that TX mode = AM -DSB with carrier.
+            {" USB  ", MIC_MOD_USB},
+            {" LSB  ", MIC_MOD_LSB},
+            {"DSB-SC", MIC_MOD_DSB}  // We are TX Double Side AM Band with suppressed carrier, and allowing in RX both indep SSB lateral band (USB/LSB).
         }};
 
     Checkbox check_va{
@@ -344,7 +344,7 @@ class MicTXView : public View {
         true};
 
     Image tx_icon{
-        {6 * 8, (31 * 8) + 4, 16, 16},
+        {6 * 8, 31 * 8 + 4, 16, 16},
         &bitmap_icon_microphone,
         Color::black(),
         Color::black()};

--- a/firmware/application/apps/ui_mictx.hpp
+++ b/firmware/application/apps/ui_mictx.hpp
@@ -219,7 +219,7 @@ class MicTXView : public View {
         {3 * 8, 8 * 7},
         10,
         "VOX enable",
-        false};        
+        false};
 
     NumberField field_va_level{
         {8 * 8, 10 * 8},

--- a/firmware/application/apps/ui_mictx.hpp
+++ b/firmware/application/apps/ui_mictx.hpp
@@ -88,7 +88,7 @@ class MicTXView : public View {
     };
 
     // Settings
-    uint32_t mic_mode_index{0};
+    uint32_t mode_index{0};
     uint32_t rxbw_index{0};
     bool va_enabled{false};
     bool rogerbeep_enabled{false};
@@ -106,7 +106,7 @@ class MicTXView : public View {
         app_settings::Mode::RX_TX,
         app_settings::Options::UseGlobalTargetFrequency,
         {
-            {"mic_mode_index"sv, &mic_mode_index},
+            {"mode_index"sv, &mode_index},
             {"rxbw_index"sv, &rxbw_index},
             {"va_enabled"sv, &va_enabled},
             {"rogerbeep_enabled"sv, &rogerbeep_enabled},

--- a/firmware/application/apps/ui_mictx.hpp
+++ b/firmware/application/apps/ui_mictx.hpp
@@ -73,11 +73,13 @@ class MicTXView : public View {
     bool tx_button_held();
     void do_timing();
     void set_tx(bool enable);
-    //	void on_target_frequency_changed(rf::Frequency f);
     void on_tx_progress(const bool done);
     void update_tx_icon();
+    uint8_t shift_bits(void);
     void configure_baseband();
-
+    void set_rxbw_options(void);
+    void set_rxbw_defaults(bool use_app_settings);
+    void update_receiver_rxbw(void);
     void rxaudio(bool is_on);
 
     RxRadioState rx_radio_state_{};
@@ -87,13 +89,23 @@ class MicTXView : public View {
         sampling_rate /* sampling rate */
     };
 
+    enum Mic_Modulation:uint32_t {
+        MIC_MOD_NFM = 0,
+        MIC_MOD_WFM,
+        MIC_MOD_AM,
+        MIC_MOD_DSB,
+        MIC_MOD_USB,
+        MIC_MOD_LSB
+    };
+
     // Settings
-    uint32_t mode_index{0};
+    uint32_t mic_mod_index{0};
     uint32_t rxbw_index{0};
     bool va_enabled{false};
     bool rogerbeep_enabled{false};
     bool mic_to_HP_enabled{false};
     bool bool_same_F_tx_rx_enabled{false};
+    rf::Frequency rx_frequency{0};
     bool rx_enabled{false};
     uint32_t tone_key_index{0};
     uint32_t mic_gain_x10{1};
@@ -106,44 +118,31 @@ class MicTXView : public View {
         app_settings::Mode::RX_TX,
         app_settings::Options::UseGlobalTargetFrequency,
         {
-            {"mode_index"sv, &mode_index},
+            {"mic_mod_index"sv, &mic_mod_index},
             {"rxbw_index"sv, &rxbw_index},
-            {"va_enabled"sv, &va_enabled},
-            {"rogerbeep_enabled"sv, &rogerbeep_enabled},
-            {"mic_to_HP_enabled"sv, &mic_to_HP_enabled},
-            {"bool_same_F_tx_rx_enabled"sv, &bool_same_F_tx_rx_enabled},
+            {"same_F_tx_rx"sv, &bool_same_F_tx_rx_enabled},
+            {"mic_rx_frequency"sv, &rx_frequency},
             {"rx_enabled"sv, &rx_enabled},
-            {"tone_key_index"sv, &tone_key_index},
             {"mic_gain_x10"sv, &mic_gain_x10},
-            {"ak4951_alc_and_wm8731_boost_GUI"sv, &ak4951_alc_and_wm8731_boost_GUI},
+            {"mic_to_HP"sv, &mic_to_HP_enabled},
+            {"alc_and_boost"sv, &ak4951_alc_and_wm8731_boost_GUI},
             {"va_level"sv, &va_level},
             {"attack_ms"sv, &attack_ms},
             {"decay_ms"sv, &decay_ms},
+            {"vox"sv, &va_enabled},
+            {"rogerbeep"sv, &rogerbeep_enabled},
+            {"tone_key_index"sv, &tone_key_index},
         }};
 
-    bool use_app_settings{false};
+    rf::Frequency tx_frequency{0};
     bool transmitting{false};
     uint32_t audio_level{0};
     uint32_t attack_timer{0};
     uint32_t decay_timer{0};
     int32_t tx_gain{47};
     bool rf_amp{false};
-    int32_t rx_lna{32};
-    int32_t rx_vga{32};
-    bool rx_amp{false};
-    rf::Frequency tx_frequency{0};
-    rf::Frequency rx_frequency{0};
     int32_t focused_ui{2};
     bool button_touch{false};
-    uint8_t shift_bits_s16{4};  // shift bits factor to the captured ADC S16 audio sample.
-
-    // AM TX Stuff
-    // TODO: Some of this stuff is mutually exclusive. Need a better representation.
-    bool enable_am{false};
-    bool enable_dsb{false};
-    bool enable_usb{false};
-    bool enable_lsb{false};
-    bool enable_wfm{false};  // added to distinguish in the FM mode, RX BW : NFM (8K5, 11K), FM (16K), WFM(200K)
 
     Labels labels_both{
         {{3 * 8, 1 * 8}, "MIC-GAIN:", Color::light_grey()},


### PR DESCRIPTION
Proposing the following changes (see enhancement #1525):

1.  Added an icon to the screen to indicate when Transmitting.  I find this helpful in VOX (voice activated transmit) mode.

2.  Allow PTT TX button to be pressed any time, whether VOX mode is enabled or not.  (Pressing TX button and VOX are now functional at same time; either one activates TX, and TX doesn't stop until both TX released and VOX audio level is low enough [if VOX is enabled]).

3.  Changed "Transmit activation" from an OptionsField back to a "VOX enable" Checkbox.  IMO, I didn't see any need for the "OFF" mode in the Mic app, since it's the same as the user not pressing the TX button.

4.  As in existing code, RX Audio and VOX cannot be enabled at the same time, as this feature hasn't been implemented yet.  To indicate this, only one of these two check boxes can be selected (the other is automatically deselected).

5.  Clean-up of duplicated declarations between WM8751 & AK4951.

6.  Persist Mic App settings across runs.  (Except the TX_frequency; see NOTE below)

7.  Squelch level now has same meaning as in Audio & POCSAG RX apps.  (There is still an inconsistency between some apps; should 0 or 100 mean no squelch?)   Also hide unsupported squelch value in modes other than NFM.

8.  Added enum's for the modulation modes.

9.  Changed "F TX=RX" checkbox description to "F RX=TX", since setting it causes the RX frequency to be updated, not the TX frequency.

NOTE that the TX frequency comes from the "global target frequency" stored in persistent memory so it currently gets carried over from the previous app executed, NOT from app settings.  (May fix this in future)

An updated test version has been posted on Discord with all changes above.  Feedback requested.  @Brumi-2021 

5th test version on Discord:
https://discord.com/channels/719669764804444213/722101917135798312/1168704812305621043