### PR TITLE
conform to clang spec

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,14 +1,13 @@
 ---
 BasedOnStyle: Chromium
-IndentWidth: '4'
-SortIncludes: 'false'
-AllowAllArgumentsOnNextLine: 'true'
+IndentWidth: 4
+SortIncludes: false
+AllowAllArgumentsOnNextLine: true
 ColumnLimit: 0
-Cpp11BracedListStyle: 'true'
-AllowShortLoopsOnASingleLine: 'true'
-AllowShortIfStatementsOnASingleLine: 'true'
+Cpp11BracedListStyle: true
+AllowShortLoopsOnASingleLine: true
+AllowShortIfStatementsOnASingleLine: true
 SpacesInLineCommentPrefix:
   Minimum: 1
   Maximum: 1
-
 ...

--- a/format-code.sh
+++ b/format-code.sh
@@ -1,2 +1,11 @@
 #!/bin/sh
-find firmware/common firmware/baseband firmware/application firmware/test/application firmware/test/baseband -iname '*.h' -o -iname '*.hpp' -o -iname '*.cpp' -o -iname '*.c' | xargs clang-format-18 -style=file -i
+
+find firmware/common \
+     firmware/baseband \
+     firmware/application \
+     firmware/test/application \
+     firmware/test/baseband \
+     \( -iname '*.h' -o -iname '*.hpp' -o -iname '*.c' -o -iname '*.cpp' \) \
+     -print0 \
+| xargs -0 clang-format-18 -style=file -i
+

--- a/format-code.sh
+++ b/format-code.sh
@@ -6,6 +6,6 @@ find firmware/common \
      firmware/test/application \
      firmware/test/baseband \
      \( -iname '*.h' -o -iname '*.hpp' -o -iname '*.c' -o -iname '*.cpp' \) \
-     -print0 \
-| xargs -0 clang-format-18 -style=file -i
+     -print0 | \
+     xargs -0 clang-format-18 -style=file -i
 


### PR DESCRIPTION
## Brief description what you did
- Converted numeric values from strings to integers  
- Converted boolean values from strings to booleans  
- Ensured all option value types now match `clang-format` expectations  
  - Integers are unquoted numbers  
  - Booleans are unquoted `true` / `false`
- Rewrite the find part in the format-code.sh so it's calling -o options properly as per the manual
- Rewrite the find and xargs options to use print0 / -0 to make the script safe for filenames containing spaces, tabs, or newlines.
## Checklist
- [X]  Kept changes minimal and limited to necessary files
- [X]  Verified functionality remains intact and code compiles
~~- [ ] Ship custom clang-format so users do not have disparities~~
