### PR TITLE
First version of rtcget and rtcset

### DIFF
--- a/firmware/application/shell.hpp
+++ b/firmware/application/shell.hpp
@@ -36,7 +36,7 @@
  * @brief   Shell maximum arguments per command.
  */
 #if !defined(SHELL_MAX_ARGUMENTS) || defined(__DOXYGEN__)
-#define SHELL_MAX_ARGUMENTS 4
+#define SHELL_MAX_ARGUMENTS 6
 #endif
 
 /**

--- a/firmware/application/usb_serial_shell.cpp
+++ b/firmware/application/usb_serial_shell.cpp
@@ -583,6 +583,39 @@ static void cmd_sd_write(BaseSequentialStream* chp, int argc, char* argv[]) {
     chprintf(chp, "ok\r\n");
 }
 
+static void cmd_rtcget(BaseSequentialStream* chp, int argc, char* argv[]) {
+    (void)chp;
+    (void)argc;
+    (void)argv;
+
+    rtc::RTC datetime;
+    rtcGetTime(&RTCD1, &datetime);
+
+    chprintf(chp, "Current time: %04d-%02d-%02d %02d:%02d:%02d\r\n",
+        datetime.year(), datetime.month(), datetime.day(),
+        datetime.hour(), datetime.minute(), datetime.second());
+}
+
+static void cmd_rtcset(BaseSequentialStream* chp, int argc, char* argv[]) {
+    const char* usage =
+        "usage: rtcset [year] [month] [day] [hour] [minute] [second]\r\n"
+        "  all fields are required; milliseconds zero when set\r\n"
+        "  (fractional seconds are not supported)\r\n";
+
+    if (argc != 6) {
+        chprintf(chp, usage);
+        return;
+    }
+
+    rtc::RTC new_datetime{
+        (uint16_t)strtol(argv[0], NULL, 10), (uint8_t)strtol(argv[1], NULL, 10),
+        (uint8_t)strtol(argv[2], NULL, 10), (uint32_t)strtol(argv[3], NULL, 10),
+        (uint32_t)strtol(argv[4], NULL, 10), (uint32_t)strtol(argv[5], NULL, 10)};
+    rtcSetTime(&RTCD1, &new_datetime);
+
+    chprintf(chp, "ok\r\n");
+}
+
 static void cpld_info(BaseSequentialStream* chp, int argc, char* argv[]) {
     const char* usage =
         "usage: cpld_info <device>\r\n"
@@ -913,6 +946,8 @@ static const ShellCommand commands[] = {
     {"read", cmd_sd_read},
     {"write", cmd_sd_write},
     {"filesize", cmd_sd_filesize},
+    {"rtcget", cmd_rtcget},
+    {"rtcset", cmd_rtcset},
     {"cpld_info", cpld_info},
     {"cpld_read", cmd_cpld_read},
     {NULL, NULL}};

--- a/firmware/application/usb_serial_shell.cpp
+++ b/firmware/application/usb_serial_shell.cpp
@@ -591,9 +591,7 @@ static void cmd_rtcget(BaseSequentialStream* chp, int argc, char* argv[]) {
     rtc::RTC datetime;
     rtcGetTime(&RTCD1, &datetime);
 
-    chprintf(chp, "Current time: %04d-%02d-%02d %02d:%02d:%02d\r\n",
-        datetime.year(), datetime.month(), datetime.day(),
-        datetime.hour(), datetime.minute(), datetime.second());
+    chprintf(chp, "Current time: %04d-%02d-%02d %02d:%02d:%02d\r\n", datetime.year(), datetime.month(), datetime.day(), datetime.hour(), datetime.minute(), datetime.second());
 }
 
 static void cmd_rtcset(BaseSequentialStream* chp, int argc, char* argv[]) {


### PR DESCRIPTION
Add usb_serial commands to manipulate the rtc

I decided to implement this as six arguments instead of two arguments with dashes and colons. If anyone disagrees with this choice I'm happy to parse a YYYY-MM-DD HH:MM:SS input instead ... but honestly it seemed more robust just to up the shell argument limit to 6 and do it this way.

```
rtcget
Current time: 2024-01-05 17:16:52
ch> rtcset
usage: rtcset [year] [month] [day] [hour] [minute] [second]
  all fields are required; milliseconds zero when set
  (fractional seconds are not supported)
ch> rtcset 2024 01 05 17 17 40
ok
ch> rtcget
Current time: 2024-01-05 17:17:41
```

Note that rtcset takes about 3 seconds to complete on my portapack h2 r4. So if you want to set the time to 30 seconds past the minute, you'd want to execute rtcset at approximately 27 seconds past the minute; execute rtcset about three seconds before the nominal set time. You can rtcget after set if you'd like, to verify the time is set properly.

I recommend an offset parameter for any code that programmatically updates the clock. I haven't timed it precisely; somewhere in the range of ~2500-3000 ms seems to be good on my unit. It should probably be adjustable in case this varies across hardware.

Stoked to have my first contribution to the Mayhem firmware up!! Thanks for all the hard work y'all have done! :-)