### PR TITLE
Cleanup dead code in the ADSB RX proc

### DIFF
--- a/firmware/baseband/proc_adsbrx.cpp
+++ b/firmware/baseband/proc_adsbrx.cpp
@@ -117,7 +117,7 @@ void ADSBRXProcessor::execute(const buffer_c8_t& buffer) {
             // the high levels as signals can be out of phase so part of the
             // energy can be in the near samples.
             int32_t this_amp = (shifter[1] + shifter[3] + shifter[8] + shifter[10]);
-            uint32_t high = this_amp / 9; // TBD: Why 9?
+            uint32_t high = this_amp / 9;  // TBD: Why 9?
             if (shifter[5] < high &&
                 shifter[6] < high &&
                 // Similarly samples in the range 11-13 must be low, as it is the

--- a/firmware/baseband/proc_adsbrx.hpp
+++ b/firmware/baseband/proc_adsbrx.hpp
@@ -39,21 +39,19 @@ class ADSBRXProcessor : public BasebandProcessor {
     void on_message(const Message* const message) override;
 
    private:
-    static constexpr size_t baseband_fs = 2000000;
+    static constexpr size_t baseband_fs = 2'000'000;
+    static constexpr size_t msg_len = 112;
 
     ADSBFrame frame{};
     bool configured{false};
+    bool decoding{false};
+
     uint32_t prev_mag{0};
-    size_t bit_count{0}, sample_count{0};
-    size_t msgLen{112};
-    uint32_t shifter[ADSB_PREAMBLE_LENGTH + 1];
-    bool decoding{};
-    bool preamble{}, active{};
-    uint16_t bit_pos{0};
-    uint8_t cur_bit{0};
-    uint32_t sample{0};
-    int32_t re{}, im{};
     int32_t amp{0};
+    size_t bit_count{0};
+    size_t sample_count{0};
+
+    uint32_t shifter[ADSB_PREAMBLE_LENGTH + 1];
 
     /* NB: Threads should be the last members in the class definition. */
     BasebandThread baseband_thread{baseband_fs, this, baseband::Direction::Receive};


### PR DESCRIPTION
More investigation into why ADSB sometimes fails.
This PR just cleans up dead code and simplifies logic in the ADSB_RX processor.

Again, no smoking gun here, but there are some odd values in the code that would make sense to understand.