### PR TITLE
Improved sensitivity/selectivity Weather App

### DIFF
--- a/firmware/application/apps/ui_weatherstation.hpp
+++ b/firmware/application/apps/ui_weatherstation.hpp
@@ -100,8 +100,8 @@ class WeatherView : public View {
     NavigationView& nav_;
     RxRadioState radio_state_{
         433'920'000 /* frequency */,
-        1'750'000 /* bandwidth */,
-        2'000'000 /* sampling rate */,
+        2'500'000 /* bandwidth max283x*/,
+        4'000'000 /* sampling rate */,
         ReceiverModel::Mode::AMAudio};
     app_settings::SettingsManager settings_{
         "rx_weather",

--- a/firmware/baseband/proc_weather.hpp
+++ b/firmware/baseband/proc_weather.hpp
@@ -30,6 +30,7 @@
 #include "baseband_thread.hpp"
 #include "rssi_thread.hpp"
 #include "message.hpp"
+#include "dsp_decimate.hpp"
 
 #include "fprotos/weatherprotos.hpp"
 
@@ -39,8 +40,20 @@ class WeatherProcessor : public BasebandProcessor {
     void on_message(const Message* const message) override;
 
    private:
-    static constexpr uint32_t usperTick = 500;  // we nees ms to has to divide by 1000
-    static constexpr size_t baseband_fs = 1'750'000;
+    static constexpr size_t baseband_fs = 4'000'000;  // it works, I think we need to write that master clock in the baseband_threat , even later we decimate it.
+    static constexpr uint32_t usperTick = 500 * 8;    // In current sw , we do not scale it due to clock. We scaled it due to less array buffer sampes due to /8 decimation.
+                                                      // TODO , Pending to investigate , why ticks are not proportional to the SR clock, 500 nseg (2Mhz) , 250 nseg (4Mhz) ??? ;previous comment :  "we nees ms to has to divide by 1000"
+
+    /* Array Buffer aux. used in decim0 and decim1 IQ c16 signed  data ; (decim0 defines the max length of the array) */
+    std::array<complex16_t, 512> dst{};  // decim0 /4 ,  2048/4 = 512 complex I,Q
+    const buffer_c16_t dst_buffer{
+        dst.data(),
+        dst.size()};
+
+    /* Decimates */
+    dsp::decimate::FIRC8xR16x24FS4Decim4 decim_0{};
+    dsp::decimate::FIRC16xR16x16Decim2 decim_1{};
+
     uint32_t currentDuration = 0;
     uint32_t threshold = 0x0630;  // will overwrite after the first iteration
     bool currentHiLow = false;


### PR DESCRIPTION
Hi,  this PR , improves the following points of the current  Weather App from HTotoo.
Thanks specially to HTotoo and @kallanreed , for his support in that investigation.

1-) Previous one , was applying an offset tuning (+500Khz )  , but not correcting in the post-processing. (but due to wide BW , almost not noticeable) . This PR is  also applying that offset , but later addressing it in the post-processing back-end.

2-) This PR is applying initial SR = 4Mhz , with  total decim /8 ,  then effective  sample rate is running at 500khz , 
(note, the famous  rtl_433 is running at 250Khz sample rate , then it should be ok ). 

3-) We improve the RF sensitivity around  14 to 16 dB's  
(confirmed with H2R4 and Hackrf r9 , so now we should be able to capture even neighbor Weather Stations signals !. 

4-)We also introduced available FIR filters in the decimation process. And I could confirm that all freq. response is correct for that application,  , achieving  +-220khz , (BW =  440 kHZ )
(previous Firmware , just was using anti-aliasing max283x anti-aliasing filter , and by experimental ,we could receive close stations ,  almost +-2,8 Mhz , really too wide and easy to get many interferences ). 

Maybe now ,  Mayhem is more sensible than Flipper , not sure , pending to check :)   

I hope that HTotoo will continue adding more protocols to that nice app ! 
There is in the Test-drive , a similar binary than this PR. and HTotoo also validated , but welcome to get more feedback . 
Let's enjoy . 
Cheers, 
 