### PR TITLE
waterfall and spectrum seems impacting FM audio quality

### DIFF
--- a/firmware/application/apps/ui_settings.hpp
+++ b/firmware/application/apps/ui_settings.hpp
@@ -371,6 +371,10 @@ class SetUIView : public View {
         {23 * 8, 14 * 16 + 2, 16, 16},
         &bitmap_sd_card_ok};
 
+    ImageToggle toggle_lite_mode{
+        {25 * 8, 14 * 16 + 2, 16, 16},
+        &bitmap_icon_file_iq};
+
     Button button_save{
         {2 * 8, 16 * 16, 12 * 8, 32},
         "Save"};

--- a/firmware/application/portapack.cpp
+++ b/firmware/application/portapack.cpp
@@ -97,6 +97,8 @@ bool antenna_bias{false};
 uint32_t bl_tick_counter{0};
 uint16_t touch_threshold{32};
 
+bool lite_mode{false};
+
 void set_antenna_bias(const bool v) {
     antenna_bias = v;
 }

--- a/firmware/application/portapack.hpp
+++ b/firmware/application/portapack.hpp
@@ -70,6 +70,12 @@ extern uint32_t bl_tick_counter;
 extern bool antenna_bias;
 extern uint16_t touch_threshold;
 
+// it seems those widget that kept rolling/refreshing/changing somehow would impact audio quality
+// it's either from screen interference or consuming performace and thus make decoding FM slower
+// this is to indicate if shoudl not display those widgets
+// it meant to set back to false when boot
+extern bool lite_mode;
+
 extern TemperatureLogger temperature_logger;
 
 /* Get or set the antenna_bias flag.

--- a/firmware/application/ui/ui_spectrum.cpp
+++ b/firmware/application/ui/ui_spectrum.cpp
@@ -380,10 +380,10 @@ void WaterfallView::on_channel_spectrum(const ChannelSpectrum& spectrum) {
 }
 
 void WaterfallView::on_audio_spectrum() {
-    skip_rate = (skip_rate + 1) % 32;
-    if(skip_rate != 0) {
-        return;
-    }
+    // skip_rate = (skip_rate + 1) % 32;
+    // if(skip_rate != 0) {
+    //     return;
+    // }
     audio_spectrum_view->on_audio_spectrum(audio_spectrum_data);
 }
 

--- a/firmware/application/ui/ui_spectrum.cpp
+++ b/firmware/application/ui/ui_spectrum.cpp
@@ -54,6 +54,7 @@ AudioSpectrumView::AudioSpectrumView(
 }
 
 void AudioSpectrumView::paint(Painter& painter) {
+    if (portapack::lite_mode) return;
     const auto r = screen_rect();
 
     painter.fill_rectangle(r, Theme::getInstance()->bg_darkest->background);
@@ -103,6 +104,7 @@ void FrequencyScale::set_channel_filter(
 }
 
 void FrequencyScale::paint(Painter& painter) {
+    if (portapack::lite_mode) return;
     const auto r = screen_rect();
 
     clear_background(painter, r);
@@ -268,6 +270,8 @@ void WaterfallWidget::on_hide() {
 void WaterfallWidget::on_channel_spectrum(
     const ChannelSpectrum& spectrum) {
     /* TODO: static_assert that message.spectrum.db.size() >= pixel_row.size() */
