### PR TITLE
Looking glass marker no encoder

### DIFF
--- a/firmware/application/apps/ui_looking_glass_app.cpp
+++ b/firmware/application/apps/ui_looking_glass_app.cpp
@@ -101,7 +101,14 @@ rf::Frequency GlassView::get_freq_from_bin_pos(uint16_t pos) {
     return freq_at_pos;
 }
 
-void GlassView::on_marker_change() {
+void GlassView::on_marker_change(int8_t delta) {
+    if ((marker_pixel_index + delta) < 0)
+        marker_pixel_index = marker_pixel_index + delta + screen_width;
+    else if ((marker_pixel_index + delta) > screen_width)
+        marker_pixel_index = marker_pixel_index + delta - screen_width;
+    else
+        marker_pixel_index = marker_pixel_index + delta;
+
     marker = get_freq_from_bin_pos(marker_pixel_index);
     field_marker.set_text(to_string_short_freq(marker));
     plot_marker(marker_pixel_index);  // Refresh marker on screen
@@ -285,7 +292,7 @@ void GlassView::on_range_changed() {
     max_power = 0;
     bins_hz_size = 0;
 
-    on_marker_change();
+    on_marker_change(0);
     update_range_field();
 
     // set the sample rate and bandwidth
@@ -381,9 +388,10 @@ GlassView::GlassView(
                   &button_beep_squelch,
                   &field_marker,
                   &field_trigger,
+                  &button_marker_minus,
+                  &button_marker_plus,
                   &button_jump,
                   &button_rst,
-                  &field_rx_iq_phase_cal,
                   &freq_stats});
 
     load_presets();  // Load available presets from TXT files (or default).
@@ -491,13 +499,7 @@ GlassView::GlassView(
     range_presets.set_selected_index(preset_index);
 
     field_marker.on_encoder_change = [this](TextField&, EncoderEvent delta) {
-        if ((marker_pixel_index + delta) < 0)
-            marker_pixel_index = marker_pixel_index + delta + screen_width;
-        else if ((marker_pixel_index + delta) > screen_width)
-            marker_pixel_index = marker_pixel_index + delta - screen_width;
-        else
-            marker_pixel_index = marker_pixel_index + delta;
-        on_marker_change();
+        on_marker_change(delta);
     };
 
     field_marker.on_select = [this](TextField&) {
@@ -516,6 +518,14 @@ GlassView::GlassView(
         update_range_field();
     };
 
+    button_marker_minus.on_select = [this](Button&) {
+        on_marker_change(-1);
+    };
+
+    button_marker_plus.on_select = [this](Button&) {
+        on_marker_change(1);
+    };
+
     button_jump.on_select = [this](Button&) {
         // Launch Audio with peak frequency.
         launch_audio(max_freq_hold);
@@ -524,13 +534,6 @@ GlassView::GlassView(
     button_rst.on_select = [this](Button&) {
         reset_live_view();
     };
-
-    field_rx_iq_phase_cal.set_range(0, hackrf_r9 ? 63 : 31);                 // max2839 has 6 bits [0..63],  max2837 has 5 bits [0..31]
-    field_rx_iq_phase_cal.set_value(get_spec_iq_phase_calibration_value());  // using  accessor function of AnalogAudioView to read iq_phase_calibration_value from rx_audio.ini
-    field_rx_iq_phase_cal.on_change = [this](int32_t v) {
-        set_spec_iq_phase_calibration_value(v);  // using  accessor function of AnalogAudioView to write inside SPEC submenu, register value to max283x and save it to rx_audio.ini
-    };
-    set_spec_iq_phase_calibration_value(get_spec_iq_phase_calibration_value());  // initialize iq_phase_calibration in radio
 
     display.scroll_set_area(109, screen_height - 1);  // Restart scroll on the correct coordinates
 
@@ -579,15 +582,6 @@ void GlassView::on_freqchg(int64_t freq) {
     update_min(freq - half_range);
     update_max(freq + half_range);
     on_range_changed();
-}
-
-uint8_t GlassView::get_spec_iq_phase_calibration_value() {  // define accessor functions inside AnalogAudioView to read & write real iq_phase_calibration_value
-    return iq_phase_calibration_value;
-}
-
-void GlassView::set_spec_iq_phase_calibration_value(uint8_t cal_value) {  // define accessor functions
-    iq_phase_calibration_value = cal_value;
-    radio::set_rx_max283x_iq_phase_calibration(iq_phase_calibration_value);
 }
 
 void GlassView::load_presets() {

--- a/firmware/application/apps/ui_looking_glass_app.hpp
+++ b/firmware/application/apps/ui_looking_glass_app.hpp
@@ -66,9 +66,6 @@ class GlassView : public View {
     void on_hide() override;
     void focus() override;
 
-    uint8_t get_spec_iq_phase_calibration_value();
-    void set_spec_iq_phase_calibration_value(uint8_t cal_value);
-
    private:
     NavigationView& nav_;
     Gradient gradient{};
@@ -80,11 +77,10 @@ class GlassView : public View {
     uint8_t filter_index = 0;  // OFF
     uint8_t trigger = 32;
     uint8_t mode = LOOKING_GLASS_FASTSCAN;
-    uint8_t live_frequency_view = 0;         // Spectrum
-    uint8_t live_frequency_integrate = 3;    // Default (3 * old value + new_value) / 4
-    uint8_t iq_phase_calibration_value{15};  // initial default RX IQ phase calibration value , used for both max2837 & max2839
-    int32_t beep_squelch = 20;               // range from -100 to +20, >=20 disabled
-    bool beep_enabled = false;               // activate on bip button click
+    uint8_t live_frequency_view = 0;       // Spectrum
+    uint8_t live_frequency_integrate = 3;  // Default (3 * old value + new_value) / 4
+    int32_t beep_squelch = 20;             // range from -100 to +20, >=20 disabled
+    bool beep_enabled = false;             // activate on bip button click
     app_settings::SettingsManager settings_{
         "rx_glass"sv,
         app_settings::Mode::RX,
@@ -97,7 +93,6 @@ class GlassView : public View {
             {"scan_mode"sv, &mode},
             {"freq_view"sv, &live_frequency_view},
             {"freq_integrate"sv, &live_frequency_integrate},
-            {"iq_phase_calibration"sv, &iq_phase_calibration_value},  // we are saving and restoring that CAL from Settings.
             {"beep_squelch"sv, &beep_squelch},
             {"beep_enabled"sv, &beep_enabled},
         }};
@@ -118,7 +113,7 @@ class GlassView : public View {
     void update_range_field();
     void get_max_power(const ChannelSpectrum& spectrum, uint16_t bin, uint8_t& max_power);
     rf::Frequency get_freq_from_bin_pos(uint16_t pos);
-    void on_marker_change();
+    void on_marker_change(int8_t delta);
     void retune();
     bool process_bins(uint8_t* powerlevel);
     void on_channel_spectrum(const ChannelSpectrum& spectrum);
@@ -173,8 +168,7 @@ class GlassView : public View {
         {{0, UI_POS_Y(0)}, "MIN:     MAX:     LNA   VGA  ", Theme::getInstance()->fg_light->foreground},
         {{0, 1 * 16}, "RANGE:       FILTER:     AMP:", Theme::getInstance()->fg_light->foreground},
         {{0, 2 * 16}, "P:", Theme::getInstance()->fg_light->foreground},
-        {{0, 3 * 16}, "MARKER:          MHz RXIQCAL", Theme::getInstance()->fg_light->foreground},
-        //{{0, 4 * 16}, "RES:    STEPS:", Theme::getInstance()->fg_light->foreground}};
+        {{0, 3 * 16}, "MARKER( / ):          MHz", Theme::getInstance()->fg_light->foreground},
         {{0, 4 * 16}, "RES:     VOL:", Theme::getInstance()->fg_light->foreground}};
 
     NumberField field_frequency_min{
@@ -223,16 +217,16 @@ class GlassView : public View {
         ""};
 
     TextField field_marker{
-        {7 * 8, 3 * 16, 9 * 8, 16},
+        {12 * 8, 3 * 16, 9 * 8, 16},
         ""};
 
-    NumberField field_rx_iq_phase_cal{
-        {28 * 8, 3 * 16},
-        2,
-        {0, 63},  // 5 or 6 bits IQ CAL phase adjustment (range updated later)
-        1,
-        ' ',
-    };
+    Button button_marker_minus{
+        {7 * 8, 3 * 16 + 4, 1 * 8, 1 * 8},
+        "-"};
+
+    Button button_marker_plus{
+        {9 * 8, 3 * 16 + 4, 1 * 8, 1 * 8},
+        "+"};
 
     NumberField field_trigger{
         {4 * 8, 4 * 16},

--- a/firmware/application/irq_controls.cpp
+++ b/firmware/application/irq_controls.cpp
@@ -227,8 +227,8 @@ void controls_init() {
     gptStart(&GPTD1, &timer0_config);
     gptStartContinuous(&GPTD1, timer0_match_count);
 
-    // Enable repeat for directional switches only
-    for (auto i = Switch::Right; i <= Switch::Up; incr(i))
+    // Enable repeat for directional and Select switches only
+    for (auto i = Switch::Right; i <= Switch::Sel; incr(i))
         switch_debounce[toUType(i)].enable_repeat();
 }
 


### PR DESCRIPTION
## Brief description what you did
- removed field_rx_iq_phase_cal and all calls related to it since it's not helping in looking glass
- added a marker '-' and '+' button to help people with bad or missing encoder to move the marker
- allowed key repeat on the select button (firmware wide, I know)

## Checklist
- [X]  Kept changes minimal and limited to necessary files
- [X]  Verified functionality remains intact and code compiles
