### PR TITLE
fix ctrl click link

### DIFF
--- a/flashing/flash_portapack_mayhem.bat
+++ b/flashing/flash_portapack_mayhem.bat
@@ -23,6 +23,10 @@ if not exist portapack-mayhem-firmware.bin (
 
 "utils/hackrf_update.exe" portapack-mayhem-firmware.bin
 echo.
-echo If your device never boot after flashing, please refer to https://github.com/portapack-mayhem/mayhem-firmware/wiki/Won%%27t-boot
+echo If your device never boot after flashing, please refer to won't boot article"
+echo.
+echo "click-to-open url: https://github.com/portapack-mayhem/mayhem-firmware/wiki/Won%%27t-boot"
+echo "or
+echo "copy-and-paste url: https://github.com/portapack-mayhem/mayhem-firmware/wiki/Won't-boot"
 echo.
 pause


### PR DESCRIPTION
## Brief description what you did
Fix for https://github.com/portapack-mayhem/mayhem-firmware/issues/2821, apostrophes in links won't play correctly in shell scripts and control-clicks to open them. Changed the apostrophe to an urlencoded character.

