### PR TITLE
Added Memory Dump app for Debug

### DIFF
--- a/firmware/application/apps/ui_debug.cpp
+++ b/firmware/application/apps/ui_debug.cpp
@@ -450,9 +450,10 @@ DebugMenuView::DebugMenuView(NavigationView& nav) {
         {"Buttons Test", ui::Color::dark_cyan(), &bitmap_icon_controls, [&nav]() { nav.push<DebugControlsView>(); }},
         {"Debug Dump", ui::Color::dark_cyan(), &bitmap_icon_memory, [&nav]() { portapack::persistent_memory::debug_dump(); }},
         {"M0 Stack Dump", ui::Color::dark_cyan(), &bitmap_icon_memory, [&nav]() { stack_dump(); }},
-        {"Memory", ui::Color::dark_cyan(), &bitmap_icon_memory, [&nav]() { nav.push<DebugMemoryView>(); }},
-        {"P.Memory", ui::Color::dark_cyan(), &bitmap_icon_memory, [&nav]() { nav.push<DebugPmemView>(); }},
+        {"Memory Dump", ui::Color::dark_cyan(), &bitmap_icon_memory, [&nav]() { nav.push<DebugMemoryDumpView>(); }},
+        {"Memory Usage", ui::Color::dark_cyan(), &bitmap_icon_memory, [&nav]() { nav.push<DebugMemoryView>(); }},
         {"Peripherals", ui::Color::dark_cyan(), &bitmap_icon_peripherals, [&nav]() { nav.push<DebugPeripheralsMenuView>(); }},
+        {"Pers. Memory", ui::Color::dark_cyan(), &bitmap_icon_memory, [&nav]() { nav.push<DebugPmemView>(); }},
         //{ "Radio State",	ui::Color::white(),	nullptr,	[&nav](){ nav.push<NotImplementedView>(); } },
         {"SD Card", ui::Color::dark_cyan(), &bitmap_icon_sdcard, [&nav]() { nav.push<SDCardDebugView>(); }},
         {"Temperature", ui::Color::dark_cyan(), &bitmap_icon_temperature, [&nav]() { nav.push<TemperatureView>(); }},
@@ -464,6 +465,29 @@ DebugMenuView::DebugMenuView(NavigationView& nav) {
     };
 
     set_max_rows(2);  // allow wider buttons
+}
+
+/* DebugMemoryDumpView *********************************************************/
+
+DebugMemoryDumpView::DebugMemoryDumpView(NavigationView& nav) {
+    add_children({
+        &button_dump,
+        &button_done,
+        &labels,
+        &field_starting_address,
+        &field_byte_count,
+    });
+
+    button_done.on_select = [&nav](Button&) { nav.pop(); };
+
+    button_dump.on_select = [this](Button&) {
+        if (field_byte_count.to_integer() != 0)
+            memory_dump((uint32_t*)field_starting_address.to_integer(), ((uint32_t)field_byte_count.to_integer() + 3) / 4, false);
+    };
+}
+
+void DebugMemoryDumpView::focus() {
+    button_done.focus();
 }
 
 /* DebugPmemView *********************************************************/

--- a/firmware/application/apps/ui_debug.cpp
+++ b/firmware/application/apps/ui_debug.cpp
@@ -277,13 +277,10 @@ RegistersView::RegistersView(
                                 static_cast<int>(title.size()) * 8, 16});
     text_title.set(title);
 
-    field_write_reg_num.set_value(0);
     field_write_reg_num.on_change = [this](SymField&) {
         field_write_data_val.set_value(this->registers_widget.reg_read(field_write_reg_num.to_integer()));
         field_write_data_val.set_dirty();
     };
-
-    field_write_data_val.on_change = [this](SymField&) {};
 
     const auto value = registers_widget.reg_read(0);
     field_write_data_val.set_value(value);
