### PR TITLE
Compiler warning WIP

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,8 @@ set(CMAKE_TOOLCHAIN_FILE ${CMAKE_CURRENT_LIST_DIR}/firmware/toolchain-arm-cortex
 
 project(portapack-h1)
 
+set(EXPECTED_GCC_VERSION "9.2.1")
+
 set(VERSION "$ENV{VERSION_STRING}")
 if ("$ENV{VERSION_STRING}" STREQUAL "")
 	execute_process(

--- a/firmware/CMakeLists.txt
+++ b/firmware/CMakeLists.txt
@@ -52,6 +52,15 @@ add_custom_target(
 	DEPENDS ${FIRMWARE_FILENAME} ${HACKRF_FIRMWARE_DFU_FILENAME}
 )
 
+if(NOT ${CMAKE_CXX_COMPILER_VERSION} VERSION_EQUAL ${EXPECTED_GCC_VERSION})
+	set(COMPILER_MISMATCH_MESSAGE "WARNING: Compiler version mismatch, please use the official compiler version $(GCC_VERSION) when sharing builds")
+	message(${COMPILER_MISMATCH_MESSAGE})
+	add_custom_command(
+		TARGET firmware POST_BUILD
+		COMMAND echo ${COMPILER_MISMATCH_MESSAGE}
+		VERBATIM)
+endif()
+
 add_custom_target(
 	program
 	COMMAND ${PROJECT_SOURCE_DIR}/tools/enter_mode.sh hackrf


### PR DESCRIPTION
Issues a warning both at configuration and at the end of compilation if the compiler version does not mach the "official" one.

Does work wihth makefiles but doesnt with ninja..