### PR TITLE
BLE TX app button label fix

### DIFF
--- a/firmware/application/apps/ble_tx_app.hpp
+++ b/firmware/application/apps/ble_tx_app.hpp
@@ -268,7 +268,7 @@ class BLETxView : public View {
 
     Button button_switch{
         {16 * 8, 16 * 16, 13 * 8, 2 * 16},
-        "Switch to Tx"};
+        "Switch to Rx"};
 
     std::string str_log{""};
     bool logging{true};


### PR DESCRIPTION
This fix the label on the switch button in BLE Tx app.

The button was wrongly named "Switch to TX" but brings back to Rx app.