+
+    if (portapack::lite_mode) return;
 
     std::array<Color, 240> pixel_row;
     for (size_t i = 0; i < 120; i++) {

--- a/firmware/application/ui/ui_spectrum.cpp
+++ b/firmware/application/ui/ui_spectrum.cpp
@@ -369,6 +369,7 @@ void WaterfallView::set_parent_rect(const Rect new_parent_rect) {
 }
 
 void WaterfallView::on_channel_spectrum(const ChannelSpectrum& spectrum) {
+
     waterfall_widget.on_channel_spectrum(spectrum);
     sampling_rate = spectrum.sampling_rate;
     frequency_scale.set_spectrum_sampling_rate(sampling_rate);
@@ -379,6 +380,10 @@ void WaterfallView::on_channel_spectrum(const ChannelSpectrum& spectrum) {
 }
 
 void WaterfallView::on_audio_spectrum() {
+    skip_rate = (skip_rate + 1) % 32;
+    if(skip_rate != 0) {
+        return;
+    }
     audio_spectrum_view->on_audio_spectrum(audio_spectrum_data);
 }
 

--- a/firmware/application/ui/ui_spectrum.hpp
+++ b/firmware/application/ui/ui_spectrum.hpp
@@ -148,6 +148,8 @@ class WaterfallView : public View {
     static constexpr Dim audio_spectrum_height = 16 * 2 + 20;
     static constexpr Dim scale_height = 20;
 
+    uint8_t skip_rate = 4;
+
     WaterfallWidget waterfall_widget{};
     FrequencyScale frequency_scale{};
     bool running_{false};

--- a/firmware/application/ui/ui_spectrum.hpp
+++ b/firmware/application/ui/ui_spectrum.hpp
@@ -148,7 +148,7 @@ class WaterfallView : public View {
     static constexpr Dim audio_spectrum_height = 16 * 2 + 20;
     static constexpr Dim scale_height = 20;
 
-    uint8_t skip_rate = 4;
+    uint8_t skip_rate = 0;
 
     WaterfallWidget waterfall_widget{};
     FrequencyScale frequency_scale{};
@@ -175,7 +175,7 @@ class WaterfallView : public View {
         Message::ID::AudioSpectrum,
         [this](const Message* const p) {
             const auto message = *reinterpret_cast<const AudioSpectrumMessage*>(p);
-            this->audio_spectrum_data = message.data;
+            if(this->audio_spectrum_update != true) this->audio_spectrum_data = message.data;
             this->audio_spectrum_update = true;
         }};
     MessageHandlerRegistration message_handler_frame_sync{

--- a/firmware/application/ui_navigation.cpp
+++ b/firmware/application/ui_navigation.cpp
@@ -295,7 +295,7 @@ SystemStatusView::SystemStatusView(
         refresh();
     };
 
-    toggle_lite_mode.on_change = [this, &nav](bool v) {
+    toggle_lite_mode.on_change = [&](bool v) {
 
         portapack::lite_mode = v;
     };

--- a/firmware/application/ui_navigation.cpp
+++ b/firmware/application/ui_navigation.cpp
@@ -295,6 +295,11 @@ SystemStatusView::SystemStatusView(
         refresh();
     };
 
+    toggle_lite_mode.on_change = [this, &nav](bool v) {
+
+        portapack::lite_mode = v;
+    };
+
     battery_icon.on_select = [this]() { on_battery_details(); };
     battery_text.on_select = [this]() { on_battery_details(); };
 
@@ -403,6 +408,7 @@ void SystemStatusView::refresh() {
     }
 
     if (!pmem::ui_hide_sd_card()) status_icons.add(&sd_card_status_view);
+    status_icons.add(&toggle_lite_mode);
 
     status_icons.update_layout();
 

--- a/firmware/application/ui_navigation.hpp
+++ b/firmware/application/ui_navigation.hpp
@@ -236,6 +236,15 @@ class SystemStatusView : public View {
         *Theme::getInstance()->status_active,
         Theme::getInstance()->bg_dark->background};
 
+    ImageToggle toggle_lite_mode{
+        {0, 0, 2 * 8, 1 * 16},
+        &bitmap_icon_file_iq,
+        &bitmap_icon_file_iq,
+        *Theme::getInstance()->status_active,
+        Theme::getInstance()->bg_dark->background,
+        Theme::getInstance()->fg_light->foreground,
+        Theme::getInstance()->bg_dark->background};
+
     ImageToggle toggle_mute{
         {0, 0, 2 * 8, 1 * 16},
         &bitmap_icon_speaker_and_headphones_mute,

--- a/firmware/common/ui_widget.cpp
+++ b/firmware/common/ui_widget.cpp
@@ -2642,6 +2642,7 @@ void Waveform::set_length(const uint32_t new_length) {
 }
 
 void Waveform::paint(Painter& painter) {
+    if (portapack::lite_mode) return;
     // previously it's upside down , low level is up and high level is down, which doesn't make sense,
     // if that was made for a reason, feel free to revert.
     size_t n;


### PR DESCRIPTION
# Issue
The FM audio quality seems bad at around 100MHz, unless turn off waterfall and spectrum (which is what this PR does) 

It's either caused by screen interference or just they consumed resource which caused FM decoding lagging

This PR is just a workaround, for discussion, unless @Brumi-2021 doesn't have a better idea I will close this work around.