### PR TITLE
Weather app tweaks

### DIFF
--- a/firmware/application/apps/ui_weatherstation.cpp
+++ b/firmware/application/apps/ui_weatherstation.cpp
@@ -90,17 +90,12 @@ WeatherView::WeatherView(NavigationView& nav)
         recent.clear();
         recent_entries_view.set_dirty();
     };
-    field_frequency.set_value(433920000);
-    field_frequency.set_step(1000);
+    field_frequency.set_step(100000);
     const Rect content_rect{0, header_height, screen_width, screen_height - header_height};
     recent_entries_view.set_parent_rect(content_rect);
     recent_entries_view.on_select = [this](const WeatherRecentEntry& entry) {
         nav_.push<WeatherRecentEntryDetailView>(entry);
     };
-    receiver_model.set_target_frequency(433'920'000);
-    receiver_model.set_sampling_rate(2'000'000);
-    receiver_model.set_baseband_bandwidth(1'750'000);
-    receiver_model.set_modulation(ReceiverModel::Mode::AMAudio);
     baseband::set_weather();
     receiver_model.enable();
 }

--- a/firmware/application/apps/ui_weatherstation.cpp
+++ b/firmware/application/apps/ui_weatherstation.cpp
@@ -36,7 +36,7 @@ void WeatherRecentEntryDetailView::update_data() {
     // set text elements
     text_type.set(WeatherView::getWeatherSensorTypeName((FPROTO_WEATHER_SENSOR)entry_.sensorType));
     text_id.set("0x" + to_string_hex(entry_.id));
-    text_temp.set(to_string_decimal(entry_.temp, 2));
+    text_temp.set(weather_units_fahr ? to_string_decimal((entry_.temp * 9 / 5) + 32, 1) : to_string_decimal(entry_.temp, 2));
     text_hum.set(to_string_dec_uint(entry_.humidity) + "%");
     text_ch.set(to_string_dec_uint(entry_.channel));
     text_batt.set(to_string_dec_uint(entry_.battery_low) + " " + ((entry_.battery_low == 0) ? "OK" : "LOW"));
@@ -81,6 +81,7 @@ WeatherView::WeatherView(NavigationView& nav)
                   &field_lna,
                   &field_vga,
                   &field_frequency,
+                  &options_temperature,
                   &button_clear_list,
                   &recent_entries_view});
 
@@ -91,6 +92,13 @@ WeatherView::WeatherView(NavigationView& nav)
         recent_entries_view.set_dirty();
     };
     field_frequency.set_step(100000);
