### PR TITLE
CLKOUT workaround for r9 boards

### DIFF
--- a/firmware/application/clock_manager.cpp
+++ b/firmware/application/clock_manager.cpp
@@ -561,26 +561,38 @@ void ClockManager::stop_audio_pll() {
 }
 
 void ClockManager::enable_clock_output(bool enable) {
-    if (enable) {
-        clock_generator.enable_output(clock_generator_output_og_clkout);
-        if (portapack::persistent_memory::clkout_freq() < 1000) {
-            clock_generator.set_ms_frequency(clock_generator_output_og_clkout, portapack::persistent_memory::clkout_freq() * 128000, si5351_vco_f, 7);
+    // NOTE: TEMPORARY CHECK FOR HACKRF_R9 BELOW TO PREVENT CLK2 FROM BEING DISABLED OF FREQ MODIFIED SINCE CLK2 ON R9 IS
+    // USED FOR BOTH CLKOUT AND FOR THE MCU_CLOCK (== GP_CLKIN) WHICH OTHER LP43XX CLOCKS CURRENTLY RELY ON.
+    // FUTURE: REMOVE OTHER LP43XX CLOCK DEPENDENCIES ON GP_CLKIN, THEN DELETE THE CHECK ON THE LINE BELOW.
+    if (!hackrf_r9) {
+        auto clkout_select = hackrf_r9 ? clock_generator_output_r9_clkout : clock_generator_output_og_clkout;
+
+        if (enable) {
+            clock_generator.enable_output(clkout_select);
+            if (portapack::persistent_memory::clkout_freq() < 1000) {
+                clock_generator.set_ms_frequency(clkout_select, portapack::persistent_memory::clkout_freq() * 128000, si5351_vco_f, 7);
+            } else {
+                clock_generator.set_ms_frequency(clkout_select, portapack::persistent_memory::clkout_freq() * 1000, si5351_vco_f, 0);
+            }
         } else {
-            clock_generator.set_ms_frequency(clock_generator_output_og_clkout, portapack::persistent_memory::clkout_freq() * 1000, si5351_vco_f, 0);
+            clock_generator.disable_output(clkout_select);
         }
-    } else {
-        clock_generator.disable_output(clock_generator_output_og_clkout);
+
+        auto si5351_clock_control_common = hackrf_r9
+                                            ? si5351a_clock_control_common
+                                            : si5351c_clock_control_common;
+        const auto ref_pll = hackrf_r9
+                                ? ClockControl::MultiSynthSource::PLLA
+                                : get_si5351c_reference_clock_generator_pll(reference.source);
+
+        if (enable)
+            clock_generator.set_clock_control(clkout_select, si5351_clock_control_common[clkout_select].ms_src(ref_pll).clk_pdn(ClockControl::ClockPowerDown::Power_On));
+        else
+            clock_generator.set_clock_control(clkout_select, ClockControl::power_off());
     }
 
-    auto si5351_clock_control_common = hackrf_r9
-                                           ? si5351a_clock_control_common
-                                           : si5351c_clock_control_common;
-    const auto ref_pll = hackrf_r9
-                             ? ClockControl::MultiSynthSource::PLLA
-                             : get_si5351c_reference_clock_generator_pll(reference.source);
-
-    if (enable)
-        clock_generator.set_clock_control(clock_generator_output_og_clkout, si5351_clock_control_common[clock_generator_output_og_clkout].ms_src(ref_pll).clk_pdn(ClockControl::ClockPowerDown::Power_On));
-    else
-        clock_generator.set_clock_control(clock_generator_output_og_clkout, ClockControl::power_off());
+    if (hackrf_r9) {
+        gpio_r9_clkout_en.output();
+        gpio_r9_clkout_en.write(enable);
+    }
 }

--- a/firmware/application/clock_manager.cpp
+++ b/firmware/application/clock_manager.cpp
@@ -581,19 +581,12 @@ void ClockManager::enable_clock_output(bool enable) {
         } else {
             clock_generator.set_ms_frequency(clkout_select, portapack::persistent_memory::clkout_freq() * 1000, si5351_vco_f, 0);
         }
+
+        auto si5351_clock_control_common = hackrf_r9 ? si5351a_clock_control_common : si5351c_clock_control_common;
+        const auto ref_pll = hackrf_r9 ? ClockControl::MultiSynthSource::PLLA : get_si5351c_reference_clock_generator_pll(reference.source);
+        clock_generator.set_clock_control(clkout_select, si5351_clock_control_common[clkout_select].ms_src(ref_pll).clk_pdn(ClockControl::ClockPowerDown::Power_On));
     } else {
         clock_generator.disable_output(clkout_select);
-    }
-
-    auto si5351_clock_control_common = hackrf_r9
-                                        ? si5351a_clock_control_common
-                                        : si5351c_clock_control_common;
-    const auto ref_pll = hackrf_r9
-                            ? ClockControl::MultiSynthSource::PLLA
-                            : get_si5351c_reference_clock_generator_pll(reference.source);
-
-    if (enable)
-        clock_generator.set_clock_control(clkout_select, si5351_clock_control_common[clkout_select].ms_src(ref_pll).clk_pdn(ClockControl::ClockPowerDown::Power_On));
-    else
         clock_generator.set_clock_control(clkout_select, ClockControl::power_off());
+    }
 }

