### PR TITLE
Configure CLKOUT at power-up per PMEM setting

### DIFF
--- a/firmware/application/ui_navigation.cpp
+++ b/firmware/application/ui_navigation.cpp
@@ -173,6 +173,9 @@ SystemStatusView::SystemStatusView(
         pmem::load_persistent_settings_from_file();
     }
 
+    // configure CLKOUT per pmem setting
+    portapack::clock_manager.enable_clock_output(pmem::clkout_enabled());
+
     // force apply of selected sdcard speed override at UI startup
     pmem::set_config_sdcard_high_speed_io(pmem::config_sdcard_high_speed_io(), false);
 


### PR DESCRIPTION
Previously it was necessary to toggle the CLKOUT setting off & on after every power-up to enable CLKOUT.
Now CLKOUT is automatically enabled at power-up if it's so configured to be enabled in PMEM.

(Note this does *not* fix the CLKOUT issue on HackRF r9 boards which is being addressed separately.)