### PR TITLE
gracefully handle i2c error

### DIFF
--- a/firmware/chibios/os/hal/src/i2c.c
+++ b/firmware/chibios/os/hal/src/i2c.c
@@ -243,8 +243,10 @@ msg_t i2cMasterReceiveTimeout(I2CDriver* i2cp,
                    (timeout != TIME_IMMEDIATE),
                "i2cMasterReceiveTimeout");
 
-    chDbgAssert(i2cp->state == I2C_READY,
-                "i2cMasterReceive(), #1", "not ready");
+    // chDbgAssert(i2cp->state == I2C_READY, "i2cMasterReceive(), #1", "not ready");
+    if (i2cp->state != I2C_READY) {
+        return RDY_TIMEOUT;
+    }
 
     chSysLock();
     i2cp->errors = I2CD_NO_ERROR;


### PR DESCRIPTION
not sure if it is the best method to override chibios stuff, but this kinda works.
now no red box, but the caller should handle the error.

for the esp32pp it means: when ota in progress, there is no red box error on pp, but the esp vanishes from the pp's memory (it is needed). and when the esp reboots, it is discovered again, and initialized again. 