### PR TITLE
updating_comments

### DIFF
--- a/firmware/application/apps/ui_mictx.cpp
+++ b/firmware/application/apps/ui_mictx.cpp
@@ -285,7 +285,7 @@ void MicTXView::set_rxbw_defaults(bool use_app_settings) {  // Initially in that
         field_rxbw.set_by_value(0);
     } else if ((mic_mod_index == MIC_MOD_USB) | (mic_mod_index == MIC_MOD_LSB)) {
         field_bw.set_value(3);     // In SSB by default let's limit TX_BW to 3kHz.
-        field_bw.set_range(2, 3);  // User range to modify that TX_BW.  (TODO pending to investigate 4khz).
+        field_bw.set_range(2, 3);  // User TXBW GUI range to modify that SSB TX_BW to limit SSB radiated spectrum.
         field_bw.set_step(1);
     }
     // field_bw is hidden in other modulation cases

--- a/firmware/baseband/dsp_hilbert.cpp
+++ b/firmware/baseband/dsp_hilbert.cpp
@@ -33,11 +33,11 @@ HilbertTransform::HilbertTransform() {
 }
 
 void HilbertTransform::execute(float in, float& out_i, float& out_q) {
+    // Synthesized Hilbert Transform, it is implemented  based on 1/2 band LPF and later freq shift fs/4, achieving a H.T_BW of transmitted = fs/2 ;
+    // Half_band LPF  means a LP filter with f_cut_off = fs/4; Half band = Half max band = 1/2 * fs_max =  1/2 x f_Nyquist = 1/2 * fs/2 = fs/4
     float a = 0, b = 0;
 
     float in_filtered = sos_input.execute(in) * 1.0f;  // Anti-aliasing LPF at fs/4 mic audio filter front-end.
-    // it is exactly matching with the usefull mic BW_cut_off =fs/4 of the following Hilbert Transf. implementation
-    // Ex. to TX SSB  3khz BW (3KHZ =fs/4) ,we need to run Hiblert_Trf fs = 12khz . And our anti-aliasing filter is also fcut =fs/4 when we use a half_band_LPF .
 
     switch (n) {
         case 0:

--- a/firmware/baseband/dsp_modulate.cpp
+++ b/firmware/baseband/dsp_modulate.cpp
@@ -84,18 +84,13 @@ SSB::SSB()
 void SSB::set_fs_div_factor(float new_bw_ssb) {
     switch ((int)new_bw_ssb / 1000) {
         case 2:
-            fs_div_factor = 192;  // TXBW_ssb = 2khz = fs/4 ; fs of Hilbert Transform => 8khz fs Hilbert = 1536.000/8000= 192
+            fs_div_factor = 192;  // TXBW_ssb = 2khz = BW_cut_off LPF = fs/4 ; BW_HT fs Hilbert Transform (4khz=fs/2) ==> (8k=fs) Hilbert_fs = 1.536.000/8000= 192
             break;
         case 3:
-            fs_div_factor = 128;  // TXBW_ssb = 3khz = fs/4 ; fs of Hilbert Transform => 12khz fs Hilbert = 1536.000/12000= 128
+            fs_div_factor = 128;  // TXBW_ssb = 3khz = BW_cut_off LPF = fs/4 ; BW_HT fs Hilbert Transform (6khz=fs/2) ==> (12k=fs) Hilbert_fs = 1.536.000/12000= 128
             break;
-        /* TODO pending to investigate 4khz,     now is making aliasing folding with audio sweep .
-        case 4:
-            fs_div_factor = 96;  // TXBW_ssb = 4khz = fs/4 ; fs of Hilbert Transform => 16khz fs Hilbert = 1536.000/16000= 96
-            break;
-        */
         default:
-            fs_div_factor = 128;  // TXBW_ssb = 3khz = fs/4 ; fs of Hilbert Transform => 12khz fs Hilbert = 1536.000/12000= 128
+            fs_div_factor = 128;  // TXBW_ssb = 3khz = BW_cut_off LPF = fs/4 ; BW_HT fs Hilbert Transform (6khz=fs/2) ==> (12k=fs) Hilbert_fs = 1.536.000/12000= 128
             break;
     }
 }

--- a/firmware/baseband/proc_mictx.cpp
+++ b/firmware/baseband/proc_mictx.cpp
@@ -144,7 +144,7 @@ void MicTXProcessor::on_message(const Message* const msg) {
                 modulator->set_mode(dsp::modulate::Mode::DSB);
             }
 
-            modulator->set_over(baseband_fs / 24000);  // Keep no change.
+            modulator->set_over(baseband_fs / 24000);  // "over" is calculated based on relationship fs_transceiver / fs_audio_mic_capture, to be used in dsp_modulate.cpp
 
             am_enabled = config_message.am_enabled;
             usb_enabled = config_message.usb_enabled;


### PR DESCRIPTION
I already investigated, the indicated "TODO" comments , that I added in yesterday's PR #2186 

It is already clear , why the deleted options SSB TX BW  = 4khz , was not working correctly and producing some artifacts. 
In all TX modes (AM, SSB, NFM , WFM ),fs_baseband_transceiver = 1.536.000 (at RX time different ), and in parallel ,the fs_mic_Audio_capture = 24khz..

My current understanding is that to solve that SSB TX BW  = 4khz, we will need to increase fs_mic_Audio_capture to 48khz,
And later make the correct adjustments and revisions in all TX modes (AM,SSB, NFM, WFM) .
This is not a big change, but it will request many test,  therefore I prefer not to do it , and just keep the two added options : 
SSB TX_BW  (2kHz,  3kHz) . 

Then this  PR , will just remove my previous notes about "TODO"  related to  TX_BW  "4KHZ"  and add more correct comments.

Just in case, I checked its compilation and all working as expected , 
(Because that PR , is  just updating  comments without any code change)

Cheers,  


