### PR TITLE
make the ptext_prompt func can define which keyboard to enter

### DIFF
--- a/firmware/application/apps/ble_rx_app.cpp
+++ b/firmware/application/apps/ble_rx_app.cpp
@@ -203,7 +203,7 @@ BleRecentEntryDetailView::BleRecentEntryDetailView(NavigationView& nav, const Bl
             nav,
             packetFileBuffer,
             64,
-            0,
+            ENTER_KEYBOARD_MODE_ALPHA,
             [this, packetToSave](std::string& buffer) {
                 on_save_file(buffer, packetToSave);
             });
@@ -472,7 +472,7 @@ BLERxView::BLERxView(NavigationView& nav)
             nav_,
             filterBuffer,
             64,
-            0,
+            ENTER_KEYBOARD_MODE_ALPHA,
             [this](std::string& buffer) {
                 on_filter_change(buffer);
             });
@@ -495,7 +495,7 @@ BLERxView::BLERxView(NavigationView& nav)
             nav,
             listFileBuffer,
             64,
-            0,
+            ENTER_KEYBOARD_MODE_ALPHA,
             [this](std::string& buffer) {
                 on_save_file(buffer);
             });

--- a/firmware/application/apps/ble_rx_app.cpp
+++ b/firmware/application/apps/ble_rx_app.cpp
@@ -203,6 +203,7 @@ BleRecentEntryDetailView::BleRecentEntryDetailView(NavigationView& nav, const Bl
             nav,
             packetFileBuffer,
             64,
+            0,
             [this, packetToSave](std::string& buffer) {
                 on_save_file(buffer, packetToSave);
             });
@@ -471,6 +472,7 @@ BLERxView::BLERxView(NavigationView& nav)
             nav_,
             filterBuffer,
             64,
+            0,
             [this](std::string& buffer) {
                 on_filter_change(buffer);
             });
@@ -493,6 +495,7 @@ BLERxView::BLERxView(NavigationView& nav)
             nav,
             listFileBuffer,
             64,
+            0,
             [this](std::string& buffer) {
                 on_save_file(buffer);
             });

--- a/firmware/application/apps/ble_tx_app.cpp
+++ b/firmware/application/apps/ble_tx_app.cpp
@@ -399,7 +399,7 @@ BLETxView::BLETxView(NavigationView& nav)
             nav,
             packetFileBuffer,
             64,
-            0,
+            ENTER_KEYBOARD_MODE_ALPHA,
             [this](std::string& buffer) {
                 on_save_file(buffer);
             });

--- a/firmware/application/apps/ble_tx_app.cpp
+++ b/firmware/application/apps/ble_tx_app.cpp
@@ -399,6 +399,7 @@ BLETxView::BLETxView(NavigationView& nav)
             nav,
             packetFileBuffer,
             64,
+            0,
             [this](std::string& buffer) {
                 on_save_file(buffer);
             });

--- a/firmware/application/apps/ui_aprs_tx.cpp
+++ b/firmware/application/apps/ui_aprs_tx.cpp
@@ -94,6 +94,7 @@ APRSTXView::APRSTXView(NavigationView& nav) {
             nav,
             payload,
             30,
+            0,
             [this](std::string& s) {
                 text_payload.set(s);
             });

--- a/firmware/application/apps/ui_aprs_tx.cpp
+++ b/firmware/application/apps/ui_aprs_tx.cpp
@@ -94,7 +94,7 @@ APRSTXView::APRSTXView(NavigationView& nav) {
             nav,
             payload,
             30,
-            0,
+            ENTER_KEYBOARD_MODE_ALPHA,
             [this](std::string& s) {
                 text_payload.set(s);
             });

