### PR TITLE
fix RX AUDIO baseband async error

### DIFF
--- a/firmware/application/baseband_api.cpp
+++ b/firmware/application/baseband_api.cpp
@@ -473,7 +473,10 @@ void shutdown() {
     send_message(&message);
 
     shared_memory.application_queue.reset();
-
+    // add some time for the message to be processed and baseband to shut down before allowing another image to be run, otherwise the M4 may still be running and cause a crash when the next image is run.
+#ifdef PRALINE
+    chThdSleepMilliseconds(20);
+#endif
     baseband_image_running = false;
 }
 

--- a/firmware/application/baseband_api.cpp
+++ b/firmware/application/baseband_api.cpp
@@ -473,7 +473,9 @@ void shutdown() {
     send_message(&message);
 
     shared_memory.application_queue.reset();
-    // add some time for the message to be processed and baseband to shut down before allowing another image to be run, otherwise the M4 may still be running and cause a crash when the next image is run.
+    // Allow time for the shutdown message to be processed and for the baseband
+    // core to stop before starting another image. Otherwise, the M4 may still be
+    // running and cause a crash when the next image is started.
 #ifdef PRALINE
     chThdSleepMilliseconds(20);
 #endif


### PR DESCRIPTION
## Brief description what you did
This change fixes a baseband asynchronous failure that occurs when switching signal conversion modes in the RX AUDIO APP.

