### PR TITLE
Create cmake target ppfw

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,7 +49,7 @@
 *.map
 *.lst
 .dep/
-build/
+/build*
 CMakeFiles/
 
 # Debugging

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@
 # Boston, MA 02110-1301, USA.
 #
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 cmake_policy(SET CMP0005 NEW)
 
 set(CMAKE_TOOLCHAIN_FILE ${CMAKE_CURRENT_LIST_DIR}/firmware/toolchain-arm-cortex-m.cmake)
@@ -28,7 +28,7 @@ project(portapack-h1)
 set(EXPECTED_GCC_VERSION "9.2.1")
 
 set(VERSION "$ENV{VERSION_STRING}")
-if ("$ENV{VERSION_STRING}" STREQUAL "")
+if ("${VERSION}" STREQUAL "")
 	execute_process(
 		COMMAND git log -n 1 --format=%h
 		WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
@@ -42,6 +42,11 @@ if ("$ENV{VERSION_STRING}" STREQUAL "")
 	else (GIT_VERSION_FOUND)
 		set(VERSION "${GIT_VERSION}")
 	endif (GIT_VERSION_FOUND)
+
+	set(VERSION_NOHASH "dev")
+else()
+	set(VERSION_NOHASH "${VERSION}")
+	set(PPFW_FILENAME "portapack-mayhem.ppfw.tar")
 endif()
 
 execute_process(
@@ -49,6 +54,18 @@ execute_process(
 	OUTPUT_VARIABLE VERSION_MD5
 )
 set(VERSION_MD5 "0x${VERSION_MD5}")
+
+if (NOT DEFINED PPFW_FILENAME)
+	# Funny business here: trying to generate unique names to prevent renaming of shared test-drive builds by the browser on download to .ppfw-42.tar as it wont be recognized by the flasher
+	execute_process(
+		COMMAND date "+%y%m%d-%H%M"
+		OUTPUT_VARIABLE PPFW_FILENAME
+	)
+	string(STRIP ${PPFW_FILENAME} PPFW_FILENAME)
+	set(PPFW_FILENAME "portapack-mayhem_${PPFW_FILENAME}.ppfw.tar")
+endif()
+
+message("Building version: ${VERSION} MD5: ${VERSION_MD5}")
 
 set(LICENSE_PATH ${CMAKE_CURRENT_LIST_DIR}/LICENSE)
 set(HARDWARE_PATH ${CMAKE_CURRENT_LIST_DIR}/hardware)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,7 +62,7 @@ if (NOT DEFINED PPFW_FILENAME)
 		OUTPUT_VARIABLE PPFW_FILENAME
 	)
 	string(STRIP ${PPFW_FILENAME} PPFW_FILENAME)
-	set(PPFW_FILENAME "portapack-mayhem_${PPFW_FILENAME}.ppfw.tar")
+	set(PPFW_FILENAME "portapack-mayhem_${PPFW_FILENAME}_OCI.ppfw.tar")
 endif()
 
 message("Building version: ${VERSION} MD5: ${VERSION_MD5}")

--- a/firmware/CMakeLists.txt
+++ b/firmware/CMakeLists.txt
@@ -61,7 +61,7 @@ add_custom_command(
 )
 
 add_custom_target(
-	firmware ALL
+	firmware
 	DEPENDS ${FIRMWARE_FILENAME} ${HACKRF_FIRMWARE_DFU_FILENAME}
 )
 
@@ -100,7 +100,7 @@ add_custom_command(
 	COMMAND mkdir -p firmware_tar/APPS
 	COMMAND cp application/*.ppma firmware_tar/APPS
 	COMMAND cd firmware_tar && tar -cvaf ../${PPFW_FILENAME} *
-	DEPENDS firmware ${FIRMWARE_FILENAME}
+	DEPENDS firmware
 	# Dont use VERBATIM here as it prevents usage of globbing (*)
 	# There shouldnt be any funny business in the filenames above :)
 )
@@ -125,7 +125,12 @@ add_custom_command(
 )
 
 add_custom_target(
-	ppfw
+	ppfw ALL
+	DEPENDS ${PPFW_FILENAME}
+)
+
+add_custom_target(
+	oci
 	DEPENDS ${PPFW_FILENAME}
 )
 

--- a/firmware/CMakeLists.txt
+++ b/firmware/CMakeLists.txt
@@ -18,6 +18,8 @@
 # Boston, MA 02110-1301, USA.
 #
 
+cmake_minimum_required(VERSION 3.5)
+
 project(firmware)
 
 set(BASEBAND ${PROJECT_SOURCE_DIR}/baseband)
@@ -88,6 +90,21 @@ add_custom_target(
 	DEPENDS program
 )
 
+add_custom_command(
+	OUTPUT ${PPFW_FILENAME}
+	
+	COMMAND rm -rf firmware_tar
+	COMMAND mkdir -p firmware_tar/FIRMWARE
+	# Using VERSION_NOHASH to avoid dev builds piling up in the FIRMWARE folder of the sd card of testers in #test-drive
+	COMMAND cp ${FIRMWARE_FILENAME} firmware_tar/FIRMWARE/portapack-mayhem_${VERSION_NOHASH}.bin
+	COMMAND mkdir -p firmware_tar/APPS
+	COMMAND cp application/*.ppma firmware_tar/APPS
+	COMMAND cd firmware_tar && tar -cvaf ../${PPFW_FILENAME} *
+	DEPENDS firmware ${FIRMWARE_FILENAME}
+	# Dont use VERBATIM here as it prevents usage of globbing (*)
+	# There shouldnt be any funny business in the filenames above :)
+)
+
 # TODO: Bad hack to fix location of LICENSE file for tar.
 add_custom_command(
 	OUTPUT ${FIRMWARE_NAME}-${VERSION}.tar.bz2 ${FIRMWARE_NAME}-${VERSION}.zip
@@ -108,6 +125,12 @@ add_custom_command(
 )
 
 add_custom_target(
+	ppfw
+	DEPENDS ${PPFW_FILENAME}
+)
+
+add_custom_target(
 	release
 	DEPENDS MD5SUMS SHA256SUMS
 )
+

--- a/hackrf-portapack/CMakeLists.txt
+++ b/hackrf-portapack/CMakeLists.txt
@@ -18,7 +18,7 @@
 # Boston, MA 02110-1301, USA.
 #
 
-cmake_minimum_required(VERSION 3.1.3)
+cmake_minimum_required(VERSION 3.5)
 set(CMAKE_TOOLCHAIN_FILE ../toolchain-arm-cortex-m.cmake)
 
 project(hackrf_usb C)


### PR DESCRIPTION
It will build an OCI ppfw package to be flashed or shared on test-drive

Additionally some minor cmake cleanup
And updated gitignore to allow multiple build folders

The dev builds are named after the current time to avoid numbering the files by the OS at the wrong place. 😇 Ended up using time instead of VERSION_MD5 as its just calculated from the current commit hash so might not be unique if some dev experiments with something and shares multiple builds without a commit in between. Also its minute resolution only, I don't think there would be multiple builds shared within the same minute 🙈

For now it's a duplicate. CI still uses its own method, but wanted to get it out to fellow devs as fast as possible :)