### PR TITLE
remove redundant code from #3078

### DIFF
--- a/firmware/application/protocols/ax25.cpp
+++ b/firmware/application/protocols/ax25.cpp
@@ -131,8 +131,7 @@ void AX25Frame::make_ui_frame(char* const address, const uint8_t control, const 
     flush();
 }
 
-// __attribute__((used)) prevents dead-stripping; called only from KISS TNC external app.
-__attribute__((used)) void AX25Frame::make_frame_from_raw(const uint8_t* data, size_t len) {
+void AX25Frame::make_frame_from_raw(const uint8_t* data, size_t len) {
     bb_data_ptr = (uint16_t*)shared_memory.bb_data.data;
     memset(bb_data_ptr, 0, sizeof(shared_memory.bb_data.data));
     bit_counter = 0;


### PR DESCRIPTION
## Brief description what you did
the attribute in #3078 is not needed.  
@SarahRoseLives If your compiler/linker need this to have it correctly compile or run. feel free to discuss here.

## Checklist
- [x]  Kept changes minimal and limited to necessary files
- [x]  Verified functionality remains intact and code compiles
