### PR TITLE
Added support for extracting firmware from TAR file (with apps)

### DIFF
--- a/firmware/application/apps/ui_flash_utility.cpp
+++ b/firmware/application/apps/ui_flash_utility.cpp
@@ -98,12 +98,11 @@ std::filesystem::path FlashUtilityView::extract_tar(std::filesystem::path::strin
         painter.fill_rectangle({0, 50, portapack::display.width(), 90}, ui::Color::black());
         painter.draw_string({0, 60}, this->nav_.style(), fileName);
     });
-    if (res.empty()) {
-        nav_.push<ModalMessageView>(
-            "Warning!",
-            "Error in TAR file.",
-            INFO,
-            [this](bool choice) { (void)choice; });
+    if (res.string().empty()) {
+        ui::Painter painter;
+        painter.fill_rectangle({0, 50, portapack::display.width(), 90}, ui::Color::black());
+        painter.draw_string({0, 60}, this->nav_.style(), "BAD TAR FILE");
+        chThdSleepMilliseconds(5000);
     }
     return res;
 }

--- a/firmware/application/apps/ui_flash_utility.cpp
+++ b/firmware/application/apps/ui_flash_utility.cpp
@@ -50,6 +50,17 @@ FlashUtilityView::FlashUtilityView(NavigationView& nav)
                                 this->firmware_selected(path);
                             }});
     }
+    for (const auto& entry : std::filesystem::directory_iterator(firmware_folder, u"*.ppfw.tar")) {
+        auto filename = entry.path().filename();
+        auto path = entry.path().native();
+
+        menu_view.add_item({filename.string().substr(0, max_filename_length),
+                            ui::Color::purple(),
+                            &bitmap_icon_temperature,
+                            [this, path](KeyEvent) {
+                                this->firmware_selected(path);
+                            }});
+    }
 }
 
 void FlashUtilityView::firmware_selected(std::filesystem::path::string_type path) {
@@ -65,7 +76,40 @@ void FlashUtilityView::firmware_selected(std::filesystem::path::string_type path
         });
 }
 