--- a/firmware/application/clock_manager.cpp
+++ b/firmware/application/clock_manager.cpp
@@ -561,38 +561,39 @@ void ClockManager::stop_audio_pll() {
 }
 
 void ClockManager::enable_clock_output(bool enable) {
-    // NOTE: TEMPORARY CHECK FOR HACKRF_R9 BELOW TO PREVENT CLK2 FROM BEING DISABLED OF FREQ MODIFIED SINCE CLK2 ON R9 IS
-    // USED FOR BOTH CLKOUT AND FOR THE MCU_CLOCK (== GP_CLKIN) WHICH OTHER LP43XX CLOCKS CURRENTLY RELY ON.
-    // FUTURE: REMOVE OTHER LP43XX CLOCK DEPENDENCIES ON GP_CLKIN, THEN DELETE THE CHECK ON THE LINE BELOW.
-    if (!hackrf_r9) {
-        auto clkout_select = hackrf_r9 ? clock_generator_output_r9_clkout : clock_generator_output_og_clkout;
-
-        if (enable) {
-            clock_generator.enable_output(clkout_select);
-            if (portapack::persistent_memory::clkout_freq() < 1000) {
-                clock_generator.set_ms_frequency(clkout_select, portapack::persistent_memory::clkout_freq() * 128000, si5351_vco_f, 7);
-            } else {
-                clock_generator.set_ms_frequency(clkout_select, portapack::persistent_memory::clkout_freq() * 1000, si5351_vco_f, 0);
-            }
-        } else {
-            clock_generator.disable_output(clkout_select);
-        }
-
-        auto si5351_clock_control_common = hackrf_r9
-                                            ? si5351a_clock_control_common
-                                            : si5351c_clock_control_common;
-        const auto ref_pll = hackrf_r9
-                                ? ClockControl::MultiSynthSource::PLLA
-                                : get_si5351c_reference_clock_generator_pll(reference.source);
-
-        if (enable)
-            clock_generator.set_clock_control(clkout_select, si5351_clock_control_common[clkout_select].ms_src(ref_pll).clk_pdn(ClockControl::ClockPowerDown::Power_On));
-        else
-            clock_generator.set_clock_control(clkout_select, ClockControl::power_off());
-    }
-
     if (hackrf_r9) {
         gpio_r9_clkout_en.output();
         gpio_r9_clkout_en.write(enable);
+
+        // NOTE: RETURNING HERE IF HACKRF_R9 TO PREVENT CLK2 FROM BEING DISABLED OR FREQ MODIFIED SINCE CLK2 ON R9 IS
+        // USED FOR BOTH CLKOUT AND FOR THE MCU_CLOCK (== GP_CLKIN) WHICH OTHER LP43XX CLOCKS CURRENTLY RELY ON.
+        // FUTURE TBD: REMOVE OTHER LP43XX CLOCK DEPENDENCIES ON GP_CLKIN, THEN DELETE THE return LINE BELOW TO ALLOW
+        // CLKOUT FREQ CHANGES ON R9 BOARDS.
+        return;
     }
+
+    auto clkout_select = hackrf_r9 ? clock_generator_output_r9_clkout : clock_generator_output_og_clkout;
+
+    if (enable) {
+        clock_generator.enable_output(clkout_select);
+        if (portapack::persistent_memory::clkout_freq() < 1000) {
+            clock_generator.set_ms_frequency(clkout_select, portapack::persistent_memory::clkout_freq() * 128000, si5351_vco_f, 7);
+        } else {
+            clock_generator.set_ms_frequency(clkout_select, portapack::persistent_memory::clkout_freq() * 1000, si5351_vco_f, 0);
+        }
+    } else {
+        clock_generator.disable_output(clkout_select);
+    }
+
+    auto si5351_clock_control_common = hackrf_r9
+                                        ? si5351a_clock_control_common
+                                        : si5351c_clock_control_common;
+    const auto ref_pll = hackrf_r9
+                            ? ClockControl::MultiSynthSource::PLLA
+                            : get_si5351c_reference_clock_generator_pll(reference.source);
+
+    if (enable)
+        clock_generator.set_clock_control(clkout_select, si5351_clock_control_common[clkout_select].ms_src(ref_pll).clk_pdn(ClockControl::ClockPowerDown::Power_On));
+    else
+        clock_generator.set_clock_control(clkout_select, ClockControl::power_off());
 }

--- a/firmware/common/hackrf_hal.hpp
+++ b/firmware/common/hackrf_hal.hpp
@@ -68,6 +68,7 @@ constexpr size_t clock_generator_output_og_mcu_clkin = 7;
 
 constexpr size_t clock_generator_output_r9_if = 0;
 constexpr size_t clock_generator_output_r9_sgpio = 1;
+constexpr size_t clock_generator_output_r9_clkout = 2;
 constexpr size_t clock_generator_output_r9_mcu_clkin = 2;
 
 /* ADC0 */


### PR DESCRIPTION
Partially resolves issue #1639 by enabling CLKOUT on r9 boards, but note that the CLKOUT frequency is fixed at 10MHz on r9 boards regardless of the radio setting due to GP_CLKIN dependencies noted in #1639 comments.