### PR TITLE
Geomap speed display

### DIFF
--- a/firmware/application/apps/ais_app.cpp
+++ b/firmware/application/apps/ais_app.cpp
@@ -293,6 +293,7 @@ AISRecentEntryDetailView::AISRecentEntryDetailView(NavigationView& nav) {
             ais::format::text(entry_.name),
             0,
             GeoPos::alt_unit::METERS,
+            GeoPos::spd_unit::NONE,
             ais::format::latlon_float(entry_.last_position.latitude.normalized()),
             ais::format::latlon_float(entry_.last_position.longitude.normalized()),
             entry_.last_position.true_heading,
@@ -315,7 +316,7 @@ AISRecentEntryDetailView& AISRecentEntryDetailView::operator=(const AISRecentEnt
 
 void AISRecentEntryDetailView::update_position() {
     if (send_updates)
-        geomap_view->update_position(ais::format::latlon_float(entry_.last_position.latitude.normalized()), ais::format::latlon_float(entry_.last_position.longitude.normalized()), (float)entry_.last_position.true_heading, 0);
+        geomap_view->update_position(ais::format::latlon_float(entry_.last_position.latitude.normalized()), ais::format::latlon_float(entry_.last_position.longitude.normalized()), (float)entry_.last_position.true_heading, 0, entry_.last_position.speed_over_ground);
 }
 
 void AISRecentEntryDetailView::focus() {

--- a/firmware/application/apps/ui_adsb_rx.cpp
+++ b/firmware/application/apps/ui_adsb_rx.cpp
@@ -290,7 +290,7 @@ void ADSBRxDetailsView::update(const AircraftRecentEntry& entry) {
     } else if (geomap_view_) {
         // Map is showing, update the current item.
         geomap_view_->update_tag(get_map_tag(entry_));
-        geomap_view_->update_position(entry.pos.latitude, entry.pos.longitude, entry.velo.heading, entry.pos.altitude);
+        geomap_view_->update_position(entry.pos.latitude, entry.pos.longitude, entry.velo.heading, entry.pos.altitude, entry.velo.speed);
     } else {
         // Details is showing, update details.
         refresh_ui();

--- a/firmware/application/apps/ui_adsb_rx.cpp
+++ b/firmware/application/apps/ui_adsb_rx.cpp
@@ -266,6 +266,7 @@ ADSBRxDetailsView::ADSBRxDetailsView(
             get_map_tag(entry_),
             entry_.pos.altitude,
             GeoPos::alt_unit::FEET,
+            GeoPos::spd_unit::MPH,
             entry_.pos.latitude,
             entry_.pos.longitude,
             entry_.velo.heading);

--- a/firmware/application/apps/ui_adsb_tx.cpp
+++ b/firmware/application/apps/ui_adsb_tx.cpp
@@ -85,10 +85,12 @@ ADSBPositionView::ADSBPositionView(
         nav.push<GeoMapView>(
             geopos.altitude(),
             GeoPos::alt_unit::FEET,
+            GeoPos::spd_unit::MPH,
             geopos.lat(),
             geopos.lon(),
-            [this](int32_t altitude, float lat, float lon) {
+            [this](int32_t altitude, float lat, float lon, int32_t speed) {
                 geopos.set_altitude(altitude);
+                geopos.set_speed(speed);
                 geopos.set_lat(lat);
                 geopos.set_lon(lon);
             });

--- a/firmware/application/apps/ui_adsb_tx.hpp
+++ b/firmware/application/apps/ui_adsb_tx.hpp
@@ -58,7 +58,8 @@ class ADSBPositionView : public OptionTabView {
    private:
     GeoPos geopos{
         {0, 2 * 16},
-        GeoPos::FEET};
+        GeoPos::FEET,
+        GeoPos::MPH};
 
     Button button_set_map{
         {8 * 8, 6 * 16, 14 * 8, 2 * 16},

--- a/firmware/application/apps/ui_aprs_rx.cpp
+++ b/firmware/application/apps/ui_aprs_rx.cpp
@@ -317,7 +317,7 @@ void APRSDetailsView::update() {
     }
 
     if (send_updates)
-        geomap_view->update_position(entry_copy.pos.latitude, entry_copy.pos.longitude, 0, 0);
+        geomap_view->update_position(entry_copy.pos.latitude, entry_copy.pos.longitude, 0, 0, 0);
 }
 
 APRSDetailsView::~APRSDetailsView() {
@@ -339,6 +339,7 @@ APRSDetailsView::APRSDetailsView(
             entry_copy.source_formatted,
             0,  // entry_copy.pos.altitude,
             GeoPos::alt_unit::FEET,
+            GeoPos::spd_unit::HIDDEN,
             entry_copy.pos.latitude,
             entry_copy.pos.longitude,
             0, /*entry_copy.velo.heading,*/

--- a/firmware/application/apps/ui_sonde.cpp
+++ b/firmware/application/apps/ui_sonde.cpp
@@ -94,6 +94,7 @@ SondeView::SondeView(NavigationView& nav)
             sonde_id,
             gps_info.alt,
             GeoPos::alt_unit::METERS,
+            GeoPos::spd_unit::HIDDEN,
             gps_info.lat,
             gps_info.lon,
             999);  // set a dummy heading out of range to draw a cross...probably not ideal?

--- a/firmware/application/apps/ui_sonde.hpp
+++ b/firmware/application/apps/ui_sonde.hpp
@@ -162,7 +162,8 @@ class SondeView : public View {
 
     GeoPos geopos{
         {0, 12 * 16},
-        GeoPos::alt_unit::METERS};
+        GeoPos::alt_unit::METERS,
+        GeoPos::spd_unit::HIDDEN};
 
     Button button_see_qr{
         {2 * 8, 15 * 16, 12 * 8, 3 * 16},

--- a/firmware/application/ui/ui_geomap.cpp
+++ b/firmware/application/ui/ui_geomap.cpp
@@ -88,8 +88,8 @@ GeoPos::GeoPos(
     if (speed_unit_ == KMPH) text_speed_unit.set("kmph");
     if (speed_unit_ == MPH) text_speed_unit.set("mph");
     if (speed_unit_ == HIDDEN) {
-        text_speed_unit.hidden();
-        label_spd_position.hidden();
+        text_speed_unit.hidden(true);
+        label_spd_position.hidden(true);
     }
 }
 

--- a/firmware/application/ui/ui_geomap.hpp
+++ b/firmware/application/ui/ui_geomap.hpp
@@ -62,19 +62,25 @@ class GeoPos : public View {
         FEET = 0,
         METERS
     };
+    enum spd_unit {
+        MPH = 0,
+        KMPH
+    };
 
     std::function<void(int32_t, float, float)> on_change{};
 
-    GeoPos(const Point pos, const alt_unit altitude_unit);
+    GeoPos(const Point pos, const alt_unit altitude_unit, const spd_unit speed_unit);
 
     void focus() override;
 
     void set_read_only(bool v);
     void set_altitude(int32_t altitude);
+    void set_speed(int32_t speed);
     void set_lat(float lat);
     void set_lon(float lon);
     int32_t altitude();
-    void hide_altitude();
+    int32_t speed();
+    void hide_altandspeed();
     float lat();
     float lon();
 
@@ -84,9 +90,11 @@ class GeoPos : public View {
     bool read_only{false};
     bool report_change{true};
     alt_unit altitude_unit_{};
+    spd_unit speed_unit_{};
 
     Labels labels_position{
         {{1 * 8, 0 * 16}, "Alt:", Color::light_grey()},
+        {{16 * 8, 0 * 16}, "Spd:", Color::light_grey()},
         {{1 * 8, 1 * 16}, "Lat:    \xB0  '  \"", Color::light_grey()},  // 0xB0 is degree ° symbol in our 8x16 font
         {{1 * 8, 2 * 16}, "Lon:    \xB0  '  \"", Color::light_grey()},
     };
@@ -97,8 +105,18 @@ class GeoPos : public View {
         {-1000, 50000},
         250,
         ' '};
+
+    NumberField field_speed{
+        {22 * 8, 0 * 16},
+        5,
+        {0, 5000},
+        1,
+        ' '};
     Text text_alt_unit{
         {12 * 8, 0 * 16, 2 * 8, 16},
+        ""};
+    Text text_speed_unit{
+        {26 * 8, 0 * 16, 2 * 8, 16},
         ""};
 
     NumberField field_lat_degrees{
@@ -224,6 +242,7 @@ class GeoMapView : public View {
         const std::string& tag,
         int32_t altitude,
         GeoPos::alt_unit altitude_unit,
+        GeoPos::spd_unit speed_unit,
         float lat,
         float lon,
         uint16_t angle,
@@ -231,6 +250,7 @@ class GeoMapView : public View {
     GeoMapView(NavigationView& nav,
                int32_t altitude,
                GeoPos::alt_unit altitude_unit,
+               GeoPos::spd_unit speed_unit,
                float lat,
                float lon,
                const std::function<void(int32_t, float, float)> on_done);
@@ -243,7 +263,7 @@ class GeoMapView : public View {
 
     void focus() override;
 
-    void update_position(float lat, float lon, uint16_t angle, int32_t altitude);
+    void update_position(float lat, float lon, uint16_t angle, int32_t altitude, int32_t speed);
 
     std::string title() const override { return "Map view"; };
 
@@ -260,7 +280,9 @@ class GeoMapView : public View {
     const std::function<void(int32_t, float, float)> on_done{};
     GeoMapMode mode_{};
     int32_t altitude_{};
+    int32_t speed_{};
     GeoPos::alt_unit altitude_unit_{};
+    GeoPos::spd_unit speed_unit_{};
     float lat_{};
     float lon_{};
     uint16_t angle_{};
@@ -270,7 +292,8 @@ class GeoMapView : public View {
 
     GeoPos geopos{
         {0, 0},
-        altitude_unit_};
+        altitude_unit_,
+        speed_unit_};
 
     GeoMap geomap{
         {0, GeoMap::banner_height, GeoMap::geomap_rect_width, GeoMap::geomap_rect_height}};

--- a/firmware/application/ui/ui_geomap.hpp
+++ b/firmware/application/ui/ui_geomap.hpp
@@ -63,11 +63,13 @@ class GeoPos : public View {
         METERS
     };
     enum spd_unit {
-        MPH = 0,
-        KMPH
+        NONE = 0,
+        MPH,
+        KMPH,
+        HIDDEN = 255
     };
 
-    std::function<void(int32_t, float, float)> on_change{};
+    std::function<void(int32_t, float, float, int32_t)> on_change{};
 
     GeoPos(const Point pos, const alt_unit altitude_unit, const spd_unit speed_unit);
 
@@ -94,11 +96,12 @@ class GeoPos : public View {
 
     Labels labels_position{
         {{1 * 8, 0 * 16}, "Alt:", Color::light_grey()},
-        {{16 * 8, 0 * 16}, "Spd:", Color::light_grey()},
         {{1 * 8, 1 * 16}, "Lat:    \xB0  '  \"", Color::light_grey()},  // 0xB0 is degree ° symbol in our 8x16 font
         {{1 * 8, 2 * 16}, "Lon:    \xB0  '  \"", Color::light_grey()},
     };
-
+    Labels label_spd_position{
+        {{15 * 8, 0 * 16}, "Spd:", Color::light_grey()},
+    };
     NumberField field_altitude{
         {6 * 8, 0 * 16},
         5,
@@ -107,8 +110,8 @@ class GeoPos : public View {
         ' '};
 
     NumberField field_speed{
-        {22 * 8, 0 * 16},
-        5,
+        {19 * 8, 0 * 16},
+        4,
         {0, 5000},
         1,
         ' '};
@@ -116,7 +119,7 @@ class GeoPos : public View {
         {12 * 8, 0 * 16, 2 * 8, 16},
         ""};
     Text text_speed_unit{
-        {26 * 8, 0 * 16, 2 * 8, 16},
+        {25 * 8, 0 * 16, 4 * 8, 16},
         ""};
 
     NumberField field_lat_degrees{
@@ -253,7 +256,7 @@ class GeoMapView : public View {
                GeoPos::spd_unit speed_unit,
                float lat,
                float lon,
-               const std::function<void(int32_t, float, float)> on_done);
+               const std::function<void(int32_t, float, float, int32_t)> on_done);
     ~GeoMapView();
 
     GeoMapView(const GeoMapView&) = delete;
@@ -263,7 +266,7 @@ class GeoMapView : public View {
 
     void focus() override;
 
-    void update_position(float lat, float lon, uint16_t angle, int32_t altitude, int32_t speed);
+    void update_position(float lat, float lon, uint16_t angle, int32_t altitude, int32_t speed = 0);
 
     std::string title() const override { return "Map view"; };
 
@@ -277,7 +280,7 @@ class GeoMapView : public View {
 
     void setup();
 
-    const std::function<void(int32_t, float, float)> on_done{};
+    const std::function<void(int32_t, float, float, int32_t)> on_done{};
     GeoMapMode mode_{};
     int32_t altitude_{};
     int32_t speed_{};


### PR DESCRIPTION
Added speed to GeoMap.
Issue: https://github.com/eried/portapack-mayhem/issues/695

AIS, ADSB,  supports speed, APRS, SNODE hides the widgets.