### PR TITLE
Accessibility over serial

### DIFF
--- a/firmware/application/event_m0.cpp
+++ b/firmware/application/event_m0.cpp
@@ -262,6 +262,14 @@ void EventDispatcher::on_touch_event(ui::TouchEvent event) {
     }
 }
 
+ui::Widget* EventDispatcher::getTopWidget() {
+    return top_widget;
+}
+
+ui::Widget* EventDispatcher::getFocusedWidget() {
+    return context.focus_manager().focus_widget();
+}
+
 void EventDispatcher::handle_lcd_frame_sync() {
     DisplayFrameSyncMessage message;
     message_map.send(&message);

--- a/firmware/application/event_m0.hpp
+++ b/firmware/application/event_m0.hpp
@@ -88,6 +88,9 @@ class EventDispatcher {
 
     void emulateTouch(ui::TouchEvent event);
 
+    ui::Widget* getTopWidget();
+    ui::Widget* getFocusedWidget();
+
    private:
     static Thread* thread_event_loop;
 

--- a/firmware/application/ui/ui_receiver.cpp
+++ b/firmware/application/ui/ui_receiver.cpp
@@ -93,6 +93,13 @@ void FrequencyField::set_allow_digit_mode(bool allowed) {
     }
 }
 
+void FrequencyField::getAccessibilityText(std::string& result) {
+    result = to_string_dec_int(value_);
+}
+void FrequencyField::getWidgetName(std::string& result) {
+    result = "FrequencyField";
+}
+
 void FrequencyField::paint(Painter& painter) {
     const auto str_value = to_string_short_freq(value_);
     const auto paint_style = has_focus() ? style().invert() : style();

--- a/firmware/application/ui/ui_receiver.hpp
+++ b/firmware/application/ui/ui_receiver.hpp
@@ -66,6 +66,9 @@ class FrequencyField : public Widget {
     void on_focus() override;
     void on_blur() override;
 
+    void getAccessibilityText(std::string& result) override;
+    void getWidgetName(std::string& result) override;
+
    private:
     const size_t length_;
     range_t range_;

--- a/firmware/application/usb_serial_shell.cpp
+++ b/firmware/application/usb_serial_shell.cpp
@@ -732,15 +732,16 @@ static void cpld_info(BaseSequentialStream* chp, int argc, char* argv[]) {
 }
 
 // walks throught the given widget's childs in recurse to get all support text and pass it to a callback function
-static void widget_collect_accessibility(BaseSequentialStream* chp, ui::Widget* w, void (*callback)(BaseSequentialStream*, const std::string&, const std::string&)) {
+static void widget_collect_accessibility(BaseSequentialStream* chp, ui::Widget* w, void (*callback)(BaseSequentialStream*, const std::string&, const std::string&), ui::Widget* focusedWidget) {
     for (auto child : w->children()) {
         if (!child->hidden()) {
             std::string res = "";
             child->getAccessibilityText(res);
             std::string strtype = "";
             child->getWidgetName(strtype);
+            if (child == focusedWidget) strtype += "*";
             if (callback != NULL && !res.empty()) callback(chp, res, strtype);
-            widget_collect_accessibility(chp, child, callback);
+            widget_collect_accessibility(chp, child, callback, focusedWidget);
         }
     }
 }
@@ -770,7 +771,8 @@ static void cmd_accessibility_readall(BaseSequentialStream* chp, int argc, char*
         chprintf(chp, "error Can't get top Widget\r\n");
         return;
     }
-    widget_collect_accessibility(chp, wg, accessibility_callback);
+    auto focused = evtd->getFocusedWidget();
+    widget_collect_accessibility(chp, wg, accessibility_callback, focused);
     chprintf(chp, "ok\r\n");
 }
 

--- a/firmware/common/ui_widget.cpp
+++ b/firmware/common/ui_widget.cpp
@@ -237,6 +237,10 @@ void Widget::dirty_overlapping_children_in_rect(const Rect& child_rect) {
     }
 }
 
+void Widget::getAccessibilityText(std::string& result) {
+    result = "";
+}
+
 /* View ******************************************************************/
 
 void View::paint(Painter& painter) {
@@ -367,6 +371,10 @@ void Text::set(std::string_view value) {
     set_dirty();
 }
 
+void Text::getAccessibilityText(std::string& result) {
+    result = text;
+}
+
 void Text::paint(Painter& painter) {
     const auto rect = screen_rect();
     auto s = has_focus() ? style().invert() : style();
@@ -404,6 +412,14 @@ void Labels::paint(Painter& painter) {
             label.color,
             style().background,
             label.text);
+    }
+}
+
+void Labels::getAccessibilityText(std::string& result) {
+    result = "";
+    for (auto& label : labels_) {
+        result += label.text;
+        result += "\r\n";
     }
 }
 
@@ -577,6 +593,10 @@ void ProgressBar::set_value(const uint32_t value) {
     else
         _value = value;
     set_dirty();
+}
+
+void ProgressBar::getAccessibilityText(std::string& result) {
+    result = to_string_dec_uint(_value) + " / " + to_string_dec_uint(_max);
 }
 
 void ProgressBar::paint(Painter& painter) {

--- a/firmware/common/ui_widget.cpp
+++ b/firmware/common/ui_widget.cpp
@@ -1562,7 +1562,7 @@ bool ImageToggle::value() const {
 }
 
 void ImageToggle::getAccessibilityText(std::string& result) {
-    result = "image " + value_ ? " checked" : " unchecked";
+    result = value_ ? " checked" : " unchecked";
 }
 void ImageToggle::getWidgetName(std::string& result) {
     result = "ImageToggle";

--- a/firmware/common/ui_widget.cpp
+++ b/firmware/common/ui_widget.cpp
@@ -376,7 +376,9 @@ void Text::set(std::string_view value) {
 void Text::getAccessibilityText(std::string& result) {
     result = text;
 }
-
+void Text::getWidgetName(std::string& result) {
+    result = "Text";
+}
 void Text::paint(Painter& painter) {
     const auto rect = screen_rect();
     auto s = has_focus() ? style().invert() : style();
@@ -421,8 +423,11 @@ void Labels::getAccessibilityText(std::string& result) {
     result = "";
     for (auto& label : labels_) {
         result += label.text;
-        result += "\r\n";
+        result += ", ";
     }
+}
+void Labels::getWidgetName(std::string& result) {
+    result = "Labels";
 }
 
 /* LiveDateTime **********************************************************/
@@ -600,6 +605,9 @@ void ProgressBar::set_value(const uint32_t value) {
 void ProgressBar::getAccessibilityText(std::string& result) {
     result = to_string_dec_uint(_value) + " / " + to_string_dec_uint(_max);
 }
+void ProgressBar::getWidgetName(std::string& result) {
+    result = "ProgressBar";
+}
 
 void ProgressBar::paint(Painter& painter) {
     int v_scaled;
@@ -702,7 +710,10 @@ void Console::write(std::string message) {
 }
 
 void Console::getAccessibilityText(std::string& result) {
-    result = "Console: [" + buffer + "]";
+    result = "{" + buffer + "}";
+}
+void Console::getWidgetName(std::string& result) {
+    result = "Console";
 }
 
 void Console::writeln(std::string message) {
@@ -815,6 +826,9 @@ bool Checkbox::set_value(const bool value) {
 
 void Checkbox::getAccessibilityText(std::string& result) {
     result = text_ + ((value_) ? " checked" : " unchecked");
+}
+void Checkbox::getWidgetName(std::string& result) {
+    result = "Checkbox";
 }
 
 bool Checkbox::value() const {
@@ -936,6 +950,9 @@ std::string Button::text() const {
 
 void Button::getAccessibilityText(std::string& result) {
     result = text_;
+}
+void Button::getWidgetName(std::string& result) {
+    result = "Button";
 }
 
 void Button::paint(Painter& painter) {
@@ -1086,6 +1103,9 @@ std::string ButtonWithEncoder::text() const {
 
 void ButtonWithEncoder::getAccessibilityText(std::string& result) {
     result = text_;
+}
+void ButtonWithEncoder::getWidgetName(std::string& result) {
+    result = "ButtonWithEncoder";
 }
 
 void ButtonWithEncoder::paint(Painter& painter) {
@@ -1245,6 +1265,9 @@ void NewButton::set_text(const std::string value) {
 
 void NewButton::getAccessibilityText(std::string& result) {
     result = text_;
+}
+void NewButton::getWidgetName(std::string& result) {
+    result = "NewButton";
 }
 
 std::string NewButton::text() const {
@@ -1444,6 +1467,9 @@ ImageButton::ImageButton(
 void ImageButton::getAccessibilityText(std::string& result) {
     result = "image";
 }
+void ImageButton::getWidgetName(std::string& result) {
+    result = "ImageButton";
+}
 
 bool ImageButton::on_key(const KeyEvent key) {
     if (key == KeyEvent::Select) {
@@ -1538,6 +1564,9 @@ bool ImageToggle::value() const {
 void ImageToggle::getAccessibilityText(std::string& result) {
     result = "image " + value_ ? " checked" : " unchecked";
 }
+void ImageToggle::getWidgetName(std::string& result) {
+    result = "ImageToggle";
+}
 
 void ImageToggle::set_value(bool b) {
     if (b == value_)
@@ -1576,6 +1605,9 @@ size_t ImageOptionsField::selected_index_value() const {
 
 void ImageOptionsField::getAccessibilityText(std::string& result) {
     result = "selected index: " + to_string_dec_uint(selected_index_);
+}
+void ImageOptionsField::getWidgetName(std::string& result) {
+    result = "ImageOptionsField";
 }
 
 void ImageOptionsField::set_selected_index(const size_t new_index) {
@@ -1686,6 +1718,9 @@ void OptionsField::getAccessibilityText(std::string& result) {
         result += option.first;
     }
     result += "; selected: " + selected_index_name();
+}
+void OptionsField::getWidgetName(std::string& result) {
+    result = "OptionsField";
 }
 
 void OptionsField::set_selected_index(const size_t new_index, bool trigger_change) {
@@ -1808,6 +1843,9 @@ const std::string& TextEdit::value() const {
 
 void TextEdit::getAccessibilityText(std::string& result) {
     result = text_;
+}
+void TextEdit::getWidgetName(std::string& result) {
+    result = "TextEdit";
 }
 
 void TextEdit::set_cursor(uint32_t pos) {
@@ -1962,6 +2000,9 @@ const std::string& TextField::get_text() const {
 void TextField::getAccessibilityText(std::string& result) {
     result = text;
 }
+void TextField::getWidgetName(std::string& result) {
+    result = "TextField";
+}
 
 void TextField::set_text(std::string_view value) {
     set(value);
@@ -2020,6 +2061,9 @@ int32_t NumberField::value() const {
 
 void NumberField::getAccessibilityText(std::string& result) {
     result = to_string_dec_int(value_);
+}
+void NumberField::getWidgetName(std::string& result) {
+    result = "NumberField";
 }
 
 void NumberField::set_value(int32_t new_value, bool trigger_change) {
@@ -2235,7 +2279,9 @@ const std::string& SymField::to_string() const {
 void SymField::getAccessibilityText(std::string& result) {
     result = value_;
 }
-
+void SymField::getWidgetName(std::string& result) {
+    result = "SymField";
+}
 void SymField::paint(Painter& painter) {
     Point p = screen_pos();
 

--- a/firmware/common/ui_widget.cpp
+++ b/firmware/common/ui_widget.cpp
@@ -240,7 +240,9 @@ void Widget::dirty_overlapping_children_in_rect(const Rect& child_rect) {
 void Widget::getAccessibilityText(std::string& result) {
     result = "";
 }
-
+void Widget::getWidgetName(std::string& result) {
+    result = "";
+}
 /* View ******************************************************************/
 
 void View::paint(Painter& painter) {
@@ -699,6 +701,10 @@ void Console::write(std::string message) {
     }
 }
 
+void Console::getAccessibilityText(std::string& result) {
+    result = "Console: [" + buffer + "]";
+}
+
 void Console::writeln(std::string message) {
     write(message + "\n");
 }
@@ -805,6 +811,10 @@ bool Checkbox::set_value(const bool value) {
     }
 
     return false;
+}
+
+void Checkbox::getAccessibilityText(std::string& result) {
+    result = text_ + ((value_) ? " checked" : " unchecked");
 }
 
 bool Checkbox::value() const {
@@ -922,6 +932,10 @@ void Button::set_text(const std::string value) {
 
 std::string Button::text() const {
     return text_;
+}
+
+void Button::getAccessibilityText(std::string& result) {
+    result = text_;
 }
 
 void Button::paint(Painter& painter) {
@@ -1068,6 +1082,10 @@ void ButtonWithEncoder::set_encoder_delta(const int32_t delta) {
 
 std::string ButtonWithEncoder::text() const {
     return text_;
+}
+
+void ButtonWithEncoder::getAccessibilityText(std::string& result) {
+    result = text_;
 }
 
 void ButtonWithEncoder::paint(Painter& painter) {
@@ -1223,6 +1241,10 @@ NewButton::NewButton(
 void NewButton::set_text(const std::string value) {
     text_ = value;
     set_dirty();
+}
+
+void NewButton::getAccessibilityText(std::string& result) {
+    result = text_;
 }
 
 std::string NewButton::text() const {
@@ -1419,6 +1441,10 @@ ImageButton::ImageButton(
     set_focusable(true);
 }
 
+void ImageButton::getAccessibilityText(std::string& result) {
+    result = "image";
+}
+
 bool ImageButton::on_key(const KeyEvent key) {
     if (key == KeyEvent::Select) {
         if (on_select) {
@@ -1509,6 +1535,10 @@ bool ImageToggle::value() const {
     return value_;
 }
 
+void ImageToggle::getAccessibilityText(std::string& result) {
+    result = "image " + value_ ? " checked" : " unchecked";
+}
+
 void ImageToggle::set_value(bool b) {
     if (b == value_)
         return;
@@ -1542,6 +1572,10 @@ size_t ImageOptionsField::selected_index() const {
 
 size_t ImageOptionsField::selected_index_value() const {
     return options[selected_index_].second;
+}
+
+void ImageOptionsField::getAccessibilityText(std::string& result) {
+    result = "selected index: " + to_string_dec_uint(selected_index_);
 }
 
 void ImageOptionsField::set_selected_index(const size_t new_index) {
@@ -1641,6 +1675,17 @@ const OptionsField::name_t& OptionsField::selected_index_name() const {
 
 const OptionsField::value_t& OptionsField::selected_index_value() const {
     return options_[selected_index_].second;
+}
+
+void OptionsField::getAccessibilityText(std::string& result) {
+    result = "options: ";
+    bool first = true;
+    for (const auto& option : options_) {
+        if (!first) result += " ,";
+        first = false;
+        result += option.first;
+    }
+    result += "; selected: " + selected_index_name();
 }
 
 void OptionsField::set_selected_index(const size_t new_index, bool trigger_change) {
@@ -1759,6 +1804,10 @@ TextEdit::TextEdit(
 
 const std::string& TextEdit::value() const {
     return text_;
+}
+
+void TextEdit::getAccessibilityText(std::string& result) {
+    result = text_;
 }
 
 void TextEdit::set_cursor(uint32_t pos) {
@@ -1910,6 +1959,10 @@ const std::string& TextField::get_text() const {
     return text;
 }
 
+void TextField::getAccessibilityText(std::string& result) {
+    result = text;
+}
+
 void TextField::set_text(std::string_view value) {
     set(value);
     if (on_change)
@@ -1963,6 +2016,10 @@ NumberField::NumberField(
 
 int32_t NumberField::value() const {
     return value_;
+}
+
+void NumberField::getAccessibilityText(std::string& result) {
+    result = to_string_dec_int(value_);
 }
 
 void NumberField::set_value(int32_t new_value, bool trigger_change) {
@@ -2173,6 +2230,10 @@ uint64_t SymField::to_integer() const {
 
 const std::string& SymField::to_string() const {
     return value_;
+}
+
+void SymField::getAccessibilityText(std::string& result) {
+    result = value_;
 }
 
 void SymField::paint(Painter& painter) {

--- a/firmware/common/ui_widget.cpp
+++ b/firmware/common/ui_widget.cpp
@@ -1562,7 +1562,7 @@ bool ImageToggle::value() const {
 }
 
 void ImageToggle::getAccessibilityText(std::string& result) {
-    result = value_ ? " checked" : " unchecked";
+    result = value_ ? "checked" : "unchecked";
 }
 void ImageToggle::getWidgetName(std::string& result) {
     result = "ImageToggle";

--- a/firmware/common/ui_widget.hpp
+++ b/firmware/common/ui_widget.hpp
@@ -211,6 +211,7 @@ class Text : public Widget {
 
     void paint(Painter& painter) override;
     void getAccessibilityText(std::string& result) override;
+    void getWidgetName(std::string& result) override;
 
    protected:
     // NB: Don't truncate this string. The UI will only render
@@ -239,6 +240,7 @@ class Labels : public Widget {
 
     void paint(Painter& painter) override;
     void getAccessibilityText(std::string& result) override;
+    void getWidgetName(std::string& result) override;
 
    private:
     std::vector<Label> labels_;
@@ -318,6 +320,7 @@ class ProgressBar : public Widget {
 
     void paint(Painter& painter) override;
     void getAccessibilityText(std::string& result) override;
+    void getWidgetName(std::string& result) override;
 
    private:
     uint32_t _value = 0;
@@ -352,6 +355,7 @@ class Console : public Widget {
     void on_show() override;
     void on_hide() override;
     void getAccessibilityText(std::string& result) override;
+    void getWidgetName(std::string& result) override;
 
    private:
     Point pos{0, 0};
@@ -393,6 +397,7 @@ class Checkbox : public Widget {
     bool on_keyboard(const KeyboardEvent key) override;
     bool on_touch(const TouchEvent event) override;
     void getAccessibilityText(std::string& result) override;
+    void getWidgetName(std::string& result) override;
 
    private:
     std::string text_;
@@ -430,6 +435,7 @@ class Button : public Widget {
     bool on_touch(const TouchEvent event) override;
     bool on_keyboard(const KeyboardEvent event) override;
     void getAccessibilityText(std::string& result) override;
+    void getWidgetName(std::string& result) override;
 
    private:
     std::string text_;
@@ -471,6 +477,7 @@ class ButtonWithEncoder : public Widget {
     bool on_keyboard(const KeyboardEvent event) override;
 
     void getAccessibilityText(std::string& result) override;
+    void getWidgetName(std::string& result) override;
 
    private:
     std::string text_;
@@ -508,6 +515,7 @@ class NewButton : public Widget {
     bool on_keyboard(const KeyboardEvent event) override;
 
     void getAccessibilityText(std::string& result) override;
+    void getWidgetName(std::string& result) override;
 
     void paint(Painter& painter) override;
 
@@ -564,6 +572,7 @@ class ImageButton : public Image {
     bool on_touch(const TouchEvent event) override;
     bool on_keyboard(const KeyboardEvent event) override;
     void getAccessibilityText(std::string& result) override;
+    void getWidgetName(std::string& result) override;
 };
 
 /* A button that toggles between two images when set. */
@@ -598,6 +607,7 @@ class ImageToggle : public ImageButton {
     void set_value(bool b);
 
     void getAccessibilityText(std::string& result) override;
+    void getWidgetName(std::string& result) override;
 
    private:
     // Hide this field.
@@ -645,6 +655,7 @@ class ImageOptionsField : public Widget {
     bool on_touch(const TouchEvent event) override;
     bool on_keyboard(const KeyboardEvent event) override;
     void getAccessibilityText(std::string& result) override;
+    void getWidgetName(std::string& result) override;
 
    private:
     options_t options;
@@ -685,6 +696,7 @@ class OptionsField : public Widget {
     bool on_keyboard(const KeyboardEvent event) override;
 
     void getAccessibilityText(std::string& result) override;
+    void getWidgetName(std::string& result) override;
 
    private:
     const size_t length_;
@@ -732,6 +744,7 @@ class TextEdit : public Widget {
     bool on_keyboard(const KeyboardEvent event) override;
 
     void getAccessibilityText(std::string& result) override;
+    void getWidgetName(std::string& result) override;
 
     void on_focus() override;
     void on_blur() override;
@@ -760,6 +773,7 @@ class TextField : public Text {
     bool on_touch(TouchEvent event) override;
 
     void getAccessibilityText(std::string& result) override;
+    void getWidgetName(std::string& result) override;
 
    private:
     using Text::set;
@@ -798,6 +812,7 @@ class NumberField : public Widget {
     bool on_keyboard(const KeyboardEvent event) override;
 
     void getAccessibilityText(std::string& result) override;
+    void getWidgetName(std::string& result) override;
 
    private:
     range_t range;
@@ -875,6 +890,7 @@ class SymField : public Widget {
     bool on_touch(TouchEvent event) override;
 
     void getAccessibilityText(std::string& result) override;
+    void getWidgetName(std::string& result) override;
 
    private:
     /* Ensure the specified symbol is in the symbol list. */

--- a/firmware/common/ui_widget.hpp
+++ b/firmware/common/ui_widget.hpp
@@ -106,6 +106,8 @@ class Widget {
 
     virtual Context& context() const;
 
+    virtual void getAccessibilityText(std::string& result);
+
     void set_style(const Style* new_style);
 
     const Style& style() const;
@@ -207,6 +209,7 @@ class Text : public Widget {
     void set(std::string_view value);
 
     void paint(Painter& painter) override;
+    void getAccessibilityText(std::string& result) override;
 
    protected:
     // NB: Don't truncate this string. The UI will only render
@@ -234,6 +237,7 @@ class Labels : public Widget {
     void set_labels(std::initializer_list<Label> labels);
 
     void paint(Painter& painter) override;
+    void getAccessibilityText(std::string& result) override;
 
    private:
     std::vector<Label> labels_;
@@ -312,6 +316,7 @@ class ProgressBar : public Widget {
     void set_value(const uint32_t value);
 
     void paint(Painter& painter) override;
+    void getAccessibilityText(std::string& result) override;
 
    private:
     uint32_t _value = 0;

--- a/firmware/common/ui_widget.hpp
+++ b/firmware/common/ui_widget.hpp
@@ -107,6 +107,7 @@ class Widget {
     virtual Context& context() const;
 
     virtual void getAccessibilityText(std::string& result);
+    virtual void getWidgetName(std::string& result);
 
     void set_style(const Style* new_style);
 
@@ -350,6 +351,7 @@ class Console : public Widget {
     void enable_scrolling(bool enable);
     void on_show() override;
     void on_hide() override;
+    void getAccessibilityText(std::string& result) override;
 
    private:
     Point pos{0, 0};
@@ -390,6 +392,7 @@ class Checkbox : public Widget {
     bool on_key(const KeyEvent key) override;
     bool on_keyboard(const KeyboardEvent key) override;
     bool on_touch(const TouchEvent event) override;
+    void getAccessibilityText(std::string& result) override;
 
    private:
     std::string text_;
@@ -426,6 +429,7 @@ class Button : public Widget {
     bool on_key(const KeyEvent key) override;
     bool on_touch(const TouchEvent event) override;
     bool on_keyboard(const KeyboardEvent event) override;
+    void getAccessibilityText(std::string& result) override;
 
    private:
     std::string text_;
@@ -466,6 +470,8 @@ class ButtonWithEncoder : public Widget {
     bool on_encoder(const EncoderEvent delta) override;
     bool on_keyboard(const KeyboardEvent event) override;
 
+    void getAccessibilityText(std::string& result) override;
+
    private:
     std::string text_;
     int32_t encoder_delta = 0;
@@ -500,6 +506,8 @@ class NewButton : public Widget {
     bool on_key(const KeyEvent key) override;
     bool on_touch(const TouchEvent event) override;
     bool on_keyboard(const KeyboardEvent event) override;
+
+    void getAccessibilityText(std::string& result) override;
 
     void paint(Painter& painter) override;
 
@@ -555,6 +563,7 @@ class ImageButton : public Image {
     bool on_key(const KeyEvent key) override;
     bool on_touch(const TouchEvent event) override;
     bool on_keyboard(const KeyboardEvent event) override;
+    void getAccessibilityText(std::string& result) override;
 };
 
 /* A button that toggles between two images when set. */
@@ -587,6 +596,8 @@ class ImageToggle : public ImageButton {
 
     bool value() const;
     void set_value(bool b);
+
+    void getAccessibilityText(std::string& result) override;
 
    private:
     // Hide this field.
@@ -633,6 +644,7 @@ class ImageOptionsField : public Widget {
     bool on_encoder(const EncoderEvent delta) override;
     bool on_touch(const TouchEvent event) override;
     bool on_keyboard(const KeyboardEvent event) override;
+    void getAccessibilityText(std::string& result) override;
 
    private:
     options_t options;
@@ -671,6 +683,8 @@ class OptionsField : public Widget {
     bool on_encoder(const EncoderEvent delta) override;
     bool on_touch(const TouchEvent event) override;
     bool on_keyboard(const KeyboardEvent event) override;
+
+    void getAccessibilityText(std::string& result) override;
 
    private:
     const size_t length_;
@@ -717,6 +731,8 @@ class TextEdit : public Widget {
     bool on_touch(const TouchEvent event) override;
     bool on_keyboard(const KeyboardEvent event) override;
 
+    void getAccessibilityText(std::string& result) override;
+
     void on_focus() override;
     void on_blur() override;
 
@@ -742,6 +758,8 @@ class TextField : public Text {
     bool on_key(KeyEvent key) override;
     bool on_encoder(EncoderEvent delta) override;
     bool on_touch(TouchEvent event) override;
+
+    void getAccessibilityText(std::string& result) override;
 
    private:
     using Text::set;
@@ -778,6 +796,8 @@ class NumberField : public Widget {
     bool on_encoder(const EncoderEvent delta) override;
     bool on_touch(const TouchEvent event) override;
     bool on_keyboard(const KeyboardEvent event) override;
+
+    void getAccessibilityText(std::string& result) override;
 
    private:
     range_t range;
@@ -853,6 +873,8 @@ class SymField : public Widget {
     bool on_key(KeyEvent key) override;
     bool on_encoder(EncoderEvent delta) override;
     bool on_touch(TouchEvent event) override;
+
+    void getAccessibilityText(std::string& result) override;
 
    private:
     /* Ensure the specified symbol is in the symbol list. */


### PR DESCRIPTION
2 commands added to serial usb:
accessibility_readall: will walk trough all widgets on screen, and prints the widget type and "value".
cmd_accessibility_readcurr: shows the focused widget type and "value".

By value I mean if it is a checkbox, then the label, and checked / unchecked. For a Labels, it's texts, ...

May not implemented all widgets, feel free to add what i miss.
This could help solve the https://github.com/eried/portapack-mayhem/issues/1599 issue with an app that support these commands.