### PR TITLE
fine tune waveform and ook again

### DIFF
--- a/firmware/application/apps/ui_encoders.cpp
+++ b/firmware/application/apps/ui_encoders.cpp
@@ -159,9 +159,9 @@ void EncodersConfigView::draw_waveform() {
     the waveform_buffer only controls drawing, the real send logic that been sent is controlled by frame_fragments
     so just for out of looking things*/
 
+    // clang-format off
     size_t length = frame_fragments.length();
 
-    // clang-format off
     #define PADDING_LEFT 1
     #define PADDING_RIGHT 1
     // clang-format on

--- a/firmware/application/apps/ui_encoders.cpp
+++ b/firmware/application/apps/ui_encoders.cpp
@@ -167,8 +167,8 @@ void EncodersConfigView::draw_waveform() {
     // clang-format on
 
     // currently not needed since all the supported OOK protocol wont exceed 550 yet
-    if (length + PADDING_LEFT >= WAVEFORM_BUFFER_SIZE) {
-        length = WAVEFORM_BUFFER_SIZE - PADDING_LEFT;
+    if (length + (PADDING_LEFT + PADDING_RIGHT) >= WAVEFORM_BUFFER_SIZE) {
+        length = WAVEFORM_BUFFER_SIZE - (PADDING_LEFT + PADDING_RIGHT);
     }
 
     // padding l

--- a/firmware/application/apps/ui_encoders.cpp
+++ b/firmware/application/apps/ui_encoders.cpp
@@ -154,12 +154,30 @@ void EncodersConfigView::on_show() {
 }
 
 void EncodersConfigView::draw_waveform() {
+    /*the waveform_buffer only controls drawing, the real wf that been sent is controlled by frame_fragments*/
+
     size_t length = frame_fragments.length();
 
-    for (size_t n = 0; n < length; n++)
-        waveform_buffer[n] = (frame_fragments[n] == '0') ? 0 : 1;
+    // clang-format off
+    #define PADDING_LEFT 1
+    // clang-format on
 
-    waveform.set_length(length);
+    // currently not needed since all the supported OOK protocol wont exceed 550 yet
+    if (length + PADDING_LEFT >= WAVEFORM_BUFFER_SIZE) {
+        length = WAVEFORM_BUFFER_SIZE - PADDING_LEFT;
+    }
+
+    // padding
+    for (size_t i = 0; i < PADDING_LEFT; i++) {
+        waveform_buffer[i] = 0;
+    }
+
+    // real wf
+    for (size_t n = 0; n < length; n++) {
+        waveform_buffer[n + PADDING_LEFT] = (frame_fragments[n] == '0') ? 0 : 1;
+    }
+
+    waveform.set_length(length + PADDING_LEFT);
     waveform.set_dirty();
 }
 

--- a/firmware/application/apps/ui_encoders.cpp
+++ b/firmware/application/apps/ui_encoders.cpp
@@ -25,6 +25,9 @@
 #include "baseband_api.hpp"
 #include "string_format.hpp"
 
+#define PADDING_LEFT 1
+#define PADDING_RIGHT 1
+
 using namespace portapack;
 
 namespace ui {
@@ -153,15 +156,11 @@ void EncodersConfigView::on_show() {
     on_type_change(0);
 }
 
-// clang-format off
 void EncodersConfigView::draw_waveform() {
     // padding reason:
     // in real world the signal would always start with low level and became low level again after yout turn off the radio;
     // the waveform_buffer only controls drawing, the real send logic that been sent is controlled by frame_fragments
     // so just for out of looking things
-    
-    #define PADDING_LEFT 1
-    #define PADDING_RIGHT 1
 
     size_t length = frame_fragments.length();
 
@@ -188,7 +187,6 @@ void EncodersConfigView::draw_waveform() {
     waveform.set_length(length + PADDING_LEFT + PADDING_RIGHT);
     waveform.set_dirty();
 }
-// clang-format on
 
 void EncodersConfigView::generate_frame() {
     frame_fragments.clear();

--- a/firmware/application/apps/ui_encoders.cpp
+++ b/firmware/application/apps/ui_encoders.cpp
@@ -154,12 +154,16 @@ void EncodersConfigView::on_show() {
 }
 
 void EncodersConfigView::draw_waveform() {
-    /*the waveform_buffer only controls drawing, the real wf that been sent is controlled by frame_fragments*/
+    /*padding reason:
+    in real world the signal would always start with low level and became low level again after yout turn off the radio;
+    the waveform_buffer only controls drawing, the real send logic that been sent is controlled by frame_fragments
+    so just for out of looking things*/
 
     size_t length = frame_fragments.length();
 
     // clang-format off
     #define PADDING_LEFT 1
+    #define PADDING_RIGHT 1
     // clang-format on
 
     // currently not needed since all the supported OOK protocol wont exceed 550 yet
@@ -167,7 +171,7 @@ void EncodersConfigView::draw_waveform() {
         length = WAVEFORM_BUFFER_SIZE - PADDING_LEFT;
     }
 
-    // padding
+    // padding l
     for (size_t i = 0; i < PADDING_LEFT; i++) {
         waveform_buffer[i] = 0;
     }
@@ -177,7 +181,12 @@ void EncodersConfigView::draw_waveform() {
         waveform_buffer[n + PADDING_LEFT] = (frame_fragments[n] == '0') ? 0 : 1;
     }
 
-    waveform.set_length(length + PADDING_LEFT);
+    // padding r
+    for (size_t i = length + PADDING_LEFT; i < WAVEFORM_BUFFER_SIZE; i++) {
+        waveform_buffer[i] = 0;
+    }
+
+    waveform.set_length(length + PADDING_LEFT + PADDING_RIGHT);
     waveform.set_dirty();
 }
 

--- a/firmware/application/apps/ui_encoders.cpp
+++ b/firmware/application/apps/ui_encoders.cpp
@@ -160,11 +160,11 @@ void EncodersConfigView::draw_waveform() {
     so just for out of looking things*/
 
     // clang-format off
-    size_t length = frame_fragments.length();
-
     #define PADDING_LEFT 1
     #define PADDING_RIGHT 1
     // clang-format on
+
+    size_t length = frame_fragments.length();
 
     // currently not needed since all the supported OOK protocol wont exceed 550 yet
     if (length + (PADDING_LEFT + PADDING_RIGHT) >= WAVEFORM_BUFFER_SIZE) {

--- a/firmware/application/apps/ui_encoders.cpp
+++ b/firmware/application/apps/ui_encoders.cpp
@@ -154,10 +154,10 @@ void EncodersConfigView::on_show() {
 }
 
 void EncodersConfigView::draw_waveform() {
-    /*padding reason:
-    in real world the signal would always start with low level and became low level again after yout turn off the radio;
-    the waveform_buffer only controls drawing, the real send logic that been sent is controlled by frame_fragments
-    so just for out of looking things*/
+    /* padding reason:
+     * in real world the signal would always start with low level and became low level again after yout turn off the radio;
+     * the waveform_buffer only controls drawing, the real send logic that been sent is controlled by frame_fragments
+     * so just for out of looking things*/
 
     // clang-format off
     #define PADDING_LEFT 1

--- a/firmware/application/apps/ui_encoders.cpp
+++ b/firmware/application/apps/ui_encoders.cpp
@@ -153,16 +153,15 @@ void EncodersConfigView::on_show() {
     on_type_change(0);
 }
 
+// clang-format off
 void EncodersConfigView::draw_waveform() {
     // padding reason:
     // in real world the signal would always start with low level and became low level again after yout turn off the radio;
     // the waveform_buffer only controls drawing, the real send logic that been sent is controlled by frame_fragments
     // so just for out of looking things
-
-    // clang-format off
+    
     #define PADDING_LEFT 1
     #define PADDING_RIGHT 1
-    // clang-format on
 
     size_t length = frame_fragments.length();
 
@@ -189,6 +188,7 @@ void EncodersConfigView::draw_waveform() {
     waveform.set_length(length + PADDING_LEFT + PADDING_RIGHT);
     waveform.set_dirty();
 }
+// clang-format on
 
 void EncodersConfigView::generate_frame() {
     frame_fragments.clear();

--- a/firmware/application/apps/ui_encoders.cpp
+++ b/firmware/application/apps/ui_encoders.cpp
@@ -154,10 +154,10 @@ void EncodersConfigView::on_show() {
 }
 
 void EncodersConfigView::draw_waveform() {
-    /* padding reason:
-     * in real world the signal would always start with low level and became low level again after yout turn off the radio;
-     * the waveform_buffer only controls drawing, the real send logic that been sent is controlled by frame_fragments
-     * so just for out of looking things*/
+    // padding reason:
+    // in real world the signal would always start with low level and became low level again after yout turn off the radio;
+    // the waveform_buffer only controls drawing, the real send logic that been sent is controlled by frame_fragments
+    // so just for out of looking things
 
     // clang-format off
     #define PADDING_LEFT 1

--- a/firmware/application/apps/ui_encoders.hpp
+++ b/firmware/application/apps/ui_encoders.hpp
@@ -32,6 +32,8 @@
 #include <memory>
 #include <vector>
 
+#define WAVEFORM_BUFFER_SIZE 550
+
 using namespace encoders;
 
 namespace ui {
@@ -56,7 +58,7 @@ class EncodersConfigView : public View {
     std::string frame_fragments = "0";
 
    private:
-    int16_t waveform_buffer[550];
+    int16_t waveform_buffer[WAVEFORM_BUFFER_SIZE];
     const encoder_def_t* encoder_def{};
 
     void draw_waveform();

--- a/firmware/common/ui_widget.cpp
+++ b/firmware/common/ui_widget.cpp
@@ -2681,9 +2681,9 @@ void Waveform::paint(Painter& painter) {
         x = prev_x + x_inc;
         h /= 2;
 
-        prev_y = y_offset + h + (*(data_start++) * y_scale);
+        prev_y = y_offset + h - (*(data_start++) * y_scale);
         for (n = 1; n < length_; n++) {
-            y = y_offset + h + (*(data_start++) * y_scale);
+            y = y_offset + h - (*(data_start++) * y_scale);
             display.draw_line({prev_x, prev_y}, {(Coord)x, y}, color_);
 
             prev_x = x;


### PR DESCRIPTION
- add padding in OOK app's waveform to display correct data (start with low level and end with low level), won't impact actual wf that been sent
- my previous waveform tune edited analog wf's logic, no need, so reverted.
- now: for digital wf, low level is on the bottom and high level is on top. for analog waveform, greater number is on higher and lower number is on lower.

---
1527 SymField is broken, but it's not from all of my changes; 
it's from the refactor SymField PR by others. 
hence i don't understand how it works, i can't fix it.

---
clang-format keeps saying syntex err, ~~moving define to the top doesn't help~~ and i don't want to use const var to waste ram.

feel free to submit change-request if you don't like, and i'll use const var instead.