### PR TITLE
rename Widget::visible to Widget::drawn

### DIFF
--- a/firmware/application/external/fmradio/ui_fmradio.cpp
+++ b/firmware/application/external/fmradio/ui_fmradio.cpp
@@ -165,7 +165,7 @@ FmRadioView::FmRadioView(NavigationView& nav)
                   &gr});
 
     txt_save_help.set_focusable(false);
-    txt_save_help.drawn(false);
+    txt_save_help.hidden(true);
     for (uint8_t i = 0; i < 12; ++i) {
         if (freq_fav_list[i].frequency == 0) {
             freq_fav_list[i].frequency = 87000000;
@@ -195,7 +195,7 @@ FmRadioView::FmRadioView(NavigationView& nav)
     btn_fav_save.on_select = [this](Button&) {
         save_fav = !save_fav;
         txt_save_help.set_text(save_fav ? "Select slot" : "");
-        txt_save_help.drawn(save_fav);
+        txt_save_help.hidden(!save_fav);
         txt_save_help.set_dirty();
     };
 
@@ -229,9 +229,9 @@ void FmRadioView::on_btn_clicked(uint8_t i) {
         freq_fav_list[i].modulation = field_modulation.selected_index_value();
         freq_fav_list[i].bandwidth = radio_bw;
         update_fav_btn_texts();
-        txt_save_help.drawn(save_fav);
+        txt_save_help.hidden(true);
         txt_save_help.set_text("");
-        txt_save_help.set_dirty();
+        set_dirty();
         return;
     }
     field_frequency.set_value(freq_fav_list[i].frequency);

--- a/firmware/application/external/fmradio/ui_fmradio.cpp
+++ b/firmware/application/external/fmradio/ui_fmradio.cpp
@@ -165,7 +165,7 @@ FmRadioView::FmRadioView(NavigationView& nav)
                   &gr});
 
     txt_save_help.set_focusable(false);
