### PR TITLE
Add Multi-Device Build Support to Release Workflows

### DIFF
--- a/.github/workflows/create_nightly_release.yml
+++ b/.github/workflows/create_nightly_release.yml
@@ -26,17 +26,21 @@ jobs:
     needs: check_date
     if: ${{ needs.check_date.outputs.should_run != 'false' }}
     runs-on: ubuntu-latest
+    name: build (${{ matrix.device_name }})
     strategy:
       fail-fast: false
       matrix:
         include:
           - device: default
+            device_name: HackRF
             cmake_args: ""
             artifact_suffix: ""
           - device: portarf
+            device_name: PortaRF
             cmake_args: "-DFLASH_MB_SIZE=2 -DFLASH_MB_LIMIT_SIZE=2"
             artifact_suffix: "_portarf"
           - device: hpro
+            device_name: HackRF Pro
             cmake_args: "-DBOARD=PRALINE"
             artifact_suffix: "_hpro"
     steps:

--- a/.github/workflows/create_nightly_release.yml
+++ b/.github/workflows/create_nightly_release.yml
@@ -153,7 +153,7 @@ jobs:
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: artifacts/oci-tar-default/portapack-mayhem_OCI.ppfw.tar
-          asset_name: mayhem_nightly_${{ steps.version_date.outputs.date }}_OCI.ppfw.tar
+          asset_name: OCI_mayhem_nightly_${{ steps.version_date.outputs.date }}.ppfw.tar
           asset_content_type: application/x-tar
       - name: Upload Default Firmware Asset
         uses: actions/upload-release-asset@v1
@@ -162,7 +162,7 @@ jobs:
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: artifacts/firmware-default/firmware.zip
-          asset_name: mayhem_nightly_${{ steps.version_date.outputs.date }}_FIRMWARE.zip
+          asset_name: FIRMWARE_mayhem_nightly_${{ steps.version_date.outputs.date }}.zip
           asset_content_type: application/zip
       - name: Upload Default SD Card Asset
         uses: actions/upload-release-asset@v1
@@ -171,7 +171,7 @@ jobs:
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: artifacts/sdcard-default/sdcard.zip
-          asset_name: mayhem_nightly_${{ steps.version_date.outputs.date }}_COPY_TO_SDCARD.zip
+          asset_name: COPY_TO_SDCARD_mayhem_nightly_${{ steps.version_date.outputs.date }}.zip
           asset_content_type: application/zip
       - name: Upload Default SD Card Asset - No Map
         uses: actions/upload-release-asset@v1
@@ -180,7 +180,7 @@ jobs:
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: artifacts/sdcard-no-map-default/sdcard-no-map.zip
-          asset_name: mayhem_nightly_${{ steps.version_date.outputs.date }}_COPY_TO_SDCARD-no-world-map.zip
+          asset_name: COPY_TO_SDCARD_mayhem_nightly_${{ steps.version_date.outputs.date }}-no-world-map.zip
           asset_content_type: application/zip
       # PortaRF device assets
       - name: Upload PortaRF Firmware TAR Asset
@@ -190,7 +190,7 @@ jobs:
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: artifacts/oci-tar-portarf/portapack-mayhem_OCI.ppfw.tar
-          asset_name: mayhem_nightly_${{ steps.version_date.outputs.date }}_portarf_OCI.ppfw.tar
+          asset_name: OCI_portarf_mayhem_nightly_${{ steps.version_date.outputs.date }}.ppfw.tar
           asset_content_type: application/x-tar
       - name: Upload PortaRF Firmware Asset
         uses: actions/upload-release-asset@v1
@@ -199,7 +199,7 @@ jobs:
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: artifacts/firmware-portarf/firmware.zip
-          asset_name: mayhem_nightly_${{ steps.version_date.outputs.date }}_portarf_FIRMWARE.zip
+          asset_name: FIRMWARE_portarf_mayhem_nightly_${{ steps.version_date.outputs.date }}.zip
           asset_content_type: application/zip
       - name: Upload PortaRF SD Card Asset
         uses: actions/upload-release-asset@v1
@@ -208,7 +208,7 @@ jobs:
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: artifacts/sdcard-portarf/sdcard.zip
-          asset_name: mayhem_nightly_${{ steps.version_date.outputs.date }}_portarf_COPY_TO_SDCARD.zip
+          asset_name: COPY_TO_SDCARD_portarf_mayhem_nightly_${{ steps.version_date.outputs.date }}.zip
           asset_content_type: application/zip
       - name: Upload PortaRF SD Card Asset - No Map
         uses: actions/upload-release-asset@v1
@@ -217,7 +217,7 @@ jobs:
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: artifacts/sdcard-no-map-portarf/sdcard-no-map.zip
-          asset_name: mayhem_nightly_${{ steps.version_date.outputs.date }}_portarf_COPY_TO_SDCARD-no-world-map.zip
+          asset_name: COPY_TO_SDCARD_portarf_mayhem_nightly_${{ steps.version_date.outputs.date }}-no-world-map.zip
           asset_content_type: application/zip
       # HPro device assets
       - name: Upload HPro Firmware TAR Asset
