### PR TITLE
Add Tamper Flags to ERT RX display and meter ID to log file

### DIFF
--- a/firmware/application/apps/ert_app.cpp
+++ b/firmware/application/apps/ert_app.cpp
@@ -77,7 +77,7 @@ void ERTLogger::on_packet(const ert::Packet& packet, const uint32_t target_frequ
     const auto formatted = packet.symbols_formatted();
     const auto target_frequency_str = to_string_dec_uint(target_frequency, 10);
 
-    std::string entry = target_frequency_str + " " + ert::format::type(packet.type()) + " " + formatted.data + "/" + formatted.errors + " ID:" + to_string_dec_uint(packet.id(),1);
+    std::string entry = target_frequency_str + " " + ert::format::type(packet.type()) + " " + formatted.data + "/" + formatted.errors + " ID:" + to_string_dec_uint(packet.id(), 1);
 
     log_file.write_entry(packet.received_at(), entry);
 }
@@ -101,7 +101,7 @@ void RecentEntriesTable<ERTRecentEntries>::draw(
     Painter& painter,
     const Style& style) {
     std::string line = ert::format::id(entry.id) + " " + ert::format::commodity_type(entry.commodity_type) + " " + ert::format::consumption(entry.last_consumption) + " ";
-    
+
     line += (entry.packet_type == ert::Packet::Type::SCM) ? ert::format::tamper_flags_scm(entry.last_tamper_flags) : ert::format::tamper_flags(entry.last_tamper_flags);
     line += (entry.received_count > 99) ? " ++" : to_string_dec_uint(entry.received_count, 3);
 

--- a/firmware/application/apps/ert_app.cpp
+++ b/firmware/application/apps/ert_app.cpp
@@ -54,11 +54,19 @@ std::string id(ID value) {
 }
 
 std::string consumption(Consumption value) {
-    return to_string_dec_uint(value, 10);
+    return to_string_dec_uint(value, 8);
 }
 
 std::string commodity_type(CommodityType value) {
     return to_string_dec_uint(value, 2);
+}
+
+std::string tamper_flags(TamperFlags value) {
+    return to_string_hex(value & 0xFFFF, 4);  // Note: ignoring bits 32-47 of tamper flags in IDM type due to screen width
+}
+
+std::string tamper_flags_scm(TamperFlags value) {
+    return " " + to_string_hex(value & 0x0F, 1) + "/" + to_string_hex(value >> 4, 1);  // Physical/Encoder flags
 }
 
 } /* namespace format */
