### PR TITLE
Revert "Additional debounce control parameters for rotary encoder settings (for bad/noisy encoders)"

### DIFF
--- a/firmware/application/apps/ui_settings.cpp
+++ b/firmware/application/apps/ui_settings.cpp
@@ -681,27 +681,35 @@ SetEncoderDialView::SetEncoderDialView(NavigationView& nav) {
     add_children({&labels,
                   &field_encoder_dial_sensitivity,
                   &field_encoder_rate_multiplier,
-                  &field_encoder_dial_direction,
-                  &field_encoder_consecutive_hits,
-                  &field_encoder_cooldown_ms,
-                  &field_encoder_debounce_ms,
                   &button_save,
-                  &button_cancel});
+                  &button_cancel,
+                  &button_dial_sensitivity_plus,
+                  &button_dial_sensitivity_minus,
+                  &button_rate_multiplier_plus,
+                  &button_rate_multiplier_minus,
+                  &field_encoder_dial_direction});
 
     field_encoder_dial_sensitivity.set_by_value(pmem::encoder_dial_sensitivity());
     field_encoder_rate_multiplier.set_value(pmem::encoder_rate_multiplier());
     field_encoder_dial_direction.set_by_value(pmem::encoder_dial_direction());
-    field_encoder_consecutive_hits.set_value(pmem::encoder_consecutive_hits());
-    field_encoder_cooldown_ms.set_value(pmem::encoder_cooldown_ms());
-    field_encoder_debounce_ms.set_value(pmem::encoder_debounce_ms());
+
+    button_dial_sensitivity_plus.on_select = [this](Button&) {
+        field_encoder_dial_sensitivity.on_encoder(1);
+    };
+    button_dial_sensitivity_minus.on_select = [this](Button&) {
+        field_encoder_dial_sensitivity.on_encoder(-1);
+    };
+    button_rate_multiplier_plus.on_select = [this](Button&) {
+        field_encoder_rate_multiplier.on_encoder(1);
+    };
+    button_rate_multiplier_minus.on_select = [this](Button&) {
+        field_encoder_rate_multiplier.on_encoder(-1);
+    };
 
     button_save.on_select = [&nav, this](Button&) {
         pmem::set_encoder_dial_sensitivity(field_encoder_dial_sensitivity.selected_index_value());
         pmem::set_encoder_rate_multiplier(field_encoder_rate_multiplier.value());
         pmem::set_encoder_dial_direction(field_encoder_dial_direction.selected_index_value());
-        pmem::set_encoder_consecutive_hits(field_encoder_consecutive_hits.value());
-        pmem::set_encoder_cooldown_ms(field_encoder_cooldown_ms.value());
-        pmem::set_encoder_debounce_ms(field_encoder_debounce_ms.value());
         nav.pop();
     };
 

