### PR TITLE
add cursor to font viewer app

### DIFF
--- a/firmware/application/external/font_viewer/ui_font_viewer.cpp
+++ b/firmware/application/external/font_viewer/ui_font_viewer.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2023 Mark Thompson
+ * copyleft Whiterose of the Dark Army
  *
  * This file is part of PortaPack.
  *
@@ -83,6 +84,10 @@ DebugFontsView::DebugFontsView(NavigationView& nav)
         update_address_text();
         set_dirty();
     };
+}
+
+void DebugFontsView::focus() {
+    field_cursor.focus();
 }
 
 } /* namespace ui::external_app::font_viewer */

--- a/firmware/application/external/font_viewer/ui_font_viewer.cpp
+++ b/firmware/application/external/font_viewer/ui_font_viewer.cpp
@@ -32,7 +32,7 @@ namespace ui::external_app::font_viewer {
 
 /* DebugFontsView *******************************************************/
 
-uint16_t DebugFontsView::display_font(Painter& painter, uint16_t y_offset, const Style* font_style, std::string_view font_name) {
+uint16_t DebugFontsView::display_font(Painter& painter, uint16_t y_offset, const Style* font_style, std::string_view font_name, bool is_big_font) {
     auto char_width{font_style->font.char_width()};
     auto char_height{font_style->font.line_height()};
     auto cpl{((screen_width / char_width) - 6) & 0xF8};  // Display a multiple of 8 characters per line
@@ -47,7 +47,15 @@ uint16_t DebugFontsView::display_font(Painter& painter, uint16_t y_offset, const
         if ((c % cpl) == 0)
             painter.draw_string({0, line_pos}, *font_style, "Ox" + to_string_hex(c + 0x20, 2));
 
-        painter.draw_char({((c % cpl) + 5) * char_width, line_pos}, *font_style, (char)(c + 0x20));
+        Style highlight_style_big = *Theme::getInstance()->fg_red;
+        Style highlight_style_small = *Theme::getInstance()->bg_important_small;
+        if (c == field_cursor.value()) {
+            painter.draw_char({((c % cpl) + 5) * char_width, line_pos},
+                              is_big_font ? highlight_style_big : highlight_style_small,
+                              (char)(c + 0x20));
+        } else {
+            painter.draw_char({((c % cpl) + 5) * char_width, line_pos}, *font_style, (char)(c + 0x20));
+        }
     }
 
     return line_pos + char_height;
@@ -56,13 +64,25 @@ uint16_t DebugFontsView::display_font(Painter& painter, uint16_t y_offset, const
 void DebugFontsView::paint(Painter& painter) {
     int16_t line_pos;
 
-    line_pos = display_font(painter, 32, Theme::getInstance()->bg_darkest, "Fixed 8x16");
-    display_font(painter, line_pos + 16, Theme::getInstance()->bg_darkest_small, "Fixed 5x8");
+    line_pos = display_font(painter, 32, Theme::getInstance()->bg_darkest, "Fixed 8x16", true);
+    display_font(painter, line_pos + 16, Theme::getInstance()->bg_darkest_small, "Fixed 5x8", false);
+}
+
+void DebugFontsView::update_address_text() {
+    uint8_t ascii_value = field_cursor.value() + 0x20;
+    text_address.set("0x" + to_string_hex(ascii_value, 2));
 }
 
 DebugFontsView::DebugFontsView(NavigationView& nav)
     : nav_{nav} {
+    add_children({&field_cursor,
+                  &text_address});
     set_focusable(true);
+
+    field_cursor.on_change = [&](int32_t) {
+        update_address_text();
+        set_dirty();
+    };
 }
 
 } /* namespace ui::external_app::font_viewer */

--- a/firmware/application/external/font_viewer/ui_font_viewer.hpp
+++ b/firmware/application/external/font_viewer/ui_font_viewer.hpp
@@ -42,7 +42,20 @@ class DebugFontsView : public View {
     std::string title() const override { return "Fonts"; };
 
    private:
-    uint16_t display_font(Painter& painter, uint16_t y_offset, const Style* font_style, std::string_view font_name);
+
+    uint16_t display_font(Painter& painter, uint16_t y_offset, const Style* font_style, std::string_view font_name, bool is_big_font);
+    void update_address_text();
+    
+    NumberField field_cursor{
+        {0 * 8, 0 * 8},
+        1,
+        {0, 1000},
+        1,
+        ' '};
+    Text text_address{
+        {screen_width / 2, 0 * 16, screen_width / 2, 16},
+        "",
+    };
     NavigationView& nav_;
 };
 

--- a/firmware/application/external/font_viewer/ui_font_viewer.hpp
+++ b/firmware/application/external/font_viewer/ui_font_viewer.hpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2023 Mark Thompson
+ * copyleft Whiterose of the Dark Army
  *
  * This file is part of PortaPack.
  *
@@ -39,13 +40,13 @@ class DebugFontsView : public View {
    public:
     DebugFontsView(NavigationView& nav);
     void paint(Painter& painter) override;
+    void focus() override;
     std::string title() const override { return "Fonts"; };
 
    private:
-
     uint16_t display_font(Painter& painter, uint16_t y_offset, const Style* font_style, std::string_view font_name, bool is_big_font);
     void update_address_text();
-    
+
     NumberField field_cursor{
         {0 * 8, 0 * 8},
         1,
@@ -54,7 +55,7 @@ class DebugFontsView : public View {
         ' '};
     Text text_address{
         {screen_width / 2, 0 * 16, screen_width / 2, 16},
-        "",
+        "0x20",
     };
     NavigationView& nav_;
 };


### PR DESCRIPTION
https://discord.com/channels/719669764804444213/722101917135798312/1342800461819936829

Q: Why style mismatch each other and ugly?
A: these are the only two usable style to use as cursor without adding more thing to theme system. It's not worth the space.