### PR TITLE
Appstart and applist from serial

### DIFF
--- a/firmware/application/ui_external_items_menu_loader.hpp
+++ b/firmware/application/ui_external_items_menu_loader.hpp
@@ -55,6 +55,7 @@ class ExternalItemsMenuLoader {
     static std::vector<GridItem> load_external_items(app_location_t, NavigationView&);
     ExternalItemsMenuLoader() = delete;
     static bool run_external_app(ui::NavigationView&, std::filesystem::path);
+    static void load_all_external_items_callback(std::function<void(AppInfoConsole&)> callback);
 
    private:
     static std::vector<DynamicBitmap<16, 16>> bitmaps;

--- a/firmware/application/ui_external_items_menu_loader.hpp
+++ b/firmware/application/ui_external_items_menu_loader.hpp
@@ -54,11 +54,10 @@ class ExternalItemsMenuLoader {
    public:
     static std::vector<GridItem> load_external_items(app_location_t, NavigationView&);
     ExternalItemsMenuLoader() = delete;
+    static bool run_external_app(ui::NavigationView&, std::filesystem::path);
 
    private:
     static std::vector<DynamicBitmap<16, 16>> bitmaps;
-
-    static void run_external_app(ui::NavigationView&, std::filesystem::path);
 };
 
 }  // namespace ui

