### PR TITLE
Fix bug that created by PR "Added menu group for transceivers"

### DIFF
--- a/firmware/application/ui_navigation.cpp
+++ b/firmware/application/ui_navigation.cpp
@@ -854,7 +854,9 @@ void TranceiversMenuView::on_populate() {
         add_items({{"..", Theme::getInstance()->fg_light->foreground, &bitmap_icon_previous, [this]() { nav_.pop(); }}});
     }
     add_apps(nav_, *this, TRX);
-    add_external_items(nav_, app_location_t::TRX, *this, return_icon ? 1 : 0);
+    // add_external_items(nav_, app_location_t::TRX, *this, return_icon ? 1 : 0);
+    // this folder doesn't have external apps, comment to prevent pop the err msg.
+    // NB: when has external app someday, uncomment this.
 }
 
 /* UtilitiesMenuView *****************************************************/


### PR DESCRIPTION
in #2623 it loaded external apps, but since external apps doesn't exist in this folder, which cause it pop out a err hint. 

(not real error, i wrote that hint just to alert user they didn't load external app)

Q: why not fix the logic of add_external_items func
A: it uses `std::vector<ExternalItemsMenuLoader::GridItemEx> ExternalItemsMenuLoader::load_external_items(app_location_t app_location, NavigationView& nav)` to fetch an vec of external app list, it's not worth to overload once just for this purpose, however it would look more "automatic" but it causes more chaotic in long run.