@@ -227,7 +227,7 @@ jobs:
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: artifacts/oci-tar-hpro/portapack-mayhem_OCI.ppfw.tar
-          asset_name: mayhem_nightly_${{ steps.version_date.outputs.date }}_hpro_OCI.ppfw.tar
+          asset_name: OCI_hpro_mayhem_nightly_${{ steps.version_date.outputs.date }}.ppfw.tar
           asset_content_type: application/x-tar
       - name: Upload HPro Firmware Asset
         uses: actions/upload-release-asset@v1
@@ -236,7 +236,7 @@ jobs:
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: artifacts/firmware-hpro/firmware.zip
-          asset_name: mayhem_nightly_${{ steps.version_date.outputs.date }}_hpro_FIRMWARE.zip
+          asset_name: FIRMWARE_hpro_mayhem_nightly_${{ steps.version_date.outputs.date }}.zip
           asset_content_type: application/zip
       - name: Upload HPro SD Card Asset
         uses: actions/upload-release-asset@v1
@@ -245,7 +245,7 @@ jobs:
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: artifacts/sdcard-hpro/sdcard.zip
-          asset_name: mayhem_nightly_${{ steps.version_date.outputs.date }}_hpro_COPY_TO_SDCARD.zip
+          asset_name: COPY_TO_SDCARD_hpro_mayhem_nightly_${{ steps.version_date.outputs.date }}.zip
           asset_content_type: application/zip
       - name: Upload HPro SD Card Asset - No Map
         uses: actions/upload-release-asset@v1
@@ -254,5 +254,5 @@ jobs:
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: artifacts/sdcard-no-map-hpro/sdcard-no-map.zip
-          asset_name: mayhem_nightly_${{ steps.version_date.outputs.date }}_hpro_COPY_TO_SDCARD-no-world-map.zip
+          asset_name: COPY_TO_SDCARD_hpro_mayhem_nightly_${{ steps.version_date.outputs.date }}-no-world-map.zip
           asset_content_type: application/zip

--- a/.github/workflows/create_nightly_release.yml
+++ b/.github/workflows/create_nightly_release.yml
@@ -3,7 +3,7 @@ name: Nightly Release
 on:
   schedule:
     - cron: "0 0 * * *"
-    
+
   workflow_dispatch:
 
 jobs:
@@ -21,27 +21,32 @@ jobs:
         id: should_run
         continue-on-error: true
         run: test -z $(git rev-list  --after="24 hours" ${{ github.sha }}) && echo "should_run=false" >> $GITHUB_OUTPUT
+
   build:
     needs: check_date
     if: ${{ needs.check_date.outputs.should_run != 'false' }}
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - device: default
+            cmake_args: ""
+            artifact_suffix: ""
+          - device: portarf
+            cmake_args: "-DFLASH_MB_SIZE=2 -DFLASH_MB_LIMIT_SIZE=2"
+            artifact_suffix: "_portarf"
+          - device: hpro
+            cmake_args: "-DBOARD=PRALINE"
+            artifact_suffix: "_hpro"
     steps:
-      - name: Get current date
-        id: date
-        run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
       - name: Get version date
         id: version_date
         run: echo "date=n_$(date +'%y%m%d')" >> $GITHUB_OUTPUT
-      - name: Checkout 
+      - name: Checkout
         uses: actions/checkout@master
         with:
           fetch-depth: 0
-          #ref: next
-          # The branch, tag or SHA to checkout. When checking out the repository that
-          # triggered a workflow, this defaults to the reference or SHA for that event.
-          # Otherwise, uses the default branch.
-          # https://github.com/actions/checkout
-          # So scheduled runs will use the default branch (next) but its now possible to trigger a workflow from another branch
           submodules: true
       - name: Git Sumbodule Update
         run: |
@@ -51,10 +56,10 @@ jobs:
       - name: Make build folder
         run: mkdir ${{ github.workspace }}/build
       - name: Run the Docker image
-        run: docker run -e VERSION_STRING=${{ steps.version_date.outputs.date }} -i -v ${{ github.workspace }}:/havoc portapack-dev
+        run: docker run -e VERSION_STRING=${{ steps.version_date.outputs.date }} -i -v ${{ github.workspace }}:/havoc portapack-dev ${{ matrix.cmake_args }}
       - name: Create Small SD Card ZIP - No World Map
         run: |
-          mkdir -p sdcard/FIRMWARE && cp build/firmware/portapack-mayhem-firmware.bin sdcard/FIRMWARE/portapack-mayhem_${{ steps.version_date.outputs.date }}.bin && cp build/firmware/portapack-mayhem_OCI.ppfw.tar sdcard/FIRMWARE/mayhem_nightly_${{ steps.version_date.outputs.date }}_OCI.ppfw.tar && mkdir -p sdcard/APPS && cp build/firmware/application/*.ppma sdcard/APPS && cp build/firmware/standalone/*/*.ppmp sdcard/APPS && cd sdcard && zip -r ../sdcard-no-map.zip . && cd ..
+          mkdir -p sdcard/FIRMWARE && cp build/firmware/portapack-mayhem-firmware.bin sdcard/FIRMWARE/portapack-mayhem_${{ steps.version_date.outputs.date }}.bin && cp build/firmware/portapack-mayhem_OCI.ppfw.tar sdcard/FIRMWARE/mayhem_nightly_${{ steps.version_date.outputs.date }}${{ matrix.artifact_suffix }}_OCI.ppfw.tar && mkdir -p sdcard/APPS && cp build/firmware/application/*.ppma sdcard/APPS && cp build/firmware/standalone/*/*.ppmp sdcard/APPS && cd sdcard && zip -r ../sdcard-no-map.zip . && cd ..
       - name: Download world map
         run: |
           wget https://github.com/portapack-mayhem/mayhem-firmware/releases/download/world_map/world_map.zip
