### PR TITLE
added usb event to not wait for the next frame

### DIFF
--- a/firmware/application/event_m0.cpp
+++ b/firmware/application/event_m0.cpp
@@ -113,7 +113,6 @@ void EventDispatcher::run() {
     while (is_running) {
         const auto events = wait();
         dispatch(events);
-        portapack::usb_serial.dispatch();
     }
 }
 
@@ -161,6 +160,10 @@ void EventDispatcher::dispatch(const eventmask_t events) {
 
     if (events & EVT_MASK_RTC_TICK) {
         handle_rtc_tick();
+    }
+
+    if (events & EVT_MASK_USB) {
+        handle_usb();
     }
 
     if (events & EVT_MASK_SWITCHES) {
@@ -214,6 +217,10 @@ void EventDispatcher::handle_rtc_tick() {
     rtc_time::on_tick_second();
 
     portapack::persistent_memory::cache::persist();
+}
+
+void EventDispatcher::handle_usb() {
+    portapack::usb_serial.dispatch();
 }
 
 ui::Widget* EventDispatcher::touch_widget(ui::Widget* const w, ui::TouchEvent event) {

--- a/firmware/application/event_m0.hpp
+++ b/firmware/application/event_m0.hpp
@@ -45,6 +45,7 @@ constexpr auto EVT_MASK_ENCODER = EVENT_MASK(4);
 constexpr auto EVT_MASK_TOUCH = EVENT_MASK(5);
 constexpr auto EVT_MASK_APPLICATION = EVENT_MASK(6);
 constexpr auto EVT_MASK_LOCAL = EVENT_MASK(7);
+constexpr auto EVT_MASK_USB = EVENT_MASK(8);
 
 class EventDispatcher {
    public:
@@ -111,6 +112,7 @@ class EventDispatcher {
     void handle_application_queue();
     void handle_local_queue();
     void handle_rtc_tick();
+    void handle_usb();
 
     static ui::Widget* touch_widget(ui::Widget* const w, ui::TouchEvent event);
 

--- a/firmware/application/usb_serial_cdc.c
+++ b/firmware/application/usb_serial_cdc.c
@@ -23,10 +23,20 @@
 #include "usb_serial_endpoints.h"
 #include "usb_serial_event.hpp"
 
+uint32_t EVT_MASK_USB = EVENT_MASK(8);
+
 extern void usb0_isr(void);
+
+static Thread* thread_usb_event = NULL;
+
 CH_IRQ_HANDLER(USB0_IRQHandler) {
     CH_IRQ_PROLOGUE();
     usb0_isr();
+
+    chSysLockFromIsr();
+    chEvtSignalI(thread_usb_event, EVT_MASK_USB);
+    chSysUnlockFromIsr();
+
     CH_IRQ_EPILOGUE();
 }
 
@@ -46,6 +56,7 @@ uint32_t __strex(uint32_t val, volatile uint32_t* addr) {
 
 void nvic_enable_irq(uint8_t irqn) {
     NVIC_ISER(irqn / 32) = (1 << (irqn % 32));
+    thread_usb_event = chThdSelf();
 }
 
 void usb_configuration_changed(usb_device_t* const device) {

--- a/firmware/application/usb_serial_shell.cpp
+++ b/firmware/application/usb_serial_shell.cpp
@@ -1040,5 +1040,5 @@ static const ShellConfig shell_cfg1 = {
 
 void create_shell(EventDispatcher* evtd) {
     _eventDispatcherInstance = evtd;
-    shellCreate(&shell_cfg1, SHELL_WA_SIZE, NORMALPRIO);
+    shellCreate(&shell_cfg1, SHELL_WA_SIZE, NORMALPRIO + 10);
 }


### PR DESCRIPTION
This pull request adds a usb event to not wait for the next frame to handle when a usb packet arrived. This should speed up host to portapack traffic with usb serial significantly