--- a/firmware/application/ui_navigation.cpp
+++ b/firmware/application/ui_navigation.cpp
@@ -111,6 +111,169 @@ namespace pmem = portapack::persistent_memory;
 
 namespace ui {
 
+// When adding or removing apps from the Menu, please update it here:
+std::vector<AppInfoConsole> NavigationView::fixedAppListFC = {
+    {"adsbrx", "ADS-B", RX},
+    {"ais", "AIS Boats", RX},
+    {"aprsrx", "APRS", RX},
+    {"audio", "Audio", RX},
+    {"blerx", "BLE Rx", RX},
+    {"ert", "ERT Meter", RX},
+    {"level", "Level", RX},
+    {"pocsagrx", "POCSAG", RX},
+    {"radiosnde", "Radiosnde", RX},
+    {"recon", "Recon", RX},
+    {"search", "Search", RX},
+    {"tpms", "TPMS Cars", RX},
+    {"weather", "Weather", RX},
+    {"subghzd", "SubGhzD", RX},
+    {"adsbtx", "ADS-B", TX},
+    {"aprstx", "APRS TX", TX},
+    {"bht", "BHT Xy/EP", TX},
+    {"bletx", "BLE Tx", TX},
+    {"morsetx", "Morse", TX},
+    {"ooktx", "OOK", TX},
+    {"pocsatx", "POCSAG TX", TX},
+    {"rdstx", "RDS TX", TX},
+    {"soundbrd", "Soundbrd", TX},
+    {"sstvtx", "SSTV", TX},
+    {"touchtune", "TouchTune", TX},
+    {"capture", "Capture", RX},
+    {"replay", "Replay", TX},
+    {"remote", "Remote", TX},
+    {"scanner", "Scanner", RX},
+    {"microphone", "Microphone", TX},
+    {"lookingglass", "Looking Glass", RX}};
+
+bool NavigationView::StartAppByName(const char* name) {
+    pop();
+    if (strcmp(name, "adsbrx") == 0) {
+        push<ADSBRxView>();
+        return true;
+    }
+    if (strcmp(name, "ais") == 0) {
+        push<AISAppView>();
+        return true;
+    }
+    if (strcmp(name, "aprsrx") == 0) {
+        push<APRSRXView>();
+        return true;
+    }
+    if (strcmp(name, "audio") == 0) {
+        push<AnalogAudioView>();
+        return true;
+    }
+    if (strcmp(name, "blerx") == 0) {
+        push<BLERxView>();
+        return true;
+    }
+    if (strcmp(name, "ert") == 0) {
+        push<ERTAppView>();
+        return true;
+    }
+    if (strcmp(name, "level") == 0) {
+        push<LevelView>();
+        return true;
+    }
+    if (strcmp(name, "pocsagrx") == 0) {
+        push<POCSAGAppView>();
+        return true;
+    }
+    if (strcmp(name, "radiosnode") == 0) {
+        push<SondeView>();
+        return true;
+    }
+    if (strcmp(name, "recon") == 0) {
+        push<ReconView>();
+        return true;
+    }
+    if (strcmp(name, "search") == 0) {
+        push<SearchView>();
+        return true;
+    }
+    if (strcmp(name, "tpms") == 0) {
+        push<TPMSAppView>();
+        return true;
+    }
+    if (strcmp(name, "weather") == 0) {
+        push<WeatherView>();
+        return true;
+    }
+    if (strcmp(name, "subghzd") == 0) {
+        push<SubGhzDView>();
+        return true;
+    }
+    if (strcmp(name, "adsbtx") == 0) {
+        push<ADSBTxView>();
+        return true;
+    }
+    if (strcmp(name, "aprstx") == 0) {
+        push<APRSTXView>();
+        return true;
+    }
+    if (strcmp(name, "bht") == 0) {
+        push<BHTView>();
+        return true;
+    }
+    if (strcmp(name, "bletx") == 0) {
+        push<BLETxView>();
+        return true;
+    }
+    if (strcmp(name, "morsetx") == 0) {
+        push<MorseView>();
+        return true;
+    }
+    if (strcmp(name, "ooktx") == 0) {
+        push<EncodersView>();
+        return true;
+    }
+    if (strcmp(name, "pocsatx") == 0) {
+        push<POCSAGTXView>();
+        return true;
+    }
+    if (strcmp(name, "rdstx") == 0) {
+        push<RDSView>();
+        return true;
+    }
+    if (strcmp(name, "soundbrd") == 0) {
+        push<SoundBoardView>();
+        return true;
+    }
+    if (strcmp(name, "sstvtx") == 0) {
+        push<SSTVTXView>();
+        return true;
+    }
+    if (strcmp(name, "touchtune") == 0) {
+        push<TouchTunesView>();
+        return true;
+    }
+    if (strcmp(name, "capture") == 0) {
+        push<CaptureAppView>();
+        return true;
+    }
+    if (strcmp(name, "replay") == 0) {
+        push<PlaylistView>();
+        return true;
+    }
+    if (strcmp(name, "remote") == 0) {
+        push<RemoteView>();
+        return true;
+    }
+    if (strcmp(name, "scanner") == 0) {
+        push<ScannerView>();
+        return true;
+    }
+    if (strcmp(name, "microphone") == 0) {
+        push<MicTXView>();
+        return true;
+    }
+    if (strcmp(name, "lookingglass") == 0) {
+        push<GlassView>();
+        return true;
+    }
+    return false;
+}
+
 /* StatusTray ************************************************************/
 
 StatusTray::StatusTray(Point pos)

--- a/firmware/application/ui_navigation.cpp
+++ b/firmware/application/ui_navigation.cpp
@@ -751,6 +751,9 @@ SystemView::SystemView(
 Context& SystemView::context() const {
     return context_;
 }
+NavigationView* SystemView::get_navigation_view() {
+    return &navigation_view;
+}
 
 void SystemView::toggle_overlay() {
     switch (++overlay_active) {

--- a/firmware/application/ui_navigation.hpp
+++ b/firmware/application/ui_navigation.hpp
@@ -40,7 +40,7 @@
 #include "diskio.h"
 #include "lfsr_random.hpp"
 #include "sd_card.hpp"
-
+#include "external_app.hpp"
 #include <vector>
 #include <utility>
 
@@ -55,6 +55,12 @@ enum modal_t {
     INFO = 0,
     YESNO,
     ABORT
+};
+
+struct AppInfoConsole {
+    const char* appCallName;
+    const char* appFriendlyName;
+    const app_location_t appLocation;
 };
 
 class NavigationView : public View {
@@ -99,6 +105,8 @@ class NavigationView : public View {
      * Returns true if the handler was bound successfully. */
     bool set_on_pop(std::function<void()> on_pop);
 
+    static std::vector<AppInfoConsole> fixedAppListFC;  // fixed app list for console. vector, so can be incomplete and still iterateable
+    bool StartAppByName(const char* name);              // Starts a View  (app) by name stored in fixedAppListFC. This is to start apps from console
    private:
     struct ViewState {
         std::unique_ptr<View> view;

--- a/firmware/application/ui_navigation.hpp
+++ b/firmware/application/ui_navigation.hpp
@@ -321,6 +321,8 @@ class SystemView : public View {
     void toggle_overlay();
     void paint_overlay();
 
+    NavigationView* get_navigation_view();
+
    private:
     uint8_t overlay_active{0};
 

--- a/firmware/application/usb_serial_shell.cpp
+++ b/firmware/application/usb_serial_shell.cpp
@@ -846,7 +846,7 @@ static void cmd_appstart(BaseSequentialStream* chp, int argc, char* argv[]) {
         return;
     }
     auto evtd = getEventDispatcherInstance();
-    if (evtd) return;
+    if (!evtd) return;
     auto top_widget = evtd->getTopWidget();
     if (!top_widget) return;
     auto nav = static_cast<ui::SystemView*>(top_widget)->get_navigation_view();

--- a/firmware/application/usb_serial_shell.cpp
+++ b/firmware/application/usb_serial_shell.cpp
@@ -42,6 +42,7 @@
 #include "chqueues.h"
 #include "untar.hpp"
 #include "ui_widget.hpp"
+#include "ui_navigation.hpp"
 
 #include <string>
 #include <codecvt>
@@ -812,6 +813,19 @@ static void cmd_accessibility_readcurr(BaseSequentialStream* chp, int argc, char
     chprintf(chp, "\r\nok\r\n");
 }
 
+// returns the installed apps, those can be called by appstart APPNAME
+static void cmd_applist(BaseSequentialStream* chp, int argc, char* argv[]) {
+    (void)argc;
+    (void)argv;
+    auto evtd = getEventDispatcherInstance();
+    if (+evtd) return;
+    auto top_widget = evtd->getTopWidget();
+    if (!top_widget) return;
+    auto nav = static_cast<ui::SystemView*>(top_widget)->get_navigation_view();
+    if (!nav) return;
+    chprintf(chp, "\r\nok\r\n");
+}
+
 static void cmd_cpld_read(BaseSequentialStream* chp, int argc, char* argv[]) {
     const char* usage =
         "usage: cpld_read <device> <target>\r\n"
@@ -999,6 +1013,7 @@ static const ShellCommand commands[] = {
     {"cpld_read", cmd_cpld_read},
     {"accessibility_readall", cmd_accessibility_readall},
     {"accessibility_readcurr", cmd_accessibility_readcurr},
+    {"applist", cmd_applist},
     {NULL, NULL}};
 
 static const ShellConfig shell_cfg1 = {

--- a/firmware/application/usb_serial_shell.cpp
+++ b/firmware/application/usb_serial_shell.cpp
@@ -59,30 +59,6 @@ static EventDispatcher* getEventDispatcherInstance() {
     return _eventDispatcherInstance;
 }
 
-struct AppInfoFS {
-    const char* appCallName;
-    const char* appFriendlyName;
-    const app_location_t appLocation;
-};
-
-AppInfoFS fixedAppList[] = {
-    {"adsbrx", "ADS-B", RX},
-    {"ais", "AIS Boats", RX},
-    {"aprs", "APRS", RX},
-    {"audio", "Audio", RX},
-    {"blerx", "BLE Rx", RX},
-    {"ert", "ERT Meter", RX},
-    {"level", "Level", RX},
-    {"pocsagrx", "POCSAG", RX},
-    {"radiosnde", "Radiosnde", RX},
-    {"recon", "Recon", RX},
-    {"search", "Search", RX},
-    {"tpms", "TPMS Cars", RX},
-    {"weather", "Weather", RX},
-    {"subghzd", "SubGhzD", RX},
-    {"adsbtx", "ADS-B", TX},  // TODO add more
-};
-
 // queue handler from ch
 static msg_t qwait(GenericQueue* qp, systime_t time) {
     if (TIME_IMMEDIATE == time)
@@ -882,12 +858,9 @@ static void cmd_appstart(BaseSequentialStream* chp, int argc, char* argv[]) {
     if (!top_widget) return;
     auto nav = static_cast<ui::SystemView*>(top_widget)->get_navigation_view();
     if (!nav) return;
-    for (auto element : fixedAppList) {
-        if (std::strcmp(element.appCallName, argv[0]) == 0) {
-            // todo start app
-            chprintf(chp, "ok\r\n");
-            return;
-        }
+    if (nav->StartAppByName(argv[0])) {
+        chprintf(chp, "ok\r\n");
+        return;
     }
     // todo look for ext apps
     chprintf(chp, "error\r\n");
@@ -903,7 +876,7 @@ static void cmd_applist(BaseSequentialStream* chp, int argc, char* argv[]) {
     if (!top_widget) return;
     auto nav = static_cast<ui::SystemView*>(top_widget)->get_navigation_view();
     if (!nav) return;
-    for (auto element : fixedAppList) {
+    for (auto element : ui::NavigationView::fixedAppListFC) {
         if (strlen(element.appCallName) == 0) continue;
         chprintf(chp, element.appCallName);
         chprintf(chp, " ");


### PR DESCRIPTION
appstart appname will pop the current app and push the selected. 
applist returns the app name (needed for the start command), a human friendly name, and the category.

IMPORTANT!
ui_navigation.cpp contains the database and logic for list and start the app (main). So if you add a new or remove one (eg make it external) you must edit it in 2 places.
At the top of the file: 
std::vector<AppInfoConsole> NavigationView::fixedAppListFC  - this contains the 3 data mentioned before.
bool NavigationView::StartAppByName(const char* name) - this vill associate the View with the char* name, and it will start the app.