### PR TITLE
BLE Rx Refactoring / Cleanup

### DIFF
--- a/firmware/application/apps/ble_rx_app.cpp
+++ b/firmware/application/apps/ble_rx_app.cpp
@@ -212,8 +212,7 @@ void BleRecentEntryDetailView::paint(Painter& painter) {
         case ADV_NONCONN_IND:
         case SCAN_RSP:
         case ADV_SCAN_IND: {
-
-            ADV_PDU_PAYLOAD_TYPE_0_2_4_6 * advertiseData = (ADV_PDU_PAYLOAD_TYPE_0_2_4_6 *)entry_.packetData.data;
+            ADV_PDU_PAYLOAD_TYPE_0_2_4_6* advertiseData = (ADV_PDU_PAYLOAD_TYPE_0_2_4_6*)entry_.packetData.data;
 
             for (currentByte = 0; (currentByte < entry_.packetData.dataLen) && (currentPacket < total_data_lines);) {
                 length[currentPacket] = advertiseData->Data[currentByte++];
@@ -254,21 +253,19 @@ void BleRecentEntryDetailView::paint(Painter& painter) {
         } break;
 
         case ADV_DIRECT_IND:
-        case SCAN_REQ:
-        {
-            ADV_PDU_PAYLOAD_TYPE_1_3 * directed_mac_data = (ADV_PDU_PAYLOAD_TYPE_1_3 *)entry_.packetData.data;
+        case SCAN_REQ: {
+            ADV_PDU_PAYLOAD_TYPE_1_3* directed_mac_data = (ADV_PDU_PAYLOAD_TYPE_1_3*)entry_.packetData.data;
             uint8_t type = 0xFF;
             field_rect = draw_field(painter, field_rect, s, to_string_hex(entry_.packetData.dataLen), to_string_hex(type) + pad_string_with_spaces(3) + to_string_mac_address(directed_mac_data->A1, 6, false));
-        }
-        break;
+        } break;
 
         case CONNECT_REQ:
         default: {
             uint8_t type = 0xFF;
-            
-            //TODO: Display Connect Request Information. For right now just printing full hex data.
-            //This struct will eventually be used to break apart containing data of Connect Request.
-            //ADV_PDU_PAYLOAD_TYPE_5 * connect_req = (ADV_PDU_PAYLOAD_TYPE_5 *)entry_.packetData.data;
+
+            // TODO: Display Connect Request Information. For right now just printing full hex data.
+            // This struct will eventually be used to break apart containing data of Connect Request.
+            // ADV_PDU_PAYLOAD_TYPE_5 * connect_req = (ADV_PDU_PAYLOAD_TYPE_5 *)entry_.packetData.data;
 
             for (currentByte = 0; (currentByte < entry_.packetData.dataLen); currentByte++) {
                 data[0][currentByte] = entry_.packetData.data[currentByte];
@@ -563,8 +560,7 @@ void BLERxView::updateEntry(const BlePacketData* packet, BleRecentEntry& entry, 
 
     // Only parse name for advertisment packets and empty name entries
     if ((pdu_type == ADV_IND || pdu_type == ADV_NONCONN_IND || pdu_type == SCAN_RSP || pdu_type == ADV_SCAN_IND) && entry.nameString.empty()) {
-
-        ADV_PDU_PAYLOAD_TYPE_0_2_4_6 * advertiseData = (ADV_PDU_PAYLOAD_TYPE_0_2_4_6 *)entry.packetData.data;
+        ADV_PDU_PAYLOAD_TYPE_0_2_4_6* advertiseData = (ADV_PDU_PAYLOAD_TYPE_0_2_4_6*)entry.packetData.data;
 
         uint8_t currentByte = 0;
         uint8_t length = 0;

--- a/firmware/baseband/proc_btlerx.cpp
+++ b/firmware/baseband/proc_btlerx.cpp
@@ -104,7 +104,7 @@ int BTLERxProcessor::verify_payload_byte(int num_payload_byte, ADV_PDU_TYPE pdu_
     }
 
     if (pdu_type == ADV_IND || pdu_type == ADV_NONCONN_IND || pdu_type == SCAN_RSP || pdu_type == ADV_SCAN_IND) {
-            return 0;
+        return 0;
     } else if (pdu_type == ADV_DIRECT_IND || pdu_type == SCAN_REQ) {
         if (num_payload_byte != 12) {
             // printf("Error: Payload length %d bytes. Need to be 12 for PDU Type %s!\n", num_payload_byte, ADV_PDU_TYPE_STR[pdu_type]);
@@ -204,7 +204,6 @@ void BTLERxProcessor::handleBeginState() {
 }
 
 void BTLERxProcessor::handlePDUHeaderState() {
-
     int num_demod_byte = 2;  // PDU header has 2 octets
 
     symbols_eaten += 8 * num_demod_byte * SAMPLE_PER_SYMBOL;
@@ -247,9 +246,7 @@ void BTLERxProcessor::handlePDUHeaderState() {
     if ((payload_len < 6) || (payload_len > 37)) {
         parseState = Parse_State_Begin;
         return;
-    }
-    else
-    {
+    } else {
         parseState = Parse_State_PDU_Payload;
     }
 }
@@ -357,12 +354,12 @@ void BTLERxProcessor::execute(const buffer_c8_t& buffer) {
     // Handle parsing based on parseState
     if (parseState == Parse_State_Begin) {
         handleBeginState();
-    } 
-    
+    }
+
     if (parseState == Parse_State_PDU_Header) {
         handlePDUHeaderState();
-    } 
-    
+    }
+
     if (parseState == Parse_State_PDU_Payload) {
         handlePDUPayloadState();
     }

--- a/firmware/common/message.hpp
+++ b/firmware/common/message.hpp
@@ -403,6 +403,28 @@ class AFSKDataMessage : public Message {
     uint32_t value;
 };
 
+struct ADV_PDU_PAYLOAD_TYPE_0_2_4_6 {
+    uint8_t Data[31];
+};
+
+struct ADV_PDU_PAYLOAD_TYPE_1_3 {
+    uint8_t A1[6];
+};
+
+struct ADV_PDU_PAYLOAD_TYPE_5 {
+    uint8_t AdvA[6];
+    uint8_t AA[4];
+    uint32_t CRCInit;
+    uint8_t WinSize;
+    uint16_t WinOffset;
+    uint16_t Interval;
+    uint16_t Latency;
+    uint16_t Timeout;
+    uint8_t ChM[5];
+    uint8_t Hop;
+    uint8_t SCA;
+};
+
 struct BlePacketData {
     int max_dB;
     uint8_t type;


### PR DESCRIPTION
I condensed the long execute function into multiple function calls. I felt like it was difficult to understand what was going on in that long mess. I also added structs to be used in apps, or more so moved them. It's apparent in ble_rx_app.cpp we can just cast as the PDU TYPE we need and access its data. Maybe those structs are better defined somewhere else or even a union? Anyway, no new functionality changes aside from now showing the MAC Address when we get SCAN_RSP and ADV_DIRECT packets, when viewing in details view.