+bool FlashUtilityView::endsWith(const std::u16string& str, const std::u16string& suffix) {
+    if (str.length() >= suffix.length()) {
+        std::u16string endOfString = str.substr(str.length() - suffix.length());
+        return endOfString == suffix;
+    } else {
+        return false;
+    }
+}
+
+std::filesystem::path FlashUtilityView::extract_tar(std::filesystem::path::string_type path) {
+    //
+    ui::Painter painter;
+    painter.fill_rectangle(
+        {0, 0, portapack::display.width(), portapack::display.height()},
+        ui::Color::black());
+    painter.draw_string({12, 24}, this->nav_.style(), "Unpacking TAR file...");
+
+    auto res = UnTar::untar(path);
+    if (res.empty()) {
+        nav_.push<ModalMessageView>(
+            "Warning!",
+            "Error in TAR file.",
+            INFO,
+            [this](bool choice) { (void)choice; });
+    }
+    return res;
+}
+
 void FlashUtilityView::flash_firmware(std::filesystem::path::string_type path) {
+    if (endsWith(path, u".ppfw.tar")) {
+        // extract, then update
+        path = extract_tar(u'/' + path).native();
+        if (path.empty()) return;
+    }
     ui::Painter painter;
     painter.fill_rectangle(
         {0, 0, portapack::display.width(), portapack::display.height()},

--- a/firmware/application/apps/ui_flash_utility.cpp
+++ b/firmware/application/apps/ui_flash_utility.cpp
@@ -93,7 +93,11 @@ std::filesystem::path FlashUtilityView::extract_tar(std::filesystem::path::strin
         ui::Color::black());
     painter.draw_string({12, 24}, this->nav_.style(), "Unpacking TAR file...");
 
-    auto res = UnTar::untar(path);
+    auto res = UnTar::untar(path, [this](const std::string fileName) {
+        ui::Painter painter;
+        painter.fill_rectangle({0, 50, portapack::display.width(), 90}, ui::Color::black());
+        painter.draw_string({0, 60}, this->nav_.style(), fileName);
+    });
     if (res.empty()) {
         nav_.push<ModalMessageView>(
             "Warning!",

--- a/firmware/application/apps/ui_flash_utility.hpp
+++ b/firmware/application/apps/ui_flash_utility.hpp
@@ -29,7 +29,7 @@
 #include "ff.h"
 #include "baseband_api.hpp"
 #include "core_control.hpp"
-
+#include "untar.hpp"
 #include <cstdint>
 
 namespace ui {
@@ -55,8 +55,10 @@ class FlashUtilityView : public View {
         {0, 2 * 8, 240, 26 * 8},
         true};
 
+    std::filesystem::path extract_tar(std::filesystem::path::string_type path);  // extracts the tar file, and returns the firmware.bin path from it. empty string if no fw
     void firmware_selected(std::filesystem::path::string_type path);
     void flash_firmware(std::filesystem::path::string_type path);
+    bool endsWith(const std::u16string& str, const std::u16string& suffix);
 };
 
 } /* namespace ui */

--- a/firmware/common/untar.hpp
+++ b/firmware/common/untar.hpp
@@ -1,0 +1,145 @@
+#ifndef __UNTAR
+#define __UNTAR
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "string_format.hpp"
+#include "file.hpp"
+
+class UnTar {
+   public:
+    static std::filesystem::path untar(std::u16string& tar) {
+        File tf;
+        auto result = tf.open(tar, true, false);
+        if (!result.value().ok()) return "";
+        return untar_int(&tf);
+    }
+
+   private:
+    static int parseoct(const char* p, size_t n) {
+        int i = 0;
+        while (*p < '0' || *p > '7') {
+            ++p;
+            --n;
+        }
+        while (*p >= '0' && *p <= '7' && n > 0) {
+            i *= 8;
+            i += *p - '0';
+            ++p;
+            --n;
+        }
+        return i;
+    }
+
+    static bool is_end_of_archive(const char* p) {
+        for (int n = 511; n >= 0; --n)
+            if (p[n] != '\0') return false;
+        return true;
+    }
+
+    static bool create_dir(char* pathname) {
+        char* p;
+        std::filesystem::filesystem_error r;
+
+        /* Strip trailing '/' */
+        if (pathname[strlen(pathname) - 1] == '/')
+            pathname[strlen(pathname) - 1] = '\0';
+
+        /* Try creating the directory. */
+        std::string dirnameStr = u'/' + pathname;
+        std::filesystem::path dirname = dirnameStr;
+
+        r = make_new_directory(dirname);
+
+        if (!r.ok()) {
+            /* On failure, try creating parent directory. */
+            p = strrchr(pathname, '/');
+            if (p != NULL) {
+                *p = '\0';
+                create_dir(pathname);
+                *p = '/';
+                r = make_new_directory(dirname);
+            }
+        }
+        return (r.ok());
+    }
+
+    static bool verify_checksum(const char* p) {
+        int n, u = 0;
+        for (n = 0; n < 512; ++n) {
+            if (n < 148 || n > 155)
+                /* Standard tar checksum adds unsigned bytes. */
+                u += ((unsigned char*)p)[n];
+            else
+                u += 0x20;
+        }
+        return (u == parseoct(p + 148, 8));
+    }
+
+    static std::filesystem::path untar_int(File* a) {
+        char buff[512];
+        UINT bytes_read;
+        std::string binfile = "";
+        std::string fn = "";
+        int filesize;
+        for (;;) {
+            auto readres = a->read(buff, 512);
+            if (!readres.is_ok()) return "";
+            bytes_read = readres.value();
+            if (bytes_read < 512) {
+                return "";
+            }
+            if (is_end_of_archive(buff)) {
+                return binfile;
+            }
+            if (!verify_checksum(buff)) {
+                return "";
+            }
+            filesize = parseoct(buff + 124, 12);
+            switch (buff[156]) {
+                case '1':
+                    break;
+                case '2':
+                    break;
+                case '3':
+                    break;
+                case '4':
+                    break;
+                case '5':
+                    create_dir(buff);
+                    filesize = 0;
+                    break;
+                case '6':
+                    break;
+                default:
+                    fn = buff;
+                    if (fn.length() > 5 && fn.substr(fn.length() - 4) == ".bin") {
+                        binfile = fn;
+                    }
+                    break;
+            }
+            File f;
+            if (filesize > 0) {
+                delete_file(fn);
+                auto fres = f.open(fn, false, true);
+                if (!fres.value().ok()) return "";
+            }
+            while (filesize > 0) {
+                readres = a->read(buff, 512);
+                if (!readres.is_ok()) return "";
+                bytes_read = readres.value();
+                if (bytes_read < 512) {
+                    return "";
+                }
+                if (filesize < 512)
+                    bytes_read = filesize;
+                auto fwres = f.write(buff, bytes_read);
+                if (!fwres.is_ok()) return "";
+                filesize -= bytes_read;
+            }
+        }
+        return binfile;
+    }
+};
+#endif

--- a/firmware/common/untar.hpp
+++ b/firmware/common/untar.hpp
@@ -9,11 +9,11 @@
 
 class UnTar {
    public:
-    static std::filesystem::path untar(std::u16string tar) {
+    static std::filesystem::path untar(std::u16string tar, std::function<void(const std::string)> cb = NULL) {
         File tf;
         auto result = tf.open(tar, true, false);
         if (!result.value().ok()) return "";
-        return untar_int(&tf);
+        return untar_int(&tf, cb);
     }
 
    private:
@@ -77,7 +77,7 @@ class UnTar {
         return (u == parseoct(p + 148, 8));
     }
 
-    static std::filesystem::path untar_int(File* a) {
+    static std::filesystem::path untar_int(File* a, std::function<void(const std::string)> cb = NULL) {
         char buff[512];
         UINT bytes_read;
         std::string binfile = "";
@@ -117,6 +117,7 @@ class UnTar {
                     if (fn.length() > 5 && fn.substr(fn.length() - 4) == ".bin") {
                         binfile = fn;
                     }
+                    if (cb != NULL) cb(fn);
                     break;
             }
             File f;
@@ -137,6 +138,7 @@ class UnTar {
                 auto fwres = f.write(buff, bytes_read);
                 if (!fwres.is_ok()) return "";
                 filesize -= bytes_read;
+                f.sync();
             }
         }
         return binfile;

--- a/firmware/common/untar.hpp
+++ b/firmware/common/untar.hpp
@@ -9,7 +9,7 @@
 
 class UnTar {
    public:
-    static std::filesystem::path untar(std::u16string& tar) {
+    static std::filesystem::path untar(std::u16string tar) {
         File tf;
         auto result = tf.open(tar, true, false);
         if (!result.value().ok()) return "";

--- a/firmware/common/untar.hpp
+++ b/firmware/common/untar.hpp
@@ -38,10 +38,25 @@ class UnTar {
         return true;
     }
 
+    static size_t strnlen(const char* s, size_t maxlen) {
+        for (size_t i = 0; i < maxlen; i++) {
+            if (s[i] == '\0')
+                return i;
+        }
+        return maxlen;
+    }
+
+    static bool isValidName(char* name) {
+        size_t pathStrLen = strnlen(name, 100);
+        if (pathStrLen == 0 || pathStrLen >= 100) return false;
+        return true;
+    }
+
     static bool create_dir(char* pathname) {
         char* p;
         std::filesystem::filesystem_error r;
 
+        if (!isValidName(pathname)) return false;
         /* Strip trailing '/' */
         if (pathname[strlen(pathname) - 1] == '/')
             pathname[strlen(pathname) - 1] = '\0';
@@ -113,11 +128,15 @@ class UnTar {
                 case '6':
                     break;
                 default:
-                    fn = buff;
-                    if (fn.length() > 5 && fn.substr(fn.length() - 4) == ".bin") {
-                        binfile = fn;
+                    if (isValidName(buff)) {
+                        fn = buff;
+                        if (fn.length() > 5 && fn.substr(fn.length() - 4) == ".bin") {
+                            binfile = fn;
+                        }
+                        if (cb != NULL) cb(fn);
+                    } else {
+                        return "";  // bad tar
                     }
-                    if (cb != NULL) cb(fn);
                     break;
             }
             File f;


### PR DESCRIPTION
This PR adds the Firmware updater app (the app only, no serial command yet) the ability, to use TAR files.

Each file extracted from the tar, and OVERWRITTEN on SD.
After extracting it, the standard FW update process starts with the bin file it extracted last. (eg FIRMWARE/portapack-h1_h2-mayhem.bin)
The files in the TAR file must use the same directory structure that on the SD. Like APPS/ FIRMWARE/.

This way we can include apps, new databases, etc.

The extension of the tar file must be ".ppfw.tar". (kept the tar to be able to edit in pc easier, but added the ppfw to be identifiable).

This won't delete anything from SD, but overwrite (so there could be leftover APPS for example). I don't think deleting is a good idea, even if the update breaks it.

This is a partial solution for [#1631](https://github.com/eried/portapack-mayhem/issues/1631)

Todo:
- add automation at builds to generate the tar file (this pr won't include this)

ONLY TEST IT IF YOU CAN RECOVER YOUR PP WITH DFU!
(tested and working, but things can go wrong)