### PR TITLE
disable select key repeat

### DIFF
--- a/firmware/application/apps/ui_mictx.cpp
+++ b/firmware/application/apps/ui_mictx.cpp
@@ -356,7 +356,7 @@ MicTXView::MicTXView(
     config[toUType(Switch::Sel)] = false;
     set_switches_repeat_config(config);
 
-        set_rxbw_options();
+    set_rxbw_options();
     set_rxbw_defaults(settings_.loaded());
 
     tone_keys_populate(options_tone_key);

--- a/firmware/application/apps/ui_mictx.cpp
+++ b/firmware/application/apps/ui_mictx.cpp
@@ -350,7 +350,13 @@ MicTXView::MicTXView(
                   &tx_button,
                   &tx_icon});
 
-    set_rxbw_options();
+    // disable key repeat on select
+    initial_switch_config_ = get_switches_repeat_config();
+    SwitchesState config = initial_switch_config_;
+    config[toUType(Switch::Sel)] = false;
+    set_switches_repeat_config(config);
+
+        set_rxbw_options();
     set_rxbw_defaults(settings_.loaded());
 
     tone_keys_populate(options_tone_key);
@@ -640,6 +646,9 @@ MicTXView::MicTXView(
 }
 
 MicTXView::~MicTXView() {
+    // restore select key repeat mode
+    set_switches_repeat_config(initial_switch_config_);
+
     audio::input::stop();
     if (rx_enabled) {  // Also turn off both (audio rx if enabled, and disable  mic_loop to HP)
         rxaudio(false);

--- a/firmware/application/apps/ui_mictx.hpp
+++ b/firmware/application/apps/ui_mictx.hpp
@@ -90,6 +90,9 @@ class MicTXView : public View {
         sampling_rate /* sampling rate */
     };
 
+    // structure used to control key repeat
+    SwitchesState initial_switch_config_{};
+
     enum Mic_Modulation : uint32_t {
         MIC_MOD_NFM = 0,
         MIC_MOD_WFM = 1,


### PR DESCRIPTION
## Brief description what you did

Following example by @Pezsma I disabled  select key repeat mode in Mic TX app.

## Checklist
- [X]  Kept changes minimal and limited to necessary files
- [X]  Verified functionality remains intact and code compiles
