### PR TITLE
fix: serial shell stability (fread deadlock, setfreq bounds, rssi/rxstart commands)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,6 +79,7 @@ venv/
 
 # Other
 *.bak
+CLAUDE.md
 
 # generated bitmap arr file
 # TODO: generate bitmap during build, since we use python during build anyway, lemme know if this is a bad idea @zxkmm

--- a/firmware/application/event_m0.cpp
+++ b/firmware/application/event_m0.cpp
@@ -93,7 +93,8 @@ class MessageHandlerMap {
 
 static MessageHandlerMap message_map;
 
-/* Global latest channel statistics, updated on every M4→M0 dispatch.
+/* Global latest channel statistics, updated when handling
+ * Message::ID::ChannelStatistics from M4→M0.
  * Readable from serial shell thread via cmd_rssi. */
 volatile int32_t global_last_max_db = -120;
 volatile uint32_t global_stats_update_count = 0;

--- a/firmware/application/event_m0.cpp
+++ b/firmware/application/event_m0.cpp
@@ -92,6 +92,11 @@ class MessageHandlerMap {
 };
 
 static MessageHandlerMap message_map;
+
+/* Global latest channel statistics, updated on every M4→M0 dispatch.
+ * Readable from serial shell thread via cmd_rssi. */
+volatile int32_t global_last_max_db = -120;
+volatile uint32_t global_stats_update_count = 0;
 Thread* EventDispatcher::thread_event_loop = nullptr;
 bool EventDispatcher::is_running = false;
 bool EventDispatcher::display_sleep = false;
@@ -196,6 +201,11 @@ void EventDispatcher::dispatch(const eventmask_t events) {
 
 void EventDispatcher::handle_application_queue() {
     shared_memory.application_queue.handle([](Message* const message) {
+        if (message->id == Message::ID::ChannelStatistics) {
+            auto stats_msg = static_cast<const ChannelStatisticsMessage*>(message);
+            global_last_max_db = stats_msg->statistics.max_db;
+            global_stats_update_count++;
+        }
         message_map.send(message);
     });
 }

--- a/firmware/application/event_m0.hpp
+++ b/firmware/application/event_m0.hpp
@@ -156,4 +156,8 @@ class MessageHandlerRegistration {
     const Message::ID message_id;
 };
 
+/* Global channel statistics from M4 baseband, readable from any thread. */
+extern volatile int32_t global_last_max_db;
+extern volatile uint32_t global_stats_update_count;
+
 #endif /*__EVENT_M0_H__*/

--- a/firmware/application/usb_serial_shell.cpp
+++ b/firmware/application/usb_serial_shell.cpp
@@ -1361,9 +1361,10 @@ static void cmd_setfreq(BaseSequentialStream* chp, int argc, char* argv[]) {
         chprintf(chp, usage);
         return;
     }
-    int64_t freq = atol(argv[0]);
+    char* endptr;
+    int64_t freq = strtoll(argv[0], &endptr, 10);
 
-    if (freq <= 0) {
+    if (*endptr != '\0' || freq <= 0) {
         chprintf(chp, usage);
         return;
     }
@@ -1416,8 +1417,9 @@ static void cmd_rxstart(BaseSequentialStream* chp, int argc, char* argv[]) {
         return;
     }
 
-    int64_t freq = atol(argv[0]);
-    if (freq <= 0 || freq > 7200000000LL) {
+    char* endptr;
+    int64_t freq = strtoll(argv[0], &endptr, 10);
+    if (*endptr != '\0' || freq <= 0 || freq > 7200000000LL) {
         chprintf(chp, "error: invalid frequency\r\n");
         return;
     }
@@ -1432,6 +1434,10 @@ static void cmd_rxstart(BaseSequentialStream* chp, int argc, char* argv[]) {
             return;
         }
     }
+
+    /* Shut down any running baseband before starting a new one */
+    portapack::receiver_model.disable();
+    baseband::shutdown();
 
     /* Configure receiver directly — no app view, no race condition */
     switch (mode) {
@@ -1458,8 +1464,11 @@ static void cmd_rxstart(BaseSequentialStream* chp, int argc, char* argv[]) {
 }
 
 static void cmd_rxstop(BaseSequentialStream* chp, int argc, char* argv[]) {
-    (void)argc;
     (void)argv;
+    if (argc != 0) {
+        chprintf(chp, "usage: rxstop\r\n");
+        return;
+    }
     portapack::receiver_model.disable();
     baseband::shutdown();
     chprintf(chp, "ok\r\n");

--- a/firmware/application/usb_serial_shell.cpp
+++ b/firmware/application/usb_serial_shell.cpp
@@ -1367,9 +1367,101 @@ static void cmd_setfreq(BaseSequentialStream* chp, int argc, char* argv[]) {
         chprintf(chp, usage);
         return;
     }
+    if (freq > 7200000000LL) {
+        chprintf(chp, "error: frequency exceeds maximum 7200 MHz\r\n");
+        return;
+    }
     // radio::set_tuning_frequency(freq); // sadly this doesn't update any widget, just change the frequency.
     FreqChangeCommandMessage message{freq};
     EventDispatcher::send_message(message);
+    chprintf(chp, "ok\r\n");
+}
+
+static void cmd_rssi(BaseSequentialStream* chp, int argc, char* argv[]) {
+    (void)argv;
+    if (argc > 1) {
+        chprintf(chp, "usage: rssi [count]\r\n");
+        return;
+    }
+
+    int count = 1;
+    if (argc == 1) {
+        count = atoi(argv[0]);
+        if (count < 1) count = 1;
+        if (count > 100) count = 100;
+    }
+
+    uint32_t prev_update = global_stats_update_count;
+    for (int i = 0; i < count; i++) {
+        /* Wait up to 500ms for a fresh stats update from M4 baseband */
+        int wait_ms = 0;
+        while (global_stats_update_count == prev_update && wait_ms < 500) {
+            chThdSleepMilliseconds(10);
+            wait_ms += 10;
+        }
+        if (global_stats_update_count == prev_update) {
+            chprintf(chp, "error: no baseband active\r\n");
+            return;
+        }
+        prev_update = global_stats_update_count;
+        chprintf(chp, "%d\r\n", (int)global_last_max_db);
+    }
+    chprintf(chp, "ok\r\n");
+}
+
+static void cmd_rxstart(BaseSequentialStream* chp, int argc, char* argv[]) {
+    const char* usage = "usage: rxstart freq_hz [am|nfm|wfm]\r\n";
+    if (argc < 1 || argc > 2) {
+        chprintf(chp, usage);
+        return;
+    }
+
+    int64_t freq = atol(argv[0]);
+    if (freq <= 0 || freq > 7200000000LL) {
+        chprintf(chp, "error: invalid frequency\r\n");
+        return;
+    }
+
+    /* Default to AM for broadest signal detection */
+    int mode = 0;  /* 0=AM, 1=NFM, 2=WFM */
+    if (argc == 2) {
+        if (strcmp(argv[1], "nfm") == 0) mode = 1;
+        else if (strcmp(argv[1], "wfm") == 0) mode = 2;
+        else if (strcmp(argv[1], "am") != 0) {
+            chprintf(chp, usage);
+            return;
+        }
+    }
+
+    /* Configure receiver directly — no app view, no race condition */
+    switch (mode) {
+        case 0:
+            baseband::run_image(portapack::spi_flash::image_tag_am_audio);
+            portapack::receiver_model.set_modulation(ReceiverModel::Mode::AMAudio);
+            portapack::receiver_model.set_am_configuration(0);
+            break;
+        case 1:
+            baseband::run_image(portapack::spi_flash::image_tag_nfm_audio);
+            portapack::receiver_model.set_modulation(ReceiverModel::Mode::NarrowbandFMAudio);
+            portapack::receiver_model.set_nbfm_configuration(2);
+            break;
+        case 2:
+            baseband::run_image(portapack::spi_flash::image_tag_wfm_audio);
+            portapack::receiver_model.set_modulation(ReceiverModel::Mode::WidebandFMAudio);
+            portapack::receiver_model.set_wfm_configuration(0);
+            break;
+    }
+
+    portapack::receiver_model.set_target_frequency(freq);
+    portapack::receiver_model.enable();
+    chprintf(chp, "ok\r\n");
+}
+
+static void cmd_rxstop(BaseSequentialStream* chp, int argc, char* argv[]) {
+    (void)argc;
+    (void)argv;
+    portapack::receiver_model.disable();
+    baseband::shutdown();
     chprintf(chp, "ok\r\n");
 }
 
@@ -1488,6 +1580,9 @@ static const ShellCommand commands[] = {
     {"sendpocsag", cmd_sendpocsag},
     {"asyncmsg", cmd_asyncmsg},
     {"setfreq", cmd_setfreq},
+    {"rssi", cmd_rssi},
+    {"rxstart", cmd_rxstart},
+    {"rxstop", cmd_rxstop},
     {"getres", cmd_getres},
     {"getflash", cmd_getflash},
     {"getdevtype", cmd_getdevtype},

--- a/firmware/application/usb_serial_shell_filesystem.cpp
+++ b/firmware/application/usb_serial_shell_filesystem.cpp
@@ -267,10 +267,10 @@ void cmd_sd_read(BaseSequentialStream* chp, int argc, char* argv[]) {
 
     int size = (int)strtol(argv[0], NULL, 10);
 
-    uint8_t buffer[62];
+    uint8_t buffer[32];
 
     do {
-        File::Size bytes_to_read = size > 62 ? 62 : size;
+        File::Size bytes_to_read = size > 32 ? 32 : size;
         auto bytes_read = shell_file->read(buffer, bytes_to_read);
         if (report_on_error(chp, bytes_read)) return;
 


### PR DESCRIPTION
## Summary

- **Fix fread USB buffer deadlock**: Reduce hex-encode chunk size from 62→32 bytes. With the 128-byte USB serial buffer (reduced from 400 in commit 40924250), 62-byte chunks produce 126 bytes of hex output (98.4% of buffer), deadlocking the subsequent `ok\r\n` response.

- **Add setfreq upper bounds check**: Reject frequencies above 7200 MHz to prevent invalid values reaching the radio hardware.

- **Add `rxstart`/`rssi`/`rxstop` serial commands** for headless RF signal measurement:
  - `rxstart <freq_hz> [am|nfm|wfm]` — Start receiver directly via `receiver_model` without an app view. Eliminates the `FreqChangeCommandMessage` race condition (Hard Fault at pc=0x00078164) that occurs when `setfreq` is called before an app's message handler registers.
  - `rssi [count]` — Read signal power in dB (1-100 samples) from global `ChannelStatistics` updated every ~100ms by M4 baseband.
  - `rxstop` — Stop receiver and shut down baseband.

- **Expose ChannelStatistics globally**: Intercept `ChannelStatisticsMessage` in `handle_application_queue()` to update `global_last_max_db` before dispatching to app handlers. This allows the serial shell thread to read signal power without registering a message handler.

## Motivation

The existing `setfreq` command dispatches a `FreqChangeCommandMessage` whose handler lambda captures a raw `this` pointer. If called before the active view's message handler is registered (<5s after `appstart`) or during view destruction, it dereferences a dangling pointer causing a Hard Fault. This makes automated serial workflows (spectrum sweeps, signal monitoring) unreliable.

The new `rxstart` command configures the receiver directly via `receiver_model` and `baseband::run_image()`, bypassing the app view lifecycle entirely. Combined with `rssi`, this enables reliable automated signal measurement over the serial console.

Related: #3045 (POCSAG TX Hard Fault — same `FreqChangeCommandMessage` race condition pattern)

## Test plan

- [ ] Verify `fread` works without deadlock: `fopen /path 0` → `fread 64` → `fclose`
- [ ] Verify `setfreq` rejects >7200 MHz: `setfreq 8000000000` → error
- [ ] Verify `rxstart 100000000 am` → `rssi 5` returns 5 dB readings → `rxstop`
- [ ] Verify `rssi` without active baseband returns "error: no baseband active"
- [ ] Verify existing apps still receive `ChannelStatistics` normally
- [ ] Verify `setfreq` still works for frequency changes after `rxstart`

🤖 Generated with [Claude Code](https://claude.com/claude-code)