### PR TITLE
Touch to paging the button grid (AKA home menu tiles)

### DIFF
--- a/firmware/application/ui/ui_btngrid.cpp
+++ b/firmware/application/ui/ui_btngrid.cpp
@@ -281,6 +281,32 @@ bool BtnGridView::on_encoder(const EncoderEvent event) {
     return set_highlighted(highlighted_item + event);
 }
 
+bool BtnGridView::on_touch(const TouchEvent event) {
+    if (event.type == TouchEvent::Type::Start) {
+        bool child_ever_hit = false;
+        for (auto& child : children_) {
+            if (child->screen_rect().contains(event.point)) {
+                child_ever_hit = true;
+                break;
+            }
+        }
+
+        if (!child_ever_hit) {
+            offset += 6;
+            // it would be nice to real paging but i think there's no way to detect how much tile on this screen currently
+            // (settings and homepage and debug has 2 row, while Tx and Rx has 3 row), this is just add 6 (the least common multiple of 2 and 3) item and it kinda works.
+            if (offset >= menu_items.size()) {
+                offset = 0;
+            }
+            update_items();
+            set_dirty();
+            return true;
+        }
+    }
+
+    return View::on_touch(event);
+}
+
 /* BlackList ******************************************************/
 
 std::unique_ptr<char> blacklist_ptr{};

--- a/firmware/application/ui/ui_btngrid.hpp
+++ b/firmware/application/ui/ui_btngrid.hpp
@@ -80,6 +80,7 @@ class BtnGridView : public View {
     bool on_key(const KeyEvent event) override;
     bool on_encoder(const EncoderEvent event) override;
     bool blacklisted_app(GridItem new_item);
+    bool on_touch(const TouchEvent event) override;
 
     void update_items();
 


### PR DESCRIPTION
Previously I implemented a up and down button to paging the button grid, but was rejected by community due to it was ugly

This PR doesn't change the visual thing, but you can paging by touch the gap on the bottom of the screen

We have more and more app now. I make this design is because it doesn't make sense to need an encoder to enter some of the app. it should be done by touchscreen.


---
test fw: https://discord.com/channels/719669764804444213/722101917135798312/1322965133869453312
