### PR TITLE
Dockerfile overhaul

### DIFF
--- a/dockerfile-nogit
+++ b/dockerfile-nogit
@@ -10,32 +10,40 @@ VOLUME /havoc
 WORKDIR /havoc/firmware
 
 # Fetch dependencies from APT
-RUN apt-get update && \
-	apt-get install -y git tar wget dfu-util cmake python3 ccache bzip2 liblz4-tool curl && \
-	apt-get -qy autoremove
+RUN apt-get update \
+ && apt-get install -y git tar wget dfu-util cmake python3 ccache bzip2 liblz4-tool curl ninja-build \
+ && apt-get -qy autoremove \
+ && rm -rf /var/lib/apt/lists/*
 
 #Install current pip from PyPa
 RUN curl https://bootstrap.pypa.io/pip/3.4/get-pip.py -o get-pip.py && \
 	python3 get-pip.py
 
 #Fetch additional dependencies from Python 3.x pip
-RUN pip install pyyaml
-RUN ln -s /usr/bin/python3 /usr/bin/python && \
-	ln -s /usr/bin/pip3 /usr/bin/pip
+RUN pip install pyyaml \
+ && ln -s /usr/bin/python3 /usr/bin/python \
+ && ln -s /usr/bin/pip3 /usr/bin/pip
 
 ENV LANG C.UTF-8
 ENV LC_ALL C.UTF-8
 
 # Grab the GNU ARM toolchain from arm.com
 # Then extract contents to /opt/build/armbin/
-RUN mkdir /opt/build && cd /opt/build && \
-	wget -O gcc-arm-none-eabi $ARMBINURL && \
-	mkdir armbin && \
-	tar --strip=1 -xjvf gcc-arm-none-eabi -C armbin
+RUN mkdir /opt/build \
+ && cd /opt/build \
+ && wget -O gcc-arm-none-eabi $ARMBINURL \
+ && mkdir armbin \
+ && tar --strip=1 -xjvf gcc-arm-none-eabi -C armbin
 
 # Configure CCACHE
-RUN mkdir ~/bin && cd ~/bin && \
-	for tool in gcc g++ cpp c++;do ln -s $(which ccache) arm-none-eabi-$tool;done
+RUN mkdir ~/bin \
+ && cd ~/bin \
+ && for tool in gcc g++ cpp c++; do \
+ 		ln -s $(which ccache) arm-none-eabi-$tool \
+	 ; done
 
-CMD cd .. && cd build && \
-	cmake .. && make ppfw
+ADD firmware/tools/docker-entrypoint.sh /usr/local/bin/entrypoint.sh
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+
+# replace make with ninja temporarily while building your image if you prefer to use that by default
+CMD ["make"]

--- a/dockerfile-nogit-arm
+++ b/dockerfile-nogit-arm
@@ -10,32 +10,40 @@ VOLUME /havoc
 WORKDIR /havoc/firmware
 
 # Fetch dependencies from APT
-RUN apt-get update && \
-	apt-get install -y git tar wget dfu-util cmake python3 ccache bzip2 liblz4-tool curl && \
-	apt-get -qy autoremove
+RUN apt-get update \
+ && apt-get install -y git tar wget dfu-util cmake python3 ccache bzip2 liblz4-tool curl ninja-build \
+ && apt-get -qy autoremove \
+ && rm -rf /var/lib/apt/lists/*
 
 #Install current pip from PyPa
 RUN curl https://bootstrap.pypa.io/pip/3.4/get-pip.py -o get-pip.py && \
 	python3 get-pip.py
 
 #Fetch additional dependencies from Python 3.x pip
-RUN pip install pyyaml
-RUN ln -s /usr/bin/python3 /usr/bin/python && \
-	ln -s /usr/bin/pip3 /usr/bin/pip
+RUN pip install pyyaml \
+ && ln -s /usr/bin/python3 /usr/bin/python \
+ && ln -s /usr/bin/pip3 /usr/bin/pip
 
 ENV LANG C.UTF-8
 ENV LC_ALL C.UTF-8
 
 # Grab the GNU ARM toolchain from arm.com
 # Then extract contents to /opt/build/armbin/
-RUN mkdir /opt/build && cd /opt/build && \
-	wget -O gcc-arm-none-eabi $ARMBINURL && \
-	mkdir armbin && \
-	tar --strip=1 -xjvf gcc-arm-none-eabi -C armbin
+RUN mkdir /opt/build \
+ && cd /opt/build \
+ && wget -O gcc-arm-none-eabi $ARMBINURL \
+ && mkdir armbin \
+ && tar --strip=1 -xjvf gcc-arm-none-eabi -C armbin
 
 # Configure CCACHE
-RUN mkdir ~/bin && cd ~/bin && \
-	for tool in gcc g++ cpp c++;do ln -s $(which ccache) arm-none-eabi-$tool;done
+RUN mkdir ~/bin \
+ && cd ~/bin \
+ && for tool in gcc g++ cpp c++; do \
+ 		ln -s $(which ccache) arm-none-eabi-$tool \
+	 ; done
 
-CMD cd .. && cd build && \
-	cmake .. && make ppfw
+ADD firmware/tools/docker-entrypoint.sh /usr/local/bin/entrypoint.sh
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+
+# replace make with ninja temporarily while building your image if you prefer to use that by default
+CMD ["make"]

--- a/firmware/tools/docker-entrypoint.sh
+++ b/firmware/tools/docker-entrypoint.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+set -e # exit immediatelly on any failure
+
+build_make() {
+   cd ..
+   mkdir -p build
+   cd build
+	cmake ..
+   make "$@"
+   exit 0 # Report success :)
+}
+
+build_ninja() {
+   cd ..
+   mkdir -p build
+   cd build
+	cmake -G Ninja ..
+   ninja "$@"
+   exit 0 # Report success :)
+}
+
+if [ "$1" = 'make' ]; then # build the default (or specified) target with make
+   shift # remove the first item from $@ as we consumed it, we can then pass the rest on to make
+   build_make "$@"
+elif [[ $1 == -j* ]]; then # allow passing -j without typing make_default
+   # dont shift here as we wanna pass the -j
+   build_make "$@"
+elif [ "$1" = 'ninja' ]; then # build the default (or specified) target with ninja
+   shift # remove the first item from $@ as we consumed it, we can then pass the rest on to make
+   build_ninja "$@"
+fi
+
+exec "$@"


### PR DESCRIPTION
Create entrypoint to orchestrate the build steps
- Supported commands: make, ninja
- Passes additional arguments to the make / ninja command at the end (like -jNN) There is a shortcut to make -jNN by just specifying -jNN
- Anything else will be directly executed (like getting a shell into the container with bash -li is still possible)

It shouldnt break existing usage as documented on the wiki, but will anyhow need to update it to show the new features 😉

Also installs ninja-build in the containers

Only updated dockerfile-nogit and dockerfile-nogit-arm. Does anyone use the the others? They seem to be complately broken 😞 Could we just get rid of them?

Needed to more easily integrate ci with cmake and reduce some code duplication 🙂

Aaaand dont get too exiced for ninja :/ it doesnt seem to be working correctly in this old configuration, so further investigation is needed there..