@@ -69,7 +74,47 @@ jobs:
           zip -j firmware.zip build/firmware/portapack-mayhem-firmware.bin && cd flashing && zip -r ../firmware.zip *
       - name: Create SD Card ZIP
         run: |
-          mkdir -p sdcard/FIRMWARE && cp build/firmware/portapack-mayhem-firmware.bin sdcard/FIRMWARE/portapack-mayhem_${{ steps.version_date.outputs.date }}.bin && cp build/firmware/portapack-mayhem_OCI.ppfw.tar sdcard/FIRMWARE/mayhem_nightly_${{ steps.version_date.outputs.date }}_OCI.ppfw.tar && mkdir -p sdcard/APPS && cp build/firmware/application/*.ppma sdcard/APPS && cp build/firmware/standalone/*/*.ppmp sdcard/APPS && cd sdcard && zip -r ../sdcard.zip . && cd ..
+          mkdir -p sdcard/FIRMWARE && cp build/firmware/portapack-mayhem-firmware.bin sdcard/FIRMWARE/portapack-mayhem_${{ steps.version_date.outputs.date }}.bin && cp build/firmware/portapack-mayhem_OCI.ppfw.tar sdcard/FIRMWARE/mayhem_nightly_${{ steps.version_date.outputs.date }}${{ matrix.artifact_suffix }}_OCI.ppfw.tar && mkdir -p sdcard/APPS && cp build/firmware/application/*.ppma sdcard/APPS && cp build/firmware/standalone/*/*.ppmp sdcard/APPS && cd sdcard && zip -r ../sdcard.zip . && cd ..
+      - name: Upload firmware zip artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: firmware-${{ matrix.device }}
+          path: ./firmware.zip
+      - name: Upload SD card artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: sdcard-${{ matrix.device }}
+          path: ./sdcard.zip
+      - name: Upload SD card no-map artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: sdcard-no-map-${{ matrix.device }}
+          path: ./sdcard-no-map.zip
+      - name: Upload OCI tar artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: oci-tar-${{ matrix.device }}
+          path: build/firmware/portapack-mayhem_OCI.ppfw.tar
+
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get current date
+        id: date
+        run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
+      - name: Get version date
+        id: version_date
+        run: echo "date=n_$(date +'%y%m%d')" >> $GITHUB_OUTPUT
+      - name: Checkout
+        uses: actions/checkout@master
+        with:
+          fetch-depth: 0
+          submodules: true
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
       - name: Create changelog
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -96,43 +141,114 @@ jobs:
             ${{ steps.changelog.outputs.content }}
           draft: false
           prerelease: true
-      - name: Upload Firmware TAR Asset
-        id: upload-firmware-tar-asset 
+      # Default device assets
+      - name: Upload Default Firmware TAR Asset
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: build/firmware/portapack-mayhem_OCI.ppfw.tar
+          asset_path: artifacts/oci-tar-default/portapack-mayhem_OCI.ppfw.tar
           asset_name: mayhem_nightly_${{ steps.version_date.outputs.date }}_OCI.ppfw.tar
           asset_content_type: application/x-tar
-      - name: Upload Firmware Asset
-        id: upload-firmware-asset 
+      - name: Upload Default Firmware Asset
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./firmware.zip
+          asset_path: artifacts/firmware-default/firmware.zip
           asset_name: mayhem_nightly_${{ steps.version_date.outputs.date }}_FIRMWARE.zip
           asset_content_type: application/zip
-      - name: Upload SD Card Assets
-        id: upload-sd-card-asset 
+      - name: Upload Default SD Card Asset
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./sdcard.zip
+          asset_path: artifacts/sdcard-default/sdcard.zip
           asset_name: mayhem_nightly_${{ steps.version_date.outputs.date }}_COPY_TO_SDCARD.zip
           asset_content_type: application/zip
-      - name: Upload SD Card Assets - No Map
-        id: upload-sd-card-asset-no-map 
+      - name: Upload Default SD Card Asset - No Map
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./sdcard-no-map.zip
+          asset_path: artifacts/sdcard-no-map-default/sdcard-no-map.zip
           asset_name: mayhem_nightly_${{ steps.version_date.outputs.date }}_COPY_TO_SDCARD-no-world-map.zip
