### PR TITLE
Add + - buttons in Encoder dial settings

### DIFF
--- a/firmware/application/apps/ui_settings.cpp
+++ b/firmware/application/apps/ui_settings.cpp
@@ -707,10 +707,27 @@ SetEncoderDialView::SetEncoderDialView(NavigationView& nav) {
                   &field_encoder_dial_sensitivity,
                   &field_encoder_rate_multiplier,
                   &button_save,
-                  &button_cancel});
+                  &button_cancel,
+                  &button_dial_sensitivity_plus,
+                  &button_dial_sensitivity_minus,
+                  &button_rate_multiplier_plus,
+                  &button_rate_multiplier_minus});
 
     field_encoder_dial_sensitivity.set_by_value(pmem::encoder_dial_sensitivity());
     field_encoder_rate_multiplier.set_value(pmem::encoder_rate_multiplier());
+
+    button_dial_sensitivity_plus.on_select = [this](Button&) {
+        field_encoder_dial_sensitivity.on_encoder(1);
+    };
+    button_dial_sensitivity_minus.on_select = [this](Button&) {
+        field_encoder_dial_sensitivity.on_encoder(-1);
+    };
+    button_rate_multiplier_plus.on_select = [this](Button&) {
+        field_encoder_rate_multiplier.on_encoder(1);
+    };
+    button_rate_multiplier_minus.on_select = [this](Button&) {
+        field_encoder_rate_multiplier.on_encoder(-1);
+    };
 
     button_save.on_select = [&nav, this](Button&) {
         pmem::set_encoder_dial_sensitivity(field_encoder_dial_sensitivity.selected_index_value());

--- a/firmware/application/apps/ui_settings.hpp
+++ b/firmware/application/apps/ui_settings.hpp
@@ -611,6 +611,22 @@ class SetEncoderDialView : public View {
         1,
         ' '};
 
+    Button button_dial_sensitivity_plus{
+        {20 * 8, 4 * 16, 16, 16},
+        "+"};
+
+    Button button_dial_sensitivity_minus{
+        {20 * 8, 6 * 16, 16, 16},
+        "-"};
+
+    Button button_rate_multiplier_plus{
+        {20 * 8, 11 * 16, 16, 16},
+        "+"};
+
+    Button button_rate_multiplier_minus{
+        {20 * 8, 13 * 16, 16, 16},
+        "-"};
+
     Button button_save{
         {2 * 8, 16 * 16, 12 * 8, 32},
         "Save"};


### PR DESCRIPTION
This was a designing logic issue, that for those user who need to adjust this, it means their encoder not working correctly, thus they cannot use encoder to adjust the optionfield and number field