### PR TITLE
fix external app address list

### DIFF
--- a/firmware/application/external/external.cmake
+++ b/firmware/application/external/external.cmake
@@ -1,20 +1,5 @@
 set(EXTCPPSRC
 
-	#tetris
-	external/tetris/main.cpp
-	external/tetris/ui_tetris.cpp
-
-	#breakout
-	external/breakout/main.cpp
-	external/breakout/ui_breakout.cpp
-
-	#doom
-	external/doom/main.cpp
-	external/doom/ui_doom.cpp
-	#snake
-	external/snake/main.cpp
-	external/snake/ui_snake.cpp
-
 	#afsk_rx
 	external/afsk_rx/main.cpp
 	external/afsk_rx/ui_afsk_rx.cpp
@@ -69,6 +54,10 @@ set(EXTCPPSRC
 	external/keyfob/main.cpp
 	external/keyfob/ui_keyfob.cpp
 	external/keyfob/ui_keyfob.hpp
+
+	#tetris
+	external/tetris/main.cpp
+	external/tetris/ui_tetris.cpp
 
 	#extsensors
 	external/extsensors/main.cpp
@@ -187,9 +176,21 @@ set(EXTCPPSRC
 	external/playlist_editor/main.cpp
 	external/playlist_editor/ui_playlist_editor.cpp
 
+	#snake
+	external/snake/main.cpp
+	external/snake/ui_snake.cpp
+
 	#stopwatch
 	external/stopwatch/main.cpp
 	external/stopwatch/ui_stopwatch.cpp
+
+	#breakout
+	external/breakout/main.cpp
+	external/breakout/ui_breakout.cpp
+
+	#doom
+	external/doom/main.cpp
+	external/doom/ui_doom.cpp
 )
 
 set(EXTAPPLIST
@@ -207,9 +208,6 @@ set(EXTAPPLIST
 	spainter
 	keyfob
 	tetris
-	breakout
-	doom
-	snake
 	extsensors
 	foxhunt_rx
 	audio_test
@@ -238,5 +236,8 @@ set(EXTAPPLIST
 	view_wav
 	sd_wipe
 	playlist_editor
+	snake
 	stopwatch
+	breakout
+	doom
 )

--- a/firmware/application/external/external.ld
+++ b/firmware/application/external/external.ld
@@ -26,50 +26,49 @@ MEMORY
     ram_external_app_afsk_rx    (rwx) : org = 0xADB10000, len = 32k
     ram_external_app_calculator (rwx) : org = 0xADB20000, len = 32k
     ram_external_app_font_viewer(rwx) : org = 0xADB30000, len = 32k
-    ram_external_app_blespam(rwx) : org = 0xADB40000, len = 32k
-    ram_external_app_analogtv(rwx) : org = 0xADB50000, len = 32k
-    ram_external_app_nrf_rx(rwx) : org = 0xADB60000, len = 32k
-    ram_external_app_coasterp(rwx) : org = 0xADB70000, len = 32k
-    ram_external_app_lge(rwx) : org = 0xADB80000, len = 32k
-    ram_external_app_lcr(rwx) : org = 0xADB90000, len = 32k
-    ram_external_app_jammer(rwx) : org = 0xADBA0000, len = 32k
-    ram_external_app_gpssim(rwx) : org = 0xADBB0000, len = 32k
-    ram_external_app_spainter(rwx) : org = 0xADBC0000, len = 32k
-    ram_external_app_keyfob(rwx) : org = 0xADBD0000, len = 32k
-    ram_external_app_tetris(rwx) : org = 0xADBE0000, len = 32k
-    ram_external_app_extsensors(rwx) : org = 0xADBF0000, len = 32k
-    ram_external_app_breakout(rwx) : org = 0xADE00000, len = 32k
-    ram_external_app_doom(rwx) : org = 0xADE20000, len = 32k
-    ram_external_app_foxhunt_rx(rwx) : org = 0xADC00000, len = 32k
-    ram_external_app_audio_test(rwx) : org = 0xADC10000, len = 32k
+    ram_external_app_blespam    (rwx) : org = 0xADB40000, len = 32k
+    ram_external_app_analogtv   (rwx) : org = 0xADB50000, len = 32k
+    ram_external_app_nrf_rx     (rwx) : org = 0xADB60000, len = 32k
+    ram_external_app_coasterp   (rwx) : org = 0xADB70000, len = 32k
+    ram_external_app_lge        (rwx) : org = 0xADB80000, len = 32k
+    ram_external_app_lcr        (rwx) : org = 0xADB90000, len = 32k
+    ram_external_app_jammer     (rwx) : org = 0xADBA0000, len = 32k
+    ram_external_app_gpssim     (rwx) : org = 0xADBB0000, len = 32k
+    ram_external_app_spainter   (rwx) : org = 0xADBC0000, len = 32k
+    ram_external_app_keyfob     (rwx) : org = 0xADBD0000, len = 32k
+    ram_external_app_tetris     (rwx) : org = 0xADBE0000, len = 32k
+    ram_external_app_extsensors (rwx) : org = 0xADBF0000, len = 32k
+    ram_external_app_foxhunt_rx (rwx) : org = 0xADC00000, len = 32k
+    ram_external_app_audio_test (rwx) : org = 0xADC10000, len = 32k
     ram_external_app_wardrivemap(rwx) : org = 0xADC20000, len = 32k
-    ram_external_app_tpmsrx(rwx) : org = 0xADC30000, len = 32k
-    ram_external_app_protoview(rwx) : org = 0xADC40000, len = 32k
-    ram_external_app_adsbtx(rwx) : org = 0xADC50000, len = 32k
-    ram_external_app_morse_tx(rwx) : org = 0xADC60000, len = 32k
-    ram_external_app_sstvtx(rwx) : org = 0xADC70000, len = 32k
-    ram_external_app_random_password(rwx) : org = 0xADC80000, len = 32k
-    ram_external_app_acars_rx(rwx) : org = 0xADC90000, len = 32k
-    ram_external_app_shoppingcart_lock(rwx) : org = 0xADCA0000, len = 32k
-    ram_external_app_cvs_spam(rwx) : org = 0xADCB0000, len = 32k
-    ram_external_app_ookbrute(rwx) : org = 0xADCC0000, len = 32k
-    ram_external_app_flippertx(rwx) : org = 0xADCD0000, len = 32k
-    ram_external_app_ook_editor(rwx) : org = 0xADCE0000, len = 32k
-    ram_external_app_remote(rwx) : org = 0xADCF0000, len = 32k
-    ram_external_app_mcu_temperature(rwx) : org = 0xADD00000, len = 32k
-    ram_external_app_fmradio(rwx) : org = 0xADD10000, len = 32k
-    ram_external_app_tuner(rwx) : org = 0xADD20000, len = 32k
-    ram_external_app_metronome(rwx) : org = 0xADD30000, len = 32k
+    ram_external_app_tpmsrx     (rwx) : org = 0xADC30000, len = 32k
+    ram_external_app_protoview  (rwx) : org = 0xADC40000, len = 32k
+    ram_external_app_adsbtx     (rwx) : org = 0xADC50000, len = 32k
+    ram_external_app_morse_tx   (rwx) : org = 0xADC60000, len = 32k
+    ram_external_app_sstvtx     (rwx) : org = 0xADC70000, len = 32k
+    ram_external_app_random_password(rwx): org = 0xADC80000, len = 32k
+    ram_external_app_acars_rx   (rwx) : org = 0xADC90000, len = 32k
+    ram_external_app_shoppingcart_lock(rwx): org = 0xADCA0000, len = 32k
+    ram_external_app_cvs_spam   (rwx) : org = 0xADCB0000, len = 32k
+    ram_external_app_ookbrute   (rwx) : org = 0xADCC0000, len = 32k
+    ram_external_app_flippertx  (rwx) : org = 0xADCD0000, len = 32k
+    ram_external_app_ook_editor (rwx) : org = 0xADCE0000, len = 32k
+    ram_external_app_remote     (rwx) : org = 0xADCF0000, len = 32k
+    ram_external_app_mcu_temperature(rwx): org = 0xADD00000, len = 32k
+    ram_external_app_fmradio    (rwx) : org = 0xADD10000, len = 32k
+    ram_external_app_tuner      (rwx) : org = 0xADD20000, len = 32k
+    ram_external_app_metronome  (rwx) : org = 0xADD30000, len = 32k
     ram_external_app_app_manager(rwx) : org = 0xADD40000, len = 32k
-    ram_external_app_hopper(rwx) : org = 0xADD50000, len = 32k
-    ram_external_app_antenna_length(rwx) : org = 0xADD60000, len = 32k
-    ram_external_app_view_wav(rwx) : org = 0xADD70000, len = 32k
-    ram_external_app_sd_wipe(rwx) : org = 0xADD80000, len = 32k
-    ram_external_app_playlist_editor(rwx) : org = 0xADD90000, len = 32k
-    ram_external_app_breakout(rwx) : org = 0xADDA0000, len = 32k
-    ram_external_app_snake(rwx) : org = 0xADDB0000, len = 32k
-    ram_external_app_stopwatch(rwx) : org = 0xADDC0000, len = 32k
-    ram_external_app_wefax_rx(rwx) : org = 0xADDD0000, len = 32k 
+    ram_external_app_hopper     (rwx) : org = 0xADD50000, len = 32k
+    ram_external_app_antenna_length(rwx): org = 0xADD60000, len = 32k
+    ram_external_app_view_wav   (rwx) : org = 0xADD70000, len = 32k
+    ram_external_app_sd_wipe    (rwx) : org = 0xADD80000, len = 32k
+    ram_external_app_playlist_editor(rwx): org = 0xADD90000, len = 32k
+    ram_external_app_snake      (rwx) : org = 0xADDA0000, len = 32k
+    ram_external_app_stopwatch  (rwx) : org = 0xADDB0000, len = 32k
+    ram_external_app_wefax_rx   (rwx) : org = 0xADDC0000, len = 32k
+    ram_external_app_breakout   (rwx) : org = 0xADDD0000, len = 32k
+    ram_external_app_doom       (rwx) : org = 0xADDE0000, len = 32k
 }
 
 SECTIONS

--- a/firmware/application/external/external.ld
+++ b/firmware/application/external/external.ld
@@ -157,24 +157,6 @@ SECTIONS
         *(*ui*external_app*tetris*);
     } > ram_external_app_tetris
 
-    .external_app_breakout : ALIGN(4) SUBALIGN(4)
-    {
-        KEEP(*(.external_app.app_breakout.application_information));
-        *(*ui*external_app*breakout*);
-    } > ram_external_app_breakout
-
-    .external_app_snake : ALIGN(4) SUBALIGN(4)
-    {
-        KEEP(*(.external_app.app_snake.application_information));
-        *(*ui*external_app*snake*);
-    } > ram_external_app_snake
-
-    .external_app_doom : ALIGN(4) SUBALIGN(4)
-    {
-        KEEP(*(.external_app.app_doom.application_information));
-        *(*ui*external_app*doom*);
-    } > ram_external_app_doom    
-
    .external_app_extsensors : ALIGN(4) SUBALIGN(4)
     {
         KEEP(*(.external_app.app_extsensors.application_information));
@@ -337,6 +319,12 @@ SECTIONS
         *(*ui*external_app*playlist_editor*);
     } > ram_external_app_playlist_editor
 
+    .external_app_snake : ALIGN(4) SUBALIGN(4)
+    {
+        KEEP(*(.external_app.app_snake.application_information));
+        *(*ui*external_app*snake*);
+    } > ram_external_app_snake
+
     .external_app_stopwatch : ALIGN(4) SUBALIGN(4)
     {
         KEEP(*(.external_app.app_stopwatch.application_information));
@@ -347,6 +335,18 @@ SECTIONS
         KEEP(*(.external_app.app_wefax_rx.application_information));
         *(*ui*external_app*wefax_rx*);
     } > ram_external_app_wefax_rx
+
+    .external_app_breakout : ALIGN(4) SUBALIGN(4)
+    {
+        KEEP(*(.external_app.app_breakout.application_information));
+        *(*ui*external_app*breakout*);
+    } > ram_external_app_breakout
+
+    .external_app_doom : ALIGN(4) SUBALIGN(4)
+    {
+        KEEP(*(.external_app.app_doom.application_information));
+        *(*ui*external_app*doom*);
+    } > ram_external_app_doom    
 
 
 }

--- a/firmware/application/external/shoppingcart_lock/main.cpp
+++ b/firmware/application/external/shoppingcart_lock/main.cpp
@@ -57,7 +57,7 @@ __attribute__((section(".external_app.app_shoppingcart_lock.application_informat
         0x00,
     },
     /*.icon_color = */ ui::Color::red().v,
-    /*.menu_location = */ app_location_t::UTILITIES,
+    /*.menu_location = */ app_location_t::TX,
     /*.desired_menu_position = */ -1,
 
     /*.m4_app_tag = portapack::spi_flash::image_tag_afsk_rx */ {'P', 'A', 'T', 'X'},

--- a/firmware/application/external/shoppingcart_lock/shoppingcart_lock.cpp
+++ b/firmware/application/external/shoppingcart_lock/shoppingcart_lock.cpp
@@ -225,6 +225,9 @@ ShoppingCartLock::ShoppingCartLock(NavigationView& nav)
     log_event("[+] INITIALIZATION COMPLETE");
     log_event("[+] PORTAPACK ARMED");
     log_event("[*] STATUS: READY");
+    log_event("This app use speaker to");
+    log_event("produce LF signal, but");
+    log_event("also trigger radio TX");
 }
 
 ShoppingCartLock::~ShoppingCartLock() {

--- a/firmware/tools/check_external_app_linker_script_correct.py
+++ b/firmware/tools/check_external_app_linker_script_correct.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+
+#
+# Copyleft (ɔ) 2024 Whiterose from the Dark Army
+#
+# This file is part of PortaPack.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2, or (at your option)
+# any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; see the file COPYING.  If not, write to
+# the Free Software Foundation, Inc., 51 Franklin Street,
+# Boston, MA 02110-1301, USA.
+#
+
+import re
+import sys
+from pathlib import Path
+
+def parse_memory_regions(ld_file_path):
+    regions = []
+    
+    with open(ld_file_path, 'r') as f:
+        content = f.read()
+        
+    memory_section = re.search(r'MEMORY\s*\{(.*?)\}', content, re.DOTALL)
+    if not memory_section:
+        print("ERROR: Could not find MEMORY section in the linker script.")
+        return []
+    
+    memory_content = memory_section.group(1)
+    
+    pattern = r'ram_external_app_(\w+)\s*\(rwx\)\s*:\s*org\s*=\s*(0x[A-Fa-f0-9]+),\s*len\s*=\s*(\d+)k'
+    matches = re.finditer(pattern, memory_content)
+    
+    for match in matches:
+        app_name = match.group(1)
+        address = int(match.group(2), 16)  # string with hex -> int
+        length = int(match.group(3)) * 1024  # kb -> bytes
+        
+        regions.append({
+            'app_name': app_name,
+            'address': address,
+            'length': length
+        })
+        
+    return sorted(regions, key=lambda x: x['address'])
+
+def validate_memory_regions(regions):
+    if not regions:
+        return False
+    
+    expected_step = 0x10000  # 64k as step (not sure why)
+    expected_base = 0xADB10000 # the start (not sure why this one)
+    expected_size = 32 * 1024  # 32k
+    issues_found = False
+    
+    print("\n")
+    print(f"checking {len(regions)} external apps address memory regions")
+    
+    if regions[0]['address'] != expected_base:
+        print(f"WARNING: external app first region should start at {hex(expected_base)}, but starts at {hex(regions[0]['address'])}")
+        issues_found = True
+    
+    for i, region in enumerate(regions):
+        expected_address = expected_base + (i * expected_step)
+        
+        # address count
+        if region['address'] != expected_address:
+            print(f"WARNING: external app region '{region['app_name']}' has incorrect address")
+            print(f"want: {hex(expected_address)}, Found: {hex(region['address'])}")
+            issues_found = True
+        
+        # size
+        if region['length'] != expected_size:
+            print(f"WARNING: external app region '{region['app_name']}' has incorrect size")
+            print(f"want: {expected_size//1024}KB, Found: {region['length']//1024}KB")
+            issues_found = True
+        
+        # overlap
+        if i < len(regions) - 1:
+            next_region = regions[i + 1]
+            if region['address'] + region['length'] > next_region['address']:
+                print(f"WARNING: external app region '{region['app_name']}' overlapped with '{next_region['app_name']}'")
+                issues_found = True
+    
+    return not issues_found
+
+def main():
+    if len(sys.argv) > 1:
+        # arg
+        input_path = Path(sys.argv[1])
+        if input_path.is_dir():
+            ld_file_path = input_path / "external.ld"
+            if not ld_file_path.exists():
+                print(f"some issue causing that we can't see external app's linker script {input_path}, pass.")
+                return
+        else:
+            ld_file_path = input_path
+    else:
+        # if no arg, this assume this script is in mayhemrepo/firmware/tools
+        ld_file_path = Path("..") / "application" / "external" / "external.ld"
+        
+    try:
+        regions = parse_memory_regions(ld_file_path)
+        
+        if not regions:
+            print("some issue causing that we can't see external app's linker script's address list, pass")
+
+            return
+        
+        if validate_memory_regions(regions):
+            print("external app addr seems correct, pass")
+        else:
+            print("\nWARENING: It seems you are having incorrect external app addresses.")
+            
+    except Exception as e:
+        print(f"err: {e}")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
- I'm not sure what's the impact but it at least have to be correct anyways
- also added scripts that check if developers input them correctly
- move shopping car app into TX, because user could thought they are not related to radio, so swap/takeoff antenna when the app running, which is dangerous.
- ref. https://github.com/portapack-mayhem/mayhem-firmware/pull/2540