### PR TITLE
Change BLE RX filter to look at MAC address and device name only

### DIFF
--- a/firmware/application/apps/ble_rx_app.cpp
+++ b/firmware/application/apps/ble_rx_app.cpp
@@ -700,7 +700,7 @@ void BLERxView::on_data(BlePacketData* packet) {
     // Add entries if they meet the criteria.
     auto value = filter;
     resetFilteredEntries(recent, [&value](const BleRecentEntry& entry) {
-        return (entry.dataString.find(value) == std::string::npos) && (entry.nameString.find(value) == std::string::npos);
+        return (to_string_mac_address(entry.packetData.macAddress, 6, false).find(value) == std::string::npos) && (entry.nameString.find(value) == std::string::npos);
     });
 
     handle_entries_sort(options_sort.selected_index());
@@ -715,7 +715,7 @@ void BLERxView::on_filter_change(std::string value) {
     // New filter? Reset list from recent entries.
     if (filter != value) {
         resetFilteredEntries(recent, [&value](const BleRecentEntry& entry) {
-            return (entry.dataString.find(value) == std::string::npos) && (entry.nameString.find(value) == std::string::npos);
+            return (to_string_mac_address(entry.packetData.macAddress, 6, false).find(value) == std::string::npos) && (entry.nameString.find(value) == std::string::npos);
         });
     }
 


### PR DESCRIPTION
I'm proposing to change BLE RX "filter" to look at MAC address and name strings only (versus the entire unprocessed packet), per enhancement suggestion #1623