+
+    options_temperature.on_change = [this](size_t, int32_t i) {
+        weather_units_fahr = (bool)i;
+        recent_entries_view.set_dirty();
+    };
+    options_temperature.set_selected_index(weather_units_fahr, false);
+
     const Rect content_rect{0, header_height, screen_width, screen_height - header_height};
     recent_entries_view.set_parent_rect(content_rect);
     recent_entries_view.on_select = [this](const WeatherRecentEntry& entry) {

--- a/firmware/application/apps/ui_weatherstation.cpp
+++ b/firmware/application/apps/ui_weatherstation.cpp
@@ -36,7 +36,7 @@ void WeatherRecentEntryDetailView::update_data() {
     // set text elements
     text_type.set(WeatherView::getWeatherSensorTypeName((FPROTO_WEATHER_SENSOR)entry_.sensorType));
     text_id.set("0x" + to_string_hex(entry_.id));
-    text_temp.set(weather_units_fahr ? to_string_decimal((entry_.temp * 9 / 5) + 32, 1) : to_string_decimal(entry_.temp, 2));
+    text_temp.set(weather_units_fahr ? to_string_decimal((entry_.temp * 9 / 5) + 32, 1) + STR_DEGREES_F : to_string_decimal(entry_.temp, 2) + STR_DEGREES_C);
     text_hum.set(to_string_dec_uint(entry_.humidity) + "%");
     text_ch.set(to_string_dec_uint(entry_.channel));
     text_batt.set(to_string_dec_uint(entry_.battery_low) + " " + ((entry_.battery_low == 0) ? "OK" : "LOW"));
@@ -193,7 +193,7 @@ void RecentEntriesTable<ui::WeatherRecentEntries>::draw(
         line = truncate(line, 13);
     }
 
-    std::string temp = to_string_decimal(entry.temp, 2);
+    std::string temp = (weather_units_fahr ? to_string_decimal((entry.temp * 9 / 5) + 32, 1) : to_string_decimal(entry.temp, 2));
     std::string humStr = to_string_dec_uint(entry.humidity) + "%";
     std::string chStr = to_string_dec_uint(entry.channel);
 

--- a/firmware/application/apps/ui_weatherstation.hpp
+++ b/firmware/application/apps/ui_weatherstation.hpp
@@ -92,7 +92,7 @@ class WeatherView : public View {
         433'920'000 /* frequency */,
         1'750'000 /* bandwidth */,
         2'000'000 /* sampling rate */,
-        ReceiverModel::Mode::SpectrumAnalysis};
+        ReceiverModel::Mode::AMAudio};
     app_settings::SettingsManager settings_{
         "rx_weather", app_settings::Mode::RX};
 

--- a/firmware/application/apps/ui_weatherstation.hpp
+++ b/firmware/application/apps/ui_weatherstation.hpp
@@ -37,6 +37,8 @@ using namespace ui;
 
 namespace ui {
 
+static bool weather_units_fahr{false};
+
 struct WeatherRecentEntry {
     using Key = uint64_t;
     static constexpr Key invalid_key = 0x0fffffff;  // todo calc the invalid all
@@ -94,9 +96,19 @@ class WeatherView : public View {
         2'000'000 /* sampling rate */,
         ReceiverModel::Mode::AMAudio};
     app_settings::SettingsManager settings_{
-        "rx_weather", app_settings::Mode::RX};
+        "rx_weather",
+        app_settings::Mode::RX,
+        {
+            {"units_fahr"sv, &weather_units_fahr},
+        }};
 
     WeatherRecentEntries recent{};
+
+    OptionsField options_temperature{
+        {10 * 8, 0 * 16},
+        2,
+        {{STR_DEGREES_C, 0},
+         {STR_DEGREES_F, 1}}};
 
     RFAmpField field_rf_amp{
         {13 * 8, 0 * 16}};

--- a/firmware/application/ui_navigation.cpp
+++ b/firmware/application/ui_navigation.cpp
@@ -566,7 +566,7 @@ ReceiversMenuView::ReceiversMenuView(NavigationView& nav) {
         {"Recon", Color::green(), &bitmap_icon_scanner, [&nav]() { nav.push<ReconView>(); }},
         {"Search", Color::yellow(), &bitmap_icon_search, [&nav]() { nav.push<SearchView>(); }},
         {"TPMS Cars", Color::green(), &bitmap_icon_tpms, [&nav]() { nav.push<TPMSAppView>(); }},
-        {"Weather", Color::green(), &bitmap_icon_lge, [&nav]() { nav.push<WeatherView>(); }},
+        {"Weather", Color::orange(), &bitmap_icon_lge, [&nav]() { nav.push<WeatherView>(); }},
         // {"FSK RX", Color::yellow(), &bitmap_icon_remote, [&nav]() { nav.push<FskxRxMainView>(); }},
         // {"DMR", Color::dark_grey(), &bitmap_icon_dmr, [&nav](){ nav.push<NotImplementedView>(); }},
         // {"SIGFOX", Color::dark_grey(), &bitmap_icon_fox, [&nav](){ nav.push<NotImplementedView>(); }},

--- a/firmware/application/ui_navigation.cpp
+++ b/firmware/application/ui_navigation.cpp
@@ -566,7 +566,7 @@ ReceiversMenuView::ReceiversMenuView(NavigationView& nav) {
         {"Recon", Color::green(), &bitmap_icon_scanner, [&nav]() { nav.push<ReconView>(); }},
         {"Search", Color::yellow(), &bitmap_icon_search, [&nav]() { nav.push<SearchView>(); }},
         {"TPMS Cars", Color::green(), &bitmap_icon_tpms, [&nav]() { nav.push<TPMSAppView>(); }},
-        {"Weather", Color::orange(), &bitmap_icon_lge, [&nav]() { nav.push<WeatherView>(); }},
+        {"Weather", Color::yellow(), &bitmap_icon_lge, [&nav]() { nav.push<WeatherView>(); }},
         // {"FSK RX", Color::yellow(), &bitmap_icon_remote, [&nav]() { nav.push<FskxRxMainView>(); }},
         // {"DMR", Color::dark_grey(), &bitmap_icon_dmr, [&nav](){ nav.push<NotImplementedView>(); }},
         // {"SIGFOX", Color::dark_grey(), &bitmap_icon_fox, [&nav](){ nav.push<NotImplementedView>(); }},


### PR DESCRIPTION
Proposed minor changes to weather app.

1.  Allow frequency to be saved across runs in App Settings file.
2.  Use bandwidth, sample rate, and modulation set in RadioState constructor (and allow override in App Settings file).
3.  Propose changing frequency step to a larger value (0.1 Mhz).
4.  Changed icon color to represent new development state.  See: https://github.com/eried/portapack-mayhem/wiki/Applications
5.  Added support for displaying temperatures in Fahrenheit, and save units preference in App Settings file.

Feedback requested from @htotoo on these proposed changes.