+          asset_content_type: application/zip
+      # PortaRF device assets
+      - name: Upload PortaRF Firmware TAR Asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: artifacts/oci-tar-portarf/portapack-mayhem_OCI.ppfw.tar
+          asset_name: mayhem_nightly_${{ steps.version_date.outputs.date }}_portarf_OCI.ppfw.tar
+          asset_content_type: application/x-tar
+      - name: Upload PortaRF Firmware Asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: artifacts/firmware-portarf/firmware.zip
+          asset_name: mayhem_nightly_${{ steps.version_date.outputs.date }}_portarf_FIRMWARE.zip
+          asset_content_type: application/zip
+      - name: Upload PortaRF SD Card Asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: artifacts/sdcard-portarf/sdcard.zip
+          asset_name: mayhem_nightly_${{ steps.version_date.outputs.date }}_portarf_COPY_TO_SDCARD.zip
+          asset_content_type: application/zip
+      - name: Upload PortaRF SD Card Asset - No Map
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: artifacts/sdcard-no-map-portarf/sdcard-no-map.zip
+          asset_name: mayhem_nightly_${{ steps.version_date.outputs.date }}_portarf_COPY_TO_SDCARD-no-world-map.zip
+          asset_content_type: application/zip
+      # HPro device assets
+      - name: Upload HPro Firmware TAR Asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: artifacts/oci-tar-hpro/portapack-mayhem_OCI.ppfw.tar
+          asset_name: mayhem_nightly_${{ steps.version_date.outputs.date }}_hpro_OCI.ppfw.tar
+          asset_content_type: application/x-tar
+      - name: Upload HPro Firmware Asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: artifacts/firmware-hpro/firmware.zip
+          asset_name: mayhem_nightly_${{ steps.version_date.outputs.date }}_hpro_FIRMWARE.zip
+          asset_content_type: application/zip
+      - name: Upload HPro SD Card Asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: artifacts/sdcard-hpro/sdcard.zip
+          asset_name: mayhem_nightly_${{ steps.version_date.outputs.date }}_hpro_COPY_TO_SDCARD.zip
+          asset_content_type: application/zip
+      - name: Upload HPro SD Card Asset - No Map
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: artifacts/sdcard-no-map-hpro/sdcard-no-map.zip
+          asset_name: mayhem_nightly_${{ steps.version_date.outputs.date }}_hpro_COPY_TO_SDCARD-no-world-map.zip
           asset_content_type: application/zip

--- a/.github/workflows/create_nightly_release.yml
+++ b/.github/workflows/create_nightly_release.yml
@@ -34,7 +34,7 @@ jobs:
           - device: default
             device_name: HackRF
             cmake_args: ""
-            artifact_suffix: ""
+            artifact_suffix: "_hackrf"
           - device: portarf
             device_name: PortaRF
             cmake_args: "-DFLASH_MB_SIZE=2 -DFLASH_MB_LIMIT_SIZE=2"
@@ -153,7 +153,7 @@ jobs:
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: artifacts/oci-tar-default/portapack-mayhem_OCI.ppfw.tar
-          asset_name: OCI_mayhem_nightly_${{ steps.version_date.outputs.date }}.ppfw.tar
+          asset_name: OCI_hackrf_mayhem_nightly_${{ steps.version_date.outputs.date }}.ppfw.tar
           asset_content_type: application/x-tar
       - name: Upload Default Firmware Asset
         uses: actions/upload-release-asset@v1
@@ -162,7 +162,7 @@ jobs:
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: artifacts/firmware-default/firmware.zip
-          asset_name: FIRMWARE_mayhem_nightly_${{ steps.version_date.outputs.date }}.zip
+          asset_name: FIRMWARE_hackrf_mayhem_nightly_${{ steps.version_date.outputs.date }}.zip
           asset_content_type: application/zip
       - name: Upload Default SD Card Asset
         uses: actions/upload-release-asset@v1
@@ -171,7 +171,7 @@ jobs:
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: artifacts/sdcard-default/sdcard.zip
-          asset_name: COPY_TO_SDCARD_mayhem_nightly_${{ steps.version_date.outputs.date }}.zip
+          asset_name: COPY_TO_SDCARD_hackrf_mayhem_nightly_${{ steps.version_date.outputs.date }}.zip
           asset_content_type: application/zip
       - name: Upload Default SD Card Asset - No Map
         uses: actions/upload-release-asset@v1
@@ -180,7 +180,7 @@ jobs:
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: artifacts/sdcard-no-map-default/sdcard-no-map.zip
-          asset_name: COPY_TO_SDCARD_mayhem_nightly_${{ steps.version_date.outputs.date }}-no-world-map.zip
+          asset_name: COPY_TO_SDCARD_hackrf_mayhem_nightly_${{ steps.version_date.outputs.date }}-no-world-map.zip
           asset_content_type: application/zip
       # PortaRF device assets
       - name: Upload PortaRF Firmware TAR Asset

--- a/.github/workflows/create_stable_release.yml
+++ b/.github/workflows/create_stable_release.yml
@@ -1,25 +1,32 @@
 name: Stable Release
 
-on:    
+on:
   workflow_dispatch:
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - device: default
+            cmake_args: ""
+            artifact_suffix: ""
+          - device: portarf
+            cmake_args: "-DFLASH_MB_SIZE=2 -DFLASH_MB_LIMIT_SIZE=2"
+            artifact_suffix: "_portarf"
+          - device: hpro
+            cmake_args: "-DBOARD=PRALINE"
+            artifact_suffix: "_hpro"
     steps:
       - name: Get current date
         id: date
         run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
-      - name: Checkout 
+      - name: Checkout
         uses: actions/checkout@master
         with:
           fetch-depth: 0
