### PR TITLE
autostart fix 2

### DIFF
--- a/firmware/application/ui_navigation.cpp
+++ b/firmware/application/ui_navigation.cpp
@@ -731,17 +731,25 @@ void NavigationView::handle_autostart() {
             return;
         }
 
-        // outside app
-        if (!app_started) {
-            std::string appwithpath = "/" + apps_dir.string() + "/";
-            appwithpath += autostart_app;
-            appwithpath += ".ppma";
+        // lambda
+        auto execute_app = [=](const std::string& extension) {  // TODO: capture ref aka [&] would also lagging th GUI, no idea why
+            std::string appwithpath = "/" + apps_dir.string() + "/" + autostart_app + extension;
             std::wstring_convert<std::codecvt_utf8_utf16<char16_t>, char16_t> conv;
             std::filesystem::path pth = conv.from_bytes(appwithpath.c_str());
             if (ui::ExternalItemsMenuLoader::run_external_app(*this, pth)) {
-                app_started = true;
-                // return; //TODO: return here would cause UI lagging, just like the about page string order lagging issue
+                return true;
             }
+            return false;
+        };
+
+        // outside app
+        if (!app_started) {
+            app_started = execute_app(".ppma");
+        }
+
+        // standalone app
+        if (!app_started) {
+            app_started = execute_app(".ppmp");
         }
 
         if (!app_started) {

--- a/firmware/application/ui_navigation.cpp
+++ b/firmware/application/ui_navigation.cpp
@@ -739,7 +739,8 @@ void NavigationView::handle_autostart() {
             std::wstring_convert<std::codecvt_utf8_utf16<char16_t>, char16_t> conv;
             std::filesystem::path pth = conv.from_bytes(appwithpath.c_str());
             if (ui::ExternalItemsMenuLoader::run_external_app(*this, pth)) {
-                return;
+                app_started = true;
+                // return; //TODO: return here would cause UI lagging, just like the about page string order lagging issue
             }
         }
 

--- a/firmware/application/ui_navigation.cpp
+++ b/firmware/application/ui_navigation.cpp
@@ -725,19 +725,21 @@ void NavigationView::handle_autostart() {
         {{"autostart_app"sv, &autostart_app}}};
     if (!autostart_app.empty()) {
         bool app_started = false;
-
-        // try innerapp
+        // inner app
         if (StartAppByName(autostart_app.c_str())) {
             app_started = true;
-        } else {
-            // try outside app
-            auto external_items = ExternalItemsMenuLoader::load_external_items(app_location_t::HOME, *this);
-            for (const auto& item : external_items) {
-                if (item.text == autostart_app) {
-                    item.on_select();
-                    app_started = true;
-                    break;
-                }
+            return;
+        }
+
+        // outside app
+        if (!app_started) {
+            std::string appwithpath = "/" + apps_dir.string() + "/";
+            appwithpath += autostart_app;
+            appwithpath += ".ppma";
+            std::wstring_convert<std::codecvt_utf8_utf16<char16_t>, char16_t> conv;
+            std::filesystem::path pth = conv.from_bytes(appwithpath.c_str());
+            if (ui::ExternalItemsMenuLoader::run_external_app(*this, pth)) {
+                return;
             }
         }
 


### PR DESCRIPTION
it must a gcc bug, that when active the retun and remove the bool, the UI became lagging (not halt, just visually lag).