### PR TITLE
Preallocate enough vectors for common app settings

### DIFF
--- a/firmware/application/app_settings.cpp
+++ b/firmware/application/app_settings.cpp
@@ -250,7 +250,7 @@ SettingsManager::SettingsManager(
     settings_.options = options;
 
     // Pre-alloc enough for app settings and additional settings.
-    additional_settings.reserve(17 + additional_settings.size());
+    additional_settings.reserve(COMMON_APP_SETTINGS_COUNT + additional_settings.size());
     bindings_ = std::move(additional_settings);
 
     // Settings should always be loaded because apps now rely

--- a/firmware/application/app_settings.hpp
+++ b/firmware/application/app_settings.hpp
@@ -42,6 +42,8 @@
 // Bring in the string_view literal.
 using std::literals::operator""sv;
 
+#define COMMON_APP_SETTINGS_COUNT 19
+
 /* Represents a named setting bound to a variable instance. */
 /* Using void* instead of std::variant, because variant is a pain to dispatch over. */
 class BoundSetting {
@@ -143,8 +145,8 @@ struct AppSettings {
     uint8_t nbfm_config_index = 0;
     uint8_t wfm_config_index = 0;
     uint8_t squelch = 80;
-
     uint8_t volume;
+    // NOTE: update COMMON_APP_SETTINGS_COUNT when adding to this
 };
 
 /* Copies common values to the receiver/transmitter models. */


### PR DESCRIPTION
Looks like a few more app settings were added but the hard-coded count in app_settings.hpp wasn't incremented.  I added a #define which might help to remind us.