### PR TITLE
add bitmap arr to file (or reverse) converter

### DIFF
--- a/firmware/tools/bmp_to_hex_cpp_arr.py
+++ b/firmware/tools/bmp_to_hex_cpp_arr.py
@@ -1,0 +1,44 @@
+# copyleft zxkmm 2024
+
+import os
+import sys
+
+
+def bmp_to_hex_cpp_arr(input_file, output_file):
+
+    with open(input_file, 'rb') as f:
+        data = f.read()
+
+    name_without_extension = os.path.splitext(os.path.basename(input_file))[0]
+
+    with open(output_file, 'w') as f:
+
+        f.write(f"// converted by bmp_to_hex_cpp_arr.py at the firmware/tools dir\n")
+        f.write(f"// fake transparent px should be the exact color rgb(255,0,255), then use true for the last arg "
+                f"when drawing bmp with the draw func\n")
+        f.write(f"\n")
+        f.write(f"const unsigned char {name_without_extension}[] = {{\n")
+
+        # idk about the clang-format rule, but the splash arr is 12 item per line. but other bmp arr is 2 item per line
+        for i in range(0, len(data), 12):
+            line = data[i:i + 12]
+            hex_values = [f"0x{byte:02x}" for byte in line]
+
+            if i + 16 >= len(data):
+                f.write("    " + ", ".join(hex_values) + "};\n")
+            else:
+                f.write("    " + ", ".join(hex_values) + ",\n")
+
+        f.write(f"unsigned int {name_without_extension}_len = {len(data)};\n")
+
+    print(f"done, outputted, pls clang-format yourself before commit (if necessary)：{output_file}")
+
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
+        print("usage: python script.py INPUTFILE OUTPUTFILE")
+        sys.exit(1)
+
+    input_file = sys.argv[1]
+    output_file = sys.argv[2]
+
+    bmp_to_hex_cpp_arr(input_file, output_file)

--- a/firmware/tools/bmp_to_hex_cpp_arr.py
+++ b/firmware/tools/bmp_to_hex_cpp_arr.py
@@ -23,11 +23,13 @@ def bmp_to_hex_cpp_arr(input_file, output_file):
         for i in range(0, len(data), 12):
             line = data[i:i + 12]
             hex_values = [f"0x{byte:02x}" for byte in line]
+            f.write(f"    {', '.join(hex_values)},\n")
 
-            if i + 16 >= len(data):
-                f.write("    " + ", ".join(hex_values) + "};\n")
-            else:
-                f.write("    " + ", ".join(hex_values) + ",\n")
+        # this is for remove last the extra comma
+        f.seek(f.tell() - 2, os.SEEK_SET)
+        f.truncate()
+        
+        f.write("};\n")
 
         f.write(f"unsigned int {name_without_extension}_len = {len(data)};\n")
 

--- a/firmware/tools/bmp_to_hex_cpp_arr.py
+++ b/firmware/tools/bmp_to_hex_cpp_arr.py
@@ -23,13 +23,16 @@ def bmp_to_hex_cpp_arr(input_file, output_file):
         for i in range(0, len(data), 12):
             line = data[i:i + 12]
             hex_values = [f"0x{byte:02x}" for byte in line]
+
             f.write(f"    {', '.join(hex_values)},\n")
 
         # this is for remove last the extra comma
         f.seek(f.tell() - 2, os.SEEK_SET)
         f.truncate()
-        
+
         f.write("};\n")
+
+
 
         f.write(f"unsigned int {name_without_extension}_len = {len(data)};\n")
 
@@ -37,7 +40,7 @@ def bmp_to_hex_cpp_arr(input_file, output_file):
 
 if __name__ == "__main__":
     if len(sys.argv) != 3:
-        print("usage: python script.py INPUTFILE OUTPUTFILE")
+        print("usage: python bmp_to_hex_cpp_arr.py INPUTFILE OUTPUTFILE")
         sys.exit(1)
 
     input_file = sys.argv[1]

--- a/firmware/tools/hex_cpp_arr_to_bmp.py
+++ b/firmware/tools/hex_cpp_arr_to_bmp.py
@@ -1,0 +1,51 @@
+# copyleft zxkmm 2024
+
+import sys
+import re
+
+
+def hex_cpp_arr_to_bmp(input_file, output_file):
+    with open(input_file, 'r') as f:
+        content = f.read()
+
+    # in the mayhem code some of them not const
+    array_name_const = re.search(r'const unsigned char (\w+)\[\]', content)
+    array_name_no_const = re.search(r'unsigned char (\w+)\[]', content)
+    if array_name_const or array_name_no_const:
+
+        if array_name_const:
+            array_name = array_name_const.group(1)
+        else:
+            array_name = array_name_no_const.group(1)
+
+        print(f"Array name: {array_name}")
+
+    else:
+        print("the file provided seems doesn't contains needed arr.")
+        return
+
+    hex_data = re.findall(r'0x[0-9A-Fa-f]{2}', content)
+
+    if not hex_data:
+        print("Error: No hex data found.")
+        return
+
+    binary_data = bytes([int(x, 16) for x in hex_data])
+
+    with open(output_file, 'wb') as f:
+        f.write(binary_data)
+
+    print(f"Done. Output file: {output_file}")
+    print(f"Array name: {array_name}")
+    print(f"Data length: {len(binary_data)} bytes")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
+        print("usage: python hex_cpp_arr_to_bmp.py INPUTFILE OUTPUTFILE")
+        sys.exit(1)
+
+    input_file = sys.argv[1]
+    output_file = sys.argv[2]
+
+    hex_cpp_arr_to_bmp(input_file, output_file)


### PR DESCRIPTION
the behavior of draw bmp func is weird. for the modal, it is black backgroud ( [bd2492b36e23f7d9e7908df4a5d0e4e7a074f476](https://github.com/portapack-mayhem/graphics-resources/commit/bd2492b36e23f7d9e7908df4a5d0e4e7a074f476) ) but works, for mayhem logo, i made a bg with (255,0,255) but display weirdly. 

pls merge these two scripts and ill do deep research later next months, or someone who's capable can do it.

---


this is because with the latest theme change, the default splash not quite seems normal (it's with black square).


and to resolve this, you have to put(photoshop) black background into rgb(255,0,255) to fake it transparent. but the original image file of the default splash [seems missing](https://discord.com/channels/719669764804444213/956561375155589192/1281952412122218627) so I cant photoshop it.

This also save some of the SPI flash space.

**This is just a discussion PR, so feel free to close if anyone not happy with this change.**
