### PR TITLE
Fix units tpms not compiling

### DIFF
--- a/firmware/application/external/tpmsrx/tpms_app.cpp
+++ b/firmware/application/external/tpmsrx/tpms_app.cpp
@@ -47,14 +47,13 @@ std::string id(tpms::TransponderID id) {
 }
 
 std::string pressure(Pressure pressure) {
-    return to_string_dec_int(
-        format::units_pressure == format::PressureUnit::PSI ? pressure.psi() : format::units_pressure == format::PressureUnit::BAR ? pressure.bar()
-                                                                                                                                   : pressure.kilopascal(),
-        3);
+    return to_string_dec_int(pressure_unit == PRESSURE_UNIT_PSI ? pressure.psi() : pressure_unit == PRESSURE_UNIT_BAR ? pressure.bar()
+                                                                                                                      : pressure.kilopascal(),
+                             3);
 }
 
 std::string temperature(Temperature temperature) {
-    return to_string_dec_int(units_fahr ? temperature.fahrenheit() : temperature.celsius(), 3);
+    return to_string_dec_int(temp_unit == TEMP_UNIT_CELSIUS ? temperature.celsius() : temperature.fahrenheit(), 3);
 }
 
 std::string flags(tpms::Flags flags) {
@@ -125,16 +124,16 @@ TPMSAppView::TPMSAppView(NavigationView&) {
     options_band.set_by_value(receiver_model.target_frequency());
 
     options_pressure.on_change = [this](size_t, int32_t i) {
-        format::units_pressure = static_cast<format::PressureUnit>(i);
+        format::pressure_unit = (uint8_t)i;
         update_view();
     };
-    options_pressure.set_selected_index(static_cast<int>(format::units_pressure), true);
+    options_pressure.set_selected_index(format::pressure_unit, true);
 
     options_temperature.on_change = [this](size_t, int32_t i) {
-        format::units_fahr = (bool)i;
+        format::temp_unit = (uint8_t)i;
         update_view();
     };
-    options_temperature.set_selected_index(format::units_fahr, true);
+    options_temperature.set_selected_index(format::temp_unit, true);
 
     logger = std::make_unique<TPMSLogger>();
     if (logger) {

--- a/firmware/application/external/tpmsrx/tpms_app.hpp
+++ b/firmware/application/external/tpmsrx/tpms_app.hpp
@@ -42,16 +42,9 @@ namespace ui::external_app::tpmsrx {
 
 namespace format {
 
-enum class PressureUnit : int {
-    kPa = 0,
-    PSI = 1,
-    BAR = 2,
-};
-
-static PressureUnit units_pressure{PressureUnit::kPa};
-static bool units_fahr{false};
-
-} /* namespace format */
+static uint8_t pressure_unit{PRESSURE_UNIT_KPA};
+static uint8_t temp_unit{TEMP_UNIT_CELSIUS};
+}  // namespace format
 
 struct TPMSRecentEntry {
     using Key = std::pair<tpms::Reading::Type, tpms::TransponderID>;
@@ -123,8 +116,8 @@ class TPMSAppView : public View {
         "rx_tpms",
         app_settings::Mode::RX,
         {
-            {"units_pressure"sv, &format::units_pressure},
-            {"units_fahr"sv, &format::units_fahr},
+            {"pressure_unit"sv, &format::pressure_unit},
+            {"temp_unit"sv, &format::temp_unit},
         }};
 
     MessageHandlerRegistration message_handler_packet{
@@ -161,15 +154,15 @@ class TPMSAppView : public View {
     OptionsField options_pressure{
         {6 * 8, UI_POS_Y(0)},
         4,
-        {{"kPa", static_cast<int>(PressureUnit::kPa)},
-         {"PSI", static_cast<int>(PressureUnit::PSI)},
-         {"BAR", static_cast<int>(PressureUnit::BAR)}}};
+        {{"kPa", PRESSURE_UNIT_KPA},
+         {"PSI", PRESSURE_UNIT_PSI},
+         {"BAR", PRESSURE_UNIT_BAR}}};
 
     OptionsField options_temperature{
         {10 * 8, UI_POS_Y(0)},
         2,
-        {{STR_DEGREES_C, 0},
-         {STR_DEGREES_F, 1}}};
+        {{STR_DEGREES_C, TEMP_UNIT_CELSIUS},
+         {STR_DEGREES_F, TEMP_UNIT_FAHRENHEIT}}};
 
     RFAmpField field_rf_amp{
         {13 * 8, UI_POS_Y(0)}};

--- a/firmware/common/units.hpp
+++ b/firmware/common/units.hpp
@@ -22,6 +22,12 @@
 #ifndef __UNITS_H__
 #define __UNITS_H__
 
+#define TEMP_UNIT_CELSIUS 0
+#define TEMP_UNIT_FAHRENHEIT 1
+#define PRESSURE_UNIT_KPA 2
+#define PRESSURE_UNIT_BAR 3
+#define PRESSURE_UNIT_PSI 4
+
 #include <cstdint>
 
 #define STR_DEGREES_C "\xB0\x43"  // ºC - 0xB0 is degree ° symbol in our 8x16 font, 0x43 is "C"


### PR DESCRIPTION
## Brief description what you did

Following https://github.com/portapack-mayhem/mayhem-firmware/pull/2988 I saw that it was not compiling correctly.

Hence I:
- fixed the compilation
- fixed the units usage and variables names
- added defines for unit types

## Checklist
- [X]  Kept changes minimal and limited to necessary files
- [X]  Verified functionality remains intact and code compiles
