### PR TITLE
Recon repeat delay

### DIFF
--- a/firmware/application/apps/ui_recon.hpp
+++ b/firmware/application/apps/ui_recon.hpp
@@ -110,7 +110,7 @@ class ReconView : public View {
     void load_persisted_settings();
     bool recon_save_freq(const std::filesystem::path& path, size_t index, bool warn_if_exists);
     // placeholder for possible void recon_start_recording();
-    void recon_stop_recording();
+    void recon_stop_recording(bool exiting);
 
     // Returns true if 'current_index' is in bounds of frequency_list.
     bool current_is_valid();

--- a/firmware/application/apps/ui_recon_settings.cpp
+++ b/firmware/application/apps/ui_recon_settings.cpp
@@ -106,6 +106,7 @@ void ReconSetupViewMore::save() {
     persistent_memory::set_recon_repeat_nb(field_repeat_nb.value());
     persistent_memory::set_recon_repeat_amp(checkbox_repeat_amp.value());
     persistent_memory::set_recon_repeat_gain(field_repeat_gain.value());
+    persistent_memory::set_recon_repeat_delay(field_repeat_delay.value());
 };
 
 void ReconSetupViewMain::focus() {
@@ -128,7 +129,9 @@ ReconSetupViewMore::ReconSetupViewMore(NavigationView& nav, Rect parent_rect)
                   &field_repeat_nb,
                   &checkbox_repeat_amp,
                   &text_repeat_gain,
-                  &field_repeat_gain});
+                  &field_repeat_gain,
+                  &text_repeat_delay,
+                  &field_repeat_delay});
 
     // tx options have to be in yellow to inform the users that activating them will make the device transmit
     checkbox_repeat_recorded.set_style(&Styles::yellow);
@@ -137,6 +140,8 @@ ReconSetupViewMore::ReconSetupViewMore(NavigationView& nav, Rect parent_rect)
     checkbox_repeat_amp.set_style(&Styles::yellow);
     text_repeat_gain.set_style(&Styles::yellow);
     field_repeat_gain.set_style(&Styles::yellow);
+    text_repeat_delay.set_style(&Styles::yellow);
+    field_repeat_delay.set_style(&Styles::yellow);
 
     checkbox_load_freqs.set_value(persistent_memory::recon_load_freqs());
     checkbox_load_repeaters.set_value(persistent_memory::recon_load_repeaters());
@@ -148,6 +153,7 @@ ReconSetupViewMore::ReconSetupViewMore(NavigationView& nav, Rect parent_rect)
     checkbox_repeat_amp.set_value(persistent_memory::recon_repeat_amp());
     field_repeat_nb.set_value(persistent_memory::recon_repeat_nb());
     field_repeat_gain.set_value(persistent_memory::recon_repeat_gain());
