### PR TITLE
Improve blacklist to require precise app name matches

### DIFF
--- a/firmware/application/ui/ui_btngrid.cpp
+++ b/firmware/application/ui/ui_btngrid.cpp
@@ -246,13 +246,22 @@ void load_blacklist() {
     if (error)
         return;
 
-    blacklist_ptr = std::unique_ptr<char>(new char[f.size()]);
+    // allocating one extra byte for trailing comma
+    blacklist_ptr = std::unique_ptr<char>(new char[f.size() + 1]);
     if (f.read(blacklist_ptr.get(), f.size()))
-        blacklist_len = f.size();
+        blacklist_len = f.size() + 1;
+
+    // replace any CR/LF characters with commas to simplify searching
+    char* ptr = (char *)blacklist_ptr.get();
+    for (size_t i = 0; i < f.size(); i++, ptr++) {
+        if (*ptr == 0x0D || *ptr == 0x0A)
+            *ptr = ',';
+    }
+    *ptr = ',';
 }
 
 bool BtnGridView::blacklisted_app(GridItem new_item) {
-    std::string app_name = new_item.text;
+    std::string app_name = new_item.text + ",";
 
     if (blacklist_len < app_name.size())
         return false;

--- a/firmware/application/ui/ui_btngrid.cpp
+++ b/firmware/application/ui/ui_btngrid.cpp
@@ -252,7 +252,7 @@ void load_blacklist() {
         blacklist_len = f.size() + 2;
 
         // replace any CR/LF characters with comma delineator, and add comma prefix/suffix, to simplify searching
-        char* ptr = (char*)blacklist_ptr.get();
+        char* ptr = blacklist_ptr.get();
         *ptr = ',';
         *(ptr + blacklist_len - 1) = ',';
         for (size_t i = 0; i < blacklist_len; i++, ptr++) {

--- a/firmware/application/ui/ui_btngrid.cpp
+++ b/firmware/application/ui/ui_btngrid.cpp
@@ -246,7 +246,7 @@ void load_blacklist() {
     if (error)
         return;
 
-    // allocating one extra byte for trailing comma
+    // allocating two extra bytes for leading & trailing commas
     blacklist_ptr = std::unique_ptr<char>(new char[f.size() + 2]);
     if (f.read(blacklist_ptr.get() + 1, f.size())) {
         blacklist_len = f.size() + 2;

--- a/firmware/application/ui/ui_btngrid.cpp
+++ b/firmware/application/ui/ui_btngrid.cpp
@@ -248,16 +248,17 @@ void load_blacklist() {
 
     // allocating one extra byte for trailing comma
     blacklist_ptr = std::unique_ptr<char>(new char[f.size() + 2]);
-    if (f.read(blacklist_ptr.get() + 1, f.size()))
+    if (f.read(blacklist_ptr.get() + 1, f.size())) {
         blacklist_len = f.size() + 2;
 
-    // replace any CR/LF characters with comma delineator, and add comma prefix/suffix, to simplify searching
-    char* ptr = (char *)blacklist_ptr.get();
-    *ptr = ',';
-    *(ptr + blacklist_len - 1) = ',';
-    for (size_t i = 0; i < blacklist_len; i++, ptr++) {
-        if (*ptr == 0x0D || *ptr == 0x0A)
-            *ptr = ',';
+        // replace any CR/LF characters with comma delineator, and add comma prefix/suffix, to simplify searching
+        char* ptr = (char *)blacklist_ptr.get();
+        *ptr = ',';
+        *(ptr + blacklist_len - 1) = ',';
+        for (size_t i = 0; i < blacklist_len; i++, ptr++) {
+            if (*ptr == 0x0D || *ptr == 0x0A)
+                *ptr = ',';
+        }
     }
 }
 

--- a/firmware/application/ui/ui_btngrid.cpp
+++ b/firmware/application/ui/ui_btngrid.cpp
@@ -252,7 +252,7 @@ void load_blacklist() {
         blacklist_len = f.size() + 2;
 
         // replace any CR/LF characters with comma delineator, and add comma prefix/suffix, to simplify searching
-        char* ptr = (char *)blacklist_ptr.get();
+        char* ptr = (char*)blacklist_ptr.get();
         *ptr = ',';
         *(ptr + blacklist_len - 1) = ',';
         for (size_t i = 0; i < blacklist_len; i++, ptr++) {

--- a/firmware/application/ui/ui_btngrid.cpp
+++ b/firmware/application/ui/ui_btngrid.cpp
@@ -247,21 +247,22 @@ void load_blacklist() {
         return;
 
     // allocating one extra byte for trailing comma
-    blacklist_ptr = std::unique_ptr<char>(new char[f.size() + 1]);
-    if (f.read(blacklist_ptr.get(), f.size()))
-        blacklist_len = f.size() + 1;
+    blacklist_ptr = std::unique_ptr<char>(new char[f.size() + 2]);
+    if (f.read(blacklist_ptr.get() + 1, f.size()))
+        blacklist_len = f.size() + 2;
 
-    // replace any CR/LF characters with commas to simplify searching
+    // replace any CR/LF characters with comma delineator, and add comma prefix/suffix, to simplify searching
     char* ptr = (char *)blacklist_ptr.get();
-    for (size_t i = 0; i < f.size(); i++, ptr++) {
+    *ptr = ',';
+    *(ptr + blacklist_len - 1) = ',';
+    for (size_t i = 0; i < blacklist_len; i++, ptr++) {
         if (*ptr == 0x0D || *ptr == 0x0A)
             *ptr = ',';
     }
-    *ptr = ',';
 }
 
 bool BtnGridView::blacklisted_app(GridItem new_item) {
-    std::string app_name = new_item.text + ",";
+    std::string app_name = "," + new_item.text + ",";
 
     if (blacklist_len < app_name.size())
         return false;


### PR DESCRIPTION
Require exact app name match when searching blacklist file.

Fixes an issue with the ADS-B app being hidden when "ADS-B TX" is in the blacklist file.

Note that this now requires app names in the blacklist file to be listed on separate lines or be comma separated, and lines should not contain any other characters such as spaces, tabs, or comments.

Test version of firmware attached if you'd like to try it:
[portapack-h1_h2-mayhem.bin.zip](https://github.com/eried/portapack-mayhem/files/13184936/portapack-h1_h2-mayhem.bin.zip)