### PR TITLE
Changing BLTE FIR filter to improve RX sensitivity

### DIFF
--- a/firmware/baseband/proc_btlerx.cpp
+++ b/firmware/baseband/proc_btlerx.cpp
@@ -518,7 +518,7 @@ void BTLERxProcessor::on_message(const Message* const message) {
 
 void BTLERxProcessor::configure(const BTLERxConfigureMessage& message) {
     channel_number = message.channel_number;
-    decim_0.configure(taps_200k_decim_0.taps);
+    decim_0.configure(taps_BTLE_1M_PHY_decim_0.taps);
     demod.configure(48000, 5000);
 
     configured = true;

--- a/firmware/common/dsp_fir_taps.hpp
+++ b/firmware/common/dsp_fir_taps.hpp
@@ -1264,4 +1264,82 @@ static constexpr fir_taps_real<16> taps_200k_decim_1 = {
     }},
 };
 
+// BTLE RX decimation filters ////////////////////////////////////////////////
+// Default BTLE filter, it is supporting 1M PHY.
+// IFIR image-reject filter: fs=4000000, pass=430000, stop=825000, decim=4, fout=1000000
+// 1M PHY,  This one it is for the classic bluetooth , (BW = 1Mhz : +-500k, channel space is 2Mhz)
+// The traditional transmission of 1 Mbit in the Bluetooth Basic Rate was renamed 1M PHY
+static constexpr fir_taps_real<24> taps_BTLE_1M_PHY_decim_0 = {
+    .low_frequency_normalized = -430000.0f / 4000000.0f,
+    .high_frequency_normalized = 430000.0f / 4000000.0f,
+    .transition_normalized = 395000.0f / 4000000.0f,
+    .taps = {{
+
+        12,
+        57,
+        112,
+        83,
+        -139,
+        -531,
+        -813,
+        -507,
+        766,
+        2916,
+        5255,
+        6788,
+        6788,
+        5255,
+        2916,
+        766,
+        -507,
+        -813,
+        -531,
+        -139,
+        83,
+        112,
+        57,
+        12,
+
+    }},
+};
+
+// IFIR image-reject filter: fs=4000000, pass=920000, stop=1350000, decim=4, fout=1000000
+// Alternative filter, Note : in local test, it improves slightly the sensitivity compared to above filter, but it should have aliasing if co-adjacent channels.
+// Then , we leave that filter in the code ,as experimental , but it should not be set up as default one.
+// It may work well, in areas where we just receive few signals,  without adjacent channels and weak far away signals.
+// 2M PHY , Bluetooth 5 has introduced a new transmission mode with a doubled symbol rate.
+// Bluetooth LE has been traditionally transmitting 1 bit per symbol so that theoretically the data rate doubles as well. (BW 2Mhz : +-1Mhz, channel space 2Mhz)
+static constexpr fir_taps_real<24> taps_BTLE_2M_PHY_decim_0 = {
+    .low_frequency_normalized = -920000.0f / 4000000.0f,
+    .high_frequency_normalized = 920000.0f / 4000000.0f,
+    .transition_normalized = 430000.0f / 4000000.0f,
+    .taps = {{
+
+        -8,
+        -20,
+        42,
+        81,
+        -142,
+        -234,
+        371,
+        573,
+        -884,
+        -1414,
+        2573,
+        8062,
+        8062,
+        2573,
+        -1414,
+        -884,
+        573,
+        371,
+        -234,
+        -142,
+        81,
+        42,
+        -20,
+        -8,
+
+    }},
+};
 #endif /*__DSP_FIR_TAPS_H__*/


### PR DESCRIPTION
Hi,  this PR improves the nice BTLE RX App sensitivity introduced by @iNetro  , changing the FIR filter

I defined a local test set up , sending in total the same mesage : pkt_type DISCOVERY BTLE ,  500 x times  from one Hackrf  in Hackrf mode using ch 37 , and TX GAIN = 47  to the other Mayhem with different fw's  ,  keeping the same distance and antenna set up .  And then , I could test 4 types of filters , in different low level gain. (to avoid surround interference beacons)

I was comparing them to the current  REFERENCE fw , that has applied , the latest filter , PR #1568.

As you could see in the table , with the new filter TEST#1 , (BW = 1Mhz ) , we could improve the received Hits .
It is true that the TEST#4 (BW = 2Mhz) improves sligthly the Hits, but due to the current SR = 4 Mhz , with /4 decimation ==> means that we are in fact processing data sampled at 1Mhz rate, then that filter TEST #4 ,  shows more sensitivity using only one close transmitter signal generator, but it should have aliasing problems, if using PP in a crowded spectrum channels.
(then we leave also that filter inside the code, for testing ,or optional GUI, but it should not be the default one ) 

The other more narrow filters, TEST #2, and TEST #3 showed almost no reception Hits, worse than current REFERENCE sw ,  then  we just dropped those table proposals.

 
![image](https://github.com/eried/portapack-mayhem/assets/86470699/1f982a1b-477f-47b0-84cc-908bbe71919c)
![image](https://github.com/eried/portapack-mayhem/assets/86470699/fede388c-c06f-4c36-98ea-99366be07de5)
![image](https://github.com/eried/portapack-mayhem/assets/86470699/918a0f2b-5520-4a41-804e-56bd784d3429)

I also tested with real BTLE enviroment signals , and we can also confirm its improvement.

Cheers, 
