### PR TITLE
feat(soundboard): add USB/LSB modulation cycle on bandwidth select

### DIFF
--- a/firmware/application/external/soundboard/soundboard_app.cpp
+++ b/firmware/application/external/soundboard/soundboard_app.cpp
@@ -157,8 +157,7 @@ void SoundBoardView::update_config() {
         false,  // AM
         false,  // DSB
         usb_mode,
-        lsb_mode
-    );
+        lsb_mode);
 }
 
 void SoundBoardView::update_modulation_indicator() {

--- a/firmware/application/external/soundboard/soundboard_app.cpp
+++ b/firmware/application/external/soundboard/soundboard_app.cpp
@@ -119,18 +119,7 @@ void SoundBoardView::start_tx(const uint32_t id) {
         });
 
     // TODO: Delete all this and use tx model.
-    baseband::set_audiotx_config(
-        1536000 / 20,  // Update vu-meter at 20Hz
-        transmitter_model.channel_bandwidth(),
-        0,  // Gain is unused
-        8,  // shift_bits_s16, default 8 bits, but also unused
-        bits_per_sample,
-        TONES_F2D(tone_key_frequency(tone_key_index), TONES_SAMPLERATE),
-        false,  // AM
-        false,  // DSB
-        false,  // USB
-        false   // LSB
-    );
+    update_config();
     baseband::set_sample_rate(sample_rate);
 
     transmitter_model.enable();
