### PR TITLE
Refactor OnTouchEvent functions to return boolean values for better e…

### DIFF
--- a/firmware/application/apps/ui_standalone_view.cpp
+++ b/firmware/application/apps/ui_standalone_view.cpp
@@ -285,9 +285,9 @@ bool StandaloneView::on_encoder(const EncoderEvent event) {
 
 bool StandaloneView::on_touch(const TouchEvent event) {
     if (get_application_information()->header_version > 1) {
-        get_application_information()->OnTouchEvent(event.point.x(), event.point.y(), (uint32_t)event.type);
+        return get_application_information()->OnTouchEvent(event.point.x(), event.point.y(), (uint32_t)event.type);
     }
-    return true;
+    return false;
 }
 
 bool StandaloneView::on_keyboard(const KeyboardEvent event) {

--- a/firmware/common/standalone_app.hpp
+++ b/firmware/common/standalone_app.hpp
@@ -148,7 +148,7 @@ struct standalone_application_information_t {
     void (*shutdown)();
 
     void (*PaintViewMirror)();
-    void (*OnTouchEvent)(int x, int y, uint32_t type);
+    bool (*OnTouchEvent)(int x, int y, uint32_t type);
     void (*OnFocus)();
     bool (*OnKeyEvent)(uint8_t key);
     bool (*OnEncoder)(int32_t delta);

--- a/firmware/standalone/digitalrain/digitalrain.cpp
+++ b/firmware/standalone/digitalrain/digitalrain.cpp
@@ -77,7 +77,7 @@ ui::Widget* touch_widget(ui::Widget* const w, ui::TouchEvent event) {
 
 ui::Widget* captured_widget{nullptr};
 
-void OnTouchEvent(int, int, uint32_t) {
+bool OnTouchEvent(int, int, uint32_t) {
     if (standaloneViewMirror) {
         _api->exit_app();
         /* //left here for example, but not used in digital rain
@@ -96,6 +96,7 @@ void OnTouchEvent(int, int, uint32_t) {
             captured_widget->on_touch(event);
             */
     }
+    return false;
 }
 
 void OnFocus() {

--- a/firmware/standalone/digitalrain/digitalrain.hpp
+++ b/firmware/standalone/digitalrain/digitalrain.hpp
@@ -40,7 +40,7 @@ void shutdown();
 void OnFocus();
 bool OnKeyEvent(uint8_t);
 bool OnEncoder(int32_t);
-void OnTouchEvent(int, int, uint32_t);
+bool OnTouchEvent(int, int, uint32_t);
 bool OnKeyboad(uint8_t);
 void PaintViewMirror();
 

--- a/firmware/standalone/pacman/main.cpp
+++ b/firmware/standalone/pacman/main.cpp
@@ -23,7 +23,7 @@
 #include "pacman.hpp"
 #include <memory>
 
-void notouch(int, int, uint32_t) {
+bool notouch(int, int, uint32_t) {
     // do nothing
 }
 void nothing() {


### PR DESCRIPTION
AI:

This pull request updates the touch event handling across the standalone application framework to consistently use a boolean return type for `OnTouchEvent`, indicating whether the event was handled. This change affects the function signatures, implementations, and event dispatch logic, improving clarity and enabling more robust event management.

### Touch event API changes

* Changed the signature of `OnTouchEvent` in `standalone_application_information_t` and related implementations from `void` to `bool`, allowing touch handlers to signal whether they handled the event. [[1]](diffhunk://#diff-004e6031d027e7b6058d833efaf8d62b5573c93f58459aeeea59fa6ec334b160L151-R151) [[2]](diffhunk://#diff-74f85a759803d178d98ef89234a82ef367c265d7611dd058cbd0a96b4e3c0d6bL43-R43)
* Updated all implementations of `OnTouchEvent` (such as in `digitalrain.cpp` and the `notouch` stub in `pacman/main.cpp`) to return a boolean value. [[1]](diffhunk://#diff-a9d28740369cddcb467d6aefbda8eea10427b78c7852fe369c5f7d7407c14d2dL80-R80) [[2]](diffhunk://#diff-0cf97454a00f4a5bf6680260ce933da993404ab766f257c34e8880fd5b3e76acL26-R26) [[3]](diffhunk://#diff-a9d28740369cddcb467d6aefbda8eea10427b78c7852fe369c5f7d7407c14d2dR99)

### Event handling logic

* Modified `StandaloneView::on_touch` to return the result of `OnTouchEvent` when the header version is greater than 1, and to return `false` otherwise, aligning the event dispatch logic with the new boolean API.