### PR TITLE
fix dead link

### DIFF
--- a/firmware/application/apps/ui_about_simple.cpp
+++ b/firmware/application/apps/ui_about_simple.cpp
@@ -10,7 +10,7 @@ namespace ui {
 constexpr std::string_view mayhem_information_list[] = {
     "#****** Mayhem Community ******",
     " ",
-    "  https://discord.mayhem.app",
+    "  https://discord.hackrf.app",
     " ",
     "#**** List of contributors ****",
     " ",


### PR DESCRIPTION
the mayhem.app domain seems not owned by us or not anymore, not sure what happened but let's fix the link firstly.