### PR TITLE
Hackrf mode when no pp attached

### DIFF
--- a/firmware/application/main.cpp
+++ b/firmware/application/main.cpp
@@ -186,6 +186,8 @@ int main(void) {
         sdcStop(&SDCD1);
 
         portapack::shutdown();
+    } else {
+        config_mode_clear();
     }
 
     m4_init(portapack::spi_flash::image_tag_hackrf, portapack::memory::map::m4_code_hackrf, true);

--- a/firmware/application/portapack.cpp
+++ b/firmware/application/portapack.cpp
@@ -473,9 +473,10 @@ bool init() {
     if (i2c0.transmit(0x1a /* wm8731 */, wm8731_reset_command, 2, timeout) == false) {
         audio_codec_ak4951.reset();
         uint8_t ak4951_init_command[] = {0x00, 0x00};
+        i2c0.transmit(0x12 /* ak4951 */, ak4951_init_command, 2, timeout);
+        chThdSleepMilliseconds(10);
         if (i2c0.transmit(0x12 /* ak4951 */, ak4951_init_command, 2, timeout) == false) {
             shutdown_base();
-
             return false;
         }
     }

--- a/firmware/application/portapack.cpp
+++ b/firmware/application/portapack.cpp
@@ -467,6 +467,19 @@ bool init() {
     i2c0.start(i2c_config_fast_clock);
     chThdSleepMilliseconds(10);
 
+    /* Check if portapack is attached by checking if any of the two audio chips is present. */
+    systime_t timeout = 5000;
+    uint8_t wm8731_reset_command[] = {0x0f, 0x00};
+    if (i2c0.transmit(0x1a /* wm8731 */, wm8731_reset_command, 2, timeout) == false) {
+        audio_codec_ak4951.reset();
+        uint8_t ak4951_init_command[] = {0x00, 0x00};
+        if (i2c0.transmit(0x12 /* ak4951 */, ak4951_init_command, 2, timeout) == false) {
+            shutdown_base();
+
+            return false;
+        }
+    }
+
     touch::adc::init();
     controls_init();
     chThdSleepMilliseconds(10);

--- a/firmware/application/portapack.cpp
+++ b/firmware/application/portapack.cpp
@@ -468,7 +468,7 @@ bool init() {
     chThdSleepMilliseconds(10);
 
     /* Check if portapack is attached by checking if any of the two audio chips is present. */
-    systime_t timeout = 5000;
+    systime_t timeout = 50;
     uint8_t wm8731_reset_command[] = {0x0f, 0x00};
     if (i2c0.transmit(0x1a /* wm8731 */, wm8731_reset_command, 2, timeout) == false) {
         audio_codec_ak4951.reset();


### PR DESCRIPTION
Added presence detection for the portapack.

When no portapack is attached, the hackrf mode is activated. A standalone hackrf with the mayhem firmware can be used as a normal hackrf without reflashing the hackrf firmware.

Detection method:
- Try to initialize the wm8731 audio chip. It is connected via I2C which replys with ACK if present.
- Fallback: Try the old audio chip ak4951 also connected via I2C.