### PR TITLE
Add altitude-based color coding for map markers in adsb

### DIFF
--- a/firmware/application/apps/ui_adsb_rx.cpp
+++ b/firmware/application/apps/ui_adsb_rx.cpp
@@ -320,6 +320,43 @@ void ADSBRxDetailsView::update(const AircraftRecentEntry& entry) {
     }
 }
 
+void ADSBRxDetailsView::get_altitude_color(int32_t alt_ft, uint8_t* r, uint8_t* g, uint8_t* b) {
+    static const struct {
+        int32_t alt;
+        uint8_t r, g, b;
+    } stops[] = {
+        {0, 220, 220, 220},    // 0 ft:     White/Grey (Ground)
+        {2000, 255, 255, 0},   // 2k ft:    Yellow
+        {10000, 0, 255, 0},    // 10k ft:   Green
+        {20000, 0, 255, 255},  // 20k ft:   Cyan
+        {30000, 60, 60, 255},  // 30k ft:   Blue (Lightened for visibility on Black)
+        {40000, 255, 0, 255}   // 40k+ ft:  Magenta
+    };
+    if (alt_ft <= stops[0].alt) {
+        *r = stops[0].r;
+        *g = stops[0].g;
+        *b = stops[0].b;
+        return;
+    }
+    const int count = sizeof(stops) / sizeof(stops[0]);
+    if (alt_ft >= stops[count - 1].alt) {
+        *r = stops[count - 1].r;
+        *g = stops[count - 1].g;
+        *b = stops[count - 1].b;
+        return;
+    }
+    for (int i = 0; i < count - 1; i++) {
+        if (alt_ft < stops[i + 1].alt) {
+            float t = (float)(alt_ft - stops[i].alt) / (stops[i + 1].alt - stops[i].alt);
+
+            *r = (uint8_t)(stops[i].r + (stops[i + 1].r - stops[i].r) * t);
+            *g = (uint8_t)(stops[i].g + (stops[i + 1].g - stops[i].g) * t);
+            *b = (uint8_t)(stops[i].b + (stops[i + 1].b - stops[i].b) * t);
+            return;
+        }
+    }
+}
+
 void ADSBRxDetailsView::clear_map_markers() {
     if (geomap_view_)
         geomap_view_->clear_markers();
@@ -335,6 +372,9 @@ bool ADSBRxDetailsView::add_map_marker(const AircraftRecentEntry& entry) {
     marker.lat = entry.pos.latitude;
     marker.angle = entry.velo.heading;
     marker.tag = get_map_tag(entry);
+    uint8_t r, g, b;
+    get_altitude_color(entry.pos.altitude, &r, &g, &b);
+    marker.color = Color(r, g, b);
 
     auto markerStored = geomap_view_->store_marker(marker);
     return markerStored == MARKER_STORED;

--- a/firmware/application/apps/ui_adsb_rx.cpp
+++ b/firmware/application/apps/ui_adsb_rx.cpp
@@ -355,6 +355,10 @@ void ADSBRxDetailsView::get_altitude_color(int32_t alt_ft, uint8_t* r, uint8_t* 
             return;
         }
     }
+    // Fallback: in case no interval matched, default to ground color.
+    *r = stops[0].r;
+    *g = stops[0].g;
+    *b = stops[0].b;
 }
 
 void ADSBRxDetailsView::clear_map_markers() {

--- a/firmware/application/apps/ui_adsb_rx.hpp
+++ b/firmware/application/apps/ui_adsb_rx.hpp
@@ -270,6 +270,7 @@ class ADSBRxDetailsView : public View {
     void focus() override;
     void update(const AircraftRecentEntry& entry);
 
+    void get_altitude_color(int32_t alt_ft, uint8_t* r, uint8_t* g, uint8_t* b);
     /* Calls forwarded to map view if shown. */
     bool map_active() const { return geomap_view_; }
     void clear_map_markers();

--- a/firmware/application/ui/ui_geomap.cpp
+++ b/firmware/application/ui/ui_geomap.cpp
@@ -265,7 +265,7 @@ void GeoMap::map_read_line_bin(ui::Color* buffer, uint16_t pixels) {
 
 void GeoMap::draw_markers(Painter& painter) {
     for (int i = 0; i < markerListLen; ++i) {
-        draw_marker_item(painter, markerList[i], Color::blue(), Color::blue(), Color::magenta());
+        draw_marker_item(painter, markerList[i], markerList[i].color, Color::white(), markerList[i].color);
     }
 }
 

--- a/firmware/application/ui/ui_geomap.cpp
+++ b/firmware/application/ui/ui_geomap.cpp
@@ -265,7 +265,7 @@ void GeoMap::map_read_line_bin(ui::Color* buffer, uint16_t pixels) {
 
 void GeoMap::draw_markers(Painter& painter) {
     for (int i = 0; i < markerListLen; ++i) {
-        draw_marker_item(painter, markerList[i], markerList[i].color, Color::white(), markerList[i].color);
+        draw_marker_item(painter, markerList[i], markerList[i].color, markerList[i].color, Color::black());
     }
 }
 
@@ -826,7 +826,7 @@ void GeoMap::update_my_position(float lat, float lon, int32_t altitude) {
     my_pos.lat = lat;
     my_pos.lon = lon;
     my_altitude = altitude;
-    redraw_map = is_changed;
+    redraw_map |= is_changed;
     set_dirty();
 }
 

--- a/firmware/application/ui/ui_geomap.hpp
+++ b/firmware/application/ui/ui_geomap.hpp
@@ -62,13 +62,14 @@ struct GeoMarker {
     float lon{0};
     uint16_t angle{0};
     std::string tag{""};
+    Color color{Color::blue()};
 
     GeoMarker& operator=(GeoMarker& rhs) {
         lat = rhs.lat;
         lon = rhs.lon;
         angle = rhs.angle;
         tag = rhs.tag;
-
+        color = rhs.color;
         return *this;
     }
 };

--- a/firmware/application/ui/ui_geomap.hpp
+++ b/firmware/application/ui/ui_geomap.hpp
@@ -64,7 +64,7 @@ struct GeoMarker {
     std::string tag{""};
     Color color{Color::blue()};
 
-    GeoMarker& operator=(GeoMarker& rhs) {
+    GeoMarker& operator=(const GeoMarker& rhs) {
         lat = rhs.lat;
         lon = rhs.lon;
         angle = rhs.angle;


### PR DESCRIPTION
This pull request introduces altitude-based color coding for aircraft markers in the ADS-B receiver details view, enhancing the visual representation of aircraft altitude on the map. The changes include adding a color interpolation function, updating marker creation to use altitude-derived colors, and modifying the `GeoMarker` and map drawing logic to support custom colors.

**Altitude-based marker color coding:**

* Added the `get_altitude_color` method to `ADSBRxDetailsView`, which interpolates marker colors based on aircraft altitude using defined color stops. [[1]](diffhunk://#diff-eaa5967522f422267b0ddd6fdac818497a06d0530ba4da95333409737f3ebaf1R323-R359) [[2]](diffhunk://#diff-39b0582a3f995d231667dc65ccae890ea144a11bcfe6b605e27b898ca5c1a6dcR273)
* Updated `add_map_marker` in `ADSBRxDetailsView` to assign altitude-based colors to aircraft markers using the new function.

**Map marker enhancements:**

* Modified the `GeoMarker` struct to include a `color` field, defaulting to blue, and updated its assignment operator to copy the color.
* Changed the `draw_markers` method in `GeoMap` to use each marker's assigned color for drawing, improving marker visibility and distinction based on altitude.