### PR TITLE
fix some bugs due to framesync not fired on stealth mode

### DIFF
--- a/firmware/application/event_m0.hpp
+++ b/firmware/application/event_m0.hpp
@@ -133,7 +133,7 @@ class EventDispatcher {
     void on_keyboard_event(ui::KeyboardEvent event);
 
     // void blink_timer();
-    void handle_lcd_frame_sync();
+    void handle_lcd_frame_sync(bool screen_on);
     void handle_switches();
     void handle_encoder();
     void handle_touch();

--- a/firmware/common/lcd_ili9341.cpp
+++ b/firmware/common/lcd_ili9341.cpp
@@ -77,13 +77,17 @@ void lcd_display_off() {
     io.lcd_data_write_command_and_data(0x28, {});
 }
 
-void lcd_sleep() {
+void lcd_sleep(bool hw_sleep = true) {
     lcd_display_off();
-    lcd_sleep_in();
+    if (hw_sleep) {
+        lcd_sleep_in();
+    }
 }
 
-void lcd_wake() {
-    lcd_sleep_out();
+void lcd_wake(bool hw_sleep = true) {
+    if (hw_sleep) {
+        lcd_sleep_out();
+    }
     lcd_display_on();
 }
 
@@ -394,12 +398,12 @@ void ILI9341::shutdown() {
     lcd_reset();
 }
 
-void ILI9341::sleep() {
-    lcd_sleep();
+void ILI9341::sleep(bool hw_sleep) {
+    lcd_sleep(hw_sleep);
 }
 
-void ILI9341::wake() {
-    lcd_wake();
+void ILI9341::wake(bool hw_sleep) {
+    lcd_wake(hw_sleep);
 }
 
 void ILI9341::fill_rectangle(ui::Rect r, const ui::Color c) {

--- a/firmware/common/lcd_ili9341.hpp
+++ b/firmware/common/lcd_ili9341.hpp
@@ -48,8 +48,8 @@ class ILI9341 {
     void init();
     void shutdown();
 
-    void sleep();
-    void wake();
+    void sleep(bool hw_sleep = true);
+    void wake(bool hw_sleep = true);
 
     void fill_rectangle(ui::Rect r, const ui::Color c);
     void fill_rectangle_unrolled8(ui::Rect r, const ui::Color c);


### PR DESCRIPTION
Explanations:

the framesync flag is set by some irq, that is not sent, when the screen is in sleep mode.
so we just prevent the lcd sleep mode, and check for subscriptions to that event.

but no painting.

this still draws more energy, but at least the stealth mode works as intended.

closes https://github.com/portapack-mayhem/mayhem-firmware/issues/2830
closes https://github.com/portapack-mayhem/mayhem-firmware/issues/1025