### PR TITLE
stopwatch opt

### DIFF
--- a/firmware/application/external/external.cmake
+++ b/firmware/application/external/external.cmake
@@ -191,6 +191,10 @@ set(EXTCPPSRC
 	#doom
 	external/doom/main.cpp
 	external/doom/ui_doom.cpp
+
+	#screening
+	# external/screening/main.cpp
+	# external/screening/ui_screening.cpp
 )
 
 set(EXTAPPLIST
@@ -240,4 +244,5 @@ set(EXTAPPLIST
 	stopwatch
 	breakout
 	doom
+	# screening
 )

--- a/firmware/application/external/external.ld
+++ b/firmware/application/external/external.ld
@@ -69,6 +69,8 @@ MEMORY
     ram_external_app_wefax_rx   (rwx) : org = 0xADDC0000, len = 32k
     ram_external_app_breakout   (rwx) : org = 0xADDD0000, len = 32k
     ram_external_app_doom       (rwx) : org = 0xADDE0000, len = 32k
+    /*ram_external_app_screening  (rwx) : org = 0xADDF0000, len = 32k*/
+
 }
 
 SECTIONS
@@ -347,6 +349,15 @@ SECTIONS
         KEEP(*(.external_app.app_doom.application_information));
         *(*ui*external_app*doom*);
     } > ram_external_app_doom    
+
+/*
+    .external_app_screening : ALIGN(4) SUBALIGN(4)
+    {
+        KEEP(*(.external_app.app_screening.application_information));
+        *(*ui*external_app*screening*);
+    } > ram_external_app_screening   
+
+*/
 
 
 }

--- a/firmware/application/external/stopwatch/ui_stopwatch.cpp
+++ b/firmware/application/external/stopwatch/ui_stopwatch.cpp
@@ -88,6 +88,10 @@ StopwatchView::StopwatchView(NavigationView& nav)
         nav.pop();
     };
 
+    options_ms_display_level.on_change = [&](size_t, ui::OptionsField::value_t) {
+        clean_ms_display(options_ms_display_level.selected_index());
+    };
+
     options_ms_display_level.set_selected_index(0);
 
     refresh_painting();
