### PR TITLE
ERT app - Fix freq field overlapping amp setting

### DIFF
--- a/firmware/application/apps/ert_app.hpp
+++ b/firmware/application/apps/ert_app.hpp
@@ -146,7 +146,7 @@ class ERTAppView : public View {
     static constexpr auto header_height = 1 * 16;
 
     RxFrequencyField field_frequency{
-        {5 * 8, 0 * 16},
+        {0 * 8, 0 * 16},
         nav_};
 
     RFAmpField field_rf_amp{


### PR DESCRIPTION
The "amp" field wasn't visible on the screen because it was covered by the recently-added frequency field.