+    field_repeat_delay.set_value(persistent_memory::recon_repeat_delay());
 
     // tx warning modal
     checkbox_repeat_recorded.on_select = [this, &nav](Checkbox&, bool v) {

--- a/firmware/application/apps/ui_recon_settings.hpp
+++ b/firmware/application/apps/ui_recon_settings.hpp
@@ -158,7 +158,7 @@ class ReconSetupViewMore : public View {
         "nb:"};
 
     NumberField field_repeat_nb{
-        {18 * 8, 165},
+        {17 * 8, 165},
         2,
         {1, 99},
         1,
@@ -171,13 +171,25 @@ class ReconSetupViewMore : public View {
         "AMP,"};
 
     Text text_repeat_gain{
-        {10 * 8, 196, 5 * 8, 22},
+        {9 * 8, 196, 5 * 8, 22},
         "GAIN:"};
 
     NumberField field_repeat_gain{
-        {16 * 8, 196},
+        {14 * 8, 196},
         2,
         {0, 47},
+        1,
+        ' ',
+    };
+
+    Text text_repeat_delay{
+        {16 * 8, 196, 8 * 8, 22},
+        ", delay:"};
+
+    NumberField field_repeat_delay{
+        {24 * 8, 196},
+        3,
+        {0, 254},
         1,
         ' ',
     };

--- a/firmware/common/portapack_persistent_memory.cpp
+++ b/firmware/common/portapack_persistent_memory.cpp
@@ -197,6 +197,7 @@ struct data_t {
     uint64_t recon_config;
     int8_t recon_repeat_nb;
     int8_t recon_repeat_gain;
+    uint8_t recon_repeat_delay;
 
     // enable or disable converter
     bool converter;
@@ -263,6 +264,7 @@ struct data_t {
           recon_config(0),
           recon_repeat_nb(0),
           recon_repeat_gain(0),
+          recon_repeat_delay(0),
 
           converter(false),
           updown_converter(false),
@@ -405,6 +407,7 @@ void defaults() {
     set_recon_repeat_amp(false);
     set_recon_repeat_gain(35);
     set_recon_repeat_nb(3);
+    set_recon_repeat_delay(1);
 
     set_config_sdcard_high_speed_io(false, true);
 }
@@ -766,6 +769,9 @@ int8_t recon_repeat_nb() {
 int8_t recon_repeat_gain() {
     return data->recon_repeat_gain;
 }
+uint8_t recon_repeat_delay() {
+    return data->recon_repeat_delay;
+}
 bool recon_repeat_amp() {
     return (data->recon_config & 0x00100000UL) ? true : false;
 }
@@ -811,6 +817,9 @@ void set_recon_repeat_nb(const int8_t v) {
 }
 void set_recon_repeat_gain(const int8_t v) {
     data->recon_repeat_gain = v;
+}
+void set_recon_repeat_delay(const uint8_t v) {
+    data->recon_repeat_delay = v;
 }
 void set_recon_repeat_amp(const bool v) {
     data->recon_config = (data->recon_config & ~0x00100000UL) | (v << 20);
@@ -1028,6 +1037,9 @@ bool debug_dump() {
     pmem_dump_file.write_line("tone_mix: " + to_string_dec_uint(data->tone_mix));
     pmem_dump_file.write_line("hardware_config: " + to_string_dec_uint(data->hardware_config));
     pmem_dump_file.write_line("recon_config: 0x" + to_string_hex(data->recon_config, 16));
+    pmem_dump_file.write_line("recon_repeat_nb: " + to_string_dec_int(data->recon_repeat_nb, 16));
+    pmem_dump_file.write_line("recon_repeat_gain:" + to_string_hex(data->recon_config, 16));
+    pmem_dump_file.write_line("recon_repeat_delay:" + to_string_hex(data->recon_config, 16));
     pmem_dump_file.write_line("converter: " + to_string_dec_int(data->converter));
     pmem_dump_file.write_line("updown_converter: " + to_string_dec_int(data->updown_converter));
     pmem_dump_file.write_line("updown_frequency_rx_correction: " + to_string_dec_int(data->updown_frequency_rx_correction));

--- a/firmware/common/portapack_persistent_memory.hpp
+++ b/firmware/common/portapack_persistent_memory.hpp
@@ -255,6 +255,7 @@ int8_t recon_repeat_gain();
 bool recon_repeat_amp();
 bool recon_load_hamradios();
 bool recon_match_mode();
+uint8_t recon_repeat_delay();
 void set_recon_autosave_freqs(const bool v);
 void set_recon_autostart_recon(const bool v);
 void set_recon_continuous(const bool v);
@@ -270,6 +271,7 @@ void set_recon_repeat_amp(const bool v);
 void set_recon_load_hamradios(const bool v);
 void set_recon_load_repeaters(const bool v);
 void set_recon_match_mode(const bool v);
+void set_recon_repeat_delay(const uint8_t v);
 
 /* UI Config 2 */
 bool ui_hide_speaker();


### PR DESCRIPTION
### This add a configurable repeat delay into the Recon Repeater mode:
- range: from 0s to 254s 
- timer is played before each TX
### Also:
- fixed missing '<' '>' around button names for DELETE and REMOVE name to indicate that they can also be used to skip in the list
- added missing pmem recon dump entries