### PR TITLE
Support IPS screen & brightness set for IPS screen

### DIFF
--- a/firmware/application/apps/ui_settings.cpp
+++ b/firmware/application/apps/ui_settings.cpp
@@ -810,30 +810,29 @@ SetDisplayView::SetDisplayView(NavigationView& nav) {
                   &field_fake_brightness,
                   &button_save,
                   &button_cancel,
-                  &checkbox_invert_switch,
+                  &checkbox_ips_screen_switch,
                   &checkbox_brightness_switch});
 
     field_fake_brightness.set_by_value(pmem::fake_brightness_level());
     checkbox_brightness_switch.set_value(pmem::apply_fake_brightness());
-    checkbox_invert_switch.set_value(pmem::config_lcd_inverted_mode());
+    checkbox_ips_screen_switch.set_value(pmem::config_lcd_normally_black());
 
     button_save.on_select = [&nav, this](Button&) {
         pmem::set_apply_fake_brightness(checkbox_brightness_switch.value());
         pmem::set_fake_brightness_level(field_fake_brightness.selected_index_value());
-        if (checkbox_invert_switch.value() != pmem::config_lcd_inverted_mode()) {
-            display.set_inverted(checkbox_invert_switch.value());
-            pmem::set_lcd_inverted_mode(checkbox_invert_switch.value());
+        if (checkbox_ips_screen_switch.value() != pmem::config_lcd_normally_black()) {
+            pmem::set_lcd_normally_black(checkbox_ips_screen_switch.value());
         }
         send_system_refresh();
         nav.pop();
     };
 
     // only enable invert OR fake brightness
-    checkbox_invert_switch.on_select = [this](Checkbox&, bool v) {
+    checkbox_ips_screen_switch.on_select = [this](Checkbox&, bool v) {
         if (v) checkbox_brightness_switch.set_value(false);
     };
     checkbox_brightness_switch.on_select = [this](Checkbox&, bool v) {
-        if (v) checkbox_invert_switch.set_value(false);
+        if (v) checkbox_ips_screen_switch.set_value(false);
     };
 
     button_cancel.on_select = [&nav, this](Button&) {

--- a/firmware/application/apps/ui_settings.hpp
+++ b/firmware/application/apps/ui_settings.hpp
@@ -764,7 +764,6 @@ class SetDisplayView : public View {
         {{2 * 8, 8 * 16}, "Brightness:", Theme::getInstance()->fg_light->foreground},
         {{2 * 8, 10 * 16}, "REBOOT TO APPLY SCREEN TYPE", Theme::getInstance()->fg_light->foreground},
 
-
     };
 
     OptionsField field_fake_brightness{

--- a/firmware/application/apps/ui_settings.hpp
+++ b/firmware/application/apps/ui_settings.hpp
@@ -762,6 +762,9 @@ class SetDisplayView : public View {
         {{1 * 8, 2 * 16}, "(has a small performance", Theme::getInstance()->fg_light->foreground},
         {{1 * 8, 3 * 16}, "impact when enabled).", Theme::getInstance()->fg_light->foreground},
         {{2 * 8, 8 * 16}, "Brightness:", Theme::getInstance()->fg_light->foreground},
+        {{2 * 8, 10 * 16}, "REBOOT TO APPLY SCREEN TYPE", Theme::getInstance()->fg_light->foreground},
+
+
     };
 
     OptionsField field_fake_brightness{
@@ -776,10 +779,10 @@ class SetDisplayView : public View {
         16,
         "Enable brightness adjust"};
 
-    Checkbox checkbox_invert_switch{
-        {1 * 8, 10 * 16},
+    Checkbox checkbox_ips_screen_switch{
+        {1 * 8, 12 * 16},
         23,
-        "Invert colors (For IPS)"};
+        "IPS Screen"};
 
     Button button_save{
         {2 * 8, 16 * 16, 12 * 8, 32},

--- a/firmware/application/external/debug_pmem/ui_debug_pmem.cpp
+++ b/firmware/application/external/debug_pmem/ui_debug_pmem.cpp
@@ -80,7 +80,7 @@ bool DebugDumpView::debug_dump_func() {
     pmem_dump_file.write_line("updown_converter: " + to_string_dec_int(config_updown_converter()));
     pmem_dump_file.write_line("updown_frequency_rx_correction: " + to_string_dec_int(config_freq_rx_correction_updown()));
     pmem_dump_file.write_line("updown_frequency_tx_correction: " + to_string_dec_int(config_freq_tx_correction_updown()));
-    pmem_dump_file.write_line("lcd_inverted_mode: " + to_string_dec_uint(config_lcd_inverted_mode()));
+    pmem_dump_file.write_line("lcd_normally_black: " + to_string_dec_uint(config_lcd_normally_black()));
     pmem_dump_file.write_line("converter_frequency_offset: " + to_string_dec_int(config_converter_freq()));
     pmem_dump_file.write_line("frequency_rx_correction: " + to_string_dec_uint(config_freq_rx_correction()));
     pmem_dump_file.write_line("frequency_tx_correction: " + to_string_dec_uint(config_freq_tx_correction()));

--- a/firmware/application/portapack.cpp
+++ b/firmware/application/portapack.cpp
@@ -538,7 +538,6 @@ init_status_t init() {
 
     set_cpu_clock_speed();
 
-    if (persistent_memory::config_lcd_inverted_mode()) display.set_inverted(true);
     /* sample max: 1023 sample_t AKA uint16_t
      * touch_sensitivity: range: 1 to 128
      * threshold range: 1023/1 to 1023/128  =  1023 to 8

--- a/firmware/application/ui_navigation.cpp
+++ b/firmware/application/ui_navigation.cpp
@@ -380,7 +380,7 @@ void SystemStatusView::refresh() {
     // Display "Disable speaker" icon only if AK4951 Codec which has separate speaker/headphone control
     if (audio::speaker_disable_supported() && !pmem::ui_hide_speaker()) status_icons.add(&toggle_speaker);
 
-    if (!pmem::ui_hide_fake_brightness() && !pmem::config_lcd_inverted_mode()) status_icons.add(&button_fake_brightness);
+    if (!pmem::ui_hide_fake_brightness()) status_icons.add(&button_fake_brightness);
     if (battery::BatteryManagement::isDetected()) {
         batt_was_inited = true;
         if (!pmem::ui_hide_battery_icon()) {
@@ -414,7 +414,7 @@ void SystemStatusView::refresh() {
     button_converter.set_foreground(pmem::config_converter() ? Theme::getInstance()->fg_red->foreground : Theme::getInstance()->fg_light->foreground);
 
     // Fake Brightness
-    button_fake_brightness.set_foreground((pmem::apply_fake_brightness() & (!pmem::config_lcd_inverted_mode())) ? *Theme::getInstance()->status_active : Theme::getInstance()->fg_light->foreground);
+    button_fake_brightness.set_foreground(pmem::apply_fake_brightness()  ? *Theme::getInstance()->status_active : Theme::getInstance()->fg_light->foreground);
 
     set_dirty();
 }

--- a/firmware/application/ui_navigation.cpp
+++ b/firmware/application/ui_navigation.cpp
@@ -414,7 +414,7 @@ void SystemStatusView::refresh() {
     button_converter.set_foreground(pmem::config_converter() ? Theme::getInstance()->fg_red->foreground : Theme::getInstance()->fg_light->foreground);
 
     // Fake Brightness
-    button_fake_brightness.set_foreground(pmem::apply_fake_brightness()  ? *Theme::getInstance()->status_active : Theme::getInstance()->fg_light->foreground);
+    button_fake_brightness.set_foreground(pmem::apply_fake_brightness() ? *Theme::getInstance()->status_active : Theme::getInstance()->fg_light->foreground);
 
     set_dirty();
 }

--- a/firmware/common/lcd_ili9341.cpp
+++ b/firmware/common/lcd_ili9341.cpp
@@ -146,13 +146,12 @@ void lcd_init() {
     // NL = 0b100111 (default)
     // PCDIV = 0b000000 (default?)
 
-
-    /*as per the datasheet chapter 8.3.7, addr B6h, 
+    /*as per the datasheet chapter 8.3.7, addr B6h,
     data "REV" bit, liquid crystal type:*/
-    if(portapack::persistent_memory::config_lcd_normally_black())
-        io.lcd_data_write_command_and_data(0xB6, {0x0A, 0x22, 0x27, 0x00}); //IPS : normally black : 0
+    if (portapack::persistent_memory::config_lcd_normally_black())
+        io.lcd_data_write_command_and_data(0xB6, {0x0A, 0x22, 0x27, 0x00});  // IPS : normally black : 0
     else
-        io.lcd_data_write_command_and_data(0xB6, {0x0A, 0xA2, 0x27, 0x00}); //TFT : normally white : 1
+        io.lcd_data_write_command_and_data(0xB6, {0x0A, 0xA2, 0x27, 0x00});  // TFT : normally white : 1
 
     // Power Control 1
     // VRH[5:0]
@@ -317,8 +316,6 @@ void ILI9341::sleep() {
 void ILI9341::wake() {
     lcd_wake();
 }
-
-
 
 void ILI9341::fill_rectangle(ui::Rect r, const ui::Color c) {
     const auto r_clipped = r.intersect(screen_rect());

--- a/firmware/common/lcd_ili9341.cpp
+++ b/firmware/common/lcd_ili9341.cpp
@@ -33,6 +33,8 @@ using namespace portapack;
 
 #include "file.hpp"
 
+#include "portapack_persistent_memory.hpp"
+
 #include <complex>
 
 #include <cstring>
@@ -143,7 +145,14 @@ void lcd_init() {
     // REV = 1 (normally white)
     // NL = 0b100111 (default)
     // PCDIV = 0b000000 (default?)
-    io.lcd_data_write_command_and_data(0xB6, {0x0A, 0xA2, 0x27, 0x00});
+
+
+    /*as per the datasheet chapter 8.3.7, addr B6h, 
+    data "REV" bit, liquid crystal type:*/
+    if(portapack::persistent_memory::config_lcd_normally_black())
+        io.lcd_data_write_command_and_data(0xB6, {0x0A, 0x22, 0x27, 0x00}); //IPS : normally black : 0
+    else
+        io.lcd_data_write_command_and_data(0xB6, {0x0A, 0xA2, 0x27, 0x00}); //TFT : normally white : 1
 
     // Power Control 1
     // VRH[5:0]
@@ -309,13 +318,7 @@ void ILI9341::wake() {
     lcd_wake();
 }
 
-void ILI9341::set_inverted(bool invert) {
-    if (invert) {
-        io.lcd_data_write_command_and_data(0x21, {});
-    } else {
-        io.lcd_data_write_command_and_data(0x20, {});
-    }
-}
+
 
 void ILI9341::fill_rectangle(ui::Rect r, const ui::Color c) {
     const auto r_clipped = r.intersect(screen_rect());

--- a/firmware/common/lcd_ili9341.hpp
+++ b/firmware/common/lcd_ili9341.hpp
@@ -50,7 +50,6 @@ class ILI9341 {
     void sleep();
     void wake();
 
-
     void fill_rectangle(ui::Rect r, const ui::Color c);
     void fill_rectangle_unrolled8(ui::Rect r, const ui::Color c);
     void draw_line(const ui::Point start, const ui::Point end, const ui::Color color);

--- a/firmware/common/lcd_ili9341.hpp
+++ b/firmware/common/lcd_ili9341.hpp
@@ -50,7 +50,6 @@ class ILI9341 {
     void sleep();
     void wake();
 
-    void set_inverted(bool invert);
 
     void fill_rectangle(ui::Rect r, const ui::Color c);
     void fill_rectangle_unrolled8(ui::Rect r, const ui::Color c);

--- a/firmware/common/portapack_io.cpp
+++ b/firmware/common/portapack_io.cpp
@@ -78,11 +78,11 @@ void IO::reference_oscillator(const bool enable) {
 }
 
 bool IO::get_dark_cover() {
-    return portapack::persistent_memory::apply_fake_brightness() & (!portapack::persistent_memory::config_lcd_inverted_mode());
+    return portapack::persistent_memory::apply_fake_brightness();
 }
 
-bool IO::get_is_inverted() {
-    return portapack::persistent_memory::config_lcd_inverted_mode();
+bool IO::get_is_normally_black() {
+    return portapack::persistent_memory::config_lcd_normally_black();
 }
 
 uint8_t IO::get_brightness() {
@@ -90,7 +90,7 @@ uint8_t IO::get_brightness() {
 }
 
 void IO::update_cached_values() {
-    inverted_enabled = get_is_inverted();
+    lcd_normally_black = get_is_normally_black();
     dark_cover_enabled = get_dark_cover();
     brightness = get_brightness();
 }

--- a/firmware/common/portapack_io.hpp
+++ b/firmware/common/portapack_io.hpp
@@ -231,10 +231,10 @@ class IO {
 
         return switches_raw;
     }
-    bool inverted_enabled = false;
+    bool lcd_normally_black = false;
     bool dark_cover_enabled = false;
     uint8_t brightness = 0;
-    bool get_is_inverted();
+    bool get_is_normally_black();
     bool get_dark_cover();
     uint8_t get_brightness();
     void update_cached_values();
@@ -419,7 +419,7 @@ class IO {
         const auto value_low = data_read();
         uint32_t original_value = (value_high << 8) | value_low;
 
-        if (inverted_enabled) return original_value;
+        if (lcd_normally_black) return original_value;
 
         if (dark_cover_enabled) {
             // this is read data, so if the fake brightness is enabled AKA get_dark_cover() == true,

--- a/firmware/common/portapack_persistent_memory.cpp
+++ b/firmware/common/portapack_persistent_memory.cpp
@@ -211,7 +211,7 @@ struct data_t {
     bool updown_converter;
     bool updown_frequency_rx_correction;
     bool updown_frequency_tx_correction;
-    bool lcd_inverted_mode : 1;
+    bool lcd_normally_black : 1;
     bool encoder_dial_direction : 1;  // false = normal, true = reverse
     bool UNUSED_6 : 1;
     bool UNUSED_7 : 1;
@@ -289,7 +289,7 @@ struct data_t {
           updown_converter(false),
           updown_frequency_rx_correction(false),
           updown_frequency_tx_correction(false),
-          lcd_inverted_mode(false),
+          lcd_normally_black(false),
           encoder_dial_direction(false),
           UNUSED_6(false),
           UNUSED_7(false),
@@ -1090,12 +1090,12 @@ void set_config_freq_rx_correction(uint32_t v) {
     data->frequency_rx_correction = v;
 }
 
-// LCD invert
-bool config_lcd_inverted_mode() {
-    return data->lcd_inverted_mode;
+// IPS vs TFT
+bool config_lcd_normally_black() {
+    return data->lcd_normally_black;
 }
-void set_lcd_inverted_mode(bool v) {
-    data->lcd_inverted_mode = v;
+void set_lcd_normally_black(bool v) {
+    data->lcd_normally_black = v;
 }
 
 // Rotary encoder dial settings
@@ -1164,7 +1164,6 @@ void set_fake_brightness_level(uint8_t v) {
 // Cycle through 4 brightness options: disabled -> enabled/50% -> enabled/25% -> enabled/12.5% -> disabled
 void toggle_fake_brightness_level() {
     bool fbe = apply_fake_brightness();
-    if (config_lcd_inverted_mode()) return;  // for now only inverted mode OR fake brightness
     if ((!fbe) || (data->fake_brightness_level >= BRIGHTNESS_12p5)) {
         set_apply_fake_brightness(!fbe);
         data->fake_brightness_level = BRIGHTNESS_50;

--- a/firmware/common/portapack_persistent_memory.hpp
+++ b/firmware/common/portapack_persistent_memory.hpp
@@ -249,8 +249,8 @@ void set_config_audio_mute(bool v);
 void set_config_speaker_disable(bool v);
 void set_config_backlight_timer(const backlight_config_t& new_value);
 void set_disable_touchscreen(bool v);
-bool config_lcd_inverted_mode();
-void set_lcd_inverted_mode(bool v);
+bool config_lcd_normally_black();
+void set_lcd_normally_black(bool v);
 
 uint8_t encoder_dial_sensitivity();
 void set_encoder_dial_sensitivity(uint8_t v);


### PR DESCRIPTION
- Technically the old "revert" method works the same, but during chip performance the "revert" is actually lower accuracy and also color level depth, which caused image a bit glitch and color a bit inaccurate.
- I found this setting on datasheet and it works.
![image](https://github.com/user-attachments/assets/90daa7b3-a736-4fe7-b8c8-95a1c8b3dc30)
![image](https://github.com/user-attachments/assets/ec5b9a13-5f87-466a-9883-828d8b5335f3)
- since issue are gone, i brought brightness for IPS screen back
- rename some func name and var name to prevent misunderstood
- the HackRF mode screen is still reverted because the HackRF driving the screen separately. And it would cost too much to port pmem to HackRF mode code. I'll leave it as is until we have elegant solution

tested with @tehrabbitt