### PR TITLE
fix typo: wps -> wpm in morse_tx

### DIFF
--- a/firmware/application/external/morse_tx/ui_morse.hpp
+++ b/firmware/application/external/morse_tx/ui_morse.hpp
@@ -110,7 +110,7 @@ class MorseView : public View {
     bool run{false};
 
     Labels labels{
-        {{4 * 8, 6 * 8}, "Speed:   wps", Theme::getInstance()->fg_light->foreground},
+        {{4 * 8, 6 * 8}, "Speed:   wpm", Theme::getInstance()->fg_light->foreground},
         {{4 * 8, 8 * 8}, "Tone:    Hz", Theme::getInstance()->fg_light->foreground},
         {{4 * 8, 10 * 8}, "Modulation:", Theme::getInstance()->fg_light->foreground},
         {{4 * 8, 12 * 8}, "Loop:", Theme::getInstance()->fg_light->foreground},


### PR DESCRIPTION
I believe that there is a typo in the morse_tx application. The speed is represented as wps and not as wpm. "Speed" (wps in ui) is used like this: "time_unit_ms = 1200 / speed;" which is standard morse code formula for wpm. Time unit is the duration of the dot. 1200 / WPM gives us exactly that.