### PR TITLE
Fixed SPI Read timing issue affecting MAX283x chips

### DIFF
--- a/firmware/application/hw/max2837.cpp
+++ b/firmware/application/hw/max2837.cpp
@@ -342,7 +342,7 @@ int8_t MAX2837::temp_sense() {
     _map.r.rx_top.ts_adc_trigger = 0;
     flush_one(Register::RX_TOP);
 
-    return value * 4.31 - 6;  // reg value is 0 to 31; possible return range is -6 C to 127 C
+    return std::min(127, (int)(value * 4.31 - 40));  // reg value is 0 to 31; possible return range is -40 C to 127 C
 }
 
 }  // namespace max2837

--- a/firmware/application/hw/max2839.cpp
+++ b/firmware/application/hw/max2839.cpp
@@ -372,7 +372,7 @@ int8_t MAX2839::temp_sense() {
     _map.r.rx_top_2.ts_adc_trigger = 0;
     flush_one(Register::RX_TOP_2);
 
-    return value * 4.31 - 75;  // reg value is 0 to 31; possible return range is -75 C to 58 C
+    return std::min(127, (int)(value * 4.31 - 40));  // reg value is 0 to 31; possible return range is -40 C to 127 C
 }
 
 }  // namespace max2839

--- a/firmware/application/radio.cpp
+++ b/firmware/application/radio.cpp
@@ -61,7 +61,7 @@ static constexpr SPIConfig ssp_config_max283x = {
     .ssport = gpio_max283x_select.port(),
     .sspad = gpio_max283x_select.pad(),
     .cr0 =
-        CR0_CLOCKRATE(ssp_scr(ssp1_pclk_f, ssp1_cpsr, max283x_spi_f)) | CR0_FRFSPI | CR0_DSS16BIT,
+        CR0_CLOCKRATE(ssp_scr(ssp1_pclk_f, ssp1_cpsr, max283x_spi_f) + 1) | CR0_FRFSPI | CR0_DSS16BIT,
     .cpsr = ssp1_cpsr,
 };
 


### PR DESCRIPTION
Added SPI timing margin for MAX283x chips to fix #1565.

Note that HackRF code uses a clock divisor of 21 where Mayhem code was using a clock divisor of 4, so we were attempting SPI communications 5X faster than when the HackRF module is connected to a PC.  This change only increases the clock divisor to 5, so we're still 4X faster, but it seems to resolve the issue.

Also fixed Temperature scaling since the Temperature register is now being read correctly.

Test version available here on Discord:
https://discord.com/channels/719669764804444213/722101917135798312/1175454102474465412