### PR TITLE
Increased SSP timing margin for MAX2839 register reads

### DIFF
--- a/firmware/application/radio.cpp
+++ b/firmware/application/radio.cpp
@@ -61,7 +61,7 @@ static constexpr SPIConfig ssp_config_max283x = {
     .ssport = gpio_max283x_select.port(),
     .sspad = gpio_max283x_select.pad(),
     .cr0 =
-        CR0_CLOCKRATE(ssp_scr(ssp1_pclk_f, ssp1_cpsr, max283x_spi_f) + 1) | CR0_FRFSPI | CR0_DSS16BIT,
+        CR0_CLOCKRATE(ssp_scr(ssp1_pclk_f, ssp1_cpsr, max283x_spi_f) + 3) | CR0_FRFSPI | CR0_DSS16BIT,
     .cpsr = ssp1_cpsr,
 };
 


### PR DESCRIPTION
The SSP clock speed adjustment in PR #1590 was insufficient for reading MAX2839 registers 0x10 and higher.  The data read from higher registers was still shifted by 1 bit sometimes when registers are viewed in Debug->Peripherals->MAX2839.  I hadn't noticed this earlier because the temperature sensor ADC output is at a lower register address (0x0B) which was reading correctly after PR #1590.  Increasing the clock divisor by 1 more fixes the issue on my r9 board so that all the other registers are dumped correctly, but I've increased it by 2 this time just to be sure that there is some margin.