### PR TITLE
Minor Improvement (Extending_min_CLK_out_from_10khz_to_4khz)

### DIFF
--- a/firmware/application/apps/ui_settings.cpp
+++ b/firmware/application/apps/ui_settings.cpp
@@ -194,7 +194,7 @@ SetRadioView::SetRadioView(
 
     field_clkout_freq.set_value(pmem::clkout_freq());
     field_clkout_freq.on_change = [this](SymField&) {
-        if (field_clkout_freq.to_integer() < 4)     // Min. CLK out of Si5351A/B/C-B is 2.5khz , but in our application -intermediate freq 800Mhz-,Min working CLK=4khz.  
+        if (field_clkout_freq.to_integer() < 4)  // Min. CLK out of Si5351A/B/C-B is 2.5khz , but in our application -intermediate freq 800Mhz-,Min working CLK=4khz.
             field_clkout_freq.set_value(4);
         if (field_clkout_freq.to_integer() > 60000)
             field_clkout_freq.set_value(60000);

--- a/firmware/application/apps/ui_settings.cpp
+++ b/firmware/application/apps/ui_settings.cpp
@@ -194,8 +194,8 @@ SetRadioView::SetRadioView(
 
     field_clkout_freq.set_value(pmem::clkout_freq());
     field_clkout_freq.on_change = [this](SymField&) {
-        if (field_clkout_freq.to_integer() < 10)
-            field_clkout_freq.set_value(10);
+        if (field_clkout_freq.to_integer() < 4)     // Min. CLK out of Si5351A/B/C-B is 2.5khz , but in our application -intermediate freq 800Mhz-,Min working CLK=4khz.  
+            field_clkout_freq.set_value(4);
         if (field_clkout_freq.to_integer() > 60000)
             field_clkout_freq.set_value(60000);
     };

--- a/firmware/common/portapack_persistent_memory.cpp
+++ b/firmware/common/portapack_persistent_memory.cpp
@@ -77,7 +77,7 @@ constexpr modem_repeat_range_t modem_repeat_range{1, 99};
 constexpr int32_t modem_repeat_reset_value{5};
 
 using clkout_freq_range_t = range_t<uint32_t>;
-constexpr clkout_freq_range_t clkout_freq_range{10, 60000};
+constexpr clkout_freq_range_t clkout_freq_range{4, 60000};  // Min. CLK out of Si5351A/B/C-B is 2.5khz , but in our application -intermediate freq 800Mhz-,Min working CLK=4khz. 
 constexpr uint16_t clkout_freq_reset_value{10000};
 
 enum data_structure_version_enum : uint32_t {

--- a/firmware/common/portapack_persistent_memory.cpp
+++ b/firmware/common/portapack_persistent_memory.cpp
@@ -77,7 +77,7 @@ constexpr modem_repeat_range_t modem_repeat_range{1, 99};
 constexpr int32_t modem_repeat_reset_value{5};
 
 using clkout_freq_range_t = range_t<uint32_t>;
-constexpr clkout_freq_range_t clkout_freq_range{4, 60000};  // Min. CLK out of Si5351A/B/C-B is 2.5khz , but in our application -intermediate freq 800Mhz-,Min working CLK=4khz. 
+constexpr clkout_freq_range_t clkout_freq_range{4, 60000};  // Min. CLK out of Si5351A/B/C-B is 2.5khz , but in our application -intermediate freq 800Mhz-,Min working CLK=4khz.
 constexpr uint16_t clkout_freq_reset_value{10000};
 
 enum data_structure_version_enum : uint32_t {


### PR DESCRIPTION
Hi ,  I have validated #1671  by oscilloscope , and it works correctly .

In r9 platform,  we can activate / deactivate the CLK out signal generator .
But as we commented in previous PR ,in r9, the freq. is fixed to 10Mhz  (due to our  fw architecture limittations with Si5351A) .
The generated signal quality in my r9 , @10Mhz , is not so bad , 3,22V pk-pk from GND reference , and a little distorted square signal 
![image](https://github.com/eried/portapack-mayhem/assets/86470699/648ed8bc-5a6b-4970-8664-2f2b174947ab)
In (r1 to r8 hackrf platforms, we are using Si5351C , that allows to our Mayhem , to select the freq value of the synthetized 
CLK out , but I realised that the fw is offering a freq. range from 10khz to 60Mhz . 
In Si5351A/B/C-B datasheet , it tells that the min freq. generated could reach 2.5khz . In our Application , we have a fixed intermediate freq. inside Si5351A/B/C-B fixed to 800Mhz , and that limits our functional min freq. to 4khz. 

I already validated it 
* with H1R1 and H2R4 and  in both the min. 4khz is fully functional. 
* using internal Hackrf 25Mhz and  external TCXO 10Mhz , 
![image](https://github.com/eried/portapack-mayhem/assets/86470699/049e02c8-e94f-411e-a1c8-67a8734d4c7e)


Before that PR , in platforms r1 to r8 Hackrf version , the min. synthetized freq was 10khz , now we can reach 4khz . 

![image](https://github.com/eried/portapack-mayhem/assets/86470699/7032919c-edee-4757-aa7c-cc8449a9422c)

 