@@ -472,10 +469,14 @@ DebugMenuView::DebugMenuView(NavigationView& nav) {
 DebugMemoryDumpView::DebugMemoryDumpView(NavigationView& nav) {
     add_children({
         &button_dump,
+        &button_read,
+        &button_write,
         &button_done,
         &labels,
         &field_starting_address,
         &field_byte_count,
+        &field_rw_address,
+        &field_data_value,
     });
 
     button_done.on_select = [&nav](Button&) { nav.pop(); };
@@ -483,6 +484,16 @@ DebugMemoryDumpView::DebugMemoryDumpView(NavigationView& nav) {
     button_dump.on_select = [this](Button&) {
         if (field_byte_count.to_integer() != 0)
             memory_dump((uint32_t*)field_starting_address.to_integer(), ((uint32_t)field_byte_count.to_integer() + 3) / 4, false);
+    };
+
+    button_read.on_select = [this](Button&) {
+        field_data_value.set_value(*(uint32_t*)field_rw_address.to_integer());
+        field_data_value.set_dirty();
+    };
+
+    button_write.set_style(&Styles::red);
+    button_write.on_select = [this](Button&) {
+        *(uint32_t*)field_rw_address.to_integer() = (uint32_t)field_data_value.to_integer();
     };
 }
 

--- a/firmware/application/apps/ui_debug.hpp
+++ b/firmware/application/apps/ui_debug.hpp
@@ -48,8 +48,8 @@ class DebugMemoryView : public View {
 
    private:
     Text text_title{
-        {96, 96, 48, 16},
-        "Memory",
+        {72, 96, 96, 16},
+        "Memory Usage",
     };
 
     Text text_label_m0_core_free{

--- a/firmware/application/apps/ui_debug.hpp
+++ b/firmware/application/apps/ui_debug.hpp
@@ -301,6 +301,36 @@ class DebugControlsView : public View {
         "Done"};
 };
 
+class DebugMemoryDumpView : public View {
+   public:
+    DebugMemoryDumpView(NavigationView& nav);
+    void focus() override;
+    std::string title() const override { return "Memory Dump"; };
+
+   private:
+    Button button_dump{
+        {16, 240, 96, 24},
+        "Dump"};
+
+    Button button_done{
+        {128, 240, 96, 24},
+        "Done"};
+
+    Labels labels{
+        {{0 * 8, 5 * 16}, "Starting Address: 0x", Color::light_grey()},
+        {{0 * 8, 6 * 16}, "Byte Count:       0x", Color::light_grey()}};
+
+    SymField field_starting_address{
+        {20 * 8, 5 * 16},
+        8,
+        SymField::Type::Hex};
+
+    SymField field_byte_count{
+        {20 * 8, 6 * 16},
+        8,
+        SymField::Type::Hex};
+};
+
 class DebugPmemView : public View {
    public:
     DebugPmemView(NavigationView& nav);

--- a/firmware/application/apps/ui_debug.hpp
+++ b/firmware/application/apps/ui_debug.hpp
@@ -309,24 +309,46 @@ class DebugMemoryDumpView : public View {
 
    private:
     Button button_dump{
-        {16, 240, 96, 24},
+        {72, 4 * 16, 96, 24},
         "Dump"};
+
+    Button button_read{
+        {16, 11 * 16, 96, 24},
+        "Read"};
+
+    Button button_write{
+        {128, 11 * 16, 96, 24},
+        "Write"};
 
     Button button_done{
         {128, 240, 96, 24},
         "Done"};
 
     Labels labels{
-        {{0 * 8, 5 * 16}, "Starting Address: 0x", Color::light_grey()},
-        {{0 * 8, 6 * 16}, "Byte Count:       0x", Color::light_grey()}};
+        {{5 * 8, 1 * 16}, "Dump Range to File", Color::yellow()},
+        {{0 * 8, 2 * 16}, "Starting Address: 0x", Color::light_grey()},
+        {{0 * 8, 3 * 16}, "Byte Count:       0x", Color::light_grey()},
+        {{3 * 8, 8 * 16}, "Read/Write Single Word", Color::yellow()},
+        {{0 * 8, 9 * 16}, "Memory Address:   0x", Color::light_grey()},
+        {{0 * 8, 10 * 16}, "Data Value:       0x", Color::light_grey()}};
 
     SymField field_starting_address{
-        {20 * 8, 5 * 16},
+        {20 * 8, 2 * 16},
         8,
         SymField::Type::Hex};
 
     SymField field_byte_count{
-        {20 * 8, 6 * 16},
+        {20 * 8, 3 * 16},
+        8,
+        SymField::Type::Hex};
+
+    SymField field_rw_address{
+        {20 * 8, 9 * 16},
+        8,
+        SymField::Type::Hex};
+
+    SymField field_data_value{
+        {20 * 8, 10 * 16},
         8,
         SymField::Type::Hex};
 };

--- a/firmware/application/debug.hpp
+++ b/firmware/application/debug.hpp
@@ -48,5 +48,6 @@ inline uint32_t get_free_stack_space() {
 }
 
 bool stack_dump();
+bool memory_dump(uint32_t* addr_start, uint32_t num_words, bool stack_flag);
 
 #endif /*__DEBUG_H__*/


### PR DESCRIPTION
Needed capability to dump out & modify memory-mapped CPU registers for debugging issue 1565, and also wanted capability to dump RAM to debug the intermittent ADS-B RX issue.

The "dump" option in this app dumps a range of memory in hex 32-bit words to a text file that can be viewed in the Notepad app.

The "read"/"write" options in this app allow a single word of memory to be read or modified.  Write operations are risky, so the Write button is displayed in Red.