-    txt_save_help.visible(false);
+    txt_save_help.drawn(false);
     for (uint8_t i = 0; i < 12; ++i) {
         if (freq_fav_list[i].frequency == 0) {
             freq_fav_list[i].frequency = 87000000;
@@ -195,7 +195,7 @@ FmRadioView::FmRadioView(NavigationView& nav)
     btn_fav_save.on_select = [this](Button&) {
         save_fav = !save_fav;
         txt_save_help.set_text(save_fav ? "Select slot" : "");
-        txt_save_help.visible(save_fav);
+        txt_save_help.drawn(save_fav);
         txt_save_help.set_dirty();
     };
 
@@ -229,7 +229,7 @@ void FmRadioView::on_btn_clicked(uint8_t i) {
         freq_fav_list[i].modulation = field_modulation.selected_index_value();
         freq_fav_list[i].bandwidth = radio_bw;
         update_fav_btn_texts();
-        txt_save_help.visible(save_fav);
+        txt_save_help.drawn(save_fav);
         txt_save_help.set_text("");
         txt_save_help.set_dirty();
         return;
@@ -266,7 +266,7 @@ FmRadioView::~FmRadioView() {
 }
 
 void FmRadioView::on_audio_spectrum() {
-    if (gr.visible() && audio_spectrum_data) gr.update_audio_spectrum(*audio_spectrum_data);
+    if (gr.drawn() && audio_spectrum_data) gr.update_audio_spectrum(*audio_spectrum_data);
     if (audio_spectrum_data && audio_spectrum_data->db.size() <= 128) {
         for (size_t i = 0; i < audio_spectrum_data->db.size(); ++i) {
             audio_spectrum[i] = ((int16_t)audio_spectrum_data->db[i] - 127) * 256;

--- a/firmware/application/ui/external/ui_grapheq.cpi
+++ b/firmware/application/ui/external/ui_grapheq.cpi
@@ -185,7 +185,7 @@ void GraphEq::update_audio_spectrum(const AudioSpectrum& spectrum) {
 }
 
 void GraphEq::paint(Painter& painter) {
-    if (!visible()) return;
+    if (!drawn()) return;
     if (!is_calculated) {  // calc positions first
         calculate_params();
         is_calculated = true;

--- a/firmware/application/ui/ui_btngrid.cpp
+++ b/firmware/application/ui/ui_btngrid.cpp
@@ -307,7 +307,7 @@ bool BtnGridView::set_highlighted(int32_t new_value, bool force_update) {
         update_items();
     }
 
-    if (visible()) {
+    if (drawn()) {
         size_t idx = highlighted_item - offset;
         if (idx < menu_item_views.size())
             item_view(idx)->focus();
@@ -449,7 +449,7 @@ void BtnGridView::page_up() {
         update_items();
 
         if (was_visible) {
-            if (visible()) {
+            if (drawn()) {
                 size_t idx = highlighted_item - offset;
                 if (idx < menu_item_views.size())
                     item_view(idx)->focus();
@@ -488,7 +488,7 @@ void BtnGridView::page_down() {
         update_items();
 
         if (was_visible) {
-            if (visible()) {
+            if (drawn()) {
                 size_t idx = highlighted_item - offset;
                 if (idx < menu_item_views.size())
                     item_view(idx)->focus();

--- a/firmware/common/ui_focus.cpp
+++ b/firmware/common/ui_focus.cpp
@@ -171,7 +171,7 @@ void FocusManager::update(Widget* const top_widget, const KeyEvent event) {
         const auto focus_screen_rect = focus_widget()->screen_rect();
 
         const auto test_fn = [&focus_screen_rect, event](ui::Widget* const w) -> test_result_t {
-            // if( w->visible() && w->focusable() ) {
+            // if( w->drawn() && w->focusable() ) {
             if (w->focusable()) {
                 const auto distance = rect_distances(event, focus_screen_rect, w->screen_rect());
                 if (distance >= 0) {

--- a/firmware/common/ui_painter.cpp
+++ b/firmware/common/ui_painter.cpp
@@ -121,11 +121,11 @@ void Painter::paint_widget_tree(Widget* w) {
 
 void Painter::paint_widget(Widget* w) {
     if (w->hidden()) {
-        // Mark widget (and all children) as invisible.
-        w->visible(false);
+        // Mark widget (and all children) as not drawn.
+        w->drawn(false);
     } else {
-        // Mark this widget as visible and recurse.
-        w->visible(true);
+        // Mark this widget as drawn and recurse.
+        w->drawn(true);
 
         if (w->dirty()) {
             w->paint(*this);

--- a/firmware/common/ui_widget.cpp
+++ b/firmware/common/ui_widget.cpp
@@ -91,9 +91,9 @@ void Widget::set_parent(Widget* const widget) {
     }
 
     if (parent_ && !widget) {
-        // We have a parent, but are losing it. Update visible status.
+        // We have a parent, but are losing it. Update drawn status.
         dirty_overlapping_children_in_rect(screen_rect());
-        visible(false);
+        drawn(false);
     }
 
     if (widget == nullptr)
@@ -209,9 +209,9 @@ const Style& Widget::style() const {
     return style_ ? *style_ : parent()->style();
 }
 
-void Widget::visible(bool v) {
-    if (v != flags.visible) {
-        flags.visible = v;
+void Widget::drawn(bool v) {
+    if (v != flags.drawn) {
+        flags.drawn = v;
 
         /* TODO: This on_show/on_hide implementation seems inelegant.
          * But I need *some* way to take/configure resources when
@@ -224,9 +224,9 @@ void Widget::visible(bool v) {
         } else {
             on_hide();
 
-            // Set all children invisible too.
+            // Set all children not drawn too.
             for (const auto child : children()) {
-                child->visible(false);
+                child->drawn(false);
             }
         }
     }
@@ -694,7 +694,7 @@ void Console::clear(bool clear_buffer = false) {
     if (clear_buffer)
         buffer.clear();
 
-    if (!hidden() && visible()) {
+    if (!hidden() && drawn()) {
         display.fill_rectangle(
             screen_rect(),
             Theme::getInstance()->bg_darkest->background);
@@ -706,7 +706,7 @@ void Console::clear(bool clear_buffer = false) {
 void Console::write(std::string message) {
     bool escape = false;
 
-    if (!hidden() && visible()) {
+    if (!hidden() && drawn()) {
         const Style& s = style();
         const Font& font = s.font;
         auto rect = screen_rect();
@@ -797,7 +797,7 @@ void Console::on_hide() {
 }
 
 void Console::crlf() {
-    if (hidden() || !visible()) return;
+    if (hidden() || !drawn()) return;
 
     const auto& s = style();
     auto sr = screen_rect();
@@ -3232,7 +3232,7 @@ void GraphEq::update_audio_spectrum(const AudioSpectrum& spectrum) {
 }
 
 void GraphEq::paint(Painter& painter) {
-    if (!visible()) return;
+    if (!drawn()) return;
     if (!is_calculated) {  // calc positions first
         calculate_params();
         is_calculated = true;

--- a/firmware/common/ui_widget.hpp
+++ b/firmware/common/ui_widget.hpp
@@ -126,8 +126,8 @@ class Widget {
     bool dirty() const;
     void set_clean();
 
-    void visible(bool v);
-    bool visible() { return flags.visible; };
+    void drawn(bool v);
+    bool drawn() { return flags.drawn; };
 
     bool highlighted() const;
     void set_highlighted(const bool value);
@@ -146,7 +146,7 @@ class Widget {
         bool hidden : 1;       // Hide widget and children.
         bool focusable : 1;    // Widget can receive focus.
         bool highlighted : 1;  // Show in a highlighted style.
-        bool visible : 1;      // Object was visible during last paint.
+        bool drawn : 1;        // Object was drawn during last paint.
     };
 
     flags_t flags{
@@ -154,7 +154,7 @@ class Widget {
         .hidden = false,
         .focusable = false,
         .highlighted = false,
-        .visible = false,
+        .drawn = false,
     };
 
     static const std::vector<Widget*> no_children;

--- a/firmware/standalone/common/ui/ui_focus.cpp
+++ b/firmware/standalone/common/ui/ui_focus.cpp
@@ -160,7 +160,7 @@ void FocusManager::update(
         const auto focus_screen_rect = focus_widget()->screen_rect();
 
         const auto test_fn = [&focus_screen_rect, event](ui::Widget* const w) -> test_result_t {
-            // if( w->visible() && w->focusable() ) {
+            // if( w->drawn() && w->focusable() ) {
             if (w->focusable()) {
                 const auto distance = rect_distances(event, focus_screen_rect, w->screen_rect());
                 if (distance >= 0) {

--- a/firmware/standalone/common/ui/ui_painter.cpp
+++ b/firmware/standalone/common/ui/ui_painter.cpp
@@ -118,11 +118,11 @@ void Painter::paint_widget_tree(Widget* w) {
 
 void Painter::paint_widget(Widget* w) {
     if (w->hidden()) {
-        // Mark widget (and all children) as invisible.
-        w->visible(false);
+        // Mark widget (and all children) as not drawn.
+        w->drawn(false);
     } else {
-        // Mark this widget as visible and recurse.
-        w->visible(true);
+        // Mark this widget as drawn and recurse.
+        w->drawn(true);
 
         if (w->dirty()) {
             w->paint(*this);

--- a/firmware/standalone/common/ui/ui_widget.cpp
+++ b/firmware/standalone/common/ui/ui_widget.cpp
@@ -227,7 +227,7 @@ void Widget::drawn(bool v) {
         } else {
             on_hide();
 
-            // Set all children invisible too.
+            // Mark all children as not drawn too.
             for (const auto child : children()) {
                 child->drawn(false);
             }

--- a/firmware/standalone/common/ui/ui_widget.cpp
+++ b/firmware/standalone/common/ui/ui_widget.cpp
@@ -91,9 +91,9 @@ void Widget::set_parent(Widget* const widget) {
     }
 
     if (parent_ && !widget) {
-        // We have a parent, but are losing it. Update visible status.
+        // We have a parent, but are losing it. Update drawn status.
         dirty_overlapping_children_in_rect(screen_rect());
-        visible(false);
+        drawn(false);
     }
 
     parent_ = widget;
@@ -212,9 +212,9 @@ const Style& Widget::style() const {
     }
 }
 
-void Widget::visible(bool v) {
-    if (v != flags.visible) {
-        flags.visible = v;
+void Widget::drawn(bool v) {
+    if (v != flags.drawn) {
+        flags.drawn = v;
 
         /* TODO: This on_show/on_hide implementation seems inelegant.
          * But I need *some* way to take/configure resources when
@@ -229,7 +229,7 @@ void Widget::visible(bool v) {
 
             // Set all children invisible too.
             for (const auto child : children()) {
-                child->visible(false);
+                child->drawn(false);
             }
         }
     }
@@ -701,7 +701,7 @@ void Console::clear(bool clear_buffer = false) {
     if (clear_buffer)
         buffer.clear();
 
-    if (!hidden() && visible()) {
+    if (!hidden() && drawn()) {
         _api->fill_rectangle(screen_rect().left(), screen_rect().top(), screen_rect().width(), screen_rect().height(), Theme::getInstance()->bg_darkest->background.v);
     }
 
@@ -711,7 +711,7 @@ void Console::clear(bool clear_buffer = false) {
 void Console::write(std::string message) {
     bool escape = false;
 
-    if (!hidden() && visible()) {
+    if (!hidden() && drawn()) {
         const Style& s = style();
         const Font& font = s.font;
         auto rect = screen_rect();
@@ -803,7 +803,7 @@ void Console::on_hide() {
 }
 
 void Console::crlf() {
-    if (hidden() || !visible())
+    if (hidden() || !drawn())
         return;
 
     const auto& s = style();

--- a/firmware/standalone/common/ui/ui_widget.hpp
+++ b/firmware/standalone/common/ui/ui_widget.hpp
@@ -128,7 +128,7 @@ class Widget {
     void set_clean();
 
     void drawn(bool v);
-    bool drawn() { return flags.drawn; };
+    bool drawn() const { return flags.drawn; };
 
     bool highlighted() const;
     void set_highlighted(const bool value);

--- a/firmware/standalone/common/ui/ui_widget.hpp
+++ b/firmware/standalone/common/ui/ui_widget.hpp
@@ -127,8 +127,8 @@ class Widget {
     bool dirty() const;
     void set_clean();
 
-    void visible(bool v);
-    bool visible() { return flags.visible; };
+    void drawn(bool v);
+    bool drawn() { return flags.drawn; };
 
     bool highlighted() const;
     void set_highlighted(const bool value);
@@ -147,7 +147,7 @@ class Widget {
         bool hidden : 1;       // Hide widget and children.
         bool focusable : 1;    // Widget can receive focus.
         bool highlighted : 1;  // Show in a highlighted style.
-        bool visible : 1;      // Object was visible during last paint.
+        bool drawn : 1;        // Object was drawn during last paint.
     };
 
     flags_t flags{
@@ -155,7 +155,7 @@ class Widget {
         .hidden = false,
         .focusable = false,
         .highlighted = false,
-        .visible = false,
+        .drawn = false,
     };
 
     static const std::vector<Widget*> no_children;


### PR DESCRIPTION
## Brief description what you did
When I've been digging in btngrid, I had a lot of confusion caused by the unusual terminology used with the properties hidden and visible..

In an ideal world visible should tell if something should be drawn or not, we have hidden to control that, and that stays since:
- It's kinda ok
- It would be another source of confusion if I'd make visible do what I originally thought it would :)

drawn() will now replace visible() to tell if something is currently on the screen. Linguistically, visible was alright, but probably would confuse anyone who ever used any other ui framework :)

## Checklist
- [x]  Kept changes minimal and limited to necessary files
- [x]  Verified functionality remains intact and code compiles
