### PR TITLE
Some tweaks to support some usecases without encoder, also maximize t…

### DIFF
--- a/firmware/common/ui_widget.cpp
+++ b/firmware/common/ui_widget.cpp
@@ -1358,14 +1358,18 @@ void NewButton::paint(Painter& painter) {
         }
 
         if (!text_.empty()) {
-            const auto label_r = style.font.size_of(text_);
+            auto label_r = style.font.size_of(text_);
+            std::string text_to_draw = text_;
+            if (label_r.width() > r.width() - 2) {
+                // Truncate text to fit
+                size_t max_chars = (r.width() - 2) / style.font.char_width();
+                text_to_draw = text_.substr(0, max_chars);
+                label_r = style.font.size_of(text_to_draw);
+            }
             if (bitmap_) {
                 y += spacing;
             }
-            painter.draw_string(
-                {r.left() + (r.width() - label_r.width()) / 2, y},
-                style,
-                text_);
+            painter.draw_string({r.left() + (r.width() - label_r.width()) / 2, y}, style, text_to_draw);
         }
     } else {  // no valign
         if (bitmap_) {
@@ -1379,11 +1383,16 @@ void NewButton::paint(Painter& painter) {
         }
 
         if (!text_.empty()) {
-            const auto label_r = style.font.size_of(text_);
-            painter.draw_string(
-                {r.left() + (r.width() - label_r.width()) / 2, y + (r.height() - label_r.height()) / 2},
-                style,
-                text_);
+            auto label_r = style.font.size_of(text_);
+            std::string text_to_draw = text_;
+            if (label_r.width() > r.width() - 2) {
+                // Truncate text to fit
+                size_t max_chars = (r.width() - 2) / style.font.char_width();
+                text_to_draw = text_.substr(0, max_chars);
+                label_r = style.font.size_of(text_to_draw);
+            }
+            painter.draw_string({r.left() + (r.width() - label_r.width()) / 2, y + (r.height() - label_r.height()) / 2}, style,
+                                text_to_draw);
         }
     }
 }
@@ -1732,6 +1741,14 @@ bool ImageOptionsField::on_keyboard(const KeyboardEvent key) {
     return false;
 }
 
+bool ImageOptionsField::on_key(const KeyEvent event) {
+    if (event == KeyEvent::Select) {
+        on_encoder(1);
+        return true;
+    }
+    return false;
+}
+
 bool ImageOptionsField::on_touch(const TouchEvent event) {
     if (event.type == TouchEvent::Type::Start) {
         focus();
@@ -1878,6 +1895,14 @@ bool OptionsField::on_encoder(const EncoderEvent delta) {
 bool OptionsField::on_keyboard(const KeyboardEvent key) {
     if (key == '+' || key == ' ' || key == 10) return on_encoder(1);
     if (key == '-' || key == 8) return on_encoder(-1);
+    return false;
+}
+
+bool OptionsField::on_key(const KeyEvent event) {
+    if (event == KeyEvent::Select) {
+        on_encoder(1);
+        return true;
+    }
     return false;
 }
 
@@ -2313,6 +2338,8 @@ bool NumberField::on_key(const KeyEvent key) {
         if (on_select) {
             on_select(*this);
             return true;
+        } else {
+            return on_encoder(1);
         }
     }
 

--- a/firmware/common/ui_widget.hpp
+++ b/firmware/common/ui_widget.hpp
@@ -666,6 +666,8 @@ class ImageOptionsField : public Widget {
     bool on_encoder(const EncoderEvent delta) override;
     bool on_touch(const TouchEvent event) override;
     bool on_keyboard(const KeyboardEvent event) override;
+    bool on_key(const KeyEvent event) override;
+
     void getAccessibilityText(std::string& result) override;
     void getWidgetName(std::string& result) override;
 
@@ -674,6 +676,7 @@ class ImageOptionsField : public Widget {
     size_t selected_index_{0};
     Color foreground_;
     Color background_;
+    bool is_activated = false;
 };
 
 class OptionsField : public Widget {
@@ -706,6 +709,7 @@ class OptionsField : public Widget {
     bool on_encoder(const EncoderEvent delta) override;
     bool on_touch(const TouchEvent event) override;
     bool on_keyboard(const KeyboardEvent event) override;
+    bool on_key(const KeyEvent event) override;
 
     void getAccessibilityText(std::string& result) override;
     void getWidgetName(std::string& result) override;
@@ -715,6 +719,7 @@ class OptionsField : public Widget {
     options_t options_;
     size_t selected_index_{0};
     bool centered_{false};  // e.g.: length as screen_width/8, x position as 0, it will be centered in x axis
+    bool is_activated = false;
 };
 
 // A TextEdit is bound to a string reference and allows the string
@@ -851,11 +856,11 @@ class NumberField : public Widget {
     NumberField(Point parent_pos, int length, range_t range, int32_t step, char fill_char, bool can_loop);
 
     NumberField(Point parent_pos, int length, range_t range, int32_t step, char fill_char)
-        : NumberField{parent_pos, length, range, step, fill_char, false} {
+        : NumberField{parent_pos, length, range, step, fill_char, true} {
     }
 
     NumberField()
-        : NumberField{{0, 0}, 1, {0, 1}, 1, ' ', false} {
+        : NumberField{{0, 0}, 1, {0, 1}, 1, ' ', true} {
     }
 
     NumberField(const NumberField&) = delete;


### PR DESCRIPTION
for the ImageOptionsField, and OptionsField, and Numfields  I implemented the encoderless usage (use select button to switch 1)
for the numfields if any on_select() is used, it won't change anything.

the Numfields  are loopable by default, to the on select can rotate all, and not just to the end.

The NewButton has text size limit, so if the text is longer than the button (with borders) then it'll cut the text.
This solves the problem that the stale pr https://github.com/portapack-mayhem/mayhem-firmware/pull/2872 would do.