### PR TITLE
Fine tune of navigation paging buttons

### DIFF
--- a/firmware/application/ui/ui_btngrid.cpp
+++ b/firmware/application/ui/ui_btngrid.cpp
@@ -26,7 +26,6 @@
 
 #include "ui_btngrid.hpp"
 #include "rtc_time.hpp"
-#include "usb_serial_asyncmsg.hpp"
 
 namespace ui {
 

--- a/firmware/application/ui/ui_btngrid.cpp
+++ b/firmware/application/ui/ui_btngrid.cpp
@@ -26,6 +26,7 @@
 
 #include "ui_btngrid.hpp"
 #include "rtc_time.hpp"
+#include "usb_serial_asyncmsg.hpp"
 
 namespace ui {
 
@@ -60,6 +61,8 @@ BtnGridView::BtnGridView(
 
     add_child(&button_pgup);
     add_child(&button_pgdown);
+
+    show_hide_arrows();
 }
 
 BtnGridView::~BtnGridView() {
@@ -78,8 +81,15 @@ void BtnGridView::set_parent_rect(const Rect new_parent_rect) {
 
     displayed_max = (parent_rect().size().height() / button_h);
 
-    button_pgup.set_parent_rect({0, (Coord)(displayed_max * button_h), 120, 16});
-    button_pgdown.set_parent_rect({120, (Coord)(displayed_max * button_h), 120, 16});
+    button_pgup.set_parent_rect({0,
+                                 (Coord)(displayed_max * button_h),
+                                 ((rows_ == 2) ? 120 : 80),
+                                 16});
+
+    button_pgdown.set_parent_rect({((rows_ == 2) ? 120 : 80),
+                                   (Coord)(displayed_max * button_h),
+                                   ((rows_ == 2) ? 120 : 160),
+                                   16});
 
     displayed_max *= rows_;
 
@@ -183,15 +193,25 @@ void BtnGridView::insert_item(const GridItem& new_item, size_t position, bool in
 }
 
 void BtnGridView::show_hide_arrows() {
+    portapack::async_tx_enabled = true;
     if (highlighted_item == 0) {
         set_arrow_up_enabled(false);
     } else {
         set_arrow_up_enabled(true);
     }
     if (highlighted_item == (menu_items.size() - 1) || menu_items.size() < displayed_max) {
+        /* ^ when at the last tile of this screen          ^ if the tiles isn't fullfilled this screen */
         set_arrow_down_enabled(false);
     } else {
         set_arrow_down_enabled(true);
+    }
+
+    if (menu_items.size() < displayed_max) {  // if the tiles isn't fullfilled this screen
+        button_pgup.hidden(true);
+        button_pgdown.hidden(true);
+    } else {
+        button_pgup.hidden(false);
+        button_pgdown.hidden(false);
     }
 }
 

--- a/firmware/application/ui/ui_btngrid.cpp
+++ b/firmware/application/ui/ui_btngrid.cpp
@@ -188,7 +188,7 @@ void BtnGridView::show_hide_arrows() {
     } else {
         set_arrow_up_enabled(true);
     }
-    if (highlighted_item == (menu_items.size() - 1)) {
+    if (highlighted_item == (menu_items.size() - 1) || menu_items.size() < displayed_max) {
         set_arrow_down_enabled(false);
     } else {
         set_arrow_down_enabled(true);


### PR DESCRIPTION
# tuned
- fix the situation when the page is not fulfilled with tile (found by HTotoo)
- tune the layout of buttons, in 3 raw grid, align the first line (the next page button align to row 2 and 3)

# side notes
- Also implemented the feature that when last icon is on left, hide page down to align (like image shows), but this have to set_dirty() and that would make screen flicker, so i gave up, but here's the code and we can put it back when set_dirty not flicker anymore:

BEFORE:
![image](https://github.com/user-attachments/assets/cc6048a9-e077-4893-8294-fb7cfeaaf64c)

AFTER:
![image](https://github.com/user-attachments/assets/ff5c649a-4f98-46f8-854d-979bbdd71f5f)
BEFORE:
![image](https://github.com/user-attachments/assets/01a16e52-738a-4af6-83b2-a44be5e26a64)
AFTER:
![image](https://github.com/user-attachments/assets/970404e8-63a2-4987-b756-3ae235278dfa)


```cpp
void BtnGridView::show_hide_arrows() {
    portapack::async_tx_enabled = true;
    if (highlighted_item == 0) {
        set_arrow_up_enabled(false);
    } else {
        set_arrow_up_enabled(true);
    }
    if (highlighted_item == (menu_items.size() - 1) || menu_items.size() < displayed_max) {
        /* ^ when at the last tile of this screen          ^ if the tiles isn't fullfilled this screen */
        set_arrow_down_enabled(false);
    } else {
        set_arrow_down_enabled(true);
    }

    if (menu_items.size() < displayed_max) {  // if the tiles isn't fullfilled this screen
        button_pgup.hidden(true);
        button_pgdown.hidden(true);
    } else {
        button_pgup.hidden(false);
        button_pgdown.hidden(false);
    }

    if (highlighted_item == menu_items.size() - 1) {
        UsbSerialAsyncmsg::asyncmsg("last icon");
        if (rows_ == 2) {
            UsbSerialAsyncmsg::asyncmsg("if 2 row");
            // last icon is left
            if ((highlighted_item + 1) % 2 == 1) {
                button_pgdown.hidden(true);
                set_dirty();
            }
        } else if (rows_ == 3) {
            UsbSerialAsyncmsg::asyncmsg("if 3 row");
            int position_in_row = (highlighted_item + 1) % 3;
            if (position_in_row == 1) {
                UsbSerialAsyncmsg::asyncmsg("if 3 row, last one is left");
                // last icon is left AKA 1
                button_pgdown.hidden(true);
            } else if (position_in_row == 2) {
                UsbSerialAsyncmsg::asyncmsg("if 3 row, last one is middle");
                // last icon is middle AKA 2
                button_pgdown.hidden(false);
                // button_pgdown.set_parent_rect({((rows_ == 2) ? 120 : 80),
                //                                (Coord)(displayed_max * button_h),
                //                                ((rows_ == 2) ? 120 : 80),
                //                                16});
            }
        }
    } else {
        UsbSerialAsyncmsg::asyncmsg("not last icon");
        if (rows_ == 3) {
            UsbSerialAsyncmsg::asyncmsg("if 3 row, not last one");
            // button_pgdown.set_parent_rect({((rows_ == 2) ? 120 : 80),
            //                                (Coord)(displayed_max * button_h),
            //                                ((rows_ == 2) ? 120 : 160),
            //                                16});
        }
    }
}
```