### PR TITLE
added radio saturation to performance counter

### DIFF
--- a/firmware/application/apps/ui_dfu_menu.cpp
+++ b/firmware/application/apps/ui_dfu_menu.cpp
@@ -48,7 +48,7 @@ void DfuMenu::paint(Painter& painter) {
     text_info_line_3.set(to_string_dec_uint(utilisation, 6));
     text_info_line_4.set(to_string_dec_uint(shared_memory.m4_heap_usage, 6));
     text_info_line_5.set(to_string_dec_uint(shared_memory.m4_stack_usage, 6));
-    text_info_line_6.set(to_string_dec_uint(shared_memory.m4_cpu_usage, 6));
+    text_info_line_6.set(to_string_dec_uint(shared_memory.m4_performance_counter, 6));
     text_info_line_7.set(to_string_dec_uint(shared_memory.m4_buffer_missed, 6));
     text_info_line_8.set(to_string_dec_uint(chTimeNow() / 1000, 6));
 
@@ -94,23 +94,25 @@ DfuMenu2::DfuMenu2(NavigationView& nav)
                   &text_info_line_7,
                   &text_info_line_8,
                   &text_info_line_9,
-                  &text_info_line_10});
+                  &text_info_line_10,
+                  &text_info_line_11});
 }
 
 void DfuMenu2::paint(Painter& painter) {
     text_info_line_1.set(to_string_dec_uint(portapack::receiver_model.target_frequency(), 10));
     text_info_line_2.set(to_string_dec_uint(portapack::receiver_model.baseband_bandwidth(), 10));
     text_info_line_3.set(to_string_dec_uint(portapack::receiver_model.sampling_rate(), 10));
-    text_info_line_4.set(to_string_dec_uint((uint32_t)portapack::receiver_model.modulation(), 10));
-    text_info_line_5.set(to_string_dec_uint(portapack::receiver_model.am_configuration(), 10));
-    text_info_line_6.set(to_string_dec_uint(portapack::receiver_model.nbfm_configuration(), 10));
-    text_info_line_7.set(to_string_dec_uint(portapack::receiver_model.wfm_configuration(), 10));
-    text_info_line_8.set(to_string_dec_uint(portapack::transmitter_model.target_frequency(), 10));
-    text_info_line_9.set(to_string_dec_uint(portapack::transmitter_model.baseband_bandwidth(), 10));
-    text_info_line_10.set(to_string_dec_uint(portapack::transmitter_model.sampling_rate(), 10));
+    text_info_line_4.set(to_string_dec_uint(((uint32_t)shared_memory.m4_performance_counter) * 100 / 127, 10));
+    text_info_line_5.set(to_string_dec_uint((uint32_t)portapack::receiver_model.modulation(), 10));
+    text_info_line_6.set(to_string_dec_uint(portapack::receiver_model.am_configuration(), 10));
+    text_info_line_7.set(to_string_dec_uint(portapack::receiver_model.nbfm_configuration(), 10));
+    text_info_line_8.set(to_string_dec_uint(portapack::receiver_model.wfm_configuration(), 10));
+    text_info_line_9.set(to_string_dec_uint(portapack::transmitter_model.target_frequency(), 10));
+    text_info_line_10.set(to_string_dec_uint(portapack::transmitter_model.baseband_bandwidth(), 10));
+    text_info_line_11.set(to_string_dec_uint(portapack::transmitter_model.sampling_rate(), 10));
 
     constexpr auto margin = 5;
-    constexpr auto lines = 10 + 2;
+    constexpr auto lines = 11 + 2;
 
     painter.fill_rectangle(
         {{5 * CHARACTER_WIDTH - margin, 3 * LINE_HEIGHT - margin},

--- a/firmware/application/apps/ui_dfu_menu.hpp
+++ b/firmware/application/apps/ui_dfu_menu.hpp
@@ -83,13 +83,15 @@ class DfuMenu2 : public View {
         {{5 * CHARACTER_WIDTH, 5 * LINE_HEIGHT}, "RX Freq:", Color::dark_cyan()},
         {{5 * CHARACTER_WIDTH, 6 * LINE_HEIGHT}, "RX BW:", Color::dark_cyan()},
         {{5 * CHARACTER_WIDTH, 7 * LINE_HEIGHT}, "RX SampR:", Color::dark_cyan()},
-        {{5 * CHARACTER_WIDTH, 8 * LINE_HEIGHT}, "Modulatn:", Color::dark_cyan()},
-        {{5 * CHARACTER_WIDTH, 9 * LINE_HEIGHT}, "AM cfg:", Color::dark_cyan()},
-        {{5 * CHARACTER_WIDTH, 10 * LINE_HEIGHT}, "NBFM cfg:", Color::dark_cyan()},
-        {{5 * CHARACTER_WIDTH, 11 * LINE_HEIGHT}, "WFM cfg:", Color::dark_cyan()},
-        {{5 * CHARACTER_WIDTH, 12 * LINE_HEIGHT}, "TX Freq:", Color::dark_cyan()},
-        {{5 * CHARACTER_WIDTH, 13 * LINE_HEIGHT}, "TX BW:", Color::dark_cyan()},
-        {{5 * CHARACTER_WIDTH, 14 * LINE_HEIGHT}, "TX SampR:", Color::dark_cyan()}};
+        {{5 * CHARACTER_WIDTH, 8 * LINE_HEIGHT}, "RX Satu%:", Color::dark_cyan()},
+        {{5 * CHARACTER_WIDTH, 9 * LINE_HEIGHT}, "Modulatn:", Color::dark_cyan()},
+        {{5 * CHARACTER_WIDTH, 10 * LINE_HEIGHT}, "AM cfg:", Color::dark_cyan()},
+        {{5 * CHARACTER_WIDTH, 11 * LINE_HEIGHT}, "NBFM cfg:", Color::dark_cyan()},
+        {{5 * CHARACTER_WIDTH, 12 * LINE_HEIGHT}, "WFM cfg:", Color::dark_cyan()},
+        {{5 * CHARACTER_WIDTH, 13 * LINE_HEIGHT}, "TX Freq:", Color::dark_cyan()},
+        {{5 * CHARACTER_WIDTH, 14 * LINE_HEIGHT}, "TX BW:", Color::dark_cyan()},
+        {{5 * CHARACTER_WIDTH, 15 * LINE_HEIGHT}, "TX SampR:", Color::dark_cyan()},
+    };
 
     Text text_info_line_1{{14 * CHARACTER_WIDTH, 5 * LINE_HEIGHT, 10 * CHARACTER_WIDTH, 1 * LINE_HEIGHT}, ""};
     Text text_info_line_2{{14 * CHARACTER_WIDTH, 6 * LINE_HEIGHT, 10 * CHARACTER_WIDTH, 1 * LINE_HEIGHT}, ""};
@@ -101,6 +103,7 @@ class DfuMenu2 : public View {
     Text text_info_line_8{{14 * CHARACTER_WIDTH, 12 * LINE_HEIGHT, 10 * CHARACTER_WIDTH, 1 * LINE_HEIGHT}, ""};
     Text text_info_line_9{{14 * CHARACTER_WIDTH, 13 * LINE_HEIGHT, 10 * CHARACTER_WIDTH, 1 * LINE_HEIGHT}, ""};
     Text text_info_line_10{{14 * CHARACTER_WIDTH, 14 * LINE_HEIGHT, 10 * CHARACTER_WIDTH, 1 * LINE_HEIGHT}, ""};
+    Text text_info_line_11{{14 * CHARACTER_WIDTH, 15 * LINE_HEIGHT, 10 * CHARACTER_WIDTH, 1 * LINE_HEIGHT}, ""};
 };
 
 } /* namespace ui */

--- a/firmware/application/ui_navigation.cpp
+++ b/firmware/application/ui_navigation.cpp
@@ -758,7 +758,7 @@ void SystemView::toggle_overlay() {
             this->add_child(&this->overlay);
             this->set_dirty();
             shared_memory.request_m4_performance_counter = 1;
-            shared_memory.m4_cpu_usage = 0;
+            shared_memory.m4_performance_counter = 0;
             shared_memory.m4_heap_usage = 0;
             shared_memory.m4_stack_usage = 0;
             break;
@@ -766,11 +766,12 @@ void SystemView::toggle_overlay() {
             this->remove_child(&this->overlay);
             this->add_child(&this->overlay2);
             this->set_dirty();
-            shared_memory.request_m4_performance_counter = 0;
+            shared_memory.request_m4_performance_counter = 2;
             break;
         case 3:
             this->remove_child(&this->overlay2);
             this->set_dirty();
+            shared_memory.request_m4_performance_counter = 0;
             overlay_active = 0;
             break;
     }

--- a/firmware/baseband/baseband_thread.cpp
+++ b/firmware/baseband/baseband_thread.cpp
@@ -95,6 +95,20 @@ void BasebandThread::run() {
             buffer_c8_t buffer{
                 buffer_tmp.p, buffer_tmp.count, sampling_rate_};
 
+            if (shared_memory.request_m4_performance_counter == 0x02) {
+                uint8_t max = shared_memory.m4_performance_counter;
+                for (size_t i = 0; i < buffer_tmp.count; i++) {
+                    int8_t a = buffer_tmp.p[i].real();
+                    if (a < 0)
+                        a = -a;
+
+                    if (a > max)
+                        max = a;
+                }
+
+                shared_memory.m4_performance_counter = max;
+            }
+
             if (baseband_processor_) {
                 baseband_processor_->execute(buffer);
             }

--- a/firmware/baseband/debug.cpp
+++ b/firmware/baseband/debug.cpp
@@ -135,13 +135,17 @@ void update_performance_counters() {
 
     last_paint_state = !last_paint_state;
 
-    auto utilisation = get_cpu_utilisation_in_percent();
-    auto free_stack = (uint32_t)get_free_stack_space();
-    auto free_heap = chCoreStatus();
+    if (performance_counter_active == 0x01) {
+        auto utilisation = get_cpu_utilisation_in_percent();
+        auto free_stack = (uint32_t)get_free_stack_space();
+        auto free_heap = chCoreStatus();
 
-    shared_memory.m4_cpu_usage = utilisation;
-    shared_memory.m4_stack_usage = free_stack;
-    shared_memory.m4_heap_usage = free_heap;
+        shared_memory.m4_performance_counter = utilisation;
+        shared_memory.m4_stack_usage = free_stack;
+        shared_memory.m4_heap_usage = free_heap;
+    } else if (performance_counter_active == 0x02) {
+        shared_memory.m4_performance_counter = 0;
+    }
 }
 
 } /* extern "C" */

--- a/firmware/common/portapack_shared_memory.hpp
+++ b/firmware/common/portapack_shared_memory.hpp
@@ -71,7 +71,7 @@ struct SharedMemory {
     void set_baseband_ready() { baseband_ready = true; }
 
     uint8_t volatile request_m4_performance_counter{0};
-    uint8_t volatile m4_cpu_usage{0};
+    uint8_t volatile m4_performance_counter{0};
     uint16_t volatile m4_stack_usage{0};
     uint32_t volatile m4_heap_usage{0};
     uint16_t volatile m4_buffer_missed{0};


### PR DESCRIPTION
This pull request adds the radio saturation to the dfu radio menu, so you never again have to guess what amplifier settings are good.

- Value in 0% to 100%
- Higher is better for more dynamic range
- Never touch 100, as clipping will happen

![SCR_0035](https://github.com/eried/portapack-mayhem/assets/13151053/95ef8608-f508-4313-af5c-d3b558b58182)
![SCR_0034](https://github.com/eried/portapack-mayhem/assets/13151053/fee368a8-ccc8-4f3e-a1a6-0ca9a909ba60)

![yc4Xn](https://github.com/eried/portapack-mayhem/assets/13151053/a47d5c5f-9080-40ba-82e3-04851a09e210)
