### PR TITLE
Preserve BLE RX app settings across runs, and changed BLE app settings file names

### DIFF
--- a/firmware/application/apps/ble_rx_app.cpp
+++ b/firmware/application/apps/ble_rx_app.cpp
@@ -428,6 +428,8 @@ BLERxView::BLERxView(NavigationView& nav)
         nav_.push<BleRecentEntryDetailView>(entry);
     };
 
+    filterBuffer = filter;
+
     button_filter.on_select = [this](Button&) {
         text_prompt(
             nav_,
@@ -469,34 +471,38 @@ BLERxView::BLERxView(NavigationView& nav)
             logger->append(LOG_ROOT_DIR "/BLELOG_" + to_string_timestamp(rtc_time::now()) + ".TXT");
     };
 
-    check_name.set_value(true);
+    check_name.set_value(name_enable);
 
     check_name.on_select = [this](Checkbox&, bool v) {
+        name_enable = v;
         setAllMembersToValue(recent, &BleRecentEntry::include_name, v);
         recent_entries_view.set_dirty();
     };
 
-    options_channel.on_change = [this](size_t, int32_t i) {
+    options_channel.on_change = [this](size_t index, int32_t v) {
+        channel_index = (uint8_t)index;
+
         // If we selected Auto don't do anything and Auto will handle changing.
-        if (i == 40) {
+        if (v == 40) {
             auto_channel = true;
             return;
         } else {
             auto_channel = false;
         }
 
-        field_frequency.set_value(get_freq_by_channel_number(i));
-        channel_number = i;
+        field_frequency.set_value(get_freq_by_channel_number(v));
+        channel_number = v;
 
         baseband::set_btlerx(channel_number);
     };
 
-    options_sort.on_change = [this](size_t, int32_t index) {
-        handle_entries_sort(index);
+    options_sort.on_change = [this](size_t index, int32_t v) {
+        sort_index = (uint8_t)index;
+        handle_entries_sort(v);
     };
 
-    options_channel.set_selected_index(0, true);
-    options_sort.set_selected_index(0, true);
+    options_channel.set_selected_index(channel_index, true);
+    options_sort.set_selected_index(sort_index, true);
 
     logger = std::make_unique<BLELogger>();
 

--- a/firmware/application/apps/ble_rx_app.hpp
+++ b/firmware/application/apps/ble_rx_app.hpp
@@ -205,19 +205,32 @@ class BLERxView : public View {
         4000000 /* bandwidth */,
         4000000 /* sampling rate */,
         ReceiverModel::Mode::WidebandFMAudio};
-    app_settings::SettingsManager settings_{
-        "BLE Rx", app_settings::Mode::RX};
 
+    uint8_t channel_index{0};
+    uint8_t sort_index{0};
+    std::string filter{};
+    bool logging{false};
+    bool name_enable{true};
+    app_settings::SettingsManager settings_{
+        "BLE Rx",
+        app_settings::Mode::RX,
+        {
+            {"channel_index"sv, &channel_index},
+            {"sort_index"sv, &sort_index},
+            {"filter"sv, &filter},
+            {"log"sv, &logging},
+            {"name"sv, &name_enable},
+        }};
+
+    uint8_t channel_number{37};
+    bool auto_channel{false};
     uint8_t console_color{0};
     uint32_t prev_value{0};
-    uint8_t channel_number = 37;
-    bool auto_channel = false;
 
     int16_t timer_count{0};
     int16_t timer_period{6};  // 100ms
 
     std::string filterBuffer{};
-    std::string filter{};
     std::string listFileBuffer{};
     std::string headerStr = "Timestamp, MAC Address, Name, Packet Type, Data, Hits, dB, Channel";
     uint16_t maxLineLength = 140;
@@ -296,7 +309,6 @@ class BLERxView : public View {
         "Tx"};
 
     std::string str_log{""};
-    bool logging{false};
 
     std::unique_ptr<BLELogger> logger{};
 

--- a/firmware/application/apps/ble_rx_app.hpp
+++ b/firmware/application/apps/ble_rx_app.hpp
@@ -212,7 +212,7 @@ class BLERxView : public View {
     bool logging{false};
     bool name_enable{true};
     app_settings::SettingsManager settings_{
-        "BLE Rx",
+        "rx_ble",
         app_settings::Mode::RX,
         {
             {"channel_index"sv, &channel_index},

--- a/firmware/application/apps/ble_rx_app.hpp
+++ b/firmware/application/apps/ble_rx_app.hpp
@@ -222,10 +222,10 @@ class BLERxView : public View {
             {"name"sv, &name_enable},
         }};
 
-    uint8_t channel_number{37};
-    bool auto_channel{false};
     uint8_t console_color{0};
     uint32_t prev_value{0};
+    uint8_t channel_number = 37;
+    bool auto_channel = false;
 
     int16_t timer_count{0};
     int16_t timer_period{6};  // 100ms

--- a/firmware/application/apps/ble_tx_app.hpp
+++ b/firmware/application/apps/ble_tx_app.hpp
@@ -132,7 +132,7 @@ class BLETxView : public View {
         4'000'000 /* sampling rate */
     };
     app_settings::SettingsManager settings_{
-        "ble_tx_app", app_settings::Mode::TX};
+        "tx_ble", app_settings::Mode::TX};
 
     uint8_t console_color{0};
     uint32_t prev_value{0};


### PR DESCRIPTION
1. Preserving the following additional app settings for the BLE RX app:  channel, sorting method, filter, logging option, and name option.
2. Changed the app settings file names for BLE RX and TX apps to match standardized file naming convention (rx_ble.ini, tx_ble.ini).