### PR TITLE
fix wrong cast in morse app

### DIFF
--- a/firmware/application/external/morse_tx/ui_morse.cpp
+++ b/firmware/application/external/morse_tx/ui_morse.cpp
@@ -232,9 +232,8 @@ MorseView::MorseView(
             set_foxhunt(foxhunt_code);
     };
 
-    options_modulation.on_change = [this](size_t i, int32_t value) {
-        (void)i;  // avoid unused warning
-        mode_cw = (bool)value;
+    options_modulation.on_change = [this](size_t, OptionsField::value_t v) {
+        mode_cw = (bool)v;
     };
 
     options_loop.on_change = [this](size_t i, uint32_t value) {

--- a/firmware/application/external/morse_tx/ui_morse.hpp
+++ b/firmware/application/external/morse_tx/ui_morse.hpp
@@ -142,8 +142,8 @@ class MorseView : public View {
     OptionsField options_modulation{
         {15 * 8, 10 * 8},
         2,
-        {{"CW", true},
-         {"FM", false}}};
+        {{"CW", Modulation::CW},
+         {"FM", Modulation::FM}}};
 
     OptionsField options_loop{
         {9 * 8, 12 * 8},

--- a/firmware/application/external/morse_tx/ui_morse.hpp
+++ b/firmware/application/external/morse_tx/ui_morse.hpp
@@ -41,6 +41,11 @@ using namespace morse;
 
 namespace ui::external_app::morse_tx {
 
+enum Modulation {
+    FM = 0,
+    CW = 1
+};
+
 class MorseView : public View {
    public:
     MorseView(NavigationView& nav);


### PR DESCRIPTION
- the new cpp syntex from some of the standard (iirc 11) don't need the (void)xxx. just give the type in argument and don't name it
- the original cast for bool is wrong, it would always cast to true
- this fix appear after #2430, the issue there isn't caused by here