### PR TITLE
fix github pages CNAME

### DIFF
--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,1 +1,1 @@
-portapack.ried.cl
+wiki.hackrf.app

--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,1 +1,0 @@
-wiki.hackrf.app


### PR DESCRIPTION
The domain set in GitHub Pages deployment (`portapack.ried.cl`), which is currently some weird AF page:

<img width="498" height="673" alt="image" src="https://github.com/user-attachments/assets/2fb7ba6c-2773-486b-b75c-97f35b8ece14" />

This PR changes it to `wiki.hackrf.app`.