--- a/firmware/application/apps/ui_settings.hpp
+++ b/firmware/application/apps/ui_settings.hpp
@@ -559,63 +559,58 @@ class SetEncoderDialView : public View {
 
    private:
     Labels labels{
-        {{1 * 8, 1 * 16}, "Sensitivity:", Theme::getInstance()->fg_light->foreground},
-        {{1 * 8, 4 * 16}, "Rate mult:", Theme::getInstance()->fg_light->foreground},
-        {{1 * 8, 7 * 16}, "Direction:", Theme::getInstance()->fg_light->foreground},
-        {{UI_POS_X(0), 9 * 16}, "--- Debounce (noisy dial) ---", Theme::getInstance()->fg_light->foreground},
-        {{1 * 8, 10 * 16}, "Consec hits:", Theme::getInstance()->fg_light->foreground},
-        {{1 * 8, 11 * 16}, "Cooldown ms:", Theme::getInstance()->fg_light->foreground},
-        {{1 * 8, 12 * 16}, "Debounce ms:", Theme::getInstance()->fg_light->foreground},
+        {{UI_POS_X(0), UI_POS_Y(0)}, "Sensitivity to dial rotation", Theme::getInstance()->fg_light->foreground},
+        {{UI_POS_X(0), 1 * 16}, "position (x steps per 360):", Theme::getInstance()->fg_light->foreground},
+        {{1 * 8, 3 * 16}, "Sensitivity:", Theme::getInstance()->fg_light->foreground},
+        {{UI_POS_X(0), 7 * 16}, "Rotation rate (default 1", Theme::getInstance()->fg_light->foreground},
+        {{UI_POS_X(0), 8 * 16}, "means no rate dependency):", Theme::getInstance()->fg_light->foreground},
+        {{2 * 8, 10 * 16}, "Rate multiplier:", Theme::getInstance()->fg_light->foreground},
+        {{4 * 8, 14 * 16}, "Direction:", Theme::getInstance()->fg_light->foreground},
 
     };
 
     OptionsField field_encoder_dial_sensitivity{
-        {14 * 8, 1 * 16},
+        {20 * 8, 3 * 16},
         6,
         {{"LOW", encoder_dial_sensitivity::DIAL_SENSITIVITY_LOW},
          {"NORMAL", encoder_dial_sensitivity::DIAL_SENSITIVITY_NORMAL},
          {"HIGH", encoder_dial_sensitivity::DIAL_SENSITIVITY_HIGH}}};
 
     NumberField field_encoder_rate_multiplier{
-        {14 * 8, 4 * 16},
+        {20 * 8, 10 * 16},
         2,
         {1, 15},
         1,
         ' '};
 
     OptionsField field_encoder_dial_direction{
-        {14 * 8, 7 * 16},
+        {18 * 8, 14 * 16},
         7,
         {{"NORMAL", false},
          {"REVERSE", true}}};
 
-    NumberField field_encoder_consecutive_hits{
-        {14 * 8, 10 * 16},
-        2,
-        {1, 10},
-        1,
-        ' '};
+    Button button_dial_sensitivity_plus{
+        {20 * 8, 2 * 16, 16, 16},
+        "+"};
 
-    NumberField field_encoder_cooldown_ms{
-        {14 * 8, 11 * 16},
-        3,
-        {0, 255},
-        5,
-        ' '};
+    Button button_dial_sensitivity_minus{
+        {20 * 8, 4 * 16, 16, 16},
+        "-"};
 
-    NumberField field_encoder_debounce_ms{
-        {14 * 8, 12 * 16},
-        2,
-        {4, 32},
-        2,
-        ' '};
+    Button button_rate_multiplier_plus{
+        {20 * 8, 9 * 16, 16, 16},
+        "+"};
+
+    Button button_rate_multiplier_minus{
+        {20 * 8, 11 * 16, 16, 16},
+        "-"};
 
     Button button_save{
-        {2 * 8, 14 * 16, 12 * 8, 24},
+        {UI_POS_X_CENTER(12) - UI_POS_WIDTH(8), UI_POS_Y_BOTTOM(4), 12 * 8, 32},
         "Save"};
 
     Button button_cancel{
-        {16 * 8, 14 * 16, 12 * 8, 24},
+        {UI_POS_X_CENTER(12) + UI_POS_WIDTH(8), UI_POS_Y_BOTTOM(4), 12 * 8, 32},
         "Cancel",
     };
 };

