### PR TITLE
Disallow CLKOUT frequency changes on r9

### DIFF
--- a/firmware/application/apps/ui_settings.cpp
+++ b/firmware/application/apps/ui_settings.cpp
@@ -184,6 +184,14 @@ SetRadioView::SetRadioView(
         send_system_refresh();
     };
 
+    // Disallow CLKOUT freq change on hackrf_r9 due to dependencies on GP_CLKIN (same Si5351A clock);
+    // see comments in ClockManager::enable_clock_output()
+    if (hackrf_r9) {
+        if (pmem::clkout_freq() != 10000)
+            pmem::set_clkout_freq(10000);
+        field_clkout_freq.set_focusable(false);
+    }
+
     field_clkout_freq.set_value(pmem::clkout_freq());
     field_clkout_freq.on_change = [this](SymField&) {
         if (field_clkout_freq.to_integer() < 10)


### PR DESCRIPTION
Changed Settings->Radio screen for r9 boards to disable changing the CLKOUT frequency (this change affects r9 boards only).

Currently only 10MHz CLKOUT output is supported on r9 boards due to LP43xx clock dependencies on GP_CLKIN (MCU_CLOCK) signal which uses the same Si5351A output (CLK2) as CLKOUT.