### PR TITLE
ADSB RX App cleanup

### DIFF
--- a/firmware/application/apps/ui_adsb_rx.cpp
+++ b/firmware/application/apps/ui_adsb_rx.cpp
@@ -444,7 +444,7 @@ void ADSBRxView::on_tick_second() {
         update_recent_entries();
 }
 
-void ADSBRxView::update_details_and_map(int ageStep) {
+void ADSBRxView::update_details_and_map(int age_delta) {
     ui::GeoMarker marker;
     bool storeNewMarkers = false;
 
@@ -460,7 +460,7 @@ void ADSBRxView::update_details_and_map(int ageStep) {
 
     // Calculate if it is time to update markers
     if (send_updates && details_view && details_view->geomap_view) {
-        ticksSinceMarkerRefresh += ageStep;
+        ticksSinceMarkerRefresh += age_delta;
         if (ticksSinceMarkerRefresh >= MARKER_UPDATE_SECONDS) {  // Update other aircraft every few seconds
             storeNewMarkers = true;
             ticksSinceMarkerRefresh = 0;
@@ -475,9 +475,10 @@ void ADSBRxView::update_details_and_map(int ageStep) {
     if (otherMarkersCanBeSent) {
         details_view->geomap_view->clear_markers();
     }
+    
     // Loop through all entries
     for (auto& entry : recent) {
-        entry.inc_age(ageStep);
+        entry.inc_age(age_delta);
 
         // Only if there is a details view
         if (send_updates && details_view) {

--- a/firmware/application/apps/ui_adsb_rx.cpp
+++ b/firmware/application/apps/ui_adsb_rx.cpp
@@ -235,6 +235,7 @@ ADSBRxDetailsView::ADSBRxDetailsView(
 
     // The following won't change for a given airborne aircraft.
     // Try getting the airline's name from airlines.db.
+    // NB: Only works once callsign has been read and won't be updated.
     std::database db;
     std::database::AirlinesDBRecord airline_record;
     std::string airline_code = entry_.callsign.substr(0, 3);
@@ -397,7 +398,7 @@ void ADSBRxView::on_frame(const ADSBFrameMessage* message) {
     rtcGetTime(&RTCD1, &datetime);
     frame.set_rx_timestamp(datetime.minute() * 60 + datetime.second());
 
-    // NB: Ref to update entry in-place.
+    // NB: Reference to update entry in-place.
     auto& entry = find_or_create_entry(ICAO_address);
     entry.inc_hit();
     entry.reset_age();

--- a/firmware/application/apps/ui_adsb_rx.cpp
+++ b/firmware/application/apps/ui_adsb_rx.cpp
@@ -48,19 +48,6 @@ void RecentEntriesTable<AircraftRecentEntries>::draw(
     Color target_color;
     std::string entry_string;
 
-    entry_string +=
-        (entry.callsign.empty() ? entry.icao_str + "   " : entry.callsign + " ") +
-        to_string_dec_uint((unsigned int)(entry.pos.altitude / 100), 4) +
-        to_string_dec_uint((unsigned int)entry.velo.speed, 4) +
-        to_string_dec_uint((unsigned int)(entry.amp >> 9), 4) + " " +
-        (entry.hits <= 999 ? to_string_dec_uint(entry.hits, 3) + " " : "1k+ ") +
-        to_string_dec_uint(entry.age, 4);
-
-    painter.draw_string(
-        target_rect.location(),
-        style,
-        entry_string);
-
     switch (entry.state) {
         case ADSBAgeState::Invalid:
         case ADSBAgeState::Current:
@@ -75,6 +62,19 @@ void RecentEntriesTable<AircraftRecentEntries>::draw(
             entry_string = STR_COLOR_DARK_GREY;
             target_color = Color::grey();
     };
+
+    entry_string +=
+        (entry.callsign.empty() ? entry.icao_str + "   " : entry.callsign + " ") +
+        to_string_dec_uint((unsigned int)(entry.pos.altitude / 100), 4) +
+        to_string_dec_uint((unsigned int)entry.velo.speed, 4) +
+        to_string_dec_uint((unsigned int)(entry.amp >> 9), 4) + " " +
+        (entry.hits <= 999 ? to_string_dec_uint(entry.hits, 3) + " " : "1k+ ") +
+        to_string_dec_uint(entry.age, 4);
+
+    painter.draw_string(
+        target_rect.location(),
+        style,
+        entry_string);
 
     if (entry.pos.valid)
         painter.draw_bitmap(target_rect.location() + Point(8 * 8, 0),

--- a/firmware/application/apps/ui_adsb_rx.hpp
+++ b/firmware/application/apps/ui_adsb_rx.hpp
@@ -96,9 +96,9 @@ struct AircraftRecentEntry {
     ADSBFrame frame_pos_even{};
     ADSBFrame frame_pos_odd{};
 
-    std::string icao_str{"      "};
-    std::string callsign{"        "};
-    std::string info_string{""};
+    std::string icao_str{};
+    std::string callsign{};
+    std::string info_string{};
 
     AircraftRecentEntry(const uint32_t ICAO_address)
         : ICAO_address{ICAO_address} {

--- a/firmware/application/apps/ui_adsb_rx.hpp
+++ b/firmware/application/apps/ui_adsb_rx.hpp
@@ -80,6 +80,7 @@ enum class ADSBAgeState : uint8_t {
     Expired,
 };
 
+/* Data extracted from ADSB frames. */
 struct AircraftRecentEntry {
     using Key = uint32_t;
 
@@ -163,6 +164,7 @@ struct AircraftRecentEntry {
 // NB: uses std::list underneath so assuming refs are NOT invalidated.
 using AircraftRecentEntries = RecentEntries<AircraftRecentEntry>;
 
+/* Holds data for logging. */
 struct ADSBLogEntry {
     std::string raw_data{};
     std::string icao{};
@@ -172,6 +174,8 @@ struct ADSBLogEntry {
     uint8_t vel_type{};
 };
 
+// TODO: Make logging optional.
+/* Logs entries to a log file. */
 class ADSBLogger {
    public:
     Optional<File::Error> append(const std::filesystem::path& filename) {
@@ -183,6 +187,7 @@ class ADSBLogger {
     LogFile log_file{};
 };
 
+/* Shows detailed information about an aircraft. */
 class ADSBRxAircraftDetailsView : public View {
    public:
     ADSBRxAircraftDetailsView(
@@ -245,6 +250,7 @@ class ADSBRxAircraftDetailsView : public View {
         "Back"};
 };
 
+/* Shows detailed information about an aircraft's flight. */
 class ADSBRxDetailsView : public View {
    public:
     ADSBRxDetailsView(NavigationView&, const AircraftRecentEntry& entry);

--- a/firmware/application/apps/ui_adsb_rx.hpp
+++ b/firmware/application/apps/ui_adsb_rx.hpp
@@ -256,8 +256,8 @@ class ADSBRxDetailsView : public View {
     void update(const AircraftRecentEntry& entry);
 
     /* Calls forwarded to map view if shown. */
+    bool map_active() const { return geomap_view_; }
     void clear_map_markers();
-
     /* Adds a marker for the entry to the map. Returns true on success. */
     bool add_map_marker(const AircraftRecentEntry& entry);
 

--- a/firmware/application/baseband_api.cpp
+++ b/firmware/application/baseband_api.cpp
@@ -278,8 +278,7 @@ void set_pocsag() {
 }
 
 void set_adsb() {
-    const ADSBConfigureMessage message{
-        1};
+    const ADSBConfigureMessage message{};
     send_message(&message);
 }
 

--- a/firmware/application/recent_entries.hpp
+++ b/firmware/application/recent_entries.hpp
@@ -24,19 +24,26 @@
 
 #include "ui_widget.hpp"
 
+#include <algorithm>
 #include <cstddef>
 #include <cstdint>
-#include <list>
-#include <utility>
 #include <functional>
 #include <iterator>
-#include <algorithm>
+#include <list>
+#include <utility>
 
 template <class Entry>
 using RecentEntries = std::list<Entry>;
 
 template <typename ContainerType, typename Key>
 typename ContainerType::const_iterator find(const ContainerType& entries, const Key key) {
+    return std::find_if(
+        std::begin(entries), std::end(entries),
+        [key](typename ContainerType::const_reference e) { return e.key() == key; });
+}
+
+template <typename ContainerType, typename Key>
+typename ContainerType::iterator find(ContainerType& entries, const Key key) {
     return std::find_if(
         std::begin(entries), std::end(entries),
         [key](typename ContainerType::const_reference e) { return e.key() == key; });

--- a/firmware/common/message.hpp
+++ b/firmware/common/message.hpp
@@ -1089,13 +1089,9 @@ class APRSPacketMessage : public Message {
 
 class ADSBConfigureMessage : public Message {
    public:
-    constexpr ADSBConfigureMessage(
-        const uint32_t test)
-        : Message{ID::ADSBConfigure},
-          test(test) {
+    constexpr ADSBConfigureMessage()
+        : Message{ID::ADSBConfigure} {
     }
-
-    const uint32_t test;
 };
 
 class JammerConfigureMessage : public Message {

--- a/firmware/common/ui_widget.cpp
+++ b/firmware/common/ui_widget.cpp
@@ -587,6 +587,28 @@ void ProgressBar::paint(Painter& painter) {
     painter.draw_rectangle(sr, s.foreground);
 }
 
+/* ActivityDot ***********************************************************/
+
+ActivityDot::ActivityDot(
+    Rect parent_rect,
+    Color color)
+    : Widget{parent_rect},
+      _color{color} {}
+
+void ActivityDot::paint(Painter& painter) {
+    painter.fill_rectangle(screen_rect(), _on ? _color : Color::grey());
+}
+
+void ActivityDot::toggle() {
+    _on = !_on;
+    set_dirty();
+}
+
+void ActivityDot::reset() {
+    _on = false;
+    set_dirty();
+}
+
 /* Console ***************************************************************/
 
 Console::Console(

--- a/firmware/common/ui_widget.hpp
+++ b/firmware/common/ui_widget.hpp
@@ -317,6 +317,20 @@ class ProgressBar : public Widget {
     uint32_t _max = 100;
 };
 
+/* A simple status indicator that can be used to indicate activity. */
+class ActivityDot : public Widget {
+   public:
+    ActivityDot(Rect parent_rect, Color color);
+
+    void paint(Painter& painter) override;
+    void toggle();
+    void reset();
+
+   private:
+    bool _on{false};
+    Color _color;
+};
+
 class Console : public Widget {
    public:
     Console(Rect parent_rect);


### PR DESCRIPTION
Part half of attempt to understand why this app likes to stop working. The intention here was to do some thorough code gardening to see if there was something obvious that could be fixed. Also, I wanted to add some status indicators so if the problem happens again, we might have a better understanding about where the problem is.

Summary of changes:
* I'm happy with the rewrite - was able to remove a lot of dead code and simplify quite a few ideas.
* I didn't find any "smoking gun" which would indicate a problem in this layer so that points to a problem in the proc.
* Added two status "dots" -- on that shows whenever a frame is passed up from Baseband, and a second whenever that frame passes CRC and has a valid ICAO key.

There is some slight differences in behavior w.r.t. how processing happens when there are more than 16 entries. I wasn't sure what the original code was attempting to solve for, but what I did was split apart list maintenance and UI redraw in that case so it's not doing a ton of work every tick when the list gets large. It might make more sense to chunk the work if there's more than 16, but you can't really chunk a sort/expiration.

One thing I did notice was that occasionally (usually immediately after flashing) I was seeing lots of frames come through without any of them being accepted. That lends more evidence to the idea that the proc is broken somehow.
Perhaps it's getting out of phase or something? It's just odd that it sends so much data that is just rejected.