--- a/firmware/application/hw/debounce.hpp
+++ b/firmware/application/hw/debounce.hpp
@@ -78,7 +78,7 @@ class EncoderDebounce {
     uint8_t rotation_rate();  // returns last rotation rate
 
    private:
-    uint32_t history_{0};  // shift register of previous reads from encoder (16 samples @ 2 bits each)
+    uint8_t history_{0};  // shift register of previous reads from encoder
 
     uint8_t state_{0};  // actual encoder output state (after debounce logic)
 

--- a/firmware/application/hw/encoder.hpp
+++ b/firmware/application/hw/encoder.hpp
@@ -32,8 +32,6 @@ class Encoder {
    private:
     uint_fast8_t state{0};
     int_fast8_t prev_direction{0};
-    uint8_t direction_stability_count{0};  // count consecutive same-direction changes
-    uint8_t direction_cooldown{0};         // prevent rapid direction reversals
 };
 
 #endif /*__ENCODER_H__*/

--- a/firmware/common/portapack_persistent_memory.cpp
+++ b/firmware/common/portapack_persistent_memory.cpp
@@ -234,11 +234,6 @@ struct data_t {
 
     uint16_t UNUSED : 4;
 
-    // Encoder debounce parameters for noisy hardware
-    uint8_t encoder_consecutive_hits;  // Number of consecutive same-direction hits required (1-10)
-    uint8_t encoder_cooldown_ms;       // Cooldown period in ms after movement (0-255ms)
-    uint8_t encoder_debounce_ms;       // Debounce stability window in ms (4-32ms)
-
     // Headphone volume in centibels.
     int16_t headphone_volume_cb;
 
@@ -308,10 +303,6 @@ struct data_t {
           fake_brightness_level(BRIGHTNESS_50),
           encoder_rate_multiplier(1),
           UNUSED(0),
-
-          encoder_consecutive_hits(3),  // Default: 3 hits (Version 1 setting)
-          encoder_cooldown_ms(20),      // Default: 20ms (Version 1 setting)
-          encoder_debounce_ms(16),      // Default: 16ms stability window
 
           headphone_volume_cb(-600),
           misc_config(),
@@ -1128,38 +1119,6 @@ bool encoder_dial_direction() {
 }
 void set_encoder_dial_direction(bool v) {
     data->encoder_dial_direction = v;
-}
-
-// Encoder debounce parameters for noisy hardware
-uint8_t encoder_consecutive_hits() {
-    uint8_t v = data->encoder_consecutive_hits;
-    if (v == 0) v = 3;   // default to 3 if not set
-    if (v > 10) v = 10;  // cap at 10
-    return v;
-}
-void set_encoder_consecutive_hits(uint8_t v) {
-    if (v < 1) v = 1;    // minimum 1
-    if (v > 10) v = 10;  // maximum 10
-    data->encoder_consecutive_hits = v;
-}
-
-uint8_t encoder_cooldown_ms() {
-    return data->encoder_cooldown_ms;
-}
-void set_encoder_cooldown_ms(uint8_t v) {
-    data->encoder_cooldown_ms = v;
-}
-
-uint8_t encoder_debounce_ms() {
-    uint8_t v = data->encoder_debounce_ms;
-    if (v < 4) v = 16;   // default to 16ms if not set or too low
-    if (v > 32) v = 32;  // cap at 32ms
-    return v;
-}
-void set_encoder_debounce_ms(uint8_t v) {
-    if (v < 4) v = 4;    // minimum 4ms
-    if (v > 32) v = 32;  // maximum 32ms
-    data->encoder_debounce_ms = v;
 }
 
 // Recovery mode magic value storage

--- a/firmware/common/portapack_persistent_memory.hpp
+++ b/firmware/common/portapack_persistent_memory.hpp
@@ -259,13 +259,6 @@ void set_encoder_rate_multiplier(uint8_t v);
 bool encoder_dial_direction();
 void set_encoder_dial_direction(bool v);
 
-uint8_t encoder_consecutive_hits();
-void set_encoder_consecutive_hits(uint8_t v);
-uint8_t encoder_cooldown_ms();
-void set_encoder_cooldown_ms(uint8_t v);
-uint8_t encoder_debounce_ms();
-void set_encoder_debounce_ms(uint8_t v);
-
 uint32_t config_mode_storage_direct();
 void set_config_mode_storage_direct(uint32_t v);
 bool config_disable_config_mode_direct();


### PR DESCRIPTION
Reverts portapack-mayhem/mayhem-firmware#2841

Unless original author provides better defaults and working settings, this is not working as expected.