### PR TITLE
fix dino + doom text positions

### DIFF
--- a/firmware/application/external/dinogame/ui_dinogame.cpp
+++ b/firmware/application/external/dinogame/ui_dinogame.cpp
@@ -789,8 +789,8 @@ void DinoGameView::draw_current_score() {
 
 void DinoGameView::draw_high_score() {
     auto style = *ui::Theme::getInstance()->fg_light;
-    painter.fill_rectangle({UI_POS_X_RIGHT(90), 28, 90, 18}, Color::black());
-    painter.draw_string({UI_POS_X_RIGHT(90), 30}, style, "HI " + score_to_string(highScore));
+    painter.fill_rectangle({UI_POS_X_RIGHT(10), 28, 90, 18}, Color::black());
+    painter.draw_string({UI_POS_X_RIGHT(10), 30}, style, "HI " + score_to_string(highScore));
 }
 
 void DinoGameView::jump() {

--- a/firmware/application/external/doom/ui_doom.cpp
+++ b/firmware/application/external/doom/ui_doom.cpp
@@ -1081,7 +1081,7 @@ void DoomView::paint(Painter& painter) {
             int hud_y = RENDER_HEIGHT + 5;
             painter.draw_string({5, hud_y}, style_yellow, "Health: " + std::to_string(player.health));
             painter.draw_string({UI_POS_X_CENTER(15), hud_y}, style_red, "Kills: " + std::to_string(kills));
-            painter.draw_string({UI_POS_X_RIGHT(80), hud_y}, style_blue, "Ammo: " + std::to_string(player.ammo));
+            painter.draw_string({UI_POS_X_RIGHT(10), hud_y}, style_blue, "Ammo: " + std::to_string(player.ammo));
 
             prev_velocity_moving = (player.velocity != 0);
             needs_redraw = false;
@@ -1113,7 +1113,7 @@ void DoomView::paint(Painter& painter) {
             int hud_y = RENDER_HEIGHT + 5;
             painter.draw_string({5, hud_y}, style_yellow, "Health: " + std::to_string(player.health));
             painter.draw_string({UI_POS_X_CENTER(15), hud_y}, style_red, "Kills: " + std::to_string(kills));
-            painter.draw_string({UI_POS_X_RIGHT(80), hud_y}, style_blue, "Ammo: " + std::to_string(player.ammo));
+            painter.draw_string({UI_POS_X_RIGHT(10), hud_y}, style_blue, "Ammo: " + std::to_string(player.ammo));
 
             needs_gun_redraw = false;
         }


### PR DESCRIPTION
fixed the positions of the hiscore and ammo. the UI_POS macros needs characters, as parameter, not px