### PR TITLE
setting&autostart&widgets (OptionField and Waveform) imp

### DIFF
--- a/firmware/application/apps/ui_settings.cpp
+++ b/firmware/application/apps/ui_settings.cpp
@@ -6,6 +6,7 @@
  * Copyright (C) 2024 Mark Thompson
  * Copyright (C) 2024 u-foka
  * Copyleft (ɔ) 2024 zxkmm under GPL license
+ * Copyright (C) 2024 HTotoo
  *
  * This file is part of PortaPack.
  *
@@ -876,6 +877,7 @@ SetAutostartView::SetAutostartView(NavigationView& nav) {
     add_children({&labels,
                   &button_save,
                   &button_cancel,
+                  &button_reset,
                   &options});
 
     button_save.on_select = [&nav, this](Button&) {
@@ -890,6 +892,12 @@ SetAutostartView::SetAutostartView(NavigationView& nav) {
 
     button_cancel.on_select = [&nav, this](Button&) {
         nav.pop();
+    };
+
+    button_reset.on_select = [this](Button&) {
+        selected = 0;
+        options.set_selected_index(0);
+        autostart_app = "";
     };
 
     // options

--- a/firmware/application/apps/ui_settings.cpp
+++ b/firmware/application/apps/ui_settings.cpp
@@ -5,8 +5,8 @@
  * Copyright (C) 2023 Kyle Reed
  * Copyright (C) 2024 Mark Thompson
  * Copyright (C) 2024 u-foka
- * Copyleft (ɔ) 2024 zxkmm under GPL license
  * Copyright (C) 2024 HTotoo
+ * Copyleft (ɔ) 2024 zxkmm under GPL license
  *
  * This file is part of PortaPack.
  *

--- a/firmware/application/apps/ui_settings.hpp
+++ b/firmware/application/apps/ui_settings.hpp
@@ -843,9 +843,10 @@ class SetAutostartView : public View {
         "Save"};
 
     OptionsField options{
-        {8 * 8, 4 * 16},
-        30,
-        {}};
+        {0 * 8, 4 * 16},
+        screen_width / 8,
+        {},
+        true};
 
     Button button_cancel{
         {16 * 8, 16 * 16, 12 * 8, 32},
@@ -876,15 +877,16 @@ class SetThemeView : public View {
         "Save"};
 
     OptionsField options{
-        {8 * 8, 4 * 16},
-        30,
+        {0 * 8, 4 * 16},
+        screen_width / 8,
         {
             {"Default - Grey", 0},
             {"Yellow", 1},
             {"Aqua", 2},
             {"Green", 3},
             {"Red", 4},
-        }};
+        },
+        true};
 
     Checkbox checkbox_menuset{
         {2 * 8, 6 * 16},

--- a/firmware/application/apps/ui_settings.hpp
+++ b/firmware/application/apps/ui_settings.hpp
@@ -851,6 +851,10 @@ class SetAutostartView : public View {
         {16 * 8, 16 * 16, 12 * 8, 32},
         "Cancel",
     };
+
+    Button button_reset{
+        {2 * 8, 6 * 16, screen_width - 4 * 8, 32},
+        "Reset"};
 };
 
 class SetThemeView : public View {

--- a/firmware/common/ui_widget.cpp
+++ b/firmware/common/ui_widget.cpp
@@ -1697,10 +1697,12 @@ bool ImageOptionsField::on_touch(const TouchEvent event) {
 OptionsField::OptionsField(
     Point parent_pos,
     size_t length,
-    options_t options)
+    options_t options,
+    bool centered)
     : Widget{{parent_pos, {8 * (int)length, 16}}},
       length_{length},
-      options_{std::move(options)} {
+      options_{std::move(options)},
+      centered_{centered} {
     set_focusable(true);
 }
 
@@ -1792,8 +1794,17 @@ void OptionsField::paint(Painter& painter) {
         std::string_view temp = selected_index_name();
         if (temp.length() > length_)
             temp = temp.substr(0, length_);
+        
+        Point draw_pos = screen_pos();
+        if (centered_) {
+            // 计算居中位置
+            int text_width = temp.length() * 8;
+            int available_width = length_ * 8;
+            draw_pos = Point(draw_pos.x() + (available_width - text_width) / 2, draw_pos.y());
+        }
+        
         painter.draw_string(
-            screen_pos(),
+            draw_pos,
             paint_style,
             temp);
     }

--- a/firmware/common/ui_widget.cpp
+++ b/firmware/common/ui_widget.cpp
@@ -1794,15 +1794,17 @@ void OptionsField::paint(Painter& painter) {
         std::string_view temp = selected_index_name();
         if (temp.length() > length_)
             temp = temp.substr(0, length_);
-        
+
         Point draw_pos = screen_pos();
         if (centered_) {
-            // 计算居中位置
+            // 8 is because big font width is 8px
+            // type is from: struct Point : constexpr int x() const
             int text_width = temp.length() * 8;
             int available_width = length_ * 8;
-            draw_pos = Point(draw_pos.x() + (available_width - text_width) / 2, draw_pos.y());
+            int x_offset = (available_width - text_width) / 2;
+            draw_pos = {draw_pos.x() + x_offset, draw_pos.y()};
         }
-        
+
         painter.draw_string(
             draw_pos,
             paint_style,
@@ -2633,6 +2635,8 @@ void Waveform::set_length(const uint32_t new_length) {
 }
 
 void Waveform::paint(Painter& painter) {
+    // previously it's upside down , low level is up and high level is down, which doesn't make sense,
+    // if that was made for a reason, feel free to revert.
     size_t n;
     Coord y, y_offset = screen_rect().location().y();
     Coord prev_x = screen_rect().location().x(), prev_y;
@@ -2653,7 +2657,7 @@ void Waveform::paint(Painter& painter) {
         x = 0;
         h--;
         for (n = 0; n < length_; n++) {
-            y = *(data_start++) ? h : 0;
+            y = *(data_start++) ? 0 : h;
 
             if (n) {
                 if (y != prev_y)
@@ -2669,9 +2673,10 @@ void Waveform::paint(Painter& painter) {
         // Analog waveform: each value is a point's Y coordinate
         x = prev_x + x_inc;
         h /= 2;
-        prev_y = y_offset + h - (*(data_start++) * y_scale);
+
+        prev_y = y_offset + h + (*(data_start++) * y_scale);
         for (n = 1; n < length_; n++) {
-            y = y_offset + h - (*(data_start++) * y_scale);
+            y = y_offset + h + (*(data_start++) * y_scale);
             display.draw_line({prev_x, prev_y}, {(Coord)x, y}, color_);
 
             prev_x = x;

--- a/firmware/common/ui_widget.hpp
+++ b/firmware/common/ui_widget.hpp
@@ -708,7 +708,7 @@ class OptionsField : public Widget {
     const size_t length_;
     options_t options_;
     size_t selected_index_{0};
-    bool centered_{false};
+    bool centered_{false}; // e.g.: length as screen_width/8, x position as 0, it will be centered in x axis
 };
 
 // A TextEdit is bound to a string reference and allows the string

--- a/firmware/common/ui_widget.hpp
+++ b/firmware/common/ui_widget.hpp
@@ -97,8 +97,8 @@ class Widget {
 
     virtual void paint(Painter& painter) = 0;
 
-    virtual void on_show() {};
-    virtual void on_hide() {};
+    virtual void on_show(){};
+    virtual void on_hide(){};
 
     virtual bool on_key(const KeyEvent event);
     virtual bool on_encoder(const EncoderEvent event);

--- a/firmware/common/ui_widget.hpp
+++ b/firmware/common/ui_widget.hpp
@@ -97,8 +97,8 @@ class Widget {
 
     virtual void paint(Painter& painter) = 0;
 
-    virtual void on_show(){};
-    virtual void on_hide(){};
+    virtual void on_show() {};
+    virtual void on_hide() {};
 
     virtual bool on_key(const KeyEvent event);
     virtual bool on_encoder(const EncoderEvent event);
@@ -708,7 +708,7 @@ class OptionsField : public Widget {
     const size_t length_;
     options_t options_;
     size_t selected_index_{0};
-    bool centered_{false}; // e.g.: length as screen_width/8, x position as 0, it will be centered in x axis
+    bool centered_{false};  // e.g.: length as screen_width/8, x position as 0, it will be centered in x axis
 };
 
 // A TextEdit is bound to a string reference and allows the string

--- a/firmware/common/ui_widget.hpp
+++ b/firmware/common/ui_widget.hpp
@@ -680,7 +680,7 @@ class OptionsField : public Widget {
     std::function<void(size_t, value_t)> on_change{};
     std::function<void(void)> on_show_options{};
 
-    OptionsField(Point parent_pos, size_t length, options_t options);
+    OptionsField(Point parent_pos, size_t length, options_t options, bool centered = false);
 
     options_t& options() { return options_; }
     const options_t& options() const { return options_; }
@@ -708,6 +708,7 @@ class OptionsField : public Widget {
     const size_t length_;
     options_t options_;
     size_t selected_index_{0};
+    bool centered_{false};
 };
 
 // A TextEdit is bound to a string reference and allows the string


### PR DESCRIPTION
# changes
- ad a center option for OptionField class, that when you create obj, you can make it centered.
- fix the crash that you seted a external app as auto start, but not exist or outdated. 
- fix Waveform class is upside dowm.
- add reset for auto start option in setting app cuz it’s hard to reset.

# space usage
no much differences:
``Space remaining in flash ROM: 7192 bytes ( 0.7 %)``
