### PR TITLE
fix gray box & remove multiple line text support for NewButton

### DIFF
--- a/firmware/application/ui_navigation.cpp
+++ b/firmware/application/ui_navigation.cpp
@@ -765,7 +765,7 @@ static void add_apps(NavigationView& nav, BtnGridView& grid, app_location_t loc)
 void add_external_items(NavigationView& nav, app_location_t location, BtnGridView& grid, uint8_t error_tile_pos) {
     auto externalItems = ExternalItemsMenuLoader::load_external_items(location, nav);
     if (externalItems.empty()) {
-        grid.insert_item({"ExtApp\nError",
+        grid.insert_item({"ExtAppErr",
                           Theme::getInstance()->error_dark->foreground,
                           nullptr,
                           [&nav]() {

--- a/firmware/application/ui_navigation.hpp
+++ b/firmware/application/ui_navigation.hpp
@@ -323,7 +323,7 @@ class InformationView : public View {
 
     Rectangle backdrop{
         {0, 0 * 16, 240, 16},
-        {33, 33, 33}};
+        Theme::getInstance()->bg_darker->background};
 
     Text version{
         {2, 0, 11 * 8, 16},

--- a/firmware/common/ui_widget.cpp
+++ b/firmware/common/ui_widget.cpp
@@ -1327,11 +1327,10 @@ void NewButton::paint(Painter& painter) {
         style.background);
 
     int y = r.top();
-
     if (bitmap_) {
         int offset_y = vertical_center_ ? (r.height() / 2) - (bitmap_->size.height() / 2) : 6;
         Point bmp_pos = {r.left() + (r.width() / 2) - (bitmap_->size.width() / 2), r.top() + offset_y};
-        y += bitmap_->size.height() + offset_y;
+        y += bitmap_->size.height() - offset_y;
 
         painter.draw_bitmap(
             bmp_pos,
@@ -1341,38 +1340,11 @@ void NewButton::paint(Painter& painter) {
     }
 
     if (!text_.empty()) {
-        // multi line worker
-        std::vector<std::string> lines;
-        size_t start = 0;
-        size_t end = 0;
-
-        while ((end = text_.find('\n', start)) != std::string::npos) {
-            lines.push_back(text_.substr(start, end - start));
-            start = end + 1;
-        }
-        lines.push_back(text_.substr(start));
-
-        const int line_height = style.font.line_height();
-        const int total_text_height = lines.size() * line_height;
-
-        // satisfy the situation that bitmap is nullptr
-        if (bitmap_) {
-            if (vertical_center_) {
-                y = r.top() + (r.height() - total_text_height) / 2;
-            }
-        } else {
-            y = r.top() + (r.height() - total_text_height) / 2;
-        }
-
-        // draw worker
-        for (const auto& line : lines) {
-            const auto label_r = style.font.size_of(line);
-            painter.draw_string(
-                {r.left() + (r.width() - label_r.width()) / 2, y},
-                style,
-                line);
-            y += line_height;
-        }
+        const auto label_r = style.font.size_of(text_);
+        painter.draw_string(
+            {r.left() + (r.width() - label_r.width()) / 2, y + (r.height() - label_r.height()) / 2},
+            style,
+            text_);
     }
 }
 


### PR DESCRIPTION
- fix bad gray box in the left-bottom corner and right-bottom corner
- this feat was implemented in #2420
- Currently it's not worth to consume performance for this feature, until in the future, developers want that feature
- whoever want this feature can manually add this back:
```cpp
void NewButton::paint(Painter& painter) {
    if (!bitmap_ && text_.empty())
        return;

    const auto r = screen_rect();
    const Style style = paint_style();

    painter.draw_rectangle({r.location(), {r.width(), 1}}, Theme::getInstance()->bg_light->background);
    painter.draw_rectangle({r.left(), r.top() + r.height() - 1, r.width(), 1}, Theme::getInstance()->bg_dark->background);
    painter.draw_rectangle({r.left() + r.width() - 1, r.top(), 1, r.height()}, Theme::getInstance()->bg_dark->background);

    painter.fill_rectangle(
        {r.left(), r.top() + 1, r.width() - 1, r.height() - 2},
        style.background);

    int y = r.top();

    if (bitmap_) {
        int offset_y = vertical_center_ ? (r.height() / 2) - (bitmap_->size.height() / 2) : 6;
        Point bmp_pos = {r.left() + (r.width() / 2) - (bitmap_->size.width() / 2), r.top() + offset_y};
        y += bitmap_->size.height() + offset_y;

        painter.draw_bitmap(
            bmp_pos,
            *bitmap_,
            color_,
            style.background);
    }

    if (!text_.empty()) {
        // multi line worker
        std::vector<std::string> lines;
        size_t start = 0;
        size_t end = 0;

        while ((end = text_.find('\n', start)) != std::string::npos) {
            lines.push_back(text_.substr(start, end - start));
            start = end + 1;
        }
        lines.push_back(text_.substr(start));

        const int line_height = style.font.line_height();
        const int total_text_height = lines.size() * line_height;

        // satisfy the situation that bitmap is nullptr
        if (bitmap_) {
            if (vertical_center_) {
                y = r.top() + (r.height() - total_text_height) / 2;
            }
            y += 3;
        } else {
            y = r.top() + (r.height() - total_text_height) / 2;
        }

        // draw worker
        for (const auto& line : lines) {
            const auto label_r = style.font.size_of(line);
            painter.draw_string(
                {r.left() + (r.width() - label_r.width()) / 2, y},
                style,
                line);
            y += line_height;
        }
    }
}
```
- since this feat were gone, I tuned the display string in grid (which is the only place that using this feat) to allow the width (in the receive or transmit menu, the grid is smaller)