-          #ref: next
-          # The branch, tag or SHA to checkout. When checking out the repository that
-          # triggered a workflow, this defaults to the reference or SHA for that event.
-          # Otherwise, uses the default branch.
-          # https://github.com/actions/checkout
-          # So scheduled runs will use the default branch (next) but its now possible to trigger a workflow from another branch
           submodules: true
       - name: Git Sumbodule Update
         run: |
@@ -27,18 +34,15 @@ jobs:
       - name: Get version
         id: version
         run: echo "version=$(cat .github/workflows/version.txt)" >> $GITHUB_OUTPUT
-      - name: Get past version
-        id: past_version
-        run: echo "past_version=$(cat .github/workflows/past_version.txt)" >> $GITHUB_OUTPUT
       - name: Build the Docker image
         run: docker build -t portapack-dev -f dockerfile-nogit . --tag my-image-name:$(date +%s)
       - name: Make build folder
         run: mkdir ${{ github.workspace }}/build
       - name: Run the Docker image
-        run: docker run -e VERSION_STRING=${{ steps.version.outputs.version }} -i -v ${{ github.workspace }}:/havoc portapack-dev
+        run: docker run -e VERSION_STRING=${{ steps.version.outputs.version }} -i -v ${{ github.workspace }}:/havoc portapack-dev ${{ matrix.cmake_args }}
       - name: Create Small SD Card ZIP - No World Map
         run: |
-          mkdir -p sdcard/FIRMWARE && cp build/firmware/portapack-mayhem-firmware.bin sdcard/FIRMWARE/portapack-mayhem_${{ steps.version.outputs.version }}.bin && cp build/firmware/portapack-mayhem_OCI.ppfw.tar sdcard/FIRMWARE/mayhem_${{ steps.version.outputs.version }}_OCI.ppfw.tar && mkdir -p sdcard/APPS && cp build/firmware/application/*.ppma sdcard/APPS && cp build/firmware/standalone/*/*.ppmp sdcard/APPS && cd sdcard && zip -r ../sdcard-no-map.zip . && cd ..
+          mkdir -p sdcard/FIRMWARE && cp build/firmware/portapack-mayhem-firmware.bin sdcard/FIRMWARE/portapack-mayhem_${{ steps.version.outputs.version }}.bin && cp build/firmware/portapack-mayhem_OCI.ppfw.tar sdcard/FIRMWARE/mayhem_${{ steps.version.outputs.version }}${{ matrix.artifact_suffix }}_OCI.ppfw.tar && mkdir -p sdcard/APPS && cp build/firmware/application/*.ppma sdcard/APPS && cp build/firmware/standalone/*/*.ppmp sdcard/APPS && cd sdcard && zip -r ../sdcard-no-map.zip . && cd ..
       - name: Download world map
         run: |
           wget https://github.com/portapack-mayhem/mayhem-firmware/releases/download/world_map/world_map.zip
@@ -53,7 +57,50 @@ jobs:
           zip -j firmware.zip build/firmware/portapack-mayhem-firmware.bin && cd flashing && zip -r ../firmware.zip *
       - name: Create SD Card ZIP
         run: |
-          mkdir -p sdcard/FIRMWARE && cp build/firmware/portapack-mayhem-firmware.bin sdcard/FIRMWARE/portapack-mayhem_${{ steps.version.outputs.version }}.bin && cp build/firmware/portapack-mayhem_OCI.ppfw.tar sdcard/FIRMWARE/mayhem_${{ steps.version.outputs.version }}_OCI.ppfw.tar && mkdir -p sdcard/APPS && cp build/firmware/application/*.ppma sdcard/APPS && cp build/firmware/standalone/*/*.ppmp sdcard/APPS && cd sdcard && zip -r ../sdcard.zip . && cd ..
+          mkdir -p sdcard/FIRMWARE && cp build/firmware/portapack-mayhem-firmware.bin sdcard/FIRMWARE/portapack-mayhem_${{ steps.version.outputs.version }}.bin && cp build/firmware/portapack-mayhem_OCI.ppfw.tar sdcard/FIRMWARE/mayhem_${{ steps.version.outputs.version }}${{ matrix.artifact_suffix }}_OCI.ppfw.tar && mkdir -p sdcard/APPS && cp build/firmware/application/*.ppma sdcard/APPS && cp build/firmware/standalone/*/*.ppmp sdcard/APPS && cd sdcard && zip -r ../sdcard.zip . && cd ..
+      - name: Upload firmware zip artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: firmware-${{ matrix.device }}
+          path: ./firmware.zip
+      - name: Upload SD card artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: sdcard-${{ matrix.device }}
+          path: ./sdcard.zip
+      - name: Upload SD card no-map artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: sdcard-no-map-${{ matrix.device }}
+          path: ./sdcard-no-map.zip
+      - name: Upload OCI tar artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: oci-tar-${{ matrix.device }}
+          path: build/firmware/portapack-mayhem_OCI.ppfw.tar
+
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get current date
+        id: date
+        run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
+      - name: Checkout
+        uses: actions/checkout@master
+        with:
+          fetch-depth: 0
+          submodules: true
+      - name: Get version
+        id: version
+        run: echo "version=$(cat .github/workflows/version.txt)" >> $GITHUB_OUTPUT
+      - name: Get past version
+        id: past_version
+        run: echo "past_version=$(cat .github/workflows/past_version.txt)" >> $GITHUB_OUTPUT
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
       - name: Create changelog
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -78,7 +125,7 @@ jobs:
             ## Release notes
             ###  Revision (${{ steps.version.outputs.version }}):
             ${{ steps.changelog.outputs.content }}
