### PR TITLE
Level RSSIGraph tuning

### DIFF
--- a/firmware/application/apps/ui_level.cpp
+++ b/firmware/application/apps/ui_level.cpp
@@ -142,31 +142,24 @@ LevelView::LevelView(NavigationView& nav)
 }
 
 void LevelView::on_statistics_update(const ChannelStatistics& statistics) {
-    static int last_max_db = -1000;
-    static int last_min_rssi = -1000;
-    static int last_avg_rssi = -1000;
-    static int last_max_rssi = -1000;
+    static int16_t last_max_db = -1000;
+    static int16_t last_min_rssi = -1000;
+    static int16_t last_avg_rssi = -1000;
+    static int16_t last_max_rssi = -1000;
 
     rssi_graph.add_values(rssi.get_min(), rssi.get_avg(), rssi.get_max(), statistics.max_db);
 
-    bool refresh_db = false;
-    bool refresh_rssi = false;
-
+    // refresh db
     if (last_max_db != statistics.max_db) {
-        refresh_db = true;
-    }
-    if (last_min_rssi != rssi.get_min() || last_avg_rssi != rssi.get_avg() || last_max_rssi != rssi.get_max()) {
-        refresh_rssi = true;
-    }
-    if (refresh_db) {
         last_max_db = statistics.max_db;
         freq_stats_db.set("Power: " + to_string_dec_int(statistics.max_db) + " db");
     }
-    if (refresh_rssi) {
-        last_min_rssi = rssi.get_min();
-        last_avg_rssi = rssi.get_avg();
-        last_max_rssi = rssi.get_max();
-        freq_stats_rssi.set("RSSI: " + to_string_dec_int(rssi.get_min()) + "/" + to_string_dec_int(rssi.get_avg()) + "/" + to_string_dec_int(rssi.get_max()) + ",dt: " + to_string_dec_int(rssi.get_delta()));
+    // refresh rssi
+    if (last_min_rssi != rssi_graph.get_graph_min() || last_avg_rssi != rssi_graph.get_graph_avg() || last_max_rssi != rssi_graph.get_graph_max()) {
+        last_min_rssi = rssi_graph.get_graph_min();
+        last_avg_rssi = rssi_graph.get_graph_avg();
+        last_max_rssi = rssi_graph.get_graph_max();
+        freq_stats_rssi.set("RSSI: " + to_string_dec_int(last_min_rssi) + "/" + to_string_dec_int(last_avg_rssi) + "/" + to_string_dec_int(last_max_rssi) + ",dt: " + to_string_dec_int(rssi_graph.get_graph_delta()));
     }
 } /* on_statistic_updates */
 

--- a/firmware/application/ui/ui_rssi.cpp
+++ b/firmware/application/ui/ui_rssi.cpp
@@ -30,6 +30,10 @@
 #define max(a, b) ((a) > (b) ? (a) : (b))
 #define abs(x) ((x) > 0 ? (x) : -(x))
 
+// flag value for graph min
+// If it does not change, then all graph min values are is zero
+#define GRAPH_MIN_ALL_ZERO_FLAG 666
+
 namespace ui {
 
 RSSI::RSSI(
@@ -234,7 +238,7 @@ void RSSIGraph::paint(Painter& painter) {
     int xpos = 0, prev_xpos = r.width();
     RSSIGraph_entry& prev_entry = graph_list[0];
 
-    graph_min_ = 666;  // if it stays at that value the whole graphlist min are zero
+    graph_min_ = GRAPH_MIN_ALL_ZERO_FLAG;  // if it stays at that value the whole graphlist min are zero
     graph_max_ = 0;
     int avg_sum = 0;
     for (int n = 1; (unsigned)n <= graph_list.size(); n++) {
@@ -326,7 +330,7 @@ void RSSIGraph::paint(Painter& painter) {
     }
     graph_avg_ = (avg_sum / graph_list.size());
     // hack to only set to 0 if all graphlist min values are 0
-    if (graph_min_ == 666)
+    if (graph_min_ == GRAPH_MIN_ALL_ZERO_FLAG)
         graph_min_ = 0;
 }
 

--- a/firmware/application/ui/ui_rssi.cpp
+++ b/firmware/application/ui/ui_rssi.cpp
@@ -233,8 +233,9 @@ void RSSIGraph::paint(Painter& painter) {
 
     int xpos = 0, prev_xpos = r.width();
     RSSIGraph_entry& prev_entry = graph_list[0];
-    graph_min_ = prev_entry.rssi_min;
-    graph_max_ = prev_entry.rssi_max;
+
+    graph_min_ = 666;  // if it stays at that value the whole graphlist min are zero
+    graph_max_ = 0;
     int avg_sum = 0;
     for (int n = 1; (unsigned)n <= graph_list.size(); n++) {
         xpos = (r.width() * (graph_list.size() - n)) / graph_list.size();
@@ -242,7 +243,7 @@ void RSSIGraph::paint(Painter& painter) {
         RSSIGraph_entry& entry = graph_list[n - 1];
 
         // stats
-        if (entry.rssi_min < graph_min_) {
+        if (entry.rssi_min != 0 && entry.rssi_min < graph_min_) {
             graph_min_ = entry.rssi_min;
         }
         if (entry.rssi_max > graph_max_) {
@@ -324,6 +325,9 @@ void RSSIGraph::paint(Painter& painter) {
         prev_xpos = xpos;
     }
     graph_avg_ = (avg_sum / graph_list.size());
+    // hack to only set to 0 if all graphlist min values are 0
+    if (graph_min_ == 666)
+        graph_min_ = 0;
 }
 
 /*void RSSIGraph::paintOld(Painter& painter) {

--- a/firmware/application/ui/ui_rssi.cpp
+++ b/firmware/application/ui/ui_rssi.cpp
@@ -209,16 +209,44 @@ void RSSI::on_statistics_update(const RSSIStatistics& statistics) {
     set_dirty();
 }
 
+int16_t RSSIGraph::get_graph_min() {
+    return graph_min_;
+}
+
+int16_t RSSIGraph::get_graph_avg() {
+    return graph_avg_;
+}
+
+int16_t RSSIGraph::get_graph_max() {
+    return graph_max_;
+}
+
+int16_t RSSIGraph::get_graph_delta() {
+    return graph_max_ - graph_min_;
+}
+
 void RSSIGraph::paint(Painter& painter) {
     const auto r = screen_rect();
 
     RSSIGraph_entry& prev_entry = graph_list[0];
     int xpos = 0, prev_xpos = r.width();
 
+    graph_min_ = 250;
+    graph_max_ = -250;
+    int avg_sum = 0;
     for (int n = 1; (unsigned)n <= graph_list.size(); n++) {
         xpos = (r.width() * (graph_list.size() - n)) / graph_list.size();
         int size = abs(xpos - prev_xpos);
         RSSIGraph_entry& entry = graph_list[n - 1];
+
+        // stats
+        if (entry.rssi_min < graph_min_) {
+            graph_min_ = entry.rssi_min;
+        }
+        if (entry.rssi_max > graph_max_) {
+            graph_max_ = entry.rssi_max;
+        }
+        avg_sum += entry.rssi_avg;
 
         // black
         const Rect r0{r.right() - prev_xpos, r.top(), size, r.height()};
@@ -293,6 +321,7 @@ void RSSIGraph::paint(Painter& painter) {
         prev_entry = entry;
         prev_xpos = xpos;
     }
+    graph_avg_ = (avg_sum / graph_list.size());
 }
 
 /*void RSSIGraph::paintOld(Painter& painter) {

--- a/firmware/application/ui/ui_rssi.cpp
+++ b/firmware/application/ui/ui_rssi.cpp
@@ -228,11 +228,13 @@ int16_t RSSIGraph::get_graph_delta() {
 void RSSIGraph::paint(Painter& painter) {
     const auto r = screen_rect();
 
-    RSSIGraph_entry& prev_entry = graph_list[0];
-    int xpos = 0, prev_xpos = r.width();
+    if (graph_list.size() == 0)
+        return;
 
-    graph_min_ = 250;
-    graph_max_ = -250;
+    int xpos = 0, prev_xpos = r.width();
+    RSSIGraph_entry& prev_entry = graph_list[0];
+    graph_min_ = prev_entry.rssi_min;
+    graph_max_ = prev_entry.rssi_max;
     int avg_sum = 0;
     for (int n = 1; (unsigned)n <= graph_list.size(); n++) {
         xpos = (r.width() * (graph_list.size() - n)) / graph_list.size();

--- a/firmware/application/ui/ui_rssi.hpp
+++ b/firmware/application/ui/ui_rssi.hpp
@@ -49,6 +49,7 @@ class RSSI : public Widget {
         : RSSI{{}, {}} {
     }
 
+    // get last used/received min/avg/max/delta
     int16_t get_min();
     int16_t get_avg();
     int16_t get_max();
@@ -113,8 +114,16 @@ class RSSIGraph : public Widget {
 
     void on_hide() override;
     void on_show() override;
+    // get whole graph_list min/avg/max/delta
+    int16_t get_graph_min();
+    int16_t get_graph_avg();
+    int16_t get_graph_max();
+    int16_t get_graph_delta();
 
    private:
+    int16_t graph_min_ = 0;
+    int16_t graph_avg_ = 0;
+    int16_t graph_max_ = 0;
     uint16_t nb_columns_before_hide = 16;
     uint16_t nb_columns = 16;
     RSSIGraphList graph_list{};


### PR DESCRIPTION
As I needed to use the Level app for portapack comparisons, it appeared that the displayed RSSI value are not easily usable as they were actually the last received value and not the last displayed value.

I changed this in Level app, so no RSSI: min/avg/max is giving you the value of the whole displayed graph, not the last up to date one (not really usable as signals are giggling)

Now no more giggle: you quickly see min/max/med stabilizing and can use the values