### PR TITLE
Refactor marker addition logic in ADSBRxView to eliminate shadow mark…

### DIFF
--- a/firmware/application/apps/ui_adsb_rx.cpp
+++ b/firmware/application/apps/ui_adsb_rx.cpp
@@ -695,10 +695,11 @@ void ADSBRxView::refresh_ui() {
         // Process the entries list.
         for (const auto& entry : recent) {
             // Found the entry being shown in details view. Update it.
-            if (entry.key() == detail_key) {
+            if (entry.key() == detail_key) {  // we don't add it to the markers, since this is the currently selected and shown in the middle one. This eliminates the "shadow" marker, and saves ram
                 details_view->update(entry);
                 current_updated = true;
-            } else {  // we don't add it to the markers, since this is the currently selected and shown in the middle one. This eliminates the "shadow" marker, and saves ram
+            } else {
+                // Add others only
                 // NB: current entry also gets a marker so it shows up if map is panned.
                 if (map_needs_update && entry.pos.pos_valid && entry.state <= ADSBAgeState::Recent) {
                     map_needs_update = details_view->add_map_marker(entry);

--- a/firmware/application/apps/ui_adsb_rx.cpp
+++ b/firmware/application/apps/ui_adsb_rx.cpp
@@ -698,11 +698,11 @@ void ADSBRxView::refresh_ui() {
             if (entry.key() == detail_key) {
                 details_view->update(entry);
                 current_updated = true;
-            }
-
-            // NB: current entry also gets a marker so it shows up if map is panned.
-            if (map_needs_update && entry.pos.pos_valid && entry.state <= ADSBAgeState::Recent) {
-                map_needs_update = details_view->add_map_marker(entry);
+            } else {  // we don't add it to the markers, since this is the currently selected and shown in the middle one. This eliminates the "shadow" marker, and saves ram
+                // NB: current entry also gets a marker so it shows up if map is panned.
+                if (map_needs_update && entry.pos.pos_valid && entry.state <= ADSBAgeState::Recent) {
+                    map_needs_update = details_view->add_map_marker(entry);
+                }
             }
 
             // Any work left to do?


### PR DESCRIPTION
This pull request makes a targeted improvement to the `refresh_ui()` method in `ui_adsb_rx.cpp`. The update refines how map markers are managed for ADS-B entries, specifically optimizing memory usage and UI clarity by avoiding redundant markers for the currently selected entry.

Map marker management improvement:

* Updated the logic in `ADSBRxView::refresh_ui()` so that the currently selected ADS-B entry does not get an extra map marker, preventing a "shadow" marker and saving RAM. The marker is only added if the entry is not currently selected, which also improves UI clarity.