### PR TITLE
Enable Sample Rate to be spec'd in .ini file for Weather & SubGhzDecoder apps

### DIFF
--- a/firmware/application/apps/ui_subghzd.cpp
+++ b/firmware/application/apps/ui_subghzd.cpp
@@ -88,8 +88,7 @@ SubGhzDView::SubGhzDView(NavigationView& nav)
     recent_entries_view.on_select = [this](const SubGhzDRecentEntry& entry) {
         nav_.push<SubGhzDRecentEntryDetailView>(entry);
     };
-    baseband::set_subghzd(0);  // am
-    receiver_model.set_sampling_rate(4'000'000);
+    baseband::set_subghzd_config(0, receiver_model.sampling_rate());  // 0=am
     receiver_model.enable();
     signal_token_tick_second = rtc_time::signal_tick_second += [this]() {
         on_tick_second();

--- a/firmware/application/apps/ui_weatherstation.cpp
+++ b/firmware/application/apps/ui_weatherstation.cpp
@@ -115,8 +115,7 @@ WeatherView::WeatherView(NavigationView& nav)
     recent_entries_view.on_select = [this](const WeatherRecentEntry& entry) {
         nav_.push<WeatherRecentEntryDetailView>(entry);
     };
-    baseband::set_weather();
-    receiver_model.set_sampling_rate(4'000'000);  // needed too
+    baseband::set_subghzd_config(0, receiver_model.sampling_rate());  // 0=am
     receiver_model.enable();
     signal_token_tick_second = rtc_time::signal_tick_second += [this]() {
         on_tick_second();

--- a/firmware/application/apps/ui_weatherstation.hpp
+++ b/firmware/application/apps/ui_weatherstation.hpp
@@ -100,8 +100,8 @@ class WeatherView : public View {
     NavigationView& nav_;
     RxRadioState radio_state_{
         433'920'000 /* frequency */,
-        2'500'000 /* bandwidth max283x*/,
-        4'000'000 /* sampling rate */,
+        1'750'000 /* bandwidth */,
+        2'000'000 /* sampling rate */,
         ReceiverModel::Mode::AMAudio};
     app_settings::SettingsManager settings_{
         "rx_weather",

--- a/firmware/application/baseband_api.cpp
+++ b/firmware/application/baseband_api.cpp
@@ -319,13 +319,8 @@ void set_spectrum_painter_config(const uint16_t width, const uint16_t height, bo
     send_message(&message);
 }
 
-void set_weather() {
-    const SubGhzFPRxConfigureMessage message{0};
-    send_message(&message);
-}
-
-void set_subghzd(uint8_t modulation = 0) {
-    const SubGhzFPRxConfigureMessage message{modulation};
+void set_subghzd_config(uint8_t modulation = 0, uint32_t sampling_rate = 0) {
+    const SubGhzFPRxConfigureMessage message{modulation, sampling_rate};
     send_message(&message);
 }
 

--- a/firmware/application/baseband_api.hpp
+++ b/firmware/application/baseband_api.hpp
@@ -88,8 +88,7 @@ void set_spectrum(const size_t sampling_rate, const size_t trigger);
 void set_siggen_tone(const uint32_t tone);
 void set_siggen_config(const uint32_t bw, const uint32_t shape, const uint32_t duration);
 void set_spectrum_painter_config(const uint16_t width, const uint16_t height, bool update, int32_t bw);
-void set_weather();
-void set_subghzd(uint8_t modulation);
+void set_subghzd_config(uint8_t modulation, uint32_t sampling_rate);
 void request_beep();
 
 void run_image(const portapack::spi_flash::image_tag_t image_tag);

--- a/firmware/baseband/proc_subghzd.cpp
+++ b/firmware/baseband/proc_subghzd.cpp
@@ -73,7 +73,12 @@ void SubGhzDProcessor::on_message(const Message* const message) {
 void SubGhzDProcessor::configure(const SubGhzFPRxConfigureMessage& message) {
     // constexpr size_t decim_0_output_fs = baseband_fs / decim_0.decimation_factor; //unused
     // constexpr size_t decim_1_output_fs = decim_0_output_fs / decim_1.decimation_factor; //unused
-    (void)message;  // unused
+
+    modulation = message.modulation;  // TODO: FM not yet implemented
+
+    baseband_fs = message.sampling_rate;
+    baseband_thread.set_sampling_rate(baseband_fs);
+    nsPerDecSamp = 1'000'000'000 / baseband_fs * 8;  // Scaled it due to less array buffer sampes due to /8 decimation.  250 nseg (4Mhz) * 8
 
     decim_0.configure(taps_200k_wfm_decim_0.taps);
     decim_1.configure(taps_200k_wfm_decim_1.taps);

--- a/firmware/baseband/proc_subghzd.cpp
+++ b/firmware/baseband/proc_subghzd.cpp
@@ -47,7 +47,7 @@ void SubGhzDProcessor::execute(const buffer_c8_t& buffer) {
         tm += mag;
         if (meashl == currentHiLow && currentDuration < 30'000'000)  // allow pass 'end' signal
         {
-            if (currentDuration < UINT32_MAX) currentDuration += nsPerDecSamp;
+            currentDuration += nsPerDecSamp;
         } else {  // called on change, so send the last duration and dir.
             if (protoList) protoList->feed(currentHiLow, currentDuration / 1000);
             currentDuration = nsPerDecSamp;
@@ -74,7 +74,7 @@ void SubGhzDProcessor::configure(const SubGhzFPRxConfigureMessage& message) {
     // constexpr size_t decim_0_output_fs = baseband_fs / decim_0.decimation_factor; //unused
     // constexpr size_t decim_1_output_fs = decim_0_output_fs / decim_1.decimation_factor; //unused
 
-    modulation = message.modulation;  // TODO: FM not yet implemented
+    modulation = message.modulation;  // TODO: add support for FM (currently AM only)
 
     baseband_fs = message.sampling_rate;
     baseband_thread.set_sampling_rate(baseband_fs);

--- a/firmware/baseband/proc_subghzd.hpp
+++ b/firmware/baseband/proc_subghzd.hpp
@@ -40,8 +40,9 @@ class SubGhzDProcessor : public BasebandProcessor {
     void on_message(const Message* const message) override;
 
    private:
-    static constexpr size_t baseband_fs = 4'000'000;                           // it works, I think we need to write that master clock in the baseband_threat , even later we decimate it.
-    static constexpr uint32_t nsPerDecSamp = 1'000'000'000 / baseband_fs * 8;  // 10 exp9/baseband_fs * 8
+    size_t baseband_fs = 0;  // will be set later by configure message
+    uint32_t nsPerDecSamp = 0;
+    uint8_t modulation = 0;
 
     /* Array Buffer aux. used in decim0 and decim1 IQ c16 signed  data ; (decim0 defines the max length of the array) */
     std::array<complex16_t, 512> dst{};  // decim0 /4 ,  2048/4 = 512 complex I,Q

--- a/firmware/baseband/proc_weather.hpp
+++ b/firmware/baseband/proc_weather.hpp
@@ -40,8 +40,8 @@ class WeatherProcessor : public BasebandProcessor {
     void on_message(const Message* const message) override;
 
    private:
-    static constexpr size_t baseband_fs = 4'000'000;                           // it works, I think we need to write that master clock in the baseband_threat , even later we decimate it.
-    static constexpr uint32_t nsPerDecSamp = 1'000'000'000 / baseband_fs * 8;  // Scaled it due to less array buffer sampes due to /8 decimation.  250 nseg (4Mhz) * 8
+    size_t baseband_fs = 0;  // will be set later by configure message.
+    uint32_t nsPerDecSamp = 0;
 
     /* Array Buffer aux. used in decim0 and decim1 IQ c16 signed  data ; (decim0 defines the max length of the array) */
     std::array<complex16_t, 512> dst{};  // decim0 /4 ,  2048/4 = 512 complex I,Q

--- a/firmware/common/message.hpp
+++ b/firmware/common/message.hpp
@@ -1241,10 +1241,11 @@ class SpectrumPainterBufferConfigureResponseMessage : public Message {
 
 class SubGhzFPRxConfigureMessage : public Message {
    public:
-    constexpr SubGhzFPRxConfigureMessage(uint8_t modulation = 0)
-        : Message{ID::SubGhzFPRxConfigure}, modulation{modulation} {
+    constexpr SubGhzFPRxConfigureMessage(uint8_t modulation = 0, uint32_t sampling_rate = 0)
+        : Message{ID::SubGhzFPRxConfigure}, modulation{modulation}, sampling_rate{sampling_rate} {
     }
     uint8_t modulation = 0;  // 0 am, 1 fm
+    uint32_t sampling_rate = 0;
 };
 
 class WeatherDataMessage : public Message {


### PR DESCRIPTION
1. For testing and tweaking reception issues, use the Sampling Rate specified in the rx_weather.ini or rx_subghzd.ini App Settings file, instead of using a fixed Sampling Rate value in the baseband code.  Now the "nanoseconds per decimated sample" value is also calculated from the Sample Rate specified by the application code.

2. For Weather app only, changed the default sampling_rate and bandwidth (when there is no .ini file) back to the original (2MHz/1.75MHz) values, based on my own reception testing (I was completely unable to receive neighbor's weather sensors with the most recent 4MHz/2.5MHz defaults).

3. Removed unnecessary (currentDuration < UINT32_MAX) check which wasn't doing anything because the line above was already range-checking currentDuration, and also it was not preventing an overflow on the addition because it _should_ have been comparing to UINT32_MAX - nsPerDecSamp.

Regarding change 2, please let me know if these default settings are worse for anyone and I can change the default back and just modify my own .ini file instead.