### PR TITLE
Save TPMS units in App Settings

### DIFF
--- a/firmware/application/apps/tpms_app.cpp
+++ b/firmware/application/apps/tpms_app.cpp
@@ -34,9 +34,6 @@ namespace tpms {
 
 namespace format {
 
-static bool use_kpa = true;
-static bool use_celsius = true;
-
 std::string type(Reading::Type type) {
     return to_string_dec_uint(toUType(type), 2);
 }
@@ -46,11 +43,11 @@ std::string id(TransponderID id) {
 }
 
 std::string pressure(Pressure pressure) {
-    return to_string_dec_int(use_kpa ? pressure.kilopascal() : pressure.psi(), 3);
+    return to_string_dec_int(units_psi ? pressure.psi() : pressure.kilopascal(), 3);
 }
 
 std::string temperature(Temperature temperature) {
-    return to_string_dec_int(use_celsius ? temperature.celsius() : temperature.fahrenheit(), 3);
+    return to_string_dec_int(units_fahr ? temperature.fahrenheit() : temperature.celsius(), 3);
 }
 
 std::string flags(Flags flags) {
@@ -165,18 +162,16 @@ TPMSAppView::TPMSAppView(NavigationView&) {
     options_band.set_by_value(receiver_model.target_frequency());
 
     options_pressure.on_change = [this](size_t, int32_t i) {
-        tpms::format::use_kpa = !i;
+        tpms::format::units_psi = (bool)i;
         update_view();
     };
-
-    options_pressure.set_selected_index(0, true);
+    options_pressure.set_selected_index(tpms::format::units_psi, true);
 
     options_temperature.on_change = [this](size_t, int32_t i) {
-        tpms::format::use_celsius = !i;
+        tpms::format::units_fahr = (bool)i;
         update_view();
     };
-
-    options_temperature.set_selected_index(0, true);
+    options_temperature.set_selected_index(tpms::format::units_fahr, true);
 
     logger = std::make_unique<TPMSLogger>();
     if (logger) {

--- a/firmware/application/apps/tpms_app.hpp
+++ b/firmware/application/apps/tpms_app.hpp
@@ -44,9 +44,9 @@ namespace format {
 static bool units_psi{false};
 static bool units_fahr{false};
 
-}
+} /* namespace format */
 
-}
+} /* namespace tpms */
 
 namespace std {
 

--- a/firmware/application/apps/tpms_app.hpp
+++ b/firmware/application/apps/tpms_app.hpp
@@ -37,6 +37,17 @@
 
 #include "tpms_packet.hpp"
 
+namespace tpms {
+
+namespace format {
+
+static bool units_psi{false};
+static bool units_fahr{false};
+
+}
+
+}
+
 namespace std {
 
 } /* namespace std */
@@ -106,8 +117,14 @@ class TPMSAppView : public View {
         315000000 /* frequency*/,
         1750000 /* bandwidth */,
         2457600 /* sampling rate */};
+
     app_settings::SettingsManager settings_{
-        "rx_tpms", app_settings::Mode::RX};
+        "rx_tpms",
+        app_settings::Mode::RX,
+        {
+            {"units_psi"sv, &tpms::format::units_psi},
+            {"units_fahr"sv, &tpms::format::units_fahr},
+        }};
 
     MessageHandlerRegistration message_handler_packet{
         Message::ID::TPMSPacket,
@@ -133,7 +150,7 @@ class TPMSAppView : public View {
         {0 * 8, 0 * 16},
         3,
         {
-            {"315", 315000000},
+            {"315", 314900000},
             {"434", 433920000},
         }};
 

--- a/firmware/application/apps/tpms_app.hpp
+++ b/firmware/application/apps/tpms_app.hpp
@@ -114,7 +114,7 @@ class TPMSAppView : public View {
 
    private:
     RxRadioState radio_state_{
-        315000000 /* frequency*/,
+        314950000 /* frequency*/,
         1750000 /* bandwidth */,
         2457600 /* sampling rate */};
 
@@ -146,11 +146,12 @@ class TPMSAppView : public View {
         {21 * 8, 5, 6 * 8, 4},
     };
 
+    // "315 MHz" TPMS sensors transmit at either 314.9 or 315 MHz but we should pick up either
     OptionsField options_band{
         {0 * 8, 0 * 16},
         3,
         {
-            {"315", 314900000},
+            {"315", 314950000},
             {"434", 433920000},
         }};
 


### PR DESCRIPTION
1.  Save TPMS units (celsius vs fahrenheit, and psi vs kpa) in rx_tpms.ini Settings file.

2.  Set receiver to 314.95 MHz when configured for "315", since half of the TPMS sensors transmit on 314.9 and half on 315.0.