### PR TITLE
Add HackRF Pro (PRALINE) Board Detection and Info Display

### DIFF
--- a/firmware/application/apps/ui_flash_utility.cpp
+++ b/firmware/application/apps/ui_flash_utility.cpp
@@ -46,11 +46,10 @@ bool valid_firmware_file(std::filesystem::path::string_type path) {
     auto result = firmware_file.open(path.c_str());
     if (!result.is_valid()) {
         uint64_t file_size = firmware_file.size();
-        if (portapack::device_type == portapack::DeviceType::DEV_PORTAPACK && file_size > 1 * 1024 * 1024) {
-            // Portapack firmware files must not be larger than 1MB
+        if (file_size > FLASH_ROM_SIZE) {
+            // Firmware file is larger than the flash size for this device
             return false;
         }
-        // May need to add a check to portarf and portarf pro too.
         checksum = 0;
         for (uint64_t offset = 0; offset < FLASH_ROM_SIZE && offset < file_size; offset += sizeof(read_buffer)) {
             auto readResult = firmware_file.read(&read_buffer, sizeof(read_buffer));

--- a/firmware/application/portapack.cpp
+++ b/firmware/application/portapack.cpp
@@ -553,16 +553,10 @@ init_status_t init() {
 
     chThdSleepMilliseconds(100);
 
-#ifdef PRALINE
-    // PRALINE: full pin-probing detection conflicts with hardware init;
-    // use ADC-only revision detection instead.
-    detect_praline_board_revision();
-#else
     detect_hardware_platform();
     finalize_detect_hardware_platform();
 
     chThdSleepMilliseconds(100);
-#endif
 
     configure_pins_portapack();
 

--- a/firmware/application/portapack.cpp
+++ b/firmware/application/portapack.cpp
@@ -56,11 +56,9 @@ using asahi_kasei::ak4951::AK4951;
 #include "i2cdevmanager.hpp"
 #include "battery.hpp"
 
-#ifndef PRALINE
 extern "C" {
 #include "platform_detect.h"
 }
-#endif
 
 namespace portapack {
 
@@ -555,7 +553,11 @@ init_status_t init() {
 
     chThdSleepMilliseconds(100);
 
-#ifndef PRALINE
+#ifdef PRALINE
+    // PRALINE: full pin-probing detection conflicts with hardware init;
+    // use ADC-only revision detection instead.
+    detect_praline_board_revision();
+#else
     detect_hardware_platform();
     finalize_detect_hardware_platform();
 

--- a/firmware/application/shell.cpp
+++ b/firmware/application/shell.cpp
@@ -31,6 +31,7 @@
 #include "shell.hpp"
 #include "chprintf.h"
 #include "portapack.hpp"
+#include "../flashsize.h"
 
 extern "C" {
 #include "platform_detect.h"
@@ -93,6 +94,22 @@ static const char* get_board_revision_string(board_rev_t rev) {
             return "GSG HackRF R9";
         case BOARD_REV_GSG_HACKRF1_R10:
             return "GSG HackRF R10";
+        case BOARD_REV_PRALINE_R0_1:
+        case BOARD_REV_PRALINE_R0_2:
+        case BOARD_REV_PRALINE_R0_3:
+            return "HackRF Pro R0";
+        case BOARD_REV_PRALINE_R1_0:
+        case BOARD_REV_PRALINE_R1_1:
+        case BOARD_REV_PRALINE_R1_2:
+            return "HackRF Pro R1";
+        case BOARD_REV_GSG_PRALINE_R0_1:
+        case BOARD_REV_GSG_PRALINE_R0_2:
+        case BOARD_REV_GSG_PRALINE_R0_3:
+            return "GSG HackRF Pro R0";
+        case BOARD_REV_GSG_PRALINE_R1_0:
+        case BOARD_REV_GSG_PRALINE_R1_1:
+        case BOARD_REV_GSG_PRALINE_R1_2:
+            return "GSG HackRF Pro R1";
         case BOARD_REV_UNRECOGNIZED:
             return "Unrecognized";
         case BOARD_REV_UNDETECTED:
@@ -134,6 +151,34 @@ static void cmd_info(BaseSequentialStream* chp, int argc, char* argv[]) {
     board_rev_t revision = detected_revision();
     const char* revision_string = get_board_revision_string(revision);
     chprintf(chp, "HackRF Board Rev: %s\r\n", revision_string);
+
+    // Determine device type string
+    // Note: detected_platform() does not work in the PortaPack M0 application context;
+    // FLASH_SIZE_MB is set by cmake per-device and is the reliable indicator.
+    const char* device_str;
+    if (FLASH_SIZE_MB >= 4) {
+        device_str = "HackRF Pro";
+    } else if (portapack::device_type == portapack::DEV_PORTARF) {
+        device_str = "PortaRF";
+    } else {
+        device_str = "HackRF One";
+    }
+    chprintf(chp, "Device:           %s\r\n", device_str);
+
+    // Flash info: build-time allowed MB, runtime-detected limit, current firmware size
+    // Use explicit uint32_t cast: FLASH_SIZE_LIMIT_MB may be a float (e.g. 3.5 for HPro)
+    uint8_t flash_allowrun;
+    if (FLASH_SIZE_MB >= 4) {
+        flash_allowrun = 4;  // HackRF Pro
+    } else if (portapack::device_type == portapack::DeviceType::DEV_PORTAPACK) {
+        flash_allowrun = 1;  // PortaPack classic
+    } else {
+        flash_allowrun = FLASH_SIZE_MB;  // PortaRF
+    }
+    chprintf(chp, "Flash Allowed:    %dMB\r\n", (uint32_t)FLASH_SIZE_MB);
+    chprintf(chp, "Flash Runtime:    %dMB\r\n", (uint32_t)flash_allowrun);
+    chprintf(chp, "Flash Current:    %dMB\r\n", (uint32_t)FLASH_SIZE_LIMIT_MB);
+
     chprintf(chp, "Reference Source: %s\r\n", portapack::clock_manager.get_source().c_str());
     chprintf(chp, "Reference Freq:   %s\r\n", portapack::clock_manager.get_freq().c_str());
 #ifdef __DATE__

--- a/firmware/application/shell.cpp
+++ b/firmware/application/shell.cpp
@@ -153,28 +153,30 @@ static void cmd_info(BaseSequentialStream* chp, int argc, char* argv[]) {
     chprintf(chp, "HackRF Board Rev: %s\r\n", revision_string);
 
     // Determine device type string
-    // Note: detected_platform() does not work in the PortaPack M0 application context;
-    // FLASH_SIZE_MB is set by cmake per-device and is the reliable indicator.
     const char* device_str;
-    if (FLASH_SIZE_MB >= 4) {
-        device_str = "HackRF Pro";
-    } else if (portapack::device_type == portapack::DEV_PORTARF) {
+#ifdef PRALINE
+    device_str = "HackRF Pro";
+#else
+    if (portapack::device_type == portapack::DEV_PORTARF) {
         device_str = "PortaRF";
     } else {
         device_str = "HackRF One";
     }
+#endif
     chprintf(chp, "Device:           %s\r\n", device_str);
 
     // Flash info: build-time allowed MB, runtime-detected limit, current firmware size
     // Use explicit uint32_t cast: FLASH_SIZE_LIMIT_MB may be a float (e.g. 3.5 for HPro)
     uint8_t flash_allowrun;
-    if (FLASH_SIZE_MB >= 4) {
-        flash_allowrun = 4;  // HackRF Pro
-    } else if (portapack::device_type == portapack::DeviceType::DEV_PORTAPACK) {
+#ifdef PRALINE
+    flash_allowrun = 4;  // HackRF Pro
+#else
+    if (portapack::device_type == portapack::DeviceType::DEV_PORTAPACK) {
         flash_allowrun = 1;  // PortaPack classic
     } else {
         flash_allowrun = FLASH_SIZE_MB;  // PortaRF
     }
+#endif
     chprintf(chp, "Flash Allowed:    %dMB\r\n", (uint32_t)FLASH_SIZE_MB);
     chprintf(chp, "Flash Runtime:    %dMB\r\n", (uint32_t)flash_allowrun);
     chprintf(chp, "Flash Current:    %dMB\r\n", (uint32_t)FLASH_SIZE_LIMIT_MB);

--- a/firmware/application/usb_serial_shell.cpp
+++ b/firmware/application/usb_serial_shell.cpp
@@ -1386,18 +1386,32 @@ static void cmd_getres(BaseSequentialStream* chp, int argc, char* argv[]) {
 static void cmd_getflash(BaseSequentialStream* chp, int argc, char* argv[]) {
     (void)argc;
     (void)argv;
-    uint8_t allowrun = FLASH_SIZE_MB;
-    if (portapack::device_type == portapack::DeviceType::DEV_PORTAPACK) {
-        allowrun = 1;
+    // Note: FLASH_SIZE_MB is set by cmake per-device and is the reliable HPro indicator
+    // since detected_platform() does not work in the PortaPack M0 application context.
+    // FLASH_SIZE_LIMIT_MB may be a float (e.g. 3.5 for HPro), always cast explicitly.
+    uint8_t allowrun;
+    if (FLASH_SIZE_MB >= 4) {
+        allowrun = 4;  // HackRF Pro
+    } else if (portapack::device_type == portapack::DeviceType::DEV_PORTAPACK) {
+        allowrun = 1;  // PortaPack classic
+    } else {
+        allowrun = FLASH_SIZE_MB;  // PortaRF
     }
-    std::string res = "ALLOWEDFW:" + to_string_dec_uint(FLASH_SIZE_MB) + "\r\nALLOWEDRUNTIME:" + to_string_dec_uint(allowrun) + "\r\nCURRENT:" + to_string_dec_uint(FLASH_SIZE_LIMIT_MB) + "\r\nok\r\n";
+    std::string res = "ALLOWEDFW:" + to_string_dec_uint((uint32_t)FLASH_SIZE_MB) + "\r\nALLOWEDRUNTIME:" + to_string_dec_uint((uint32_t)allowrun) + "\r\nCURRENT:" + to_string_dec_uint((uint32_t)FLASH_SIZE_LIMIT_MB) + "\r\nok\r\n";
     chprintf(chp, res.c_str());
 }
 
 static void cmd_getdevtype(BaseSequentialStream* chp, int argc, char* argv[]) {
     (void)argc;
     (void)argv;
-    std::string res = portapack::device_type == portapack::DeviceType::DEV_PORTARF ? "PORTARF" : "PORTAPACK";
+    std::string res;
+    if (FLASH_SIZE_MB >= 4) {
+        res = "HPRO";
+    } else if (portapack::device_type == portapack::DeviceType::DEV_PORTARF) {
+        res = "PORTARF";
+    } else {
+        res = "PORTAPACK";
+    }
     res += "\r\nok\r\n";
     chprintf(chp, res.c_str());
 }

--- a/firmware/application/usb_serial_shell.cpp
+++ b/firmware/application/usb_serial_shell.cpp
@@ -1386,17 +1386,17 @@ static void cmd_getres(BaseSequentialStream* chp, int argc, char* argv[]) {
 static void cmd_getflash(BaseSequentialStream* chp, int argc, char* argv[]) {
     (void)argc;
     (void)argv;
-    // Note: FLASH_SIZE_MB is set by cmake per-device and is the reliable HPro indicator
-    // since detected_platform() does not work in the PortaPack M0 application context.
     // FLASH_SIZE_LIMIT_MB may be a float (e.g. 3.5 for HPro), always cast explicitly.
     uint8_t allowrun;
-    if (FLASH_SIZE_MB >= 4) {
-        allowrun = 4;  // HackRF Pro
-    } else if (portapack::device_type == portapack::DeviceType::DEV_PORTAPACK) {
+#ifdef PRALINE
+    allowrun = 4;  // HackRF Pro
+#else
+    if (portapack::device_type == portapack::DeviceType::DEV_PORTAPACK) {
         allowrun = 1;  // PortaPack classic
     } else {
         allowrun = FLASH_SIZE_MB;  // PortaRF
     }
+#endif
     std::string res = "ALLOWEDFW:" + to_string_dec_uint((uint32_t)FLASH_SIZE_MB) + "\r\nALLOWEDRUNTIME:" + to_string_dec_uint((uint32_t)allowrun) + "\r\nCURRENT:" + to_string_dec_uint((uint32_t)FLASH_SIZE_LIMIT_MB) + "\r\nok\r\n";
     chprintf(chp, res.c_str());
 }
@@ -1405,13 +1405,15 @@ static void cmd_getdevtype(BaseSequentialStream* chp, int argc, char* argv[]) {
     (void)argc;
     (void)argv;
     std::string res;
-    if (FLASH_SIZE_MB >= 4) {
-        res = "HPRO";
-    } else if (portapack::device_type == portapack::DeviceType::DEV_PORTARF) {
+#ifdef PRALINE
+    res = "HPRO";
+#else
+    if (portapack::device_type == portapack::DeviceType::DEV_PORTARF) {
         res = "PORTARF";
     } else {
         res = "PORTAPACK";
     }
+#endif
     res += "\r\nok\r\n";
     chprintf(chp, res.c_str());
 }


### PR DESCRIPTION
## Summary
This PR enables hardware platform detection for HackRF Pro (Praline) devices by removing the `#ifndef PRALINE` preprocessor guards that were previously disabling this functionality. It also adds comprehensive device identification and flash information reporting across multiple interfaces.

## Changes

### Core Platform Detection
- **Removed&#32;`#ifndef PRALINE`&#32;guards** in `portapack.cpp` to enable `detect_hardware_platform()` and `finalize_detect_hardware_platform()` calls for all devices including HackRF Pro
- This allows proper hardware revision detection at runtime for all device types

### Board Revision Identification
Added support for HackRF Pro board revision strings in `shell.cpp`:
- `BOARD_REV_PRALINE_R0_x` → "HackRF Pro R0"
- `BOARD_REV_PRALINE_R1_x` → "HackRF Pro R1"
- `BOARD_REV_GSG_PRALINE_R0_x` → "GSG HackRF Pro R0"
- `BOARD_REV_GSG_PRALINE_R1_x` → "GSG HackRF Pro R1"

### Enhanced Device Information Reporting

#### `info` Command (shell.cpp)
Added detailed device and flash information:
- **Device Type**: Automatically detects and displays:
- "HackRF Pro" (when built with `PRALINE` defined)
- "PortaRF" (when `device_type == DEV_PORTARF`)
- "HackRF One" (default)
- **Flash Allowed**: Build-time configured flash size (`FLASH_SIZE_MB`)
- **Flash Runtime**: Runtime-determined safe flash limit based on device type
- 4MB for HackRF Pro
- 1MB for PortaPack classic
- `FLASH_SIZE_MB` for PortaRF
- **Flash Current**: Current firmware flash usage (`FLASH_SIZE_LIMIT_MB`)
- All flash values explicitly cast to `uint32_t` to handle potential float values (e.g., 3.5MB for HPro)

#### USB Serial Commands (usb\_serial\_shell.cpp)
- **`getflash`**: Updated to properly report flash configuration with device-specific runtime limits and explicit `uint32_t` casting for all values
- **`getdevtype`**: Enhanced to return:
- "HPRO" for HackRF Pro devices (when built with `PRALINE`)
- "PORTARF" for PortaRF devices
- "PORTAPACK" for HackRF One/PortaPack devices

### Firmware Validation (ui\_flash\_utility.cpp)
- **Simplified firmware size validation**: Now uses `FLASH_ROM_SIZE` for all devices instead of device-specific checks
- Firmware files larger than the device's flash size are rejected during validation
- Removed obsolete comment about needing additional checks for PortaRF variants

### Type Safety Improvements
- Explicit `uint32_t` casting throughout to handle `FLASH_SIZE_LIMIT_MB` which may be defined as a float (e.g., 3.5 for HackRF Pro)
- Ensures consistent integer output in all reporting interfaces

### Submodule Update
- Updated `hackrf` submodule to `f56e711b6` which includes the platform detection definitions for Praline board revisions

## Testing Recommendations
- Verify `info` command output on HackRF Pro, HackRF One, and PortaRF devices
- Confirm USB serial `getdevtype` returns correct device type ("HPRO", "PORTARF", or "PORTAPACK")
- Validate `getflash` reports accurate flash information with proper runtime limits
- Check that board revision strings display correctly for all Praline variants
- Test firmware file validation rejects oversized files appropriately for each device type