### PR TITLE
Touch emulation from usb cdc

### DIFF
--- a/firmware/application/event_m0.cpp
+++ b/firmware/application/event_m0.cpp
@@ -238,6 +238,10 @@ ui::Widget* EventDispatcher::touch_widget(ui::Widget* const w, ui::TouchEvent ev
     return nullptr;
 }
 
+void EventDispatcher::emulateTouch(ui::TouchEvent event) {
+    on_touch_event(event);
+}
+
 void EventDispatcher::on_touch_event(ui::TouchEvent event) {
     /* TODO: Capture widget receiving the Start event, send Move and
      * End events to the same widget.

--- a/firmware/application/event_m0.hpp
+++ b/firmware/application/event_m0.hpp
@@ -86,6 +86,8 @@ class EventDispatcher {
         events_flag(EVT_MASK_LOCAL);
     }
 
+    void emulateTouch(ui::TouchEvent event);
+
    private:
     static Thread* thread_event_loop;
 

--- a/firmware/application/main.cpp
+++ b/firmware/application/main.cpp
@@ -157,7 +157,7 @@ static void event_loop() {
         [&event_dispatcher](const Message* const) {
             event_dispatcher.set_display_sleep(true);
         }};
-
+    portapack::setEventDispatcherToUSBSerial(&event_dispatcher);
     event_dispatcher.run();
 }
 

--- a/firmware/application/portapack.cpp
+++ b/firmware/application/portapack.cpp
@@ -542,4 +542,8 @@ void shutdown(const bool leave_screen_on) {
     shutdown_base();
 }
 
+void setEventDispatcherToUSBSerial(EventDispatcher* evt) {
+    usb_serial.setEventDispatcher(evt);
+}
+
 } /* namespace portapack */

--- a/firmware/application/portapack.hpp
+++ b/firmware/application/portapack.hpp
@@ -68,6 +68,8 @@ bool get_antenna_bias();
 bool init();
 void shutdown(const bool leave_screen_on = false);
 
+void setEventDispatcherToUSBSerial(EventDispatcher* evt);
+
 Backlight* backlight();
 
 } /* namespace portapack */

--- a/firmware/application/usb_serial.cpp
+++ b/firmware/application/usb_serial.cpp
@@ -32,7 +32,7 @@ void USBSerial::dispatch() {
 
     if (shell_created == false) {
         shell_created = true;
-        create_shell();
+        create_shell(_eventDispatcher);
     }
 
     bulk_out_receive();

--- a/firmware/application/usb_serial.hpp
+++ b/firmware/application/usb_serial.hpp
@@ -24,6 +24,8 @@
 #include "ch.h"
 #include "hal.h"
 
+class EventDispatcher;
+
 namespace portapack {
 
 class USBSerial {
@@ -32,6 +34,7 @@ class USBSerial {
     void dispatch();
     void on_channel_opened();
     void on_channel_closed();
+    void setEventDispatcher(EventDispatcher* ed) { _eventDispatcher = ed; }
 
    private:
     void enable_xtal();
@@ -43,6 +46,8 @@ class USBSerial {
 
     bool connected{false};
     bool shell_created{false};
+
+    EventDispatcher* _eventDispatcher = NULL;
 };
 
 }  // namespace portapack

--- a/firmware/application/usb_serial_shell.hpp
+++ b/firmware/application/usb_serial_shell.hpp
@@ -26,4 +26,6 @@
 
 #include "shell.h"
 
-void create_shell(void);
+class EventDispatcher;
+
+void create_shell(EventDispatcher* evtd);


### PR DESCRIPTION
Had to pass the EventDispatcher to the UsbShell, but this seems to work.
Created a new function to make it expandable in the future, instead of using the private one.