### PR TITLE
splash fix and draw bmp fuc logic wrong

### DIFF
--- a/firmware/application/apps/ui_sigfrx.cpp
+++ b/firmware/application/apps/ui_sigfrx.cpp
@@ -56,7 +56,7 @@ SIGFRXView::~SIGFRXView() {
 void SIGFRXView::paint(Painter& painter) {
     uint8_t i, xp;
 
-    // portapack::display.drawBMP({0, 302-160}, fox_bmp);
+    // portapack::display.draw_bmp_from_bmp_hex_arr({0, 302-160}, fox_bmp);
     portapack::display.fill_rectangle({0, 16, 240, 160 - 16}, Theme::getInstance()->bg_darkest->foreground);
     for (i = 0; i < 6; i++) {
         xp = sigfrx_marks[i * 3];

--- a/firmware/application/apps/ui_ss_viewer.cpp
+++ b/firmware/application/apps/ui_ss_viewer.cpp
@@ -119,7 +119,7 @@ bool SplashViewer::on_key(const KeyEvent key) {
 void SplashViewer::paint(Painter& painter) {
     painter.fill_rectangle({0, 0, screen_width, screen_height}, Color::black());
 
-    if (!portapack::display.drawBMP2({0, 0}, path_)) {
+    if (!portapack::display.draw_bmp_from_sdcard_file({0, 0}, path_)) {
         painter.draw_string({10, 160}, *Theme::getInstance()->bg_darkest, "Not a valid splash image.");
         return;
     }

--- a/firmware/application/ui_navigation.cpp
+++ b/firmware/application/ui_navigation.cpp
@@ -985,7 +985,7 @@ BMPView::BMPView(NavigationView& nav)
 
 void BMPView::paint(Painter&) {
     if (!portapack::display.drawBMP2({0, 0}, splash_dot_bmp))
-        portapack::display.drawBMP({(240 - 230) / 2, (320 - 50) / 2 - 10}, splash_bmp, (const uint8_t[]){0x29, 0x18, 0x16});
+        portapack::display.draw_bmp_from_bmp_hex_arr({(240 - 230) / 2, (320 - 50) / 2 - 10}, splash_bmp, (const uint8_t[]){0x29, 0x18, 0x16});
 }
 
 bool BMPView::on_touch(const TouchEvent event) {
@@ -1079,7 +1079,7 @@ ModalMessageView::ModalMessageView(
 }
 
 void ModalMessageView::paint(Painter& painter) {
-    if (!compact) portapack::display.drawBMP({100, 48}, modal_warning_bmp, (const uint8_t[]){0, 0, 0});
+    if (!compact) portapack::display.draw_bmp_from_bmp_hex_arr({100, 48}, modal_warning_bmp, (const uint8_t[]){0, 0, 0});
 
     // Break lines.
     auto lines = split_string(message_, '\n');

--- a/firmware/application/ui_navigation.cpp
+++ b/firmware/application/ui_navigation.cpp
@@ -901,7 +901,7 @@ SystemView::SystemView(
     navigation_view.push<SystemMenuView>();
 
     if (pmem::config_splash()) {
-        navigation_view.push<BMPView>();
+        navigation_view.push<SplashView>();
     }
     status_view.set_back_enabled(false);
     status_view.set_title_image_enabled(true);
@@ -970,11 +970,11 @@ void SystemView::set_app_fullscreen(bool fullscreen) {
 
 /* ***********************************************************************/
 
-void BMPView::focus() {
+void SplashView::focus() {
     button_done.focus();
 }
 
-BMPView::BMPView(NavigationView& nav)
+SplashView::SplashView(NavigationView& nav)
     : nav_(nav) {
     add_children({&button_done});
 
@@ -983,14 +983,14 @@ BMPView::BMPView(NavigationView& nav)
     };
 }
 
-void BMPView::paint(Painter&) {
+void SplashView::paint(Painter&) {
     if (!portapack::display.draw_bmp_from_sdcard_file({0, 0}, splash_dot_bmp))
         // ^ try draw bmp file from sdcard at (0,0), and the (0,0) already bypassed the status bar, so actual pos is (0, STATUS_BAR_HEIGHT)
         portapack::display.draw_bmp_from_bmp_hex_arr({(240 - 230) / 2, (320 - 50) / 2 - 10}, splash_bmp, (const uint8_t[]){0x29, 0x18, 0x16});
     // ^ draw BMP HEX arr in firmware, note that the BMP HEX arr only cover the image part (instead of fill the screen with background, this position is located it in the center)
 }
 
-bool BMPView::on_touch(const TouchEvent event) {
+bool SplashView::on_touch(const TouchEvent event) {
     /* the event thing were resolved by HTotoo, talked here https://discord.com/channels/719669764804444213/956561375155589192/1287756910950486027
      * the touch screen policy can be better, talked here https://discord.com/channels/719669764804444213/956561375155589192/1198926225897443328
      * this workaround discussed here: https://discord.com/channels/719669764804444213/1170738202924044338/1295630640158478418
@@ -1012,7 +1012,7 @@ bool BMPView::on_touch(const TouchEvent event) {
     return false;
 }
 
-void BMPView::handle_pop() {
+void SplashView::handle_pop() {
     if (nav_.is_valid()) {
         nav_.pop();
     }

--- a/firmware/application/ui_navigation.cpp
+++ b/firmware/application/ui_navigation.cpp
@@ -901,7 +901,7 @@ SystemView::SystemView(
     navigation_view.push<SystemMenuView>();
 
     if (pmem::config_splash()) {
-        navigation_view.push<SplashView>();
+        navigation_view.push<SplashScreenView>();
     }
     status_view.set_back_enabled(false);
     status_view.set_title_image_enabled(true);
@@ -970,11 +970,11 @@ void SystemView::set_app_fullscreen(bool fullscreen) {
 
 /* ***********************************************************************/
 
-void SplashView::focus() {
+void SplashScreenView::focus() {
     button_done.focus();
 }
 
-SplashView::SplashView(NavigationView& nav)
+SplashScreenView::SplashScreenView(NavigationView& nav)
     : nav_(nav) {
     add_children({&button_done});
 
@@ -983,14 +983,14 @@ SplashView::SplashView(NavigationView& nav)
     };
 }
 
-void SplashView::paint(Painter&) {
+void SplashScreenView::paint(Painter&) {
     if (!portapack::display.draw_bmp_from_sdcard_file({0, 0}, splash_dot_bmp))
         // ^ try draw bmp file from sdcard at (0,0), and the (0,0) already bypassed the status bar, so actual pos is (0, STATUS_BAR_HEIGHT)
         portapack::display.draw_bmp_from_bmp_hex_arr({(240 - 230) / 2, (320 - 50) / 2 - 10}, splash_bmp, (const uint8_t[]){0x29, 0x18, 0x16});
     // ^ draw BMP HEX arr in firmware, note that the BMP HEX arr only cover the image part (instead of fill the screen with background, this position is located it in the center)
 }
 
-bool SplashView::on_touch(const TouchEvent event) {
+bool SplashScreenView::on_touch(const TouchEvent event) {
     /* the event thing were resolved by HTotoo, talked here https://discord.com/channels/719669764804444213/956561375155589192/1287756910950486027
      * the touch screen policy can be better, talked here https://discord.com/channels/719669764804444213/956561375155589192/1198926225897443328
      * this workaround discussed here: https://discord.com/channels/719669764804444213/1170738202924044338/1295630640158478418
@@ -1012,7 +1012,7 @@ bool SplashView::on_touch(const TouchEvent event) {
     return false;
 }
 
-void SplashView::handle_pop() {
+void SplashScreenView::handle_pop() {
     if (nav_.is_valid()) {
         nav_.pop();
     }

--- a/firmware/application/ui_navigation.cpp
+++ b/firmware/application/ui_navigation.cpp
@@ -984,7 +984,7 @@ BMPView::BMPView(NavigationView& nav)
 }
 
 void BMPView::paint(Painter&) {
-    if (!portapack::display.drawBMP2({0, 0}, splash_dot_bmp))
+    if (!portapack::display.draw_bmp_from_sdcard_file({0, 0}, splash_dot_bmp))
         portapack::display.draw_bmp_from_bmp_hex_arr({(240 - 230) / 2, (320 - 50) / 2 - 10}, splash_bmp, (const uint8_t[]){0x29, 0x18, 0x16});
 }
 

--- a/firmware/application/ui_navigation.cpp
+++ b/firmware/application/ui_navigation.cpp
@@ -985,7 +985,9 @@ BMPView::BMPView(NavigationView& nav)
 
 void BMPView::paint(Painter&) {
     if (!portapack::display.draw_bmp_from_sdcard_file({0, 0}, splash_dot_bmp))
+        // ^ try draw bmp file from sdcard at (0,0), and the (0,0) already bypassed the status bar, so actual pos is (0, STATUS_BAR_HEIGHT)
         portapack::display.draw_bmp_from_bmp_hex_arr({(240 - 230) / 2, (320 - 50) / 2 - 10}, splash_bmp, (const uint8_t[]){0x29, 0x18, 0x16});
+    // ^ draw BMP HEX arr in firmware, note that the BMP HEX arr only cover the image part (instead of fill the screen with background, this position is located it in the center)
 }
 
 bool BMPView::on_touch(const TouchEvent event) {

--- a/firmware/application/ui_navigation.cpp
+++ b/firmware/application/ui_navigation.cpp
@@ -985,7 +985,7 @@ BMPView::BMPView(NavigationView& nav)
 
 void BMPView::paint(Painter&) {
     if (!portapack::display.drawBMP2({0, 0}, splash_dot_bmp))
-        portapack::display.drawBMP({0, 16}, splash_bmp, (const uint8_t[]){0x29, 0x18, 0x16});
+        portapack::display.drawBMP({(240 - 230) / 2, (320 - 50) / 2 - 10}, splash_bmp, (const uint8_t[]){0x29, 0x18, 0x16});
 }
 
 bool BMPView::on_touch(const TouchEvent event) {

--- a/firmware/application/ui_navigation.hpp
+++ b/firmware/application/ui_navigation.hpp
@@ -332,9 +332,9 @@ class InformationView : public View {
         {86, 0, 19 * 8, 16}};
 };
 
-class SplashView : public View {
+class SplashScreenView : public View {
    public:
-    SplashView(NavigationView& nav);
+    SplashScreenView(NavigationView& nav);
     void paint(Painter&) override;
     void focus() override;
 

--- a/firmware/application/ui_navigation.hpp
+++ b/firmware/application/ui_navigation.hpp
@@ -332,9 +332,9 @@ class InformationView : public View {
         {86, 0, 19 * 8, 16}};
 };
 
-class BMPView : public View {
+class SplashView : public View {
    public:
-    BMPView(NavigationView& nav);
+    SplashView(NavigationView& nav);
     void paint(Painter&) override;
     void focus() override;
 

--- a/firmware/common/lcd_ili9341.cpp
+++ b/firmware/common/lcd_ili9341.cpp
@@ -513,8 +513,8 @@ bool ILI9341::draw_bmp_from_sdcard_file(const ui::Point p, const std::filesystem
     file_pos = bmp_header.image_data;
 
     py = height + 16 - 1;
-    /*                 ^ this is for to "start" AKA end draw at the 17th line,
-     *                   because the render_line logic below is start with p.y() + py until end*/
+    /*                 ^ this is for to "start" AKA image end draw at the 17th line,
+     *                   because the render_line logic below is start with p.y() + py until "end" AKA image start*/
 
     while (1) {
         while (px < width) {

--- a/firmware/common/lcd_ili9341.cpp
+++ b/firmware/common/lcd_ili9341.cpp
@@ -463,7 +463,7 @@ void ILI9341::draw_bmp_from_bmp_hex_arr(const ui::Point p, const uint8_t* bitmap
  *     24bpp RGB
  *     32bpp ARGB
  */
-bool ILI9341::drawBMP2(const ui::Point p, const std::filesystem::path& file) {
+bool ILI9341::draw_bmp_from_sdcard_file(const ui::Point p, const std::filesystem::path& file) {
     File bmpimage;
     size_t file_pos = 0;
     uint16_t pointer = 0;

--- a/firmware/common/lcd_ili9341.cpp
+++ b/firmware/common/lcd_ili9341.cpp
@@ -513,8 +513,8 @@ bool ILI9341::draw_bmp_from_sdcard_file(const ui::Point p, const std::filesystem
     file_pos = bmp_header.image_data;
 
     py = height + 16 - 1;
-    /*                 ^ this is for to "start" AKA image end draw at the 17th line,
-     *                   because the render_line logic below is start with p.y() + py until "end" AKA image start*/
+    /*                 ^ this is for to "start" AKA "image end" draw at the 17th line,
+     *                   because the render_line logic below is start with p.y() + py until "end" AKA "image start"*/
 
     while (1) {
         while (px < width) {

--- a/firmware/common/lcd_ili9341.cpp
+++ b/firmware/common/lcd_ili9341.cpp
@@ -513,7 +513,7 @@ bool ILI9341::draw_bmp_from_sdcard_file(const ui::Point p, const std::filesystem
     file_pos = bmp_header.image_data;
 
     py = height + 16 - 1;
-    /*                 ^ this is for to start draw at the 17th line,
+    /*                 ^ this is for to "start" AKA end draw at the 17th line,
      *                   because the render_line logic below is start with p.y() + py until end*/
 
     while (1) {

--- a/firmware/common/lcd_ili9341.cpp
+++ b/firmware/common/lcd_ili9341.cpp
@@ -512,7 +512,9 @@ bool ILI9341::draw_bmp_from_sdcard_file(const ui::Point p, const std::filesystem
 
     file_pos = bmp_header.image_data;
 
-    py = height + 16;
+    py = height + 16 - 1;
+    /*                 ^ this is for to start draw at the 17th line,
+     *                   because the render_line logic below is start with p.y() + py until end*/
 
     while (1) {
         while (px < width) {

--- a/firmware/common/lcd_ili9341.cpp
+++ b/firmware/common/lcd_ili9341.cpp
@@ -345,19 +345,19 @@ void ILI9341::render_box(const ui::Point p, const ui::Size s, const ui::Color* l
 
 // RLE_4 BMP loader (delta not implemented)
 /* draw transparent, pass transparent color as arg, usage inline anonymous obj
- * portapack::display.drawBMP({100, 100}, foo_bmp, (const uint8_t[]){41, 24, 22}); // dec, out of {255, 255, 255}
- * portapack::display.drawBMP({100, 100}, foo_bmp, (const uint8_t[]){0x29, 0x18, 0x16}); //hex out of {0xFF, 0xFF, 0xFF}
+ * portapack::display.draw_bmp_from_bmp_hex_arr({100, 100}, foo_bmp, (const uint8_t[]){41, 24, 22}); // dec, out of {255, 255, 255}
+ * portapack::display.draw_bmp_from_bmp_hex_arr({100, 100}, foo_bmp, (const uint8_t[]){0x29, 0x18, 0x16}); //hex out of {0xFF, 0xFF, 0xFF}
  *
  * draw transparent, pass transparent color as arg, usage pass uint8_t[] obj
  * const uint8_t c[] = {41, 24, 22}; or const uint8_t c[3] = {0x29, 0x18, 0x16};
- * portapack::display.drawBMP({100, 100}, foo_bmp, c);
+ * portapack::display.draw_bmp_from_bmp_hex_arr({100, 100}, foo_bmp, c);
  *
  * don't draw transparent, pass nullptr as arg, usage
- * portapack::display.drawBMP({100, 100}, foo_bmp, nullptr);
+ * portapack::display.draw_bmp_from_bmp_hex_arr({100, 100}, foo_bmp, nullptr);
  *
  * if your image use RLE compress as transparency methods, pass any valid color as arg, it doesn't matter (like the modal bmp. TODO: write RLE transparency generator)
  * */
-void ILI9341::drawBMP(const ui::Point p, const uint8_t* bitmap, const uint8_t* transparency_color) {
+void ILI9341::draw_bmp_from_bmp_hex_arr(const ui::Point p, const uint8_t* bitmap, const uint8_t* transparency_color) {
     const bmp_header_t* bmp_header = (const bmp_header_t*)bitmap;
     uint32_t data_idx;
     uint8_t by, c, count, transp_idx = 0;

--- a/firmware/common/lcd_ili9341.hpp
+++ b/firmware/common/lcd_ili9341.hpp
@@ -63,7 +63,7 @@ class ILI9341 {
 
     void draw_pixel(const ui::Point p, const ui::Color color);
     void draw_bmp_from_bmp_hex_arr(const ui::Point p, const uint8_t* bitmap, const uint8_t* transparency_color);
-    bool drawBMP2(const ui::Point p, const std::filesystem::path& file);
+    bool draw_bmp_from_sdcard_file(const ui::Point p, const std::filesystem::path& file);
     void render_line(const ui::Point p, const uint8_t count, const ui::Color* line_buffer);
     void render_box(const ui::Point p, const ui::Size s, const ui::Color* line_buffer);
 

--- a/firmware/common/lcd_ili9341.hpp
+++ b/firmware/common/lcd_ili9341.hpp
@@ -62,7 +62,7 @@ class ILI9341 {
         const ui::Color background);
 
     void draw_pixel(const ui::Point p, const ui::Color color);
-    void drawBMP(const ui::Point p, const uint8_t* bitmap, const uint8_t* transparency_color);
+    void draw_bmp_from_bmp_hex_arr(const ui::Point p, const uint8_t* bitmap, const uint8_t* transparency_color);
     bool drawBMP2(const ui::Point p, const std::filesystem::path& file);
     void render_line(const ui::Point p, const uint8_t count, const ui::Color* line_buffer);
     void render_box(const ui::Point p, const ui::Size s, const ui::Color* line_buffer);


### PR DESCRIPTION
- fix splash draw location
- fix the draw bmp from sdcard func calculated position 1 line off/wrong
- rename drawBMP to draw_bmp_from_bmp_hex_arr (to prevent the function name mislead developers)
- rename drawBMP2 to draw_bmp_from_sdcard_file (to prevent the function name mislead developers)
- rename BMPView class into SplashScreenView