@@ -67,11 +75,10 @@ std::string commodity_type(CommodityType value) {
 
 void ERTLogger::on_packet(const ert::Packet& packet, const uint32_t target_frequency) {
     const auto formatted = packet.symbols_formatted();
-
-    // TODO: function doesn't take uint64_t, so when >= 1<<32, weirdness will ensue!
     const auto target_frequency_str = to_string_dec_uint(target_frequency, 10);
 
-    std::string entry = target_frequency_str + " " + ert::format::type(packet.type()) + " " + formatted.data + "/" + formatted.errors;
+    std::string entry = target_frequency_str + " " + ert::format::type(packet.type()) + " " + formatted.data + "/" + formatted.errors + " ID:" + to_string_dec_uint(packet.id(),1);
+
     log_file.write_entry(packet.received_at(), entry);
 }
 
@@ -81,6 +88,8 @@ void ERTRecentEntry::update(const ert::Packet& packet) {
     received_count++;
 
     last_consumption = packet.consumption();
+    last_tamper_flags = packet.tamper_flags();
+    packet_type = packet.type();
 }
 
 namespace ui {
@@ -91,13 +100,10 @@ void RecentEntriesTable<ERTRecentEntries>::draw(
     const Rect& target_rect,
     Painter& painter,
     const Style& style) {
-    std::string line = ert::format::id(entry.id) + " " + ert::format::commodity_type(entry.commodity_type) + " " + ert::format::consumption(entry.last_consumption);
-
-    if (entry.received_count > 999) {
-        line += " +++";
-    } else {
-        line += " " + to_string_dec_uint(entry.received_count, 3);
-    }
+    std::string line = ert::format::id(entry.id) + " " + ert::format::commodity_type(entry.commodity_type) + " " + ert::format::consumption(entry.last_consumption) + " ";
+    
+    line += (entry.packet_type == ert::Packet::Type::SCM) ? ert::format::tamper_flags_scm(entry.last_tamper_flags) : ert::format::tamper_flags(entry.last_tamper_flags);
+    line += (entry.received_count > 99) ? " ++" : to_string_dec_uint(entry.received_count, 3);
 
     line.resize(target_rect.width() / 8, ' ');
     painter.draw_string(target_rect.location(), style, line);

--- a/firmware/application/apps/ert_app.hpp
+++ b/firmware/application/apps/ert_app.hpp
@@ -72,10 +72,11 @@ struct ERTRecentEntry {
 
     ert::ID id{ert::invalid_id};
     ert::CommodityType commodity_type{ert::invalid_commodity_type};
+    ert::Consumption last_consumption{};
+    ert::TamperFlags last_tamper_flags{};
+    ert::Packet::Type packet_type{};
 
     size_t received_count{0};
-
-    ert::Consumption last_consumption{};
 
     ERTRecentEntry(
         const Key& key)
@@ -137,9 +138,10 @@ class ERTAppView : public View {
 
     const RecentEntriesColumns columns{{
         {"ID", 10},
-        {"Tp", 2},
-        {"Consumpt", 10},
-        {"Cnt", 3},
+        {"Ty", 2},
+        {"Consumpt", 8},
+        {"Tamp", 4},
+        {"Ct", 2},
     }};
     ERTRecentEntriesView recent_entries_view{columns, recent};
 

--- a/firmware/common/ert_packet.cpp
+++ b/firmware/common/ert_packet.cpp
@@ -82,6 +82,19 @@ CommodityType Packet::commodity_type() const {
     return invalid_commodity_type;
 }
 
+TamperFlags Packet::tamper_flags() const {
+    if (type() == Type::SCM) {
+        return (reader_.read(9, 2) << 4) | reader_.read(3, 2);  // Physical/Encoder tamper flags in lower/upper nibbles
+    }
+    if (type() == Type::SCMPLUS) {
+        return reader_.read(10 * 8, 16);
+    }
+    if (type() == Type::IDM) {
+        return reader_.read(11 * 8, 48);
+    }
+    return invalid_tamper_flags;
+}
+
 FormattedSymbols Packet::symbols_formatted() const {
     return format_symbols(decoder_);
 }

--- a/firmware/common/ert_packet.hpp
+++ b/firmware/common/ert_packet.hpp
@@ -34,10 +34,12 @@ namespace ert {
 using ID = uint32_t;
 using Consumption = uint32_t;
 using CommodityType = uint32_t;
+using TamperFlags = uint32_t;
 
 constexpr ID invalid_id = 0;
 constexpr CommodityType invalid_commodity_type = -1;
 constexpr Consumption invalid_consumption = 0;
+constexpr TamperFlags invalid_tamper_flags = 0;
 
 class Packet {
    public:
@@ -67,6 +69,7 @@ class Packet {
     ID id() const;
     CommodityType commodity_type() const;
     Consumption consumption() const;
+    TamperFlags tamper_flags() const;
 
     FormattedSymbols symbols_formatted() const;
 


### PR DESCRIPTION
Squeezed consumption & count fields slightly to make room for Tamper field on the screen.

Note for SCM type meters only, flags are shown as X/Y indicating physical/encoder tamper bits respectively (for SCM+ and IDM meters the tamper flags are displayed as 4 hexadecimal digits).

Meter ID is added to log file in decimal to match screen and making it easier to search.