### PR TITLE
fixed usb descriptor product string length

### DIFF
--- a/firmware/application/usb_serial_descriptor.c
+++ b/firmware/application/usb_serial_descriptor.c
@@ -264,7 +264,7 @@ uint8_t usb_descriptor_string_manufacturer[] = {
  };
 
  uint8_t usb_descriptor_string_product[] = {
- 	43,                         // bLength
+ 	34,                         // bLength
  	USB_DESCRIPTOR_TYPE_STRING, // bDescriptorType
  	'P', 0x00,
  	'o', 0x00,

--- a/firmware/baseband/sd_over_usb/usb_descriptor.c
+++ b/firmware/baseband/sd_over_usb/usb_descriptor.c
@@ -186,7 +186,7 @@ uint8_t usb_descriptor_string_manufacturer[] = {
 
 uint8_t usb_descriptor_string_product[] = {
 #ifdef HACKRF_ONE
-	43,                         // bLength
+	34,                         // bLength
 	USB_DESCRIPTOR_TYPE_STRING, // bDescriptorType
 	'P', 0x00,
 	'o', 0x00,


### PR DESCRIPTION
This pull request fixes a missmatch in the length property in the usb descriptor product string.

Not sure if it ever caused an issue. I noticed it as i saw:
![grafik](https://github.com/eried/portapack-mayhem/assets/13151053/c9a08936-1caf-4f9d-af88-19729f3e8c92)