--- a/firmware/application/apps/ui_fileman.cpp
+++ b/firmware/application/apps/ui_fileman.cpp
@@ -499,7 +499,7 @@ FileSaveView::FileSaveView(
 
         button_edit_path.on_select = [this](Button&) {
                 buffer_ = path_.string();
-                text_prompt(nav_, buffer_, max_filename_length,
+                text_prompt(nav_, buffer_, max_filename_length,0,
                         [this](std::string&) {
                                 path_ = buffer_;
                                 refresh_widgets();
@@ -508,7 +508,7 @@ FileSaveView::FileSaveView(
 
         button_edit_name.on_select = [this](Button&) {
                 buffer_ = file_.string();
-                text_prompt(nav_, buffer_, max_filename_length,
+                text_prompt(nav_, buffer_, max_filename_length,0,
                         [this](std::string&) {
                                 file_ = buffer_;
                                 refresh_widgets();
@@ -566,7 +566,7 @@ void FileManagerView::on_rename(std::string_view hint) {
         cursor_pos = pos;
 
     text_prompt(
-        nav_, name_buffer, cursor_pos, max_filename_length,
+        nav_, name_buffer, cursor_pos, max_filename_length,0,
         [this](std::string& renamed) {
             auto renamed_path = fs::path{renamed};
             rename_file(get_selected_full_path(), current_path / renamed_path);
@@ -640,7 +640,7 @@ void FileManagerView::on_clean() {
 
 void FileManagerView::on_new_dir() {
     name_buffer = "";
-    text_prompt(nav_, name_buffer, max_filename_length, [this](std::string& dir_name) {
+    text_prompt(nav_, name_buffer, max_filename_length,0, [this](std::string& dir_name) {
         make_new_directory(current_path / dir_name);
         reload_current(true);
     });
@@ -671,7 +671,7 @@ void FileManagerView::on_paste() {
 
 void FileManagerView::on_new_file() {
     name_buffer = "";
-    text_prompt(nav_, name_buffer, max_filename_length, [this](std::string& file_name) {
+    text_prompt(nav_, name_buffer, max_filename_length,0, [this](std::string& file_name) {
         make_new_file(current_path / file_name);
         reload_current(true);
     });

--- a/firmware/application/apps/ui_fileman.cpp
+++ b/firmware/application/apps/ui_fileman.cpp
@@ -566,7 +566,7 @@ void FileManagerView::on_rename(std::string_view hint) {
         cursor_pos = pos;
 
     text_prompt(
-        nav_, name_buffer, cursor_pos, max_filename_length,0,
+        nav_, name_buffer, cursor_pos, max_filename_length, 0,
         [this](std::string& renamed) {
             auto renamed_path = fs::path{renamed};
             rename_file(get_selected_full_path(), current_path / renamed_path);
@@ -640,7 +640,7 @@ void FileManagerView::on_clean() {
 
 void FileManagerView::on_new_dir() {
     name_buffer = "";
-    text_prompt(nav_, name_buffer, max_filename_length,0, [this](std::string& dir_name) {
+    text_prompt(nav_, name_buffer, max_filename_length, 0, [this](std::string& dir_name) {
         make_new_directory(current_path / dir_name);
         reload_current(true);
     });
@@ -671,7 +671,7 @@ void FileManagerView::on_paste() {
 
 void FileManagerView::on_new_file() {
     name_buffer = "";
-    text_prompt(nav_, name_buffer, max_filename_length,0, [this](std::string& file_name) {
+    text_prompt(nav_, name_buffer, max_filename_length, 0, [this](std::string& file_name) {
         make_new_file(current_path / file_name);
         reload_current(true);
     });

--- a/firmware/application/apps/ui_fileman.cpp
+++ b/firmware/application/apps/ui_fileman.cpp
@@ -499,7 +499,7 @@ FileSaveView::FileSaveView(
 
         button_edit_path.on_select = [this](Button&) {
                 buffer_ = path_.string();
-                text_prompt(nav_, buffer_, max_filename_length,0,
+                text_prompt(nav_, buffer_, max_filename_length,ENTER_KEYBOARD_MODE_ALPHA,
                         [this](std::string&) {
                                 path_ = buffer_;
                                 refresh_widgets();
@@ -508,7 +508,7 @@ FileSaveView::FileSaveView(
 
         button_edit_name.on_select = [this](Button&) {
                 buffer_ = file_.string();
-                text_prompt(nav_, buffer_, max_filename_length,0,
+                text_prompt(nav_, buffer_, max_filename_length,ENTER_KEYBOARD_MODE_ALPHA,
                         [this](std::string&) {
                                 file_ = buffer_;
                                 refresh_widgets();
@@ -566,7 +566,7 @@ void FileManagerView::on_rename(std::string_view hint) {
         cursor_pos = pos;
 
     text_prompt(
-        nav_, name_buffer, cursor_pos, max_filename_length, 0,
+        nav_, name_buffer, cursor_pos, max_filename_length, ENTER_KEYBOARD_MODE_ALPHA,
         [this](std::string& renamed) {
             auto renamed_path = fs::path{renamed};
             rename_file(get_selected_full_path(), current_path / renamed_path);
@@ -640,7 +640,7 @@ void FileManagerView::on_clean() {
 
 void FileManagerView::on_new_dir() {
     name_buffer = "";
-    text_prompt(nav_, name_buffer, max_filename_length, 0, [this](std::string& dir_name) {
+    text_prompt(nav_, name_buffer, max_filename_length, ENTER_KEYBOARD_MODE_ALPHA, [this](std::string& dir_name) {
         make_new_directory(current_path / dir_name);
         reload_current(true);
     });
@@ -671,7 +671,7 @@ void FileManagerView::on_paste() {
 
 void FileManagerView::on_new_file() {
     name_buffer = "";
-    text_prompt(nav_, name_buffer, max_filename_length, 0, [this](std::string& file_name) {
+    text_prompt(nav_, name_buffer, max_filename_length, ENTER_KEYBOARD_MODE_ALPHA, [this](std::string& file_name) {
         make_new_file(current_path / file_name);
         reload_current(true);
     });

--- a/firmware/application/apps/ui_freqman.cpp
+++ b/firmware/application/apps/ui_freqman.cpp
@@ -240,7 +240,7 @@ void FrequencyManagerView::on_edit_freq() {
 
 void FrequencyManagerView::on_edit_desc() {
     temp_buffer_ = current_entry().description;
-    text_prompt(nav_, temp_buffer_, freqman_max_desc_size, 0, [this](std::string& new_desc) {
+    text_prompt(nav_, temp_buffer_, freqman_max_desc_size, ENTER_KEYBOARD_MODE_ALPHA, [this](std::string& new_desc) {
         auto entry = current_entry();
         entry.description = std::move(new_desc);
         db_.replace_entry(current_index(), entry);
@@ -250,7 +250,7 @@ void FrequencyManagerView::on_edit_desc() {
 
 void FrequencyManagerView::on_add_category() {
     temp_buffer_.clear();
-    text_prompt(nav_, temp_buffer_, 20, 0, [this](std::string& new_name) {
+    text_prompt(nav_, temp_buffer_, 20, ENTER_KEYBOARD_MODE_ALPHA, [this](std::string& new_name) {
         if (!new_name.empty()) {
             create_freqman_file(new_name);
             refresh_categories();

--- a/firmware/application/apps/ui_freqman.cpp
+++ b/firmware/application/apps/ui_freqman.cpp
@@ -240,7 +240,7 @@ void FrequencyManagerView::on_edit_freq() {
 
 void FrequencyManagerView::on_edit_desc() {
     temp_buffer_ = current_entry().description;
-    text_prompt(nav_, temp_buffer_, freqman_max_desc_size, [this](std::string& new_desc) {
+    text_prompt(nav_, temp_buffer_, freqman_max_desc_size,0, [this](std::string& new_desc) {
         auto entry = current_entry();
         entry.description = std::move(new_desc);
         db_.replace_entry(current_index(), entry);
@@ -250,7 +250,7 @@ void FrequencyManagerView::on_edit_desc() {
 
 void FrequencyManagerView::on_add_category() {
     temp_buffer_.clear();
-    text_prompt(nav_, temp_buffer_, 20, [this](std::string& new_name) {
+    text_prompt(nav_, temp_buffer_, 20,0, [this](std::string& new_name) {
         if (!new_name.empty()) {
             create_freqman_file(new_name);
             refresh_categories();

--- a/firmware/application/apps/ui_freqman.cpp
+++ b/firmware/application/apps/ui_freqman.cpp
@@ -240,7 +240,7 @@ void FrequencyManagerView::on_edit_freq() {
 
 void FrequencyManagerView::on_edit_desc() {
     temp_buffer_ = current_entry().description;
-    text_prompt(nav_, temp_buffer_, freqman_max_desc_size,0, [this](std::string& new_desc) {
+    text_prompt(nav_, temp_buffer_, freqman_max_desc_size, 0, [this](std::string& new_desc) {
         auto entry = current_entry();
         entry.description = std::move(new_desc);
         db_.replace_entry(current_index(), entry);
@@ -250,7 +250,7 @@ void FrequencyManagerView::on_edit_desc() {
 
 void FrequencyManagerView::on_add_category() {
     temp_buffer_.clear();
-    text_prompt(nav_, temp_buffer_, 20,0, [this](std::string& new_name) {
+    text_prompt(nav_, temp_buffer_, 20, 0, [this](std::string& new_name) {
         if (!new_name.empty()) {
             create_freqman_file(new_name);
             refresh_categories();

--- a/firmware/application/apps/ui_pocsag_tx.cpp
+++ b/firmware/application/apps/ui_pocsag_tx.cpp
@@ -153,7 +153,7 @@ void POCSAGTXView::paint(Painter&) {
 }
 
 void POCSAGTXView::on_set_text(NavigationView& nav) {
-    text_prompt(nav, buffer, MAX_POCSAG_LENGTH,0);
+    text_prompt(nav, buffer, MAX_POCSAG_LENGTH, 0);
 }
 
 POCSAGTXView::POCSAGTXView(

--- a/firmware/application/apps/ui_pocsag_tx.cpp
+++ b/firmware/application/apps/ui_pocsag_tx.cpp
@@ -153,7 +153,7 @@ void POCSAGTXView::paint(Painter&) {
 }
 
 void POCSAGTXView::on_set_text(NavigationView& nav) {
-    text_prompt(nav, buffer, MAX_POCSAG_LENGTH, 0);
+    text_prompt(nav, buffer, MAX_POCSAG_LENGTH, ENTER_KEYBOARD_MODE_ALPHA);
 }
 
 POCSAGTXView::POCSAGTXView(

--- a/firmware/application/apps/ui_pocsag_tx.cpp
+++ b/firmware/application/apps/ui_pocsag_tx.cpp
@@ -153,7 +153,7 @@ void POCSAGTXView::paint(Painter&) {
 }
 
 void POCSAGTXView::on_set_text(NavigationView& nav) {
-    text_prompt(nav, buffer, MAX_POCSAG_LENGTH);
+    text_prompt(nav, buffer, MAX_POCSAG_LENGTH,0);
 }
 
 POCSAGTXView::POCSAGTXView(

--- a/firmware/application/apps/ui_rds.cpp
+++ b/firmware/application/apps/ui_rds.cpp
@@ -65,6 +65,7 @@ RDSPSNView::RDSPSNView(
             nav,
             PSN,
             8,
+            0,
             [this](std::string& s) {
                 text_psn.set(s);
             });
@@ -86,6 +87,7 @@ RDSRadioTextView::RDSRadioTextView(
             nav,
             radiotext,
             28,
+            0,
             [this](std::string& s) {
                 text_radiotext.set(s);
             });

--- a/firmware/application/apps/ui_rds.cpp
+++ b/firmware/application/apps/ui_rds.cpp
@@ -65,7 +65,7 @@ RDSPSNView::RDSPSNView(
             nav,
             PSN,
             8,
-            0,
+            ENTER_KEYBOARD_MODE_ALPHA,
             [this](std::string& s) {
                 text_psn.set(s);
             });
@@ -87,7 +87,7 @@ RDSRadioTextView::RDSRadioTextView(
             nav,
             radiotext,
             28,
-            0,
+            ENTER_KEYBOARD_MODE_ALPHA,
             [this](std::string& s) {
                 text_radiotext.set(s);
             });

--- a/firmware/application/apps/ui_recon_settings.cpp
+++ b/firmware/application/apps/ui_recon_settings.cpp
@@ -82,7 +82,7 @@ ReconSetupViewMain::ReconSetupViewMain(NavigationView& nav, Rect parent_rect, st
     };
 
     button_choose_output_name.on_select = [this, &nav](Button&) {
-        text_prompt(nav, _output_file, 28, 0, [this](std::string& buffer) {
+        text_prompt(nav, _output_file, 28, ENTER_KEYBOARD_MODE_ALPHA, [this](std::string& buffer) {
             _output_file = buffer;
             button_choose_output_name.set_text(_output_file);
         });

--- a/firmware/application/apps/ui_recon_settings.cpp
+++ b/firmware/application/apps/ui_recon_settings.cpp
@@ -82,7 +82,7 @@ ReconSetupViewMain::ReconSetupViewMain(NavigationView& nav, Rect parent_rect, st
     };
 
     button_choose_output_name.on_select = [this, &nav](Button&) {
-        text_prompt(nav, _output_file, 28, [this](std::string& buffer) {
+        text_prompt(nav, _output_file, 28, 0,[this](std::string& buffer) {
             _output_file = buffer;
             button_choose_output_name.set_text(_output_file);
         });

--- a/firmware/application/apps/ui_recon_settings.cpp
+++ b/firmware/application/apps/ui_recon_settings.cpp
@@ -82,7 +82,7 @@ ReconSetupViewMain::ReconSetupViewMain(NavigationView& nav, Rect parent_rect, st
     };
 
     button_choose_output_name.on_select = [this, &nav](Button&) {
-        text_prompt(nav, _output_file, 28, 0,[this](std::string& buffer) {
+        text_prompt(nav, _output_file, 28, 0, [this](std::string& buffer) {
             _output_file = buffer;
             button_choose_output_name.set_text(_output_file);
         });

--- a/firmware/application/apps/ui_text_editor.cpp
+++ b/firmware/application/apps/ui_text_editor.cpp
@@ -617,6 +617,7 @@ void TextEditorView::show_edit_line() {
         edit_line_buffer_,
         viewer.col(),
         max_edit_length,
+        0,
         [this](std::string& buffer) {
             auto range = file_->line_range(viewer.line());
             if (!range)

--- a/firmware/application/apps/ui_text_editor.cpp
+++ b/firmware/application/apps/ui_text_editor.cpp
@@ -617,7 +617,7 @@ void TextEditorView::show_edit_line() {
         edit_line_buffer_,
         viewer.col(),
         max_edit_length,
-        0,
+        ENTER_KEYBOARD_MODE_ALPHA,
         [this](std::string& buffer) {
             auto range = file_->line_range(viewer.line());
             if (!range)

--- a/firmware/application/binder.hpp
+++ b/firmware/application/binder.hpp
@@ -25,6 +25,7 @@
 #include "ui.hpp"
 #include "ui_navigation.hpp"
 #include "ui_widget.hpp"
+#include "ui_textentry.hpp"
 
 namespace ui {
 
@@ -105,7 +106,7 @@ void bind(TextField& field, T& value, NavigationView& nav, Fn fn = Fn{}) {
     // Capture a new string and make the lambda mutable so it can be modified.
     field.on_select = [&nav, buf = std::string{}](TextField& tf) mutable {
         buf = tf.get_text();
-        text_prompt(nav, buf, /*max_length*/ 255, 0,
+        text_prompt(nav, buf, /*max_length*/ 255, ENTER_KEYBOARD_MODE_ALPHA,
                     [&tf](std::string& str) {
                         tf.set_text(str);
                     });

--- a/firmware/application/binder.hpp
+++ b/firmware/application/binder.hpp
@@ -105,7 +105,7 @@ void bind(TextField& field, T& value, NavigationView& nav, Fn fn = Fn{}) {
     // Capture a new string and make the lambda mutable so it can be modified.
     field.on_select = [&nav, buf = std::string{}](TextField& tf) mutable {
         buf = tf.get_text();
-        text_prompt(nav, buf, /*max_length*/ 255,0,
+        text_prompt(nav, buf, /*max_length*/ 255, 0,
                     [&tf](std::string& str) {
                         tf.set_text(str);
                     });

--- a/firmware/application/binder.hpp
+++ b/firmware/application/binder.hpp
@@ -105,7 +105,7 @@ void bind(TextField& field, T& value, NavigationView& nav, Fn fn = Fn{}) {
     // Capture a new string and make the lambda mutable so it can be modified.
     field.on_select = [&nav, buf = std::string{}](TextField& tf) mutable {
         buf = tf.get_text();
-        text_prompt(nav, buf, /*max_length*/ 255,
+        text_prompt(nav, buf, /*max_length*/ 255,0,
                     [&tf](std::string& str) {
                         tf.set_text(str);
                     });

--- a/firmware/application/external/adsbtx/ui_adsb_tx.cpp
+++ b/firmware/application/external/adsbtx/ui_adsb_tx.cpp
@@ -131,7 +131,7 @@ ADSBCallsignView::ADSBCallsignView(
             nav,
             callsign,
             8,
-            0,
+            ENTER_KEYBOARD_MODE_ALPHA,
             [this](std::string& s) {
                 button_callsign.set_text(s);
             });

--- a/firmware/application/external/adsbtx/ui_adsb_tx.cpp
+++ b/firmware/application/external/adsbtx/ui_adsb_tx.cpp
@@ -131,6 +131,7 @@ ADSBCallsignView::ADSBCallsignView(
             nav,
             callsign,
             8,
+            0,
             [this](std::string& s) {
                 button_callsign.set_text(s);
             });

--- a/firmware/application/external/hopper/ui_hopper.cpp
+++ b/firmware/application/external/hopper/ui_hopper.cpp
@@ -227,7 +227,7 @@ void HopperView::save_list() {
         nav_,
         filename_buffer,
         64,
-        0,
+        ENTER_KEYBOARD_MODE_ALPHA,
         [this](std::string& value) {
             auto path = hopper_dir / (value + ".PHOP");
 

--- a/firmware/application/external/hopper/ui_hopper.cpp
+++ b/firmware/application/external/hopper/ui_hopper.cpp
@@ -227,6 +227,7 @@ void HopperView::save_list() {
         nav_,
         filename_buffer,
         64,
+        0,
         [this](std::string& value) {
             auto path = hopper_dir / (value + ".PHOP");
 

--- a/firmware/application/external/lcr/ui_lcr.cpp
+++ b/firmware/application/external/lcr/ui_lcr.cpp
@@ -189,6 +189,7 @@ void LCRView::on_button_set_am(NavigationView& nav, int16_t button_id) {
         nav,
         litteral[button_id],
         7,
+        0,
         [this, button_id](std::string& buffer) {
             texts[button_id].set(buffer);
         });
@@ -257,6 +258,7 @@ LCRView::LCRView(NavigationView& nav) {
             nav,
             rgsb,
             4,
+            0,
             [this](std::string& buffer) {
                 button_set_rgsb.set_text(buffer);
             });

--- a/firmware/application/external/lcr/ui_lcr.cpp
+++ b/firmware/application/external/lcr/ui_lcr.cpp
@@ -189,7 +189,7 @@ void LCRView::on_button_set_am(NavigationView& nav, int16_t button_id) {
         nav,
         litteral[button_id],
         7,
-        0,
+        ENTER_KEYBOARD_MODE_ALPHA,
         [this, button_id](std::string& buffer) {
             texts[button_id].set(buffer);
         });
@@ -258,7 +258,7 @@ LCRView::LCRView(NavigationView& nav) {
             nav,
             rgsb,
             4,
-            0,
+            ENTER_KEYBOARD_MODE_ALPHA,
             [this](std::string& buffer) {
                 button_set_rgsb.set_text(buffer);
             });

--- a/firmware/application/external/lge/lge_app.cpp
+++ b/firmware/application/external/lge/lge_app.cpp
@@ -311,6 +311,7 @@ LGEView::LGEView(NavigationView& nav) {
             nav,
             nickname,
             15,
+            0,
             [this](std::string& buffer) {
                 button_text.set_text(buffer);
             });

--- a/firmware/application/external/lge/lge_app.cpp
+++ b/firmware/application/external/lge/lge_app.cpp
@@ -311,7 +311,7 @@ LGEView::LGEView(NavigationView& nav) {
             nav,
             nickname,
             15,
-            0,
+            ENTER_KEYBOARD_MODE_ALPHA,
             [this](std::string& buffer) {
                 button_text.set_text(buffer);
             });

--- a/firmware/application/external/metronome/ui_metronome.cpp
+++ b/firmware/application/external/metronome/ui_metronome.cpp
@@ -212,7 +212,7 @@ MetronomeTapTempoView::MetronomeTapTempoView(NavigationView& nav, uint16_t bpm)
             nav_,
             input_buffer,
             3,
-            1, /*enter number*/
+            ENTER_KEYBOARD_MODE_DIGITS,
             [this](std::string& buffer) {
                 if (buffer.empty()) {
                     return;

--- a/firmware/application/external/metronome/ui_metronome.cpp
+++ b/firmware/application/external/metronome/ui_metronome.cpp
@@ -212,6 +212,7 @@ MetronomeTapTempoView::MetronomeTapTempoView(NavigationView& nav, uint16_t bpm)
             nav_,
             input_buffer,
             3,
+            1,
             [this](std::string& buffer) {
                 if (buffer.empty()) {
                     return;

--- a/firmware/application/external/metronome/ui_metronome.cpp
+++ b/firmware/application/external/metronome/ui_metronome.cpp
@@ -212,7 +212,7 @@ MetronomeTapTempoView::MetronomeTapTempoView(NavigationView& nav, uint16_t bpm)
             nav_,
             input_buffer,
             3,
-            1,
+            1, /*enter number*/
             [this](std::string& buffer) {
                 if (buffer.empty()) {
                     return;

--- a/firmware/application/external/morse_tx/ui_morse.cpp
+++ b/firmware/application/external/morse_tx/ui_morse.cpp
@@ -99,7 +99,7 @@ static msg_t loopthread_fn(void* arg) {
 }
 
 void MorseView::on_set_text(NavigationView& nav) {
-    text_prompt(nav, buffer, 28);
+    text_prompt(nav, buffer, 28,0);
 }
 
 void MorseView::focus() {

--- a/firmware/application/external/morse_tx/ui_morse.cpp
+++ b/firmware/application/external/morse_tx/ui_morse.cpp
@@ -99,7 +99,7 @@ static msg_t loopthread_fn(void* arg) {
 }
 
 void MorseView::on_set_text(NavigationView& nav) {
-    text_prompt(nav, buffer, 28,0);
+    text_prompt(nav, buffer, 28, 0);
 }
 
 void MorseView::focus() {

--- a/firmware/application/external/morse_tx/ui_morse.cpp
+++ b/firmware/application/external/morse_tx/ui_morse.cpp
@@ -99,7 +99,7 @@ static msg_t loopthread_fn(void* arg) {
 }
 
 void MorseView::on_set_text(NavigationView& nav) {
-    text_prompt(nav, buffer, 28, 0);
+    text_prompt(nav, buffer, 28, ENTER_KEYBOARD_MODE_ALPHA);
 }
 
 void MorseView::focus() {

--- a/firmware/application/external/ook_editor/ui_ook_editor.cpp
+++ b/firmware/application/external/ook_editor/ui_ook_editor.cpp
@@ -210,6 +210,7 @@ OOKEditorAppView::OOKEditorAppView(NavigationView& nav)
             nav,
             outputFileBuffer,
             64,
+            0,
             [this](std::string& buffer) {
                 on_save_file(buffer);
             });
@@ -263,6 +264,7 @@ OOKEditorAppView::OOKEditorAppView(NavigationView& nav)
             nav,
             ook_data.payload,
             100,
+            1,
             [this](std::string& s) {
                 text_payload.set(s);
                 draw_waveform();

--- a/firmware/application/external/ook_editor/ui_ook_editor.cpp
+++ b/firmware/application/external/ook_editor/ui_ook_editor.cpp
@@ -264,7 +264,7 @@ OOKEditorAppView::OOKEditorAppView(NavigationView& nav)
             nav,
             ook_data.payload,
             100,
-            1,
+            1, /* enter number */
             [this](std::string& s) {
                 text_payload.set(s);
                 draw_waveform();

--- a/firmware/application/external/ook_editor/ui_ook_editor.cpp
+++ b/firmware/application/external/ook_editor/ui_ook_editor.cpp
@@ -210,7 +210,7 @@ OOKEditorAppView::OOKEditorAppView(NavigationView& nav)
             nav,
             outputFileBuffer,
             64,
-            0,
+            ENTER_KEYBOARD_MODE_ALPHA,
             [this](std::string& buffer) {
                 on_save_file(buffer);
             });
@@ -264,7 +264,7 @@ OOKEditorAppView::OOKEditorAppView(NavigationView& nav)
             nav,
             ook_data.payload,
             100,
-            1, /* enter number */
+            ENTER_KEYBOARD_MODE_DIGITS,
             [this](std::string& s) {
                 text_payload.set(s);
                 draw_waveform();

--- a/firmware/application/external/ookbrute/ui_ookbrute.cpp
+++ b/firmware/application/external/ookbrute/ui_ookbrute.cpp
@@ -83,6 +83,7 @@ OOKBruteView::OOKBruteView(NavigationView& nav)
             nav_,
             text_input_buffer,
             8,  // currently longest is princeton
+            1, /*enter number*/
             [this](std::string& buffer) {
                 field_start.set_value(atoi(buffer.c_str()));
                 validate_start_stop();
@@ -100,6 +101,7 @@ OOKBruteView::OOKBruteView(NavigationView& nav)
             nav_,
             text_input_buffer,
             8,  // currently longest is princeton
+            0,/*enter number*/
             [this](std::string& buffer) {
                 field_stop.set_value(atoi(buffer.c_str()));
                 validate_start_stop();

--- a/firmware/application/external/ookbrute/ui_ookbrute.cpp
+++ b/firmware/application/external/ookbrute/ui_ookbrute.cpp
@@ -83,7 +83,7 @@ OOKBruteView::OOKBruteView(NavigationView& nav)
             nav_,
             text_input_buffer,
             8,  // currently longest is princeton
-            1,  /*enter number*/
+            ENTER_KEYBOARD_MODE_DIGITS,
             [this](std::string& buffer) {
                 field_start.set_value(atoi(buffer.c_str()));
                 validate_start_stop();
@@ -101,7 +101,7 @@ OOKBruteView::OOKBruteView(NavigationView& nav)
             nav_,
             text_input_buffer,
             8,  // currently longest is princeton
-            0,  /*enter number*/
+            ENTER_KEYBOARD_MODE_DIGITS,
             [this](std::string& buffer) {
                 field_stop.set_value(atoi(buffer.c_str()));
                 validate_start_stop();

--- a/firmware/application/external/ookbrute/ui_ookbrute.cpp
+++ b/firmware/application/external/ookbrute/ui_ookbrute.cpp
@@ -83,7 +83,7 @@ OOKBruteView::OOKBruteView(NavigationView& nav)
             nav_,
             text_input_buffer,
             8,  // currently longest is princeton
-            1, /*enter number*/
+            1,  /*enter number*/
             [this](std::string& buffer) {
                 field_start.set_value(atoi(buffer.c_str()));
                 validate_start_stop();
@@ -101,7 +101,7 @@ OOKBruteView::OOKBruteView(NavigationView& nav)
             nav_,
             text_input_buffer,
             8,  // currently longest is princeton
-            0,/*enter number*/
+            0,  /*enter number*/
             [this](std::string& buffer) {
                 field_stop.set_value(atoi(buffer.c_str()));
                 validate_start_stop();

--- a/firmware/application/external/playlist_editor/ui_playlist_editor.cpp
+++ b/firmware/application/external/playlist_editor/ui_playlist_editor.cpp
@@ -122,6 +122,7 @@ bool PlaylistEditorView::on_create_ppl() {
         nav_,
         current_ppl_name_buffer,
         100,
+        0,
         [&](std::string& s) {
             current_ppl_name_buffer = s;
 
@@ -307,6 +308,8 @@ PlaylistItemEditView::PlaylistItemEditView(
             nav_,
             delay_str,
             100,
+            0,
+            1, /* enter number */
             [&](std::string& s) {
                 delay_ = atoi(s.c_str());
                 field_delay.set_value(delay_);

--- a/firmware/application/external/playlist_editor/ui_playlist_editor.cpp
+++ b/firmware/application/external/playlist_editor/ui_playlist_editor.cpp
@@ -122,7 +122,7 @@ bool PlaylistEditorView::on_create_ppl() {
         nav_,
         current_ppl_name_buffer,
         100,
-        0,
+        ENTER_KEYBOARD_MODE_ALPHA,
         [&](std::string& s) {
             current_ppl_name_buffer = s;
 
@@ -308,8 +308,7 @@ PlaylistItemEditView::PlaylistItemEditView(
             nav_,
             delay_str,
             100,
-            0,
-            1, /* enter number */
+            ENTER_KEYBOARD_MODE_ALPHA,
             [&](std::string& s) {
                 delay_ = atoi(s.c_str());
                 field_delay.set_value(delay_);

--- a/firmware/application/external/remote/ui_remote.cpp
+++ b/firmware/application/external/remote/ui_remote.cpp
@@ -330,7 +330,7 @@ RemoteAppView::RemoteAppView(
 
     field_title.on_select = [this, &nav](TextField&) {
         temp_buffer_ = model_.name;
-        text_prompt(nav_, temp_buffer_, text_edit_max, 0, [this](std::string& new_name) {
+        text_prompt(nav_, temp_buffer_, text_edit_max, ENTER_KEYBOARD_MODE_ALPHA, [this](std::string& new_name) {
             model_.name = new_name;
             refresh_ui();
             set_needs_save();
@@ -339,7 +339,7 @@ RemoteAppView::RemoteAppView(
 
     field_filename.on_select = [this, &nav](TextField&) {
         temp_buffer_ = remote_path_.stem().string();
-        text_prompt(nav_, temp_buffer_, text_edit_max, 0, [this](std::string& new_name) {
+        text_prompt(nav_, temp_buffer_, text_edit_max, ENTER_KEYBOARD_MODE_ALPHA, [this](std::string& new_name) {
             rename_remote(new_name);
             refresh_ui();
         });

--- a/firmware/application/external/remote/ui_remote.cpp
+++ b/firmware/application/external/remote/ui_remote.cpp
@@ -330,7 +330,7 @@ RemoteAppView::RemoteAppView(
 
     field_title.on_select = [this, &nav](TextField&) {
         temp_buffer_ = model_.name;
-        text_prompt(nav_, temp_buffer_, text_edit_max, [this](std::string& new_name) {
+        text_prompt(nav_, temp_buffer_, text_edit_max, 0,[this](std::string& new_name) {
             model_.name = new_name;
             refresh_ui();
             set_needs_save();
@@ -339,7 +339,7 @@ RemoteAppView::RemoteAppView(
 
     field_filename.on_select = [this, &nav](TextField&) {
         temp_buffer_ = remote_path_.stem().string();
-        text_prompt(nav_, temp_buffer_, text_edit_max, [this](std::string& new_name) {
+        text_prompt(nav_, temp_buffer_, text_edit_max,0, [this](std::string& new_name) {
             rename_remote(new_name);
             refresh_ui();
         });

--- a/firmware/application/external/remote/ui_remote.cpp
+++ b/firmware/application/external/remote/ui_remote.cpp
@@ -330,7 +330,7 @@ RemoteAppView::RemoteAppView(
 
     field_title.on_select = [this, &nav](TextField&) {
         temp_buffer_ = model_.name;
-        text_prompt(nav_, temp_buffer_, text_edit_max, 0,[this](std::string& new_name) {
+        text_prompt(nav_, temp_buffer_, text_edit_max, 0, [this](std::string& new_name) {
             model_.name = new_name;
             refresh_ui();
             set_needs_save();
@@ -339,7 +339,7 @@ RemoteAppView::RemoteAppView(
 
     field_filename.on_select = [this, &nav](TextField&) {
         temp_buffer_ = remote_path_.stem().string();
-        text_prompt(nav_, temp_buffer_, text_edit_max,0, [this](std::string& new_name) {
+        text_prompt(nav_, temp_buffer_, text_edit_max, 0, [this](std::string& new_name) {
             rename_remote(new_name);
             refresh_ui();
         });

--- a/firmware/application/external/spainter/ui_spectrum_painter_text.cpp
+++ b/firmware/application/external/spainter/ui_spectrum_painter_text.cpp
@@ -56,7 +56,7 @@ SpectrumInputTextView::~SpectrumInputTextView() {
 }
 
 void SpectrumInputTextView::on_set_text(NavigationView& nav) {
-    text_prompt(nav, buffer, 300,0);
+    text_prompt(nav, buffer, 300, 0);
 }
 
 void SpectrumInputTextView::focus() {

--- a/firmware/application/external/spainter/ui_spectrum_painter_text.cpp
+++ b/firmware/application/external/spainter/ui_spectrum_painter_text.cpp
@@ -56,7 +56,7 @@ SpectrumInputTextView::~SpectrumInputTextView() {
 }
 
 void SpectrumInputTextView::on_set_text(NavigationView& nav) {
-    text_prompt(nav, buffer, 300, 0);
+    text_prompt(nav, buffer, 300, ENTER_KEYBOARD_MODE_DIGITS);
 }
 
 void SpectrumInputTextView::focus() {

--- a/firmware/application/external/spainter/ui_spectrum_painter_text.cpp
+++ b/firmware/application/external/spainter/ui_spectrum_painter_text.cpp
@@ -56,7 +56,7 @@ SpectrumInputTextView::~SpectrumInputTextView() {
 }
 
 void SpectrumInputTextView::on_set_text(NavigationView& nav) {
-    text_prompt(nav, buffer, 300);
+    text_prompt(nav, buffer, 300,0);
 }
 
 void SpectrumInputTextView::focus() {

--- a/firmware/application/ui/ui_alphanum.cpp
+++ b/firmware/application/ui/ui_alphanum.cpp
@@ -32,7 +32,8 @@ namespace ui {
 AlphanumView::AlphanumView(
     NavigationView& nav,
     std::string& str,
-    size_t max_length)
+    size_t max_length,
+    uint8_t enter_mode)
     : TextEntryView(nav, str, max_length) {
     size_t n;
 
@@ -76,7 +77,7 @@ AlphanumView::AlphanumView(
         n++;
     }
 
-    set_mode(mode);
+    set_mode(enter_mode);
 
     button_mode.on_select = [this](Button&) {
         set_mode(mode + 1);

--- a/firmware/application/ui/ui_alphanum.hpp
+++ b/firmware/application/ui/ui_alphanum.hpp
@@ -37,7 +37,7 @@ namespace ui {
 
 class AlphanumView : public TextEntryView {
    public:
-    AlphanumView(NavigationView& nav, std::string& str, size_t max_length,uint8_t enter_mode);
+    AlphanumView(NavigationView& nav, std::string& str, size_t max_length, uint8_t enter_mode);
 
     AlphanumView(const AlphanumView&) = delete;
     AlphanumView(AlphanumView&&) = delete;

--- a/firmware/application/ui/ui_alphanum.hpp
+++ b/firmware/application/ui/ui_alphanum.hpp
@@ -37,7 +37,7 @@ namespace ui {
 
 class AlphanumView : public TextEntryView {
    public:
-    AlphanumView(NavigationView& nav, std::string& str, size_t max_length);
+    AlphanumView(NavigationView& nav, std::string& str, size_t max_length,uint8_t enter_mode);
 
     AlphanumView(const AlphanumView&) = delete;
     AlphanumView(AlphanumView&&) = delete;

--- a/firmware/application/ui/ui_textentry.cpp
+++ b/firmware/application/ui/ui_textentry.cpp
@@ -31,8 +31,9 @@ void text_prompt(
     NavigationView& nav,
     std::string& str,
     size_t max_length,
+    uint8_t mode,
     std::function<void(std::string&)> on_done) {
-    text_prompt(nav, str, str.length(), max_length, on_done);
+    text_prompt(nav, str, str.length(), max_length, mode,on_done);
 }
 
 void text_prompt(
@@ -40,8 +41,9 @@ void text_prompt(
     std::string& str,
     uint32_t cursor_pos,
     size_t max_length,
+    uint8_t mode,
     std::function<void(std::string&)> on_done) {
-    auto te_view = nav.push<AlphanumView>(str, max_length);
+    auto te_view = nav.push<AlphanumView>(str, max_length,mode);
     te_view->set_cursor(cursor_pos);
     te_view->on_changed = [on_done](std::string& value) {
         if (on_done)

--- a/firmware/application/ui/ui_textentry.cpp
+++ b/firmware/application/ui/ui_textentry.cpp
@@ -33,7 +33,7 @@ void text_prompt(
     size_t max_length,
     uint8_t mode,
     std::function<void(std::string&)> on_done) {
-    text_prompt(nav, str, str.length(), max_length, mode,on_done);
+    text_prompt(nav, str, str.length(), max_length, mode, on_done);
 }
 
 void text_prompt(
@@ -43,7 +43,7 @@ void text_prompt(
     size_t max_length,
     uint8_t mode,
     std::function<void(std::string&)> on_done) {
-    auto te_view = nav.push<AlphanumView>(str, max_length,mode);
+    auto te_view = nav.push<AlphanumView>(str, max_length, mode);
     te_view->set_cursor(cursor_pos);
     te_view->on_changed = [on_done](std::string& value) {
         if (on_done)

--- a/firmware/application/ui/ui_textentry.hpp
+++ b/firmware/application/ui/ui_textentry.hpp
@@ -26,6 +26,11 @@
 #include "ui.hpp"
 #include "ui_navigation.hpp"
 
+#define ENTER_KEYBOARD_MODE_ALPHA 0
+#define ENTER_KEYBOARD_MODE_DIGITS 1
+#define ENTER_KEYBOARD_MODE_SYMBOLS 2
+#define ENTER_KEYBOARD_MODE_HEX 3
+
 namespace ui {
 
 class TextEntryView : public View {

--- a/firmware/application/ui/ui_textentry.hpp
+++ b/firmware/application/ui/ui_textentry.hpp
@@ -62,6 +62,7 @@ void text_prompt(
     NavigationView& nav,
     std::string& str,
     size_t max_length,
+    uint8_t mode,
     std::function<void(std::string&)> on_done = nullptr);
 
 void text_prompt(
@@ -69,6 +70,7 @@ void text_prompt(
     std::string& str,
     uint32_t cursor_pos,
     size_t max_length,
+    uint8_t mode, // enter mode: 123 abc etc
     std::function<void(std::string&)> on_done = nullptr);
 
 } /* namespace ui */

--- a/firmware/application/ui/ui_textentry.hpp
+++ b/firmware/application/ui/ui_textentry.hpp
@@ -70,7 +70,7 @@ void text_prompt(
     std::string& str,
     uint32_t cursor_pos,
     size_t max_length,
-    uint8_t mode, // enter mode: 123 abc etc
+    uint8_t mode,  // enter mode: 123 abc etc
     std::function<void(std::string&)> on_done = nullptr);
 
 } /* namespace ui */


### PR DESCRIPTION
# what this design is for:
- in some of the apps, when you prompt text, it meant to input numbers, while in some others, it meant to input text.
- for example in OOK Brute app, when you tap to input range, it only need numbers. same as many other apps, like metronome app etc.
- it let user can press less times to get what they wanted.

# why not enum / enum class when you defining the kb type
- it's all over in different naming space and it's not worth to have that in everywhere we call the func.

# why not overload the func instead of editing such many files
- it's not worth since the base func already been changed, too expensive for the space usage.

# final
This is just a discuss PR (it works but i may imagine not all like this feat or this impl), so feel free to point out your idea regarding to this PR.