### PR TITLE
Add all jammer modes in hopper app

### DIFF
--- a/firmware/application/external/hopper/ui_hopper.hpp
+++ b/firmware/application/external/hopper/ui_hopper.hpp
@@ -143,6 +143,13 @@ class HopperView : public View {
             {"FM tone", 1},
             {"CW sweep", 2},
             {"Rand CW", 3},
+            {"Sine", 4},
+            {"Square", 5},
+            {"Sawtooth", 6},
+            {"Triangle", 7},
+            {"Chirp", 8},
+            {"Gauss", 9},
+            {"Brute", 10},
         }};
 
     Text text_range_number{


### PR DESCRIPTION
Added all modes that jammer app supports in hopper app.

## Brief description what you did
Well... Small change, but now the hopper app supports all the modes of the jammer app, no more, no less...

## Checklist
- [x]  Kept changes minimal and limited to necessary files
- [x]  Verified functionality remains intact and code compiles