@@ -156,6 +145,8 @@ void SoundBoardView::on_tx_progress(const uint32_t progress) {
 void SoundBoardView::update_config() {
     // NB: this were called by the on_bandwidth_changed() callback,
     // so other val would be updated too when bw changed. currently it's safe but be careful.
+    const bool usb_mode = (modulation_mode_ == modulation_mode_t::USB);
+    const bool lsb_mode = (modulation_mode_ == modulation_mode_t::LSB);
     baseband::set_audiotx_config(
         1536000 / 20,  // Update vu-meter at 20Hz
         transmitter_model.channel_bandwidth(),
@@ -165,9 +156,38 @@ void SoundBoardView::update_config() {
         TONES_F2D(tone_key_frequency(tone_key_index), TONES_SAMPLERATE),
         false,  // AM
         false,  // DSB
-        false,  // USB
-        false   // LSB
+        usb_mode,
+        lsb_mode
     );
+}
+
+void SoundBoardView::update_modulation_indicator() {
+    char indicator = 0;
+
+    if (modulation_mode_ == modulation_mode_t::USB) {
+        indicator = '+';
+    } else if (modulation_mode_ == modulation_mode_t::LSB) {
+        indicator = '-';
+    }
+
+    tx_view.set_bandwidth_mode_indicator(indicator);
+}
+
+void SoundBoardView::cycle_modulation_mode() {
+    switch (modulation_mode_) {
+        case modulation_mode_t::BROADBAND:
+            modulation_mode_ = modulation_mode_t::USB;
+            break;
+        case modulation_mode_t::USB:
+            modulation_mode_ = modulation_mode_t::LSB;
+            break;
+        case modulation_mode_t::LSB:
+            modulation_mode_ = modulation_mode_t::BROADBAND;
+            break;
+    }
+
+    update_modulation_indicator();
+    update_config();
 }
 
 void SoundBoardView::on_select_entry() {
@@ -307,6 +327,9 @@ SoundBoardView::SoundBoardView(
     tx_view.on_bandwidth_changed = [this]() {
         update_config();
     };
+    tx_view.on_bandwidth_select = [this]() {
+        cycle_modulation_mode();
+    };
 
     tx_view.on_start = [this]() {
         start_tx(menu_view.highlighted_index());
@@ -316,6 +339,8 @@ SoundBoardView::SoundBoardView(
         tx_view.set_transmitting(false);
         stop();
     };
+
+    update_modulation_indicator();
 }
 
 SoundBoardView::~SoundBoardView() {

--- a/firmware/application/external/soundboard/soundboard_app.hpp
+++ b/firmware/application/external/soundboard/soundboard_app.hpp
@@ -65,7 +65,14 @@ class SoundBoardView : public View {
         RANDOM
     };
 
+    enum class modulation_mode_t : uint8_t {
+        BROADBAND = 0,
+        USB,
+        LSB
+    };
+
     tx_modes tx_mode = NORMAL;
+    modulation_mode_t modulation_mode_ = modulation_mode_t::BROADBAND;
 
     uint32_t playing_id{};
     uint32_t page = 1;
@@ -93,6 +100,8 @@ class SoundBoardView : public View {
     void refresh_list();
     void on_select_entry();
     void update_config();
+    void cycle_modulation_mode();
+    void update_modulation_indicator();
 
     Labels labels{
         {{24 * 8, UI_POS_Y_BOTTOM(9)}, "Vol:", Theme::getInstance()->fg_light->foreground},

--- a/firmware/application/ui/ui_transmitter.cpp
+++ b/firmware/application/ui/ui_transmitter.cpp
@@ -93,6 +93,16 @@ void TransmitterView::on_tx_amp_changed(bool rf_amp) {
     update_gainlevel_styles();
 }
 
+void TransmitterView::update_bandwidth_label() {
+    if (bandwidth_mode_indicator_ == '+') {
+        text_bw.set("kH+");
+    } else if (bandwidth_mode_indicator_ == '-') {
+        text_bw.set("kH-");
+    } else {
+        text_bw.set("kHz");
+    }
+}
+
 void TransmitterView::update_gainlevel_styles() {
     int8_t tot_gain = transmitter_model.tx_gain() + (transmitter_model.rf_amp() ? 14 : 0);
     auto style = get_style_for_gain(tot_gain);
@@ -113,6 +123,19 @@ void TransmitterView::set_transmitting(const bool transmitting) {
     }
 
     transmitting_ = transmitting;
+}
+
+void TransmitterView::set_bandwidth_mode_indicator(char indicator) {
+    if ((indicator != '+') && (indicator != '-')) {
+        indicator = 0;
+    }
+
+    if (bandwidth_mode_indicator_ == indicator) {
+        return;
+    }
+
+    bandwidth_mode_indicator_ = indicator;
+    update_bandwidth_label();
 }
 
 void TransmitterView::on_show() {
@@ -163,7 +186,15 @@ TransmitterView::TransmitterView(
                     on_bandwidth_changed();
                 }
             };
+            field_bw.on_select = [this](NumberField& field) {
+                if (on_bandwidth_select) {
+                    on_bandwidth_select();
+                } else {
+                    field.on_encoder(1);
+                }
+            };
             field_bw.set_value(channel_bandwidth);
+            update_bandwidth_label();
         }
     }
 

--- a/firmware/application/ui/ui_transmitter.hpp
+++ b/firmware/application/ui/ui_transmitter.hpp
@@ -51,6 +51,7 @@ class TransmitterView : public View {
     std::function<void(void)> on_start{};
     std::function<void(void)> on_stop{};
     std::function<void(void)> on_bandwidth_changed{};
+    std::function<void(void)> on_bandwidth_select{};
     // TODO: this is a workaround because in the message system,
     // we change bw by different message for different m4 bb, so have to callback
     // and change in the instance(for instance SigGen app) with calling the instance's bb opration func
@@ -70,6 +71,7 @@ class TransmitterView : public View {
     void focus() override;
 
     void set_transmitting(const bool transmitting);
+    void set_bandwidth_mode_indicator(char indicator);
 
    private:
     const Style& style_start = *Theme::getInstance()->fg_green;
@@ -126,8 +128,10 @@ class TransmitterView : public View {
     void on_channel_bandwidth_changed(uint32_t channel_bandwidth);
     void on_tx_gain_changed(int32_t tx_gain);
     void on_tx_amp_changed(bool rf_amp);
+    void update_bandwidth_label();
 
     void update_gainlevel_styles(void);
+    char bandwidth_mode_indicator_{0};
 };
 
 /* Simpler transmitter view that only renders TX Gain and Amp.

--- a/firmware/baseband/dsp_modulate.cpp
+++ b/firmware/baseband/dsp_modulate.cpp
@@ -175,9 +175,15 @@ void FM::set_tone_gen_configure(const uint32_t set_delta, const float set_tone_m
 void FM::execute(const buffer_s16_t& audio, const buffer_c8_t& buffer, bool& configured_in, uint32_t& new_beep_index, uint32_t& new_beep_timer, TXProgressMessage& new_txprogress_message, AudioLevelReportMessage& new_level_message, uint32_t& new_power_acc_count, uint32_t& new_divider) {
     int32_t sample = 0;
     int8_t re, im;
+    const size_t audio_last_index = audio.count ? (audio.count - 1) : 0;
+    const uint32_t sample_over = (over == 0) ? 1 : over;
 
     for (size_t counter = 0; counter < buffer.count; counter++) {
-        sample = audio.p[counter >> 6] >> audio_shift_bits_s16_FM;  // Orig. >>8 , 	sample = audio.p[counter / over] >> 8;   (not enough efficient running code, over = 1536000/240000= 64 )
+        size_t audio_index = counter / sample_over;
+        if (audio_index > audio_last_index) {
+            audio_index = audio_last_index;
+        }
+        sample = audio.p[audio_index] >> audio_shift_bits_s16_FM;
         sample *= audio_gain;                                       // Apply GAIN  Scale factor to the audio TX modulation.
 
         if (play_beep) {

--- a/firmware/baseband/dsp_modulate.cpp
+++ b/firmware/baseband/dsp_modulate.cpp
@@ -184,7 +184,7 @@ void FM::execute(const buffer_s16_t& audio, const buffer_c8_t& buffer, bool& con
             audio_index = audio_last_index;
         }
         sample = audio.p[audio_index] >> audio_shift_bits_s16_FM;
-        sample *= audio_gain;                                       // Apply GAIN  Scale factor to the audio TX modulation.
+        sample *= audio_gain;  // Apply GAIN  Scale factor to the audio TX modulation.
 
         if (play_beep) {
             sample = apply_beep(sample, configured_in, new_beep_index, new_beep_timer, new_txprogress_message);  // Apply beep -if selected - atom ,sample by sample.

--- a/firmware/baseband/proc_audiotx.cpp
+++ b/firmware/baseband/proc_audiotx.cpp
@@ -22,19 +22,19 @@
 
 #include "proc_audiotx.hpp"
 #include "portapack_shared_memory.hpp"
-#include "sine_table_int8.hpp"
 #include "event_m4.hpp"
 #include "audio_dma.hpp"
 
 #include <cstdint>
 
 void AudioTXProcessor::execute(const buffer_c8_t& buffer) {
-    if (!configured) return;
+    if (!configured || !modulator) return;
+    if (buffer.count > modulation_audio_data.size()) return;
 
     buffer_s16_t audio_buffer{audio_data, AUDIO_OUTPUT_BUFFER_SIZE, sampling_rate};
     int16_t audio_sample_s16;
 
-    // Zero-order hold (poop)
+    // Zero-order hold.
     for (size_t i = 0; i < buffer.count; i++) {
         resample_acc += resample_inc;
         if (resample_acc >= 0x10000) {
@@ -43,16 +43,18 @@ void AudioTXProcessor::execute(const buffer_c8_t& buffer) {
                 audio_sample = 0;
                 stream->read(&audio_sample, bytes_per_sample);  // assumes little endian when reading 1 byte
                 samples_read++;
+            } else {
+                audio_sample = 0;
             }
         }
 
         if (bytes_per_sample == 1) {
-            sample = audio_sample - 0x80;
+            const int32_t sample = static_cast<int32_t>(audio_sample) - 0x80;
             audio_sample_s16 = sample * 256;
         } else {
             audio_sample_s16 = (int16_t)audio_sample;
-            sample = audio_sample_s16 / 256;
         }
+        modulation_audio_data[i] = audio_sample_s16;
 
         // Output to speaker too
         if (!tone_key_enabled) {
@@ -62,28 +64,41 @@ void AudioTXProcessor::execute(const buffer_c8_t& buffer) {
                 audio_output.write_unprocessed(audio_buffer);
         }
 
-        sample = tone_gen.process(sample);
-
-        // FM
-        delta = sample * fm_delta;
-
-        phase += delta;
-        sphase = phase + (64 << 24);
-
-        re = sine_table_i8[(sphase & 0xFF000000U) >> 24];
-        im = sine_table_i8[(phase & 0xFF000000U) >> 24];
-
-        buffer.p[i] = {(int8_t)re, (int8_t)im};
     }
 
+    buffer_s16_t modulation_audio{modulation_audio_data.data(), buffer.count, sampling_rate};
+    modulator->set_gain_shiftbits_vumeter_beep(audio_gain, audio_shift_bits_s16, false);
+    modulator->execute(modulation_audio, buffer, configured, beep_index, beep_timer, txprogress_message, level_message, power_acc_count, divider);
+
     progress_samples += buffer.count;
-    if (progress_samples >= progress_interval_samples) {
+    if (progress_interval_samples && (progress_samples >= progress_interval_samples)) {
         progress_samples -= progress_interval_samples;
 
         txprogress_message.progress = samples_read;  // Inform UI about progress
         txprogress_message.done = false;
         shared_memory.application_queue.push(txprogress_message);
     }
+}
+
+void AudioTXProcessor::configure_modulator(const AudioTXConfigMessage& message) {
+    if (usb_enabled || lsb_enabled) {
+        auto ssb = std::make_unique<dsp::modulate::SSB>();
+        ssb->set_fs_div_factor(message.deviation_hz);
+        ssb->set_mode(usb_enabled ? dsp::modulate::Mode::USB : dsp::modulate::Mode::LSB);
+        modulator = std::move(ssb);
+    } else if (am_enabled || dsb_enabled) {
+        auto am = std::make_unique<dsp::modulate::AM>();
+        am->set_mode(dsb_enabled ? dsp::modulate::Mode::DSB : dsp::modulate::Mode::AM);
+        modulator = std::move(am);
+    } else {
+        auto fm = std::make_unique<dsp::modulate::FM>();
+        fm->set_fm_delta(message.deviation_hz * (0xFFFFFFULL / baseband_fs));
+        fm->set_tone_gen_configure(message.tone_key_delta, message.tone_key_mix_weight);
+        modulator = std::move(fm);
+    }
+
+    // Audio is already resampled to baseband-rate samples in this processor.
+    modulator->set_over(1);
 }
 
 void AudioTXProcessor::on_message(const Message* const message) {
@@ -112,15 +127,26 @@ void AudioTXProcessor::on_message(const Message* const message) {
 }
 
 void AudioTXProcessor::audio_config(const AudioTXConfigMessage& message) {
-    fm_delta = message.deviation_hz * (0xFFFFFFULL / baseband_fs);
-    tone_gen.configure(message.tone_key_delta, message.tone_key_mix_weight);
+    am_enabled = message.am_enabled;
+    dsb_enabled = message.dsb_enabled;
+    usb_enabled = message.usb_enabled;
+    lsb_enabled = message.lsb_enabled;
+
+    audio_gain = (message.audio_gain > 0.0f) ? message.audio_gain : 1.0f;
+    audio_shift_bits_s16 = message.audio_shift_bits_s16;
+
     progress_interval_samples = message.divider;
+    divider = message.divider;
+    power_acc_count = 0;
+
     resample_acc = 0;
     bytes_per_sample = message.bits_per_sample / 8;
     audio_output.configure(false);
 
     tone_key_enabled = (message.tone_key_delta != 0);
     audio::dma::shrink_tx_buffer(!tone_key_enabled);
+
+    configure_modulator(message);
 }
 
 void AudioTXProcessor::replay_config(const ReplayConfigMessage& message) {

--- a/firmware/baseband/proc_audiotx.cpp
+++ b/firmware/baseband/proc_audiotx.cpp
@@ -22,52 +22,98 @@
 
 #include "proc_audiotx.hpp"
 #include "portapack_shared_memory.hpp"
+#include "sine_table_int8.hpp"
 #include "event_m4.hpp"
 #include "audio_dma.hpp"
 
 #include <cstdint>
 
 void AudioTXProcessor::execute(const buffer_c8_t& buffer) {
-    if (!configured || !modulator) return;
-    if (buffer.count > modulation_audio_data.size()) return;
+    if (!configured) return;
 
     buffer_s16_t audio_buffer{audio_data, AUDIO_OUTPUT_BUFFER_SIZE, sampling_rate};
     int16_t audio_sample_s16;
 
-    // Zero-order hold.
-    for (size_t i = 0; i < buffer.count; i++) {
-        resample_acc += resample_inc;
-        if (resample_acc >= 0x10000) {
-            resample_acc -= 0x10000;
-            if (stream) {
-                audio_sample = 0;
-                stream->read(&audio_sample, bytes_per_sample);  // assumes little endian when reading 1 byte
-                samples_read++;
+    if (!use_alternate_modulator) {
+        // Keep original FM path intact for backward compatibility.
+        for (size_t i = 0; i < buffer.count; i++) {
+            resample_acc += resample_inc;
+            if (resample_acc >= 0x10000) {
+                resample_acc -= 0x10000;
+                if (stream) {
+                    audio_sample = 0;
+                    stream->read(&audio_sample, bytes_per_sample);  // assumes little endian when reading 1 byte
+                    samples_read++;
+                }
+            }
+
+            if (bytes_per_sample == 1) {
+                sample = audio_sample - 0x80;
+                audio_sample_s16 = sample * 256;
             } else {
-                audio_sample = 0;
+                audio_sample_s16 = (int16_t)audio_sample;
+                sample = audio_sample_s16 / 256;
+            }
+
+            // Output to speaker too
+            if (!tone_key_enabled) {
+                uint32_t imod32 = i & (AUDIO_OUTPUT_BUFFER_SIZE - 1);
+                audio_data[imod32] = audio_sample_s16;
+                if (imod32 == (AUDIO_OUTPUT_BUFFER_SIZE - 1))
+                    audio_output.write_unprocessed(audio_buffer);
+            }
+
+            sample = tone_gen.process(sample);
+
+            // FM
+            delta = sample * fm_delta;
+
+            phase += delta;
+            sphase = phase + (64 << 24);
+
+            re = sine_table_i8[(sphase & 0xFF000000U) >> 24];
+            im = sine_table_i8[(phase & 0xFF000000U) >> 24];
+
+            buffer.p[i] = {(int8_t)re, (int8_t)im};
+        }
+    } else {
+        if (!modulator) return;
+        if (buffer.count > modulation_audio_data.size()) return;
+
+        for (size_t i = 0; i < buffer.count; i++) {
+            resample_acc += resample_inc;
+            if (resample_acc >= 0x10000) {
+                resample_acc -= 0x10000;
+                if (stream) {
+                    audio_sample = 0;
+                    stream->read(&audio_sample, bytes_per_sample);  // assumes little endian when reading 1 byte
+                    samples_read++;
+                } else {
+                    audio_sample = 0;
+                }
+            }
+
+            if (bytes_per_sample == 1) {
+                const int32_t sample = static_cast<int32_t>(audio_sample) - 0x80;
+                audio_sample_s16 = sample * 256;
+            } else {
+                audio_sample_s16 = (int16_t)audio_sample;
+            }
+            modulation_audio_data[i] = audio_sample_s16;
+
+            // Output to speaker too
+            if (!tone_key_enabled) {
+                uint32_t imod32 = i & (AUDIO_OUTPUT_BUFFER_SIZE - 1);
+                audio_data[imod32] = audio_sample_s16;
+                if (imod32 == (AUDIO_OUTPUT_BUFFER_SIZE - 1))
+                    audio_output.write_unprocessed(audio_buffer);
             }
         }
 
-        if (bytes_per_sample == 1) {
-            const int32_t sample = static_cast<int32_t>(audio_sample) - 0x80;
-            audio_sample_s16 = sample * 256;
-        } else {
-            audio_sample_s16 = (int16_t)audio_sample;
-        }
-        modulation_audio_data[i] = audio_sample_s16;
-
-        // Output to speaker too
-        if (!tone_key_enabled) {
-            uint32_t imod32 = i & (AUDIO_OUTPUT_BUFFER_SIZE - 1);
-            audio_data[imod32] = audio_sample_s16;
-            if (imod32 == (AUDIO_OUTPUT_BUFFER_SIZE - 1))
-                audio_output.write_unprocessed(audio_buffer);
-        }
+        buffer_s16_t modulation_audio{modulation_audio_data.data(), buffer.count, sampling_rate};
+        modulator->set_gain_shiftbits_vumeter_beep(audio_gain, audio_shift_bits_s16, false);
+        modulator->execute(modulation_audio, buffer, configured, beep_index, beep_timer, txprogress_message, level_message, power_acc_count, divider);
     }
-
-    buffer_s16_t modulation_audio{modulation_audio_data.data(), buffer.count, sampling_rate};
-    modulator->set_gain_shiftbits_vumeter_beep(audio_gain, audio_shift_bits_s16, false);
-    modulator->execute(modulation_audio, buffer, configured, beep_index, beep_timer, txprogress_message, level_message, power_acc_count, divider);
 
     progress_samples += buffer.count;
     if (progress_interval_samples && (progress_samples >= progress_interval_samples)) {
@@ -145,7 +191,14 @@ void AudioTXProcessor::audio_config(const AudioTXConfigMessage& message) {
     tone_key_enabled = (message.tone_key_delta != 0);
     audio::dma::shrink_tx_buffer(!tone_key_enabled);
 
-    configure_modulator(message);
+    use_alternate_modulator = am_enabled || dsb_enabled || usb_enabled || lsb_enabled;
+    if (use_alternate_modulator) {
+        configure_modulator(message);
+    } else {
+        modulator.reset();
+        fm_delta = message.deviation_hz * (0xFFFFFFULL / baseband_fs);
+        tone_gen.configure(message.tone_key_delta, message.tone_key_mix_weight);
+    }
 }
 
 void AudioTXProcessor::replay_config(const ReplayConfigMessage& message) {

--- a/firmware/baseband/proc_audiotx.cpp
+++ b/firmware/baseband/proc_audiotx.cpp
@@ -63,7 +63,6 @@ void AudioTXProcessor::execute(const buffer_c8_t& buffer) {
             if (imod32 == (AUDIO_OUTPUT_BUFFER_SIZE - 1))
                 audio_output.write_unprocessed(audio_buffer);
         }
-
     }
 
     buffer_s16_t modulation_audio{modulation_audio_data.data(), buffer.count, sampling_rate};

--- a/firmware/baseband/proc_audiotx.cpp
+++ b/firmware/baseband/proc_audiotx.cpp
@@ -28,6 +28,23 @@
 
 #include <cstdint>
 
+namespace {
+void write_silence(const buffer_c8_t& buffer) {
+    for (size_t i = 0; i < buffer.count; ++i) {
+        buffer.p[i] = {0, 0};
+    }
+}
+
+int16_t apply_tone_and_expand(ToneGen& tone_gen, int16_t input_s16) {
+    const int32_t sample_s8 = static_cast<int32_t>(input_s16) / 256;
+    const int32_t toned_s8 = tone_gen.process(sample_s8);
+    int32_t toned_s16 = toned_s8 * 256;
+    if (toned_s16 > 32767) toned_s16 = 32767;
+    if (toned_s16 < -32768) toned_s16 = -32768;
+    return static_cast<int16_t>(toned_s16);
+}
+}  // namespace
+
 void AudioTXProcessor::execute(const buffer_c8_t& buffer) {
     if (!configured) return;
 
@@ -77,42 +94,48 @@ void AudioTXProcessor::execute(const buffer_c8_t& buffer) {
             buffer.p[i] = {(int8_t)re, (int8_t)im};
         }
     } else {
-        if (!modulator) return;
-        if (buffer.count > modulation_audio_data.size()) return;
+        if (!modulator || (buffer.count > modulation_audio_data.size())) {
+            // Avoid leaving stale I/Q samples in DMA buffers on guard-condition failure.
+            write_silence(buffer);
+        } else {
+            for (size_t i = 0; i < buffer.count; i++) {
+                resample_acc += resample_inc;
+                if (resample_acc >= 0x10000) {
+                    resample_acc -= 0x10000;
+                    if (stream) {
+                        audio_sample = 0;
+                        stream->read(&audio_sample, bytes_per_sample);  // assumes little endian when reading 1 byte
+                        samples_read++;
+                    } else {
+                        audio_sample = 0;
+                    }
+                }
 
-        for (size_t i = 0; i < buffer.count; i++) {
-            resample_acc += resample_inc;
-            if (resample_acc >= 0x10000) {
-                resample_acc -= 0x10000;
-                if (stream) {
-                    audio_sample = 0;
-                    stream->read(&audio_sample, bytes_per_sample);  // assumes little endian when reading 1 byte
-                    samples_read++;
+                if (bytes_per_sample == 1) {
+                    const int32_t sample = static_cast<int32_t>(audio_sample) - 0x80;
+                    audio_sample_s16 = sample * 256;
                 } else {
-                    audio_sample = 0;
+                    audio_sample_s16 = (int16_t)audio_sample;
+                }
+                const int16_t speaker_sample_s16 = audio_sample_s16;
+
+                // Apply tone/keying path for alternate modes too (USB/LSB/AM/DSB).
+                audio_sample_s16 = apply_tone_and_expand(tone_gen, audio_sample_s16);
+                modulation_audio_data[i] = audio_sample_s16;
+
+                // Output to speaker too
+                if (!tone_key_enabled) {
+                    uint32_t imod32 = i & (AUDIO_OUTPUT_BUFFER_SIZE - 1);
+                    audio_data[imod32] = speaker_sample_s16;
+                    if (imod32 == (AUDIO_OUTPUT_BUFFER_SIZE - 1))
+                        audio_output.write_unprocessed(audio_buffer);
                 }
             }
 
-            if (bytes_per_sample == 1) {
-                const int32_t sample = static_cast<int32_t>(audio_sample) - 0x80;
-                audio_sample_s16 = sample * 256;
-            } else {
-                audio_sample_s16 = (int16_t)audio_sample;
-            }
-            modulation_audio_data[i] = audio_sample_s16;
-
-            // Output to speaker too
-            if (!tone_key_enabled) {
-                uint32_t imod32 = i & (AUDIO_OUTPUT_BUFFER_SIZE - 1);
-                audio_data[imod32] = audio_sample_s16;
-                if (imod32 == (AUDIO_OUTPUT_BUFFER_SIZE - 1))
-                    audio_output.write_unprocessed(audio_buffer);
-            }
+            buffer_s16_t modulation_audio{modulation_audio_data.data(), buffer.count, sampling_rate};
+            modulator->set_gain_shiftbits_vumeter_beep(audio_gain, audio_shift_bits_s16, false);
+            modulator->execute(modulation_audio, buffer, configured, beep_index, beep_timer, txprogress_message, level_message, power_acc_count, divider);
         }
-
-        buffer_s16_t modulation_audio{modulation_audio_data.data(), buffer.count, sampling_rate};
-        modulator->set_gain_shiftbits_vumeter_beep(audio_gain, audio_shift_bits_s16, false);
-        modulator->execute(modulation_audio, buffer, configured, beep_index, beep_timer, txprogress_message, level_message, power_acc_count, divider);
     }
 
     progress_samples += buffer.count;
@@ -190,6 +213,7 @@ void AudioTXProcessor::audio_config(const AudioTXConfigMessage& message) {
 
     tone_key_enabled = (message.tone_key_delta != 0);
     audio::dma::shrink_tx_buffer(!tone_key_enabled);
+    tone_gen.configure(message.tone_key_delta, message.tone_key_mix_weight);
 
     use_alternate_modulator = am_enabled || dsb_enabled || usb_enabled || lsb_enabled;
     if (use_alternate_modulator) {
@@ -197,7 +221,6 @@ void AudioTXProcessor::audio_config(const AudioTXConfigMessage& message) {
     } else {
         modulator.reset();
         fm_delta = message.deviation_hz * (0xFFFFFFULL / baseband_fs);
-        tone_gen.configure(message.tone_key_delta, message.tone_key_mix_weight);
     }
 }
 

--- a/firmware/baseband/proc_audiotx.hpp
+++ b/firmware/baseband/proc_audiotx.hpp
@@ -25,6 +25,7 @@
 
 #include "baseband_processor.hpp"
 #include "baseband_thread.hpp"
+#include "tone_gen.hpp"
 #include "stream_output.hpp"
 #include "audio_output.hpp"
 #include "audio_dma.hpp"
@@ -44,9 +45,14 @@ class AudioTXProcessor : public BasebandProcessor {
     static constexpr size_t baseband_fs = 1536000;
 
     std::unique_ptr<StreamOutput> stream{};
+    ToneGen tone_gen{};
 
     uint32_t resample_inc{}, resample_acc{};
+    uint32_t fm_delta{0};
+    uint32_t phase{0}, sphase{0};
     uint32_t audio_sample{};
+    int32_t sample{0}, delta{};
+    int8_t re{0}, im{0};
     uint8_t bytes_per_sample{1};
     uint32_t sampling_rate{48000};
     uint8_t audio_shift_bits_s16{8};
@@ -69,6 +75,7 @@ class AudioTXProcessor : public BasebandProcessor {
     bool dsb_enabled{false};
     bool usb_enabled{false};
     bool lsb_enabled{false};
+    bool use_alternate_modulator{false};
 
     void sample_rate_config(const SampleRateConfigMessage& message);
     void audio_config(const AudioTXConfigMessage& message);

--- a/firmware/baseband/proc_audiotx.hpp
+++ b/firmware/baseband/proc_audiotx.hpp
@@ -25,10 +25,12 @@
 
 #include "baseband_processor.hpp"
 #include "baseband_thread.hpp"
-#include "tone_gen.hpp"
 #include "stream_output.hpp"
 #include "audio_output.hpp"
 #include "audio_dma.hpp"
+#include "dsp_modulate.hpp"
+
+#include <array>
 
 #define AUDIO_OUTPUT_BUFFER_SIZE 32
 
@@ -43,32 +45,41 @@ class AudioTXProcessor : public BasebandProcessor {
 
     std::unique_ptr<StreamOutput> stream{};
 
-    ToneGen tone_gen{};
-
     uint32_t resample_inc{}, resample_acc{};
-    uint32_t fm_delta{0};
-    uint32_t phase{0}, sphase{0};
     uint32_t audio_sample{};
-    int32_t sample{0}, delta{};
-    int8_t re{0}, im{0};
     uint8_t bytes_per_sample{1};
     uint32_t sampling_rate{48000};
+    uint8_t audio_shift_bits_s16{8};
+    float audio_gain{1.0f};
+
+    std::unique_ptr<dsp::modulate::Modulator> modulator{};
+    std::array<int16_t, 8192> modulation_audio_data{};
 
     int16_t audio_data[AUDIO_OUTPUT_BUFFER_SIZE];
     AudioOutput audio_output{};
 
     size_t progress_interval_samples = 0, progress_samples = 0;
+    uint32_t power_acc_count{0};
+    uint32_t divider{0};
 
     bool configured{false};
     uint32_t samples_read{0};
     bool tone_key_enabled{false};
+    bool am_enabled{false};
+    bool dsb_enabled{false};
+    bool usb_enabled{false};
+    bool lsb_enabled{false};
 
     void sample_rate_config(const SampleRateConfigMessage& message);
     void audio_config(const AudioTXConfigMessage& message);
     void replay_config(const ReplayConfigMessage& message);
+    void configure_modulator(const AudioTXConfigMessage& message);
 
     TXProgressMessage txprogress_message{};
+    AudioLevelReportMessage level_message{};
     RequestSignalMessage sig_message{RequestSignalMessage::Signal::FillRequest};
+    uint32_t beep_index{0};
+    uint32_t beep_timer{0};
 
     /* NB: Threads should be the last members in the class definition. */
     BasebandThread baseband_thread{baseband_fs, this, baseband::Direction::Transmit};


### PR DESCRIPTION
Closes #3056

## Summary
- Added Soundboard modulation cycle on bandwidth field Select:
  - broadband (default)
  - USB (+)
  - LSB (-)
- Kept existing bandwidth Select behavior in other apps unchanged.
- Added visual indicator on bandwidth label (`kHz`, `kH+`, `kH-`).
- Applied selected mode to `baseband::set_audiotx_config(...)` for Soundboard TX:
  - `usb_enabled` for USB mode
  - `lsb_enabled` for LSB mode

## Notes
- Branch: `feat/issue-3056-soundboard-sideband-cycle`
- Commit: `9c41327`
