### PR TITLE
Fix standalone touch_release event

### DIFF
--- a/firmware/application/apps/ui_standalone_view.cpp
+++ b/firmware/application/apps/ui_standalone_view.cpp
@@ -287,7 +287,7 @@ bool StandaloneView::on_touch(const TouchEvent event) {
     if (get_application_information()->header_version > 1) {
         get_application_information()->OnTouchEvent(event.point.x(), event.point.y(), (uint32_t)event.type);
     }
-    return false;
+    return true;
 }
 
 bool StandaloneView::on_keyboard(const KeyboardEvent event) {


### PR DESCRIPTION
By set return true, it'll tell the touch manager, there is a widget, that can handle it. and it'll store the result, and it'll pass the other events (like touch end) to that widget.

without it, we only got the touch start.