@@ -100,7 +104,8 @@ void StopwatchView::focus() {
 void StopwatchView::run() {
     options_ms_display_level.hidden(true);
     // ^ this won't take efferts if don't set_dirty, but needed to let user can't change during ticking
-    refresh_painting();
+    if (!paused) refresh_painting();
+    paused = false;
     running = true;
     start_time = chTimeNow() - previously_elapsed;
     button_run_stop.set_text("STOP");
@@ -110,6 +115,7 @@ void StopwatchView::run() {
 void StopwatchView::stop() {
     options_ms_display_level.hidden(false);
     running = false;
+    paused = true;
     end_time = chTimeNow();
     previously_elapsed = end_time - start_time;
     button_run_stop.set_text("START");
@@ -158,6 +164,40 @@ void StopwatchView::refresh_painting() {
     painter.draw_char(LAP_MS1_POS, *Theme::getInstance()->fg_light, ' ', 2);
     painter.draw_char(LAP_MS2_POS, *Theme::getInstance()->fg_light, ' ', 2);
     painter.draw_char(LAP_MS3_POS, *Theme::getInstance()->fg_light, ' ', 2);
+}
+
+/*when user seted it to display more, then display less later, this prevent the remain value exist on screen*/
+void StopwatchView::clean_ms_display(uint8_t level) {
+    level++;
+    switch (level) {
+        case 0:
+            painter.draw_char(TOTAL_MS1_POS, *Theme::getInstance()->fg_light, ' ', 2);
+            painter.draw_char(TOTAL_MS2_POS, *Theme::getInstance()->fg_light, ' ', 2);
+            painter.draw_char(TOTAL_MS3_POS, *Theme::getInstance()->fg_light, ' ', 2);
+            break;
+        case 1:
+            painter.draw_char(TOTAL_MS2_POS, *Theme::getInstance()->fg_light, ' ', 2);
+            painter.draw_char(TOTAL_MS3_POS, *Theme::getInstance()->fg_light, ' ', 2);
+            break;
+        case 2:
+            painter.draw_char(TOTAL_MS3_POS, *Theme::getInstance()->fg_light, ' ', 2);
+            break;
+    }
+}
+
+void StopwatchView::resume_last() {
+    // minute
+    painter.draw_char(TOTAL_M1_POS, *Theme::getInstance()->fg_light, last_displayed[0], 4);
+    painter.draw_char(TOTAL_M2_POS, *Theme::getInstance()->fg_light, last_displayed[1], 4);
+
+    // sec
+    painter.draw_char(TOTAL_S1_POS, *Theme::getInstance()->fg_light, last_displayed[2], 4);
+    painter.draw_char(TOTAL_S2_POS, *Theme::getInstance()->fg_light, last_displayed[3], 4);
+
+    // ms
+    painter.draw_char(TOTAL_MS1_POS, *Theme::getInstance()->fg_light, last_displayed[4], 2);
+    painter.draw_char(TOTAL_MS2_POS, *Theme::getInstance()->fg_light, last_displayed[5], 2);
+    painter.draw_char(TOTAL_MS3_POS, *Theme::getInstance()->fg_light, last_displayed[6], 2);
 }
 
 /* NB:

--- a/firmware/application/external/stopwatch/ui_stopwatch.cpp
+++ b/firmware/application/external/stopwatch/ui_stopwatch.cpp
@@ -29,6 +29,7 @@ using namespace portapack;
 namespace ui::external_app::stopwatch {
 
 // clang-format off
+// clang-format doesn't allow use as this way but it's not worth to have const var for this thing. too expensive
 
 // minute
 #define TOTAL_M1_POS {0 * 8 * 4, 3 * 16}
@@ -159,6 +160,14 @@ void StopwatchView::refresh_painting() {
     painter.draw_char(LAP_MS3_POS, *Theme::getInstance()->fg_light, ' ', 2);
 }
 
+/* NB:
+ * Due to the flaw of dirty management, it's using work around, to reduce screen flickering:
+ *
+ * for example when xx:15:xxx turn to xx:16:xxx, it actually only paint 6, the 1 is old,
+ * but not dirty, so we can see without flikering.
+ *
+ * So with these work around, it won't show false info, but bare in mind that it could be, if you add more things.
+ */
 void StopwatchView::frame_sync() {
     uint32_t elapsed_ticks = 0;
 

--- a/firmware/application/external/stopwatch/ui_stopwatch.hpp
+++ b/firmware/application/external/stopwatch/ui_stopwatch.hpp
@@ -42,8 +42,11 @@ class StopwatchView : public View {
     void lap();
     void cover_display_area_with_0();
     void refresh_painting();
+    void resume_last();
+    void clean_ms_display(uint8_t level = 0);
 
     bool running{false};
+    bool paused{false};
     long long start_time{0};
     long long end_time{0};
     long long lap_time{0};

--- a/firmware/application/external/stopwatch/ui_stopwatch.hpp
+++ b/firmware/application/external/stopwatch/ui_stopwatch.hpp
@@ -1,5 +1,6 @@
 /*
  * Copyright 2025 Mark Thompson
+ * copyleft Mr. Robot of F.Society
  *
  * This file is part of PortaPack.
  *
@@ -39,25 +40,32 @@ class StopwatchView : public View {
     void stop();
     void reset();
     void lap();
+    void cover_display_area_with_0();
+    void refresh_painting();
 
     bool running{false};
     long long start_time{0};
     long long end_time{0};
     long long lap_time{0};
     long long previously_elapsed{0};
+    uint8_t last_displayed[7] = {0, 0, 0, 0, 0, 0, 0};
+    /*                           m  m  s  s  ms ms ms*/
+    uint8_t lap_last_displayed[7] = {0, 0, 0, 0, 0, 0, 0};
+    /*                       m     m     s      s     ms   ms    ms*/
 
     Labels labels{
         {{0 * 8, 1 * 16}, "TOTAL:", Theme::getInstance()->fg_light->foreground},
         {{0 * 8, 7 * 16}, "LAP:", Theme::getInstance()->fg_light->foreground},
     };
 
-    BigFrequency big_display{
-        {4, 2 * 16 + 4, 28 * 8, 52},
-        0};
+    OptionsField options_ms_display_level{
+        {4 * 8 * 4 + 7 * 8 + 4, 2 * 16},
+        5,
+        {{"& - -", 0},
+         {"& & -", 1},
+         {"& & &", 2}}};
 
-    BigFrequency lap_display{
-        {4, 8 * 16 + 4, 28 * 8, 52},
-        0};
+    Painter painter;
 
     Button button_run_stop{
         {72, 210, 96, 24},

--- a/firmware/common/ui_painter.hpp
+++ b/firmware/common/ui_painter.hpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2014 Jared Boone, ShareBrained Technology, Inc.
+ * copyleft Mr. Robot
  *
  * This file is part of PortaPack.
  *
@@ -64,12 +65,12 @@ class Widget;
 
 class Painter {
    public:
-    Painter(){};
+    Painter() {};
 
     Painter(const Painter&) = delete;
     Painter(Painter&&) = delete;
 
-    int draw_char(Point p, const Style& style, char c);
+    int draw_char(Point p, const Style& style, char c, uint8_t zoom_factor = 1);
 
     int draw_string(Point p, const Style& style, std::string_view text);
     int draw_string(Point p, const Font& font, Color foreground, Color background, std::string_view text);

--- a/firmware/common/ui_painter.hpp
+++ b/firmware/common/ui_painter.hpp
@@ -65,7 +65,7 @@ class Widget;
 
 class Painter {
    public:
-    Painter() {};
+    Painter(){};
 
     Painter(const Painter&) = delete;
     Painter(Painter&&) = delete;


### PR DESCRIPTION
Note that, there is one thing that missing: the "0" place holder:

For example, when time is "00 05 836", it display as "   5 836"

I didn't write it is because dirty manager has flaw and can't implement this.

Actually due to the flaw, even with current design, it's still using a bunch of work around, to reduce screen flickering:
for example when 00:15:xxx turn to 00:16:xxx, it actually only paint 6, the 1 is old but not dirty. 
Same as the lap display: it won't storage anywhere except the screen display cache buffer.

So with all these work around, it's pretty hard to have a working one, that won't show false info.