### PR TITLE
added cpld info shell commands

### DIFF
--- a/firmware/application/usb_serial_shell.cpp
+++ b/firmware/application/usb_serial_shell.cpp
@@ -45,6 +45,7 @@
 #include <codecvt>
 #include <cstring>
 #include <locale>
+#include <libopencm3/lpc43xx/wwdt.h>
 
 #define SHELL_WA_SIZE THD_WA_SIZE(1024 * 3)
 #define palOutputPad(port, pad) (LPC_GPIO->DIR[(port)] |= 1 << (pad))
@@ -588,9 +589,11 @@ static void cpld_info(BaseSequentialStream* chp, int argc, char* argv[]) {
             chprintf(chp, "CPLD firmware checksum: 0x%08X\r\n", crc.checksum());
 
             m4_request_shutdown();
-            chThdSleepMilliseconds(50);
+            chThdSleepMilliseconds(1000);
 
-            LPC_RGU->RESET_CTRL[0] = (1 << 0);
+            WWDT_MOD = WWDT_MOD_WDEN | WWDT_MOD_WDRESET;
+            WWDT_TC = 100000 & 0xFFFFFF;
+            WWDT_FEED_SEQUENCE;
 
         } else if (idcode == 0x00025610) {
             chprintf(chp, "CPLD Model: AGM AG256SL100\r\n");
@@ -615,9 +618,12 @@ static void cpld_info(BaseSequentialStream* chp, int argc, char* argv[]) {
             chprintf(chp, "CPLD firmware checksum: 0x%08X\r\n", crc.checksum());
 
             m4_request_shutdown();
-            chThdSleepMilliseconds(50);
+            chThdSleepMilliseconds(1000);
 
-            LPC_RGU->RESET_CTRL[0] = (1 << 0);
+            WWDT_MOD = WWDT_MOD_WDEN | WWDT_MOD_WDRESET;
+            WWDT_TC = 100000 & 0xFFFFFF;
+            WWDT_FEED_SEQUENCE;
+
         } else {
             chprintf(chp, "CPLD Model: unknown\r\n");
         }
@@ -742,9 +748,11 @@ static void cmd_cpld_read(BaseSequentialStream* chp, int argc, char* argv[]) {
             }
 
             m4_request_shutdown();
-            chThdSleepMilliseconds(50);
+            chThdSleepMilliseconds(1000);
 
-            LPC_RGU->RESET_CTRL[0] = (1 << 0);
+            WWDT_MOD = WWDT_MOD_WDEN | WWDT_MOD_WDRESET;
+            WWDT_TC = 100000 & 0xFFFFFF;
+            WWDT_FEED_SEQUENCE;
 
         } else if (idcode == 0x00025610) {
             chprintf(chp, "CPLD Model: AGM AG256SL100\r\n");
@@ -771,9 +779,12 @@ static void cmd_cpld_read(BaseSequentialStream* chp, int argc, char* argv[]) {
             cpld.AGM_exit_maintenance_mode();
 
             m4_request_shutdown();
-            chThdSleepMilliseconds(50);
+            chThdSleepMilliseconds(1000);
 
-            LPC_RGU->RESET_CTRL[0] = (1 << 0);
+            WWDT_MOD = WWDT_MOD_WDEN | WWDT_MOD_WDRESET;
+            WWDT_TC = 100000 & 0xFFFFFF;
+            WWDT_FEED_SEQUENCE;
+
         } else {
             chprintf(chp, "CPLD Model: unknown\r\n");
         }

--- a/firmware/common/cpld_max5.hpp
+++ b/firmware/common/cpld_max5.hpp
@@ -60,6 +60,7 @@ class CPLD {
     }
 
     bool idcode_ok();
+    uint32_t get_idcode();
 
     void enable();
 
@@ -90,6 +91,15 @@ class CPLD {
 
     std::pair<bool, uint8_t> boundary_scan();
 
+    void prepare_read(uint16_t block);
+    uint32_t read();
+
+    bool AGM_enter_maintenance_mode();
+    void AGM_exit_maintenance_mode();
+    void AGM_enter_read_mode();
+    uint32_t AGM_encode_address(uint32_t address, uint32_t trailer);
+    uint32_t AGM_read(uint32_t address);
+
    private:
     using idcode_t = uint32_t;
     static constexpr size_t idcode_length = 32;
@@ -115,6 +125,13 @@ class CPLD {
         ISC_ADDRESS_SHIFT = 0b1000000011,  // 0x203
         ISC_READ = 0b1000000101,           // 0x205
         ISC_NOOP = 0b1000010000,           // 0x210
+        AGM_RESET = 0x3f7,
+        AGM_STAGE_1 = 0x3f8,
+        AGM_STAGE_2 = 0x3f9,
+        AGM_PROGRAM = 0x3fa,
+        AGM_SET_REGISTER = 0x3fc,
+        AGM_READ = 0x3fd,
+        AGM_ERASE = 0x3fe,
     };
 
     void shift_ir(const instruction_t instruction) {

--- a/firmware/common/cpld_xilinx.hpp
+++ b/firmware/common/cpld_xilinx.hpp
@@ -68,6 +68,13 @@ class XC2C64A {
     bool verify_eeprom(const verify_blocks_t& blocks);
     void init_from_eeprom();
 
+    void prepare_read_eeprom();
+    void prepare_read_sram();
+    std::array<bool, block_length> read_block_eeprom(block_id_t id);
+    std::array<bool, block_length> read_block_sram(verify_block_t block);
+    void finalize_read_eeprom();
+    void finalize_read_sram(block_id_t id);
+
    private:
     static constexpr size_t idcode_length = 32;
     using idcode_t = uint32_t;

--- a/firmware/common/jtag.cpp
+++ b/firmware/common/jtag.cpp
@@ -37,4 +37,15 @@ uint32_t JTAG::shift(const size_t count, uint32_t value) {
     return value;
 }
 
+uint32_t JTAG::shift_header(const size_t count, uint32_t value) {
+    for (size_t i = 0; i < count; i++) {
+        const auto tdo = target.clock(
+            0,
+            value & 1);
+        value >>= 1;
+        value |= tdo << (count - 1);
+    }
+    return value;
+}
+
 } /* namespace jtag */

--- a/firmware/common/jtag.hpp
+++ b/firmware/common/jtag.hpp
@@ -89,10 +89,29 @@ class JTAG {
         return result;
     }
 
+    uint32_t shift_dr(const size_t count, const uint32_t address, const uint32_t value) {
+        /* Run-Test/Idle -> Select-DR-Scan */
+        target.clock(1, 0);
+        /* Scan -> Capture -> Shift */
+        target.clock(0, 0);
+        target.clock(0, 0);
+
+        shift_header(count, address);
+        const auto result = shift(count, value);
+
+        /* Exit1 -> Update */
+        target.clock(1, 0);
+        /* Update -> Run-Test/Idle */
+        target.clock(0, 0);
+
+        return result;
+    }
+
    private:
     Target& target;
 
     uint32_t shift(const size_t count, uint32_t value);
+    uint32_t shift_header(const size_t count, uint32_t value);
 };
 
 } /* namespace jtag */

--- a/firmware/common/jtag_tap.hpp
+++ b/firmware/common/jtag_tap.hpp
@@ -26,6 +26,7 @@
 
 #include <cstdint>
 #include <cstddef>
+#include <vector>
 
 namespace jtag {
 namespace tap {
@@ -113,13 +114,14 @@ class TAPMachine {
     void set_end_dr(const state_t state);
 
     bool shift(const bits_t& tdi, const bool end_tms) {
-        return shift(tdi, {}, {}, end_tms);
+        return shift(tdi, {}, {}, end_tms, nullptr);
     }
 
-    bool shift(const bits_t& tdi, const bits_t& tdo_expected, const bits_t& tdo_mask, const bool end_tms);
+    bool shift(const bits_t& tdi, const bits_t& tdo_expected, const bits_t& tdo_mask, const bool end_tms, std::vector<bool>* from_device);
 
     bool shift_ir(const bits_t& tdi_value, const bits_t& tdo_expected = {}, const bits_t& tdo_mask = {});
     bool shift_dr(const bits_t& tdi_value, const bits_t& tdo_expected = {}, const bits_t& tdo_mask = {});
+    std::vector<bool> shift_dr_read(const bits_t& tdi_value);
 
     void state(const state_t state);
 
@@ -142,6 +144,7 @@ class TAPMachine {
     void shift_end(const state_t end_state, const uint32_t end_delay);
 
     bool shift_data(const bits_t& tdi, const bits_t& tdo_expected, const bits_t& tdo_mask, const state_t state, const state_t end_state, const uint32_t end_delay);
+    std::vector<bool> shift_data_read(const bits_t& tdi, const state_t state, const state_t end_state, const uint32_t end_delay);
 };
 
 } /* namespace tap */


### PR DESCRIPTION
This pull request adds two commands to the usb serial shell to access the CPLDs for firmware info and dumps.

![grafik](https://github.com/eried/portapack-mayhem/assets/13151053/167748e9-771b-4b7f-845d-00341309c1a3)

List of new commands:
* cpld_info hackrf
* cpld_info portapack
* cpld_read hackrf sram
* cpld_read hackrf eeprom
* cpld_read portapack eeprom
