### PR TITLE
Temperature scaling changes for HackRF r9 (MAX2839)

### DIFF
--- a/firmware/application/apps/ui_debug.cpp
+++ b/firmware/application/apps/ui_debug.cpp
@@ -124,8 +124,8 @@ void TemperatureWidget::paint(Painter& painter) {
 }
 
 TemperatureWidget::temperature_t TemperatureWidget::temperature(const sample_t sensor_value) const {
-    /*It seems to be a temperature difference of 25C*/
-    return -40 + (sensor_value * 4.31) + 25;  // max2837 datasheet temp 25ºC has sensor value: 15
+    // Scaling is different for MAX2837 vs MAX2839 so it's now done in the respective chip-specific module
+    return sensor_value;
 }
 
 std::string TemperatureWidget::temperature_str(const temperature_t temperature) const {

--- a/firmware/application/hw/max2837.cpp
+++ b/firmware/application/hw/max2837.cpp
@@ -321,7 +321,7 @@ void MAX2837::set_rx_buff_vcm(const size_t v) {
     flush();
 }
 
-reg_t MAX2837::temp_sense() {
+int8_t MAX2837::temp_sense() {
     if (!_map.r.rx_top.ts_en) {
         _map.r.rx_top.ts_en = 1;
         flush_one(Register::RX_TOP);
@@ -334,12 +334,15 @@ reg_t MAX2837::temp_sense() {
 
     halPolledDelay(ticks_for_temperature_sense_adc_conversion);
 
-    const auto value = read(Register::TEMP_SENSE);
+    /*
+     * Conversion to degrees C determined by testing - does not match data sheet.
+     */
+    reg_t value = read(Register::TEMP_SENSE) & 0x1F;
 
     _map.r.rx_top.ts_adc_trigger = 0;
     flush_one(Register::RX_TOP);
 
-    return value;
+    return value * 4.31 - 6;  // reg value is 0 to 31; possible return range is -6 C to 127 C
 }
 
 }  // namespace max2837

--- a/firmware/application/hw/max2837.hpp
+++ b/firmware/application/hw/max2837.hpp
@@ -833,7 +833,7 @@ class MAX2837 : public MAX283x {
     void set_vco_bias(const size_t v);
     void set_rx_buff_vcm(const size_t v) override;
 
-    reg_t temp_sense() override;
+    int8_t temp_sense() override;
 
     reg_t read(const address_t reg_num) override;
 

--- a/firmware/application/hw/max2839.cpp
+++ b/firmware/application/hw/max2839.cpp
@@ -351,7 +351,7 @@ void MAX2839::set_rx_buff_vcm(const size_t v) {
     flush();
 }
 
-reg_t MAX2839::temp_sense() {
+int8_t MAX2839::temp_sense() {
     if (!_map.r.rx_top_2.ts_en) {
         _map.r.rx_top_2.ts_en = 1;
         flush_one(Register::RX_TOP_2);
@@ -365,15 +365,14 @@ reg_t MAX2839::temp_sense() {
     halPolledDelay(ticks_for_temperature_sense_adc_conversion);
 
     /*
-     * Things look very similar to MAX2837, so this probably works, but the
-     * MAX2839 data sheet does not describe the TEMP_SENSE register contents.
+     * Conversion to degrees C determined by testing - does not match data sheet.
      */
-    const auto value = read(Register::TEMP_SENSE);
+    reg_t value = read(Register::TEMP_SENSE) & 0x1F;
 
     _map.r.rx_top_2.ts_adc_trigger = 0;
     flush_one(Register::RX_TOP_2);
 
-    return value;
+    return value * 4.31 - 75;  // reg value is 0 to 31; possible return range is -75 C to 58 C
 }
 
 }  // namespace max2839

--- a/firmware/application/hw/max2839.hpp
+++ b/firmware/application/hw/max2839.hpp
@@ -692,7 +692,7 @@ class MAX2839 : public MAX283x {
     void set_rx_lo_iq_calibration(const size_t v) override;
     void set_rx_buff_vcm(const size_t v) override;
 
-    reg_t temp_sense() override;
+    int8_t temp_sense() override;
 
     reg_t read(const address_t reg_num) override;
 

--- a/firmware/application/hw/max283x.hpp
+++ b/firmware/application/hw/max283x.hpp
@@ -131,7 +131,7 @@ class MAX283x {
     virtual void set_rx_lo_iq_calibration(const size_t v);
     virtual void set_rx_buff_vcm(const size_t v);
 
-    virtual reg_t temp_sense();
+    virtual int8_t temp_sense();
 
     virtual reg_t read(const address_t reg_num);
 };

--- a/firmware/application/radio.cpp
+++ b/firmware/application/radio.cpp
@@ -295,8 +295,8 @@ uint32_t register_read(const size_t register_number) {
     return radio::second_if->read(register_number);
 }
 
-uint8_t temp_sense() {
-    return radio::second_if->temp_sense() & 0x1f;
+int8_t temp_sense() {
+    return radio::second_if->temp_sense();
 }
 
 } /* namespace second_if */

--- a/firmware/application/radio.hpp
+++ b/firmware/application/radio.hpp
@@ -73,7 +73,7 @@ namespace second_if {
 uint32_t register_read(const size_t register_number);
 
 // TODO: This belongs somewhere else.
-uint8_t temp_sense();
+int8_t temp_sense();
 
 } /* namespace second_if */
 

--- a/firmware/application/temperature_logger.hpp
+++ b/firmware/application/temperature_logger.hpp
@@ -29,7 +29,7 @@
 
 class TemperatureLogger {
    public:
-    using sample_t = uint8_t;
+    using sample_t = int8_t;
 
     void second_tick();
 


### PR DESCRIPTION
Fixes issue #1552 

It seems that the temperature register values don't match the datasheet for EITHER the MAX2837 or MAX2839 (the original MAX2837 scaling code didn't match the datasheet either), and values returned are vastly different between these two chips.

I've tweaked the code to more closely follow the actual chip temperature of my own boards.

Although the 4-5 degree granularity is very inaccurate to begin with, we could add a board-specific calibration setting to be saved in Pmem in a future PR -- if necessary.

A test version is available here on Discord:
https://discord.com/channels/719669764804444213/722101917135798312/1171146654922068018