### PR TITLE
Do hardware detection on init for shell info

### DIFF
--- a/firmware/application/portapack.cpp
+++ b/firmware/application/portapack.cpp
@@ -56,6 +56,10 @@ using asahi_kasei::ak4951::AK4951;
 #include "i2cdevmanager.hpp"
 #include "battery.hpp"
 
+extern "C" {
+#include "platform_detect.h"
+}
+
 namespace portapack {
 
 const char* init_error = nullptr;
@@ -502,6 +506,11 @@ init_status_t init() {
     set_idivc_base_clocks(cgu::CLK_SEL::IDIVC);
 
     i2c0.start(i2c_config_boot_clock);
+
+    chThdSleepMilliseconds(100);
+
+    detect_hardware_platform();
+    finalize_detect_hardware_platform();
 
     chThdSleepMilliseconds(100);
 

--- a/firmware/application/shell.cpp
+++ b/firmware/application/shell.cpp
@@ -131,7 +131,6 @@ static void cmd_info(BaseSequentialStream* chp, int argc, char* argv[]) {
     chprintf(chp, "Mayhem Version:   %s\r\n", VERSION_STRING);
 #endif
 
-    detect_hardware_platform();
     board_rev_t revision = detected_revision();
     const char* revision_string = get_board_revision_string(revision);
     chprintf(chp, "HackRF Board Rev: %s\r\n", revision_string);


### PR DESCRIPTION
## Brief description what you did
Hardware detection moved from the info shell command to firmware init, the info command will just show the saved result
After hardware detection, the state of the gpio pins is reverted (radio now works, but after entering hackrf mode, the hackrf_info command fails to detect board id still... on r10 at least...)

Closes: https://github.com/portapack-mayhem/mayhem-firmware/issues/2970

## Checklist
- [x]  Kept changes minimal and limited to necessary files
- [x]  Verified functionality remains intact and code compiles