-            
+
             **Full Changelog**: https://github.com/portapack-mayhem/mayhem-firmware/compare/${{ steps.past_version.outputs.past_version }}...${{ steps.version.outputs.version }}
 
             ## Installation
@@ -90,44 +137,114 @@ jobs:
             For certain functionality, like external apps, the world map, GPS simulator, and others you need to uncompress (using [7-zip](https://www.7-zip.org/download.html)) the files from `mayhem_vX.Y.Z_COPY_TO_SDCARD.zip` to a FAT32 formatted MicroSD card.
           draft: true
           prerelease: false
-      - name: Upload Firmware TAR Asset
-        id: upload-firmware-tar-asset 
+      # Default device assets
+      - name: Upload Default Firmware TAR Asset
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: build/firmware/portapack-mayhem_OCI.ppfw.tar
+          asset_path: artifacts/oci-tar-default/portapack-mayhem_OCI.ppfw.tar
           asset_name: mayhem_${{ steps.version.outputs.version }}_OCI.ppfw.tar
           asset_content_type: application/x-tar
-      - name: Upload Firmware Asset
-        id: upload-firmware-asset 
+      - name: Upload Default Firmware Asset
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./firmware.zip
+          asset_path: artifacts/firmware-default/firmware.zip
           asset_name: mayhem_${{ steps.version.outputs.version }}_FIRMWARE.zip
           asset_content_type: application/zip
-      - name: Upload SD Card Assets
-        id: upload-sd-card-asset 
+      - name: Upload Default SD Card Asset
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./sdcard.zip
+          asset_path: artifacts/sdcard-default/sdcard.zip
           asset_name: mayhem_${{ steps.version.outputs.version }}_COPY_TO_SDCARD.zip
           asset_content_type: application/zip
-      - name: Upload SD Card Assets - No Map
-        id: upload-sd-card-asset-no-map 
+      - name: Upload Default SD Card Asset - No Map
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./sdcard-no-map.zip
+          asset_path: artifacts/sdcard-no-map-default/sdcard-no-map.zip
           asset_name: mayhem_${{ steps.version.outputs.version }}_COPY_TO_SDCARD-no-world-map.zip
           asset_content_type: application/zip
-     
+      # PortaRF device assets
+      - name: Upload PortaRF Firmware TAR Asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: artifacts/oci-tar-portarf/portapack-mayhem_OCI.ppfw.tar
+          asset_name: mayhem_${{ steps.version.outputs.version }}_portarf_OCI.ppfw.tar
+          asset_content_type: application/x-tar
+      - name: Upload PortaRF Firmware Asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: artifacts/firmware-portarf/firmware.zip
+          asset_name: mayhem_${{ steps.version.outputs.version }}_portarf_FIRMWARE.zip
+          asset_content_type: application/zip
+      - name: Upload PortaRF SD Card Asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: artifacts/sdcard-portarf/sdcard.zip
+          asset_name: mayhem_${{ steps.version.outputs.version }}_portarf_COPY_TO_SDCARD.zip
+          asset_content_type: application/zip
+      - name: Upload PortaRF SD Card Asset - No Map
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: artifacts/sdcard-no-map-portarf/sdcard-no-map.zip
+          asset_name: mayhem_${{ steps.version.outputs.version }}_portarf_COPY_TO_SDCARD-no-world-map.zip
+          asset_content_type: application/zip
+      # HPro device assets
+      - name: Upload HPro Firmware TAR Asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: artifacts/oci-tar-hpro/portapack-mayhem_OCI.ppfw.tar
+          asset_name: mayhem_${{ steps.version.outputs.version }}_hpro_OCI.ppfw.tar
+          asset_content_type: application/x-tar
+      - name: Upload HPro Firmware Asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: artifacts/firmware-hpro/firmware.zip
+          asset_name: mayhem_${{ steps.version.outputs.version }}_hpro_FIRMWARE.zip
+          asset_content_type: application/zip
+      - name: Upload HPro SD Card Asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: artifacts/sdcard-hpro/sdcard.zip
+          asset_name: mayhem_${{ steps.version.outputs.version }}_hpro_COPY_TO_SDCARD.zip
+          asset_content_type: application/zip
+      - name: Upload HPro SD Card Asset - No Map
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: artifacts/sdcard-no-map-hpro/sdcard-no-map.zip
+          asset_name: mayhem_${{ steps.version.outputs.version }}_hpro_COPY_TO_SDCARD-no-world-map.zip
+          asset_content_type: application/zip

--- a/.github/workflows/create_stable_release.yml
+++ b/.github/workflows/create_stable_release.yml
@@ -14,7 +14,7 @@ jobs:
           - device: default
             device_name: HackRF
             cmake_args: ""
-            artifact_suffix: ""
+            artifact_suffix: "_hackrf"
           - device: portarf
             device_name: PortaRF
             cmake_args: "-DFLASH_MB_SIZE=2 -DFLASH_MB_LIMIT_SIZE=2"
@@ -149,7 +149,7 @@ jobs:
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: artifacts/oci-tar-default/portapack-mayhem_OCI.ppfw.tar
-          asset_name: OCI_mayhem_${{ steps.version.outputs.version }}.ppfw.tar
+          asset_name: OCI_hackrf_mayhem_${{ steps.version.outputs.version }}.ppfw.tar
           asset_content_type: application/x-tar
       - name: Upload Default Firmware Asset
         uses: actions/upload-release-asset@v1
@@ -158,7 +158,7 @@ jobs:
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: artifacts/firmware-default/firmware.zip
-          asset_name: FIRMWARE_mayhem_${{ steps.version.outputs.version }}.zip
+          asset_name: FIRMWARE_hackrf_mayhem_${{ steps.version.outputs.version }}.zip
           asset_content_type: application/zip
       - name: Upload Default SD Card Asset
         uses: actions/upload-release-asset@v1
@@ -167,7 +167,7 @@ jobs:
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: artifacts/sdcard-default/sdcard.zip
-          asset_name: COPY_TO_SDCARD_mayhem_${{ steps.version.outputs.version }}.zip
+          asset_name: COPY_TO_SDCARD_hackrf_mayhem_${{ steps.version.outputs.version }}.zip
           asset_content_type: application/zip
       - name: Upload Default SD Card Asset - No Map
         uses: actions/upload-release-asset@v1
@@ -176,7 +176,7 @@ jobs:
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: artifacts/sdcard-no-map-default/sdcard-no-map.zip
-          asset_name: COPY_TO_SDCARD_mayhem_${{ steps.version.outputs.version }}-no-world-map.zip
+          asset_name: COPY_TO_SDCARD_hackrf_mayhem_${{ steps.version.outputs.version }}-no-world-map.zip
           asset_content_type: application/zip
       # PortaRF device assets
       - name: Upload PortaRF Firmware TAR Asset

--- a/.github/workflows/create_stable_release.yml
+++ b/.github/workflows/create_stable_release.yml
@@ -149,7 +149,7 @@ jobs:
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: artifacts/oci-tar-default/portapack-mayhem_OCI.ppfw.tar
-          asset_name: mayhem_${{ steps.version.outputs.version }}_OCI.ppfw.tar
+          asset_name: OCI_mayhem_${{ steps.version.outputs.version }}.ppfw.tar
           asset_content_type: application/x-tar
       - name: Upload Default Firmware Asset
         uses: actions/upload-release-asset@v1
@@ -158,7 +158,7 @@ jobs:
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: artifacts/firmware-default/firmware.zip
-          asset_name: mayhem_${{ steps.version.outputs.version }}_FIRMWARE.zip
+          asset_name: FIRMWARE_mayhem_${{ steps.version.outputs.version }}.zip
           asset_content_type: application/zip
       - name: Upload Default SD Card Asset
         uses: actions/upload-release-asset@v1
@@ -167,7 +167,7 @@ jobs:
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: artifacts/sdcard-default/sdcard.zip
-          asset_name: mayhem_${{ steps.version.outputs.version }}_COPY_TO_SDCARD.zip
+          asset_name: COPY_TO_SDCARD_mayhem_${{ steps.version.outputs.version }}.zip
           asset_content_type: application/zip
       - name: Upload Default SD Card Asset - No Map
         uses: actions/upload-release-asset@v1
@@ -176,7 +176,7 @@ jobs:
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: artifacts/sdcard-no-map-default/sdcard-no-map.zip
-          asset_name: mayhem_${{ steps.version.outputs.version }}_COPY_TO_SDCARD-no-world-map.zip
+          asset_name: COPY_TO_SDCARD_mayhem_${{ steps.version.outputs.version }}-no-world-map.zip
           asset_content_type: application/zip
       # PortaRF device assets
       - name: Upload PortaRF Firmware TAR Asset
@@ -186,7 +186,7 @@ jobs:
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: artifacts/oci-tar-portarf/portapack-mayhem_OCI.ppfw.tar
-          asset_name: mayhem_${{ steps.version.outputs.version }}_portarf_OCI.ppfw.tar
+          asset_name: OCI_portarf_mayhem_${{ steps.version.outputs.version }}.ppfw.tar
           asset_content_type: application/x-tar
       - name: Upload PortaRF Firmware Asset
         uses: actions/upload-release-asset@v1
@@ -195,7 +195,7 @@ jobs:
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: artifacts/firmware-portarf/firmware.zip
-          asset_name: mayhem_${{ steps.version.outputs.version }}_portarf_FIRMWARE.zip
+          asset_name: FIRMWARE_portarf_mayhem_${{ steps.version.outputs.version }}.zip
           asset_content_type: application/zip
       - name: Upload PortaRF SD Card Asset
         uses: actions/upload-release-asset@v1
@@ -204,7 +204,7 @@ jobs:
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: artifacts/sdcard-portarf/sdcard.zip
-          asset_name: mayhem_${{ steps.version.outputs.version }}_portarf_COPY_TO_SDCARD.zip
+          asset_name: COPY_TO_SDCARD_portarf_mayhem_${{ steps.version.outputs.version }}.zip
           asset_content_type: application/zip
       - name: Upload PortaRF SD Card Asset - No Map
         uses: actions/upload-release-asset@v1
@@ -213,7 +213,7 @@ jobs:
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: artifacts/sdcard-no-map-portarf/sdcard-no-map.zip
-          asset_name: mayhem_${{ steps.version.outputs.version }}_portarf_COPY_TO_SDCARD-no-world-map.zip
+          asset_name: COPY_TO_SDCARD_portarf_mayhem_${{ steps.version.outputs.version }}-no-world-map.zip
           asset_content_type: application/zip
       # HPro device assets
       - name: Upload HPro Firmware TAR Asset
@@ -223,7 +223,7 @@ jobs:
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: artifacts/oci-tar-hpro/portapack-mayhem_OCI.ppfw.tar
-          asset_name: mayhem_${{ steps.version.outputs.version }}_hpro_OCI.ppfw.tar
+          asset_name: OCI_hpro_mayhem_${{ steps.version.outputs.version }}.ppfw.tar
           asset_content_type: application/x-tar
       - name: Upload HPro Firmware Asset
         uses: actions/upload-release-asset@v1
@@ -232,7 +232,7 @@ jobs:
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: artifacts/firmware-hpro/firmware.zip
-          asset_name: mayhem_${{ steps.version.outputs.version }}_hpro_FIRMWARE.zip
+          asset_name: FIRMWARE_hpro_mayhem_${{ steps.version.outputs.version }}.zip
           asset_content_type: application/zip
       - name: Upload HPro SD Card Asset
         uses: actions/upload-release-asset@v1
@@ -241,7 +241,7 @@ jobs:
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: artifacts/sdcard-hpro/sdcard.zip
-          asset_name: mayhem_${{ steps.version.outputs.version }}_hpro_COPY_TO_SDCARD.zip
+          asset_name: COPY_TO_SDCARD_hpro_mayhem_${{ steps.version.outputs.version }}.zip
           asset_content_type: application/zip
       - name: Upload HPro SD Card Asset - No Map
         uses: actions/upload-release-asset@v1
@@ -250,5 +250,5 @@ jobs:
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: artifacts/sdcard-no-map-hpro/sdcard-no-map.zip
-          asset_name: mayhem_${{ steps.version.outputs.version }}_hpro_COPY_TO_SDCARD-no-world-map.zip
+          asset_name: COPY_TO_SDCARD_hpro_mayhem_${{ steps.version.outputs.version }}-no-world-map.zip
           asset_content_type: application/zip

--- a/.github/workflows/create_stable_release.yml
+++ b/.github/workflows/create_stable_release.yml
@@ -6,17 +6,21 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    name: build (${{ matrix.device_name }})
     strategy:
       fail-fast: false
       matrix:
         include:
           - device: default
+            device_name: HackRF
             cmake_args: ""
             artifact_suffix: ""
           - device: portarf
+            device_name: PortaRF
             cmake_args: "-DFLASH_MB_SIZE=2 -DFLASH_MB_LIMIT_SIZE=2"
             artifact_suffix: "_portarf"
           - device: hpro
+            device_name: HackRF Pro
             cmake_args: "-DBOARD=PRALINE"
             artifact_suffix: "_hpro"
     steps:


### PR DESCRIPTION
## Summary
This PR refactors the nightly and stable release workflows to support building firmware for multiple device variants (HackRF, PortaRF, and HackRF Pro) using a matrix build strategy.

## Changes

### Workflow Structure
- **Split build and release jobs**: Build artifacts are now created in a separate job from the release creation, allowing parallel builds for different devices
- **Matrix build strategy**: Introduced a build matrix to compile firmware for three device variants:
- `default` (HackRF) - standard build
- `portarf` (PortaRF) - with flash size constraints (`-DFLASH_MB_SIZE=2 -DFLASH_MB_LIMIT_SIZE=2`)
- `hpro` (HackRF Pro) - using PRALINE board (`-DBOARD=PRALINE`)

### Artifact Management
- **Upload artifacts from build job**: Each device variant uploads 4 artifacts:
- Firmware ZIP
- SD card ZIP (with world map)
- SD card ZIP (without world map)
- OCI TAR file
- **Download artifacts in release job**: All artifacts are downloaded and uploaded as release assets with device-specific naming

### Asset Naming Convention
Updated asset naming to be more consistent and descriptive:
- **Before**: `mayhem_nightly_YYMMDD_FIRMWARE.zip`
- **After**: `FIRMWARE_hackrf_mayhem_nightly_nYYMMDD.zip`

All assets now include the device identifier (`hackrf`, `portarf`, or `hpro`) for clarity.

### Code Quality
- Removed commented-out code and outdated comments
- Fixed trailing whitespace
- Improved consistency between nightly and stable release workflows

## Benefits
1. **Multi-device support**: Users can now download firmware specifically built for their device variant
2. **Parallel builds**: Matrix strategy allows builds to run concurrently, reducing overall workflow time
3. **Better organization**: Clear separation between build and release steps
4. **Improved naming**: Asset names clearly indicate which device they're intended for

## Testing
- [ ] Verify all three device variants build successfully
- [x] Confirm artifacts are uploaded correctly
- [x] Validate release assets are created with correct names
- [x] Test both nightly and stable release workflows