### PR TITLE
rename my names in comments

### DIFF
--- a/firmware/application/apps/ui_settings.cpp
+++ b/firmware/application/apps/ui_settings.cpp
@@ -6,7 +6,7 @@
  * Copyright (C) 2024 Mark Thompson
  * Copyright (C) 2024 u-foka
  * Copyright (C) 2024 HTotoo
- * Copyleft (ɔ) 2024 zxkmm under GPL license
+ * copyleft 2024 zxkmm AKA zix aka sommermorgentraum
  *
  * This file is part of PortaPack.
  *

--- a/firmware/application/apps/ui_settings.hpp
+++ b/firmware/application/apps/ui_settings.hpp
@@ -5,7 +5,7 @@
  * Copyright (C) 2023 Kyle Reed
  * Copyright (C) 2024 Mark Thompson
  * Copyright (C) 2024 u-foka
- * Copyleft (ɔ) 2024 zxkmm under GPL license
+ * copyleft 2024 zxkmm AKA zix aka sommermorgentraum
  *
  * This file is part of PortaPack.
  *

--- a/firmware/application/external/app_manager/ui_app_manager.cpp
+++ b/firmware/application/external/app_manager/ui_app_manager.cpp
@@ -1,5 +1,5 @@
 /*
- * copyleft spammingdramaqueen
+ * copyleft 2024 zxkmm AKA zix aka sommermorgentraum
  *
  * This file is part of PortaPack.
  *

--- a/firmware/application/external/app_manager/ui_app_manager.hpp
+++ b/firmware/application/external/app_manager/ui_app_manager.hpp
@@ -1,5 +1,5 @@
 /*
- * copyleft spammingdramaqueen
+ * copyleft 2024 zxkmm AKA zix aka sommermorgentraum
  *
  * This file is part of PortaPack.
  *

--- a/firmware/application/external/font_viewer/ui_font_viewer.cpp
+++ b/firmware/application/external/font_viewer/ui_font_viewer.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2023 Mark Thompson
- * copyleft Whiterose of the Dark Army
+ * copyleft 2024 zxkmm AKA zix aka sommermorgentraum
  *
  * This file is part of PortaPack.
  *

--- a/firmware/application/external/font_viewer/ui_font_viewer.hpp
+++ b/firmware/application/external/font_viewer/ui_font_viewer.hpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2023 Mark Thompson
- * copyleft Whiterose of the Dark Army
+ * copyleft 2024 zxkmm AKA zix aka sommermorgentraum
  *
  * This file is part of PortaPack.
  *

--- a/firmware/application/external/hopper/ui_hopper.cpp
+++ b/firmware/application/external/hopper/ui_hopper.cpp
@@ -2,7 +2,7 @@
  * Copyright (C) 2015 Jared Boone, ShareBrained Technology, Inc.
  * Copyright (C) 2016 Furrtek
  * Copyright (C) 2020 euquiq
- * copyleft mr.r0b0t from the F society
+ * copyleft 2024 zxkmm AKA zix aka sommermorgentraum
  *
  * This file is part of PortaPack.
  *

--- a/firmware/application/external/hopper/ui_hopper.hpp
+++ b/firmware/application/external/hopper/ui_hopper.hpp
@@ -2,7 +2,7 @@
  * Copyright (C) 2015 Jared Boone, ShareBrained Technology, Inc.
  * Copyright (C) 2016 Furrtek
  * Copyright (C) 2020 euquiq
- * copyleft mr.r0b0t from the F society
+ * copyleft 2024 zxkmm AKA zix aka sommermorgentraum
  *
  * This file is part of PortaPack.
  *

--- a/firmware/application/external/metronome/ui_metronome.cpp
+++ b/firmware/application/external/metronome/ui_metronome.cpp
@@ -1,5 +1,5 @@
 /*
- * copyleft 2024 sommermorgentraum
+ * copyleft 2024 zxkmm AKA zix aka sommermorgentraum
  *
  * This file is part of PortaPack.
  *

--- a/firmware/application/external/metronome/ui_metronome.hpp
+++ b/firmware/application/external/metronome/ui_metronome.hpp
@@ -1,5 +1,5 @@
 /*
- * copyleft 2024 sommermorgentraum
+ * copyleft 2024 zxkmm AKA zix aka sommermorgentraum
  *
  * This file is part of PortaPack.
  *

--- a/firmware/application/external/ook_editor/ui_ook_editor.cpp
+++ b/firmware/application/external/ook_editor/ui_ook_editor.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 2024 Samir Sánchez Garnica @sasaga92
- * copyleft Elliot Alderson from F society
- * copyleft Darlene Alderson from F society
+ * copyleft 2024 zxkmm AKA zix aka sommermorgentraum
+
  *
  * This file is part of PortaPack.
  *

--- a/firmware/application/external/ook_editor/ui_ook_editor.hpp
+++ b/firmware/application/external/ook_editor/ui_ook_editor.hpp
@@ -1,7 +1,6 @@
 /*
  * Copyright (C) 2024 Samir Sánchez Garnica @sasaga92
- * copyleft Elliot Alderson from F society
- * copyleft Darlene Alderson from F society
+ * copyleft 2024 zxkmm AKA zix aka sommermorgentraum
  *
  * This file is part of PortaPack.
  *

--- a/firmware/application/external/ookbrute/ui_ookbrute.cpp
+++ b/firmware/application/external/ookbrute/ui_ookbrute.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2024 HTotoo
- * copyleft Whiterose of the Dark Army
+ * copyleft 2024 zxkmm AKA zix aka sommermorgentraum
  *
  * This file is part of PortaPack.
  *

--- a/firmware/application/external/ookbrute/ui_ookbrute.hpp
+++ b/firmware/application/external/ookbrute/ui_ookbrute.hpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2024 HTotoo
- * copyleft Whiterose of the Dark Army
+ * copyleft 2024 zxkmm AKA zix aka sommermorgentraum
  *
  * This file is part of PortaPack.
  *

--- a/firmware/application/external/playlist_editor/ui_playlist_editor.cpp
+++ b/firmware/application/external/playlist_editor/ui_playlist_editor.cpp
@@ -1,6 +1,5 @@
 /*
- * copyleft Elliot Alderson from F society
- * copyleft Darlene Alderson from F society
+ * copyleft 2025 zxkmm AKA zix aka sommermorgentraum
  *
  * This file is part of PortaPack.
  *

--- a/firmware/application/external/playlist_editor/ui_playlist_editor.hpp
+++ b/firmware/application/external/playlist_editor/ui_playlist_editor.hpp
@@ -1,6 +1,5 @@
 /*
- * copyleft Elliot Alderson from F society
- * copyleft Darlene Alderson from F society
+ * copyleft 2025 zxkmm AKA zix aka sommermorgentraum
  *
  * This file is part of PortaPack.
  *

--- a/firmware/application/external/stopwatch/ui_stopwatch.cpp
+++ b/firmware/application/external/stopwatch/ui_stopwatch.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2025 Mark Thompson
- * copyleft Mr. Robot of F.Society
+ * copyleft 2025 zxkmm AKA zix aka sommermorgentraum
  *
  * This file is part of PortaPack.
  *

--- a/firmware/application/external/stopwatch/ui_stopwatch.hpp
+++ b/firmware/application/external/stopwatch/ui_stopwatch.hpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2025 Mark Thompson
- * copyleft Mr. Robot of F.Society
+ * copyleft 2025 zxkmm AKA zix aka sommermorgentraum
  *
  * This file is part of PortaPack.
  *

--- a/firmware/application/external/tuner/ui_tuner.cpp
+++ b/firmware/application/external/tuner/ui_tuner.cpp
@@ -1,5 +1,5 @@
 /*
- * copyleft 2024 sommermorgentraum
+ * copyleft 2024 zxkmm AKA zix aka sommermorgentraum
  *
  * This file is part of PortaPack.
  *

--- a/firmware/application/external/tuner/ui_tuner.hpp
+++ b/firmware/application/external/tuner/ui_tuner.hpp
@@ -1,5 +1,5 @@
 /*
- * copyleft 2024 sommermorgentraum
+ * copyleft 2024 zxkmm AKA zix aka sommermorgentraum
  *
  * This file is part of PortaPack.
  *

--- a/firmware/application/hw/touch_adc.cpp
+++ b/firmware/application/hw/touch_adc.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2015 Jared Boone, ShareBrained Technology, Inc.
- * copyleft (ɔ) 2023 zxkmm under GPL license
+ * copyleft 2023 zxkmm AKA zix aka sommermorgentraum
  * Copyright (C) 2023 u-foka
  *
  * This file is part of PortaPack.

--- a/firmware/application/hw/touch_adc.hpp
+++ b/firmware/application/hw/touch_adc.hpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2015 Jared Boone, ShareBrained Technology, Inc.
- * copyleft (ɔ) 2023 zxkmm under GPL license
+ * copyleft 2023 zxkmm AKA zix aka sommermorgentraum
  * Copyright (C) 2023 u-foka
  *
  * This file is part of PortaPack.

--- a/firmware/application/ui/ui_btngrid.cpp
+++ b/firmware/application/ui/ui_btngrid.cpp
@@ -4,7 +4,7 @@
  * Copyright (C) 2019 Elia Yehuda (z4ziggy)
  * Copyright (C) 2023 Mark Thompson
  * Copyright (C) 2024 u-foka
- * Copyleft (ↄ) 2024 zxkmm with the GPL license
+ * copyleft 2024 zxkmm AKA zix aka sommermorgentraum
  *
  * This file is part of PortaPack.
  *

--- a/firmware/application/ui/ui_spectrum.cpp
+++ b/firmware/application/ui/ui_spectrum.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2015 Jared Boone, ShareBrained Technology, Inc.
- * Copyleft Mr. Robot 2025
+ * copyleft 2025 zxkmm AKA zix aka sommermorgentraum
  *
  * This file is part of PortaPack.
  *

--- a/firmware/application/ui/ui_spectrum.hpp
+++ b/firmware/application/ui/ui_spectrum.hpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2015 Jared Boone, ShareBrained Technology, Inc.
- * Copyleft Mr. Robot 2025
+ * copyleft 2025 zxkmm AKA zix aka sommermorgentraum
  *
  * This file is part of PortaPack.
  *

--- a/firmware/application/ui_navigation.cpp
+++ b/firmware/application/ui_navigation.cpp
@@ -2,7 +2,7 @@
  * Copyright (C) 2015 Jared Boone, ShareBrained Technology, Inc.
  * Copyright (C) 2016 Furrtek
  * Copyright (C) 2024 u-foka
- * Copyleft (ɔ) 2024 zxkmm under GPL license
+ * copyleft 2024 zxkmm AKA zix aka sommermorgentraum
  *
  * This file is part of PortaPack.
  *

--- a/firmware/application/ui_navigation.hpp
+++ b/firmware/application/ui_navigation.hpp
@@ -2,7 +2,7 @@
  * Copyright (C) 2015 Jared Boone, ShareBrained Technology, Inc.
  * Copyright (C) 2016 Furrtek
  * Copyright (C) 2024 u-foka
- * Copyleft (ɔ) 2024 zxkmm under GPL license
+ * copyleft 2024 zxkmm AKA zix aka sommermorgentraum
  *
  * This file is part of PortaPack.
  *

--- a/firmware/application/usb_serial_asyncmsg.cpp
+++ b/firmware/application/usb_serial_asyncmsg.cpp
@@ -1,6 +1,4 @@
 /*
- * Copyright (C) 2015 Jared Boone, ShareBrained Technology, Inc.
- * Copyright (C) 2017 Furrtek
  * copyleft 2024 zxkmm AKA zix aka sommermorgentraum
  * Copyright (C) 2024 HTotoo
  *

--- a/firmware/application/usb_serial_asyncmsg.cpp
+++ b/firmware/application/usb_serial_asyncmsg.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 2015 Jared Boone, ShareBrained Technology, Inc.
  * Copyright (C) 2017 Furrtek
- * Copyleft (ɔ) 2024 zxkmm with the GPL license
+ * copyleft 2024 zxkmm AKA zix aka sommermorgentraum
  * Copyright (C) 2024 HTotoo
  *
  * This file is part of PortaPack.

--- a/firmware/application/usb_serial_asyncmsg.hpp
+++ b/firmware/application/usb_serial_asyncmsg.hpp
@@ -1,7 +1,5 @@
 /*
- * Copyright (C) 2015 Jared Boone, ShareBrained Technology, Inc.
- * Copyright (C) 2017 Furrtek
- * Copyleft (ɔ) 2024 zxkmm with the GPL license
+ * copyleft 2024 zxkmm AKA zix aka sommermorgentraum
  * Copyright (C) 2024 HTotoo
  *
  * This file is part of PortaPack.

--- a/firmware/common/lcd_ili9341.cpp
+++ b/firmware/common/lcd_ili9341.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 2014 Jared Boone, ShareBrained Technology, Inc.
  * Copyright (C) 2016 Furrtek
- * copyleft 2025 Whiterose of the Dark Army
+ * copyleft 2024 zxkmm AKA zix aka sommermorgentraum
  *
  * This file is part of PortaPack.
  *

--- a/firmware/common/portapack_io.cpp
+++ b/firmware/common/portapack_io.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2014 Jared Boone, ShareBrained Technology, Inc.
- * Copyleft (ɔ) 2024 zxkmm under GPL license
+ * copyleft 2024 zxkmm AKA zix aka sommermorgentraum
  *
  * This file is part of PortaPack.
  *

--- a/firmware/common/portapack_io.hpp
+++ b/firmware/common/portapack_io.hpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2014 Jared Boone, ShareBrained Technology, Inc.
- * Copyleft (ɔ) 2024 zxkmm under GPL license
+ * copyleft 2024 zxkmm AKA zix aka sommermorgentraum
  * Copyright (C) 2024 u-foka
  * Copyright (C) 2024 Mark Thompson
  *

--- a/firmware/common/ui_painter.cpp
+++ b/firmware/common/ui_painter.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2014 Jared Boone, ShareBrained Technology, Inc.
- * copyleft Mr. Robot
+ * copyleft 2024 zxkmm AKA zix aka sommermorgentraum
  *
  * This file is part of PortaPack.
  *

--- a/firmware/common/ui_painter.hpp
+++ b/firmware/common/ui_painter.hpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2014 Jared Boone, ShareBrained Technology, Inc.
- * copyleft Mr. Robot
+ * copyleft 2024 zxkmm AKA zix aka sommermorgentraum
  *
  * This file is part of PortaPack.
  *

--- a/firmware/tools/bitmap_tools/bitmap_arr_reverse_decode.py
+++ b/firmware/tools/bitmap_tools/bitmap_arr_reverse_decode.py
@@ -1,8 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# Copyright (C) 2015 Jared Boone, ShareBrained Technology, Inc.
-# Copyleft (ɔ) 2024 zxkmm with the GPL license
+# copyleft 2024 zxkmm AKA zix aka sommermorgentraum
 #
 # This file is part of PortaPack.
 #

--- a/firmware/tools/bitmap_tools/pp_png2hpp.py
+++ b/firmware/tools/bitmap_tools/pp_png2hpp.py
@@ -4,7 +4,7 @@
 #  make_bitmap.py - Copyright (C) 2016 Furrtek
 # Convert bitmap.hpp to icons inspired by
 #  bitmap_arr_reverse_decode.py - Copyright (C) 2015 Jared Boone, ShareBrained Technology, Inc.
-#  bitmap_arr_reverse_decode.py - Copyleft (ɔ) 2024 zxkmm with the GPL license
+#  bitmap_arr_reverse_decode.py - copyleft 2024 zxkmm AKA zix aka sommermorgentraum
 # Copysomething (c) 2024 LupusE with the license, needed by the PortaPack project
 # 
 # This program is free software; you can redistribute it and/or modify

--- a/firmware/tools/bmp_tools/bmp_to_hex_cpp_arr.py
+++ b/firmware/tools/bmp_tools/bmp_to_hex_cpp_arr.py
@@ -1,4 +1,4 @@
-# copyleft zxkmm 2024
+# copyleft 2024 zxkmm AKA zix aka sommermorgentraum
 
 import os
 import sys

--- a/firmware/tools/bmp_tools/hex_cpp_arr_to_bmp.py
+++ b/firmware/tools/bmp_tools/hex_cpp_arr_to_bmp.py
@@ -1,4 +1,4 @@
-# copyleft zxkmm 2024
+# copyleft 2024 zxkmm AKA zix aka sommermorgentraum
 
 import sys
 import re

--- a/firmware/tools/check_external_app_linker_script_correct.py
+++ b/firmware/tools/check_external_app_linker_script_correct.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# Copyleft (ɔ) 2024 Whiterose from the Dark Army
+# copyleft 2025 zxkmm AKA zix aka sommermorgentraum
 #
 # This file is part of PortaPack.
 #

--- a/firmware/tools/check_gcc_version_from_elf.py
+++ b/firmware/tools/check_gcc_version_from_elf.py
@@ -1,8 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# Copyright (C) 2015 Jared Boone, ShareBrained Technology, Inc.
-# Copyleft (ɔ) 2024 zxkmm with the GPL license
+# copyleft 2024 zxkmm AKA zix aka sommermorgentraum
 #
 # This file is part of PortaPack.
 #

--- a/firmware/tools/fast_flash_pp_and_copy_apps.py
+++ b/firmware/tools/fast_flash_pp_and_copy_apps.py
@@ -1,4 +1,4 @@
-# Copyleft Whiterose from the Dark Army
+# copyleft 2024 zxkmm AKA zix aka sommermorgentraum
 #
 # This file is part of PortaPack.
 #

--- a/firmware/tools/make_spi_image.py
+++ b/firmware/tools/make_spi_image.py
@@ -3,7 +3,7 @@
 #
 # Copyright (C) 2015 Jared Boone, ShareBrained Technology, Inc.
 # Copyright (C) 2024 Mark Thompson
-# Copyleft (ɔ) 2024 zxkmm with the GPL license
+# copyleft 2025 zxkmm AKA zix aka sommermorgentraum
 #
 # This file is part of PortaPack.
 #

--- a/firmware/tools/widget_preview.py
+++ b/firmware/tools/widget_preview.py
@@ -1,6 +1,5 @@
 #
-# copyleft Elliot Alderson from F society
-# copyleft Darlene Alderson from F society
+# copyleft 2025 zxkmm AKA zix aka sommermorgentraum
 #
 # This file is part of PortaPack.
 #


### PR DESCRIPTION
Sorry for the spam PR.
- Previously, in copy right/left comment messages, I used some of the Mr. Robot characters' names because it was fun.
- And now I need to build my IP cuz I'm seriously needed to work to make money. So this change may help me find more changes.

- I didn't change name order for example move mine above others.
- For those files that I wrote from stretch, I deleted the old copyright message.