### PR TITLE
fix audio mode change crash

### DIFF
--- a/firmware/application/apps/analog_audio_app.cpp
+++ b/firmware/application/apps/analog_audio_app.cpp
@@ -419,10 +419,10 @@ void AnalogAudioView::on_baseband_bandwidth_changed(uint32_t bandwidth_hz) {
 }
 
 void AnalogAudioView::on_modulation_changed(ReceiverModel::Mode modulation) {
-    baseband::spectrum_streaming_stop();
+    waterfall.stop();
     update_modulation(modulation);
     on_show_options_modulation();
-    baseband::spectrum_streaming_start();
+    waterfall.start();
 }
 
 void AnalogAudioView::remove_options_widget() {

--- a/firmware/application/ui/ui_spectrum.cpp
+++ b/firmware/application/ui/ui_spectrum.cpp
@@ -361,6 +361,8 @@ void WaterfallView::stop() {
         baseband::spectrum_streaming_stop();
         running_ = false;
     }
+    this->channel_fifo = nullptr;
+    this->audio_spectrum_data = nullptr;
 }
 
 void WaterfallView::show_audio_spectrum_view(const bool show) {

--- a/firmware/application/ui/ui_spectrum.hpp
+++ b/firmware/application/ui/ui_spectrum.hpp
@@ -173,12 +173,16 @@ class WaterfallView : public View {
     MessageHandlerRegistration message_handler_channel_spectrum_config{
         Message::ID::ChannelSpectrumConfig,
         [this](const Message* const p) {
+            if (!running_)
+                return;
             const auto message = *reinterpret_cast<const ChannelSpectrumConfigMessage*>(p);
             this->channel_fifo = message.fifo;
         }};
     MessageHandlerRegistration message_handler_audio_spectrum{
         Message::ID::AudioSpectrum,
         [this](const Message* const p) {
+            if (!running_)
+                return;
             const auto message = *reinterpret_cast<const AudioSpectrumMessage*>(p);
             this->audio_spectrum_data = message.data;
             this->audio_spectrum_update = true;
@@ -186,6 +190,8 @@ class WaterfallView : public View {
     MessageHandlerRegistration message_handler_frame_sync{
         Message::ID::DisplayFrameSync,
         [this](const Message* const) {
+            if (!running_)
+                return;
             if (this->channel_fifo) {
                 ChannelSpectrum channel_spectrum;
                 while (channel_fifo->out(channel_spectrum)) {


### PR DESCRIPTION
This pull request refactors how spectrum streaming is controlled when the modulation changes and improves the robustness of the `WaterfallView` by ensuring that message handlers only update state when the view is running. The changes also ensure proper cleanup of internal pointers when stopping the waterfall view.

**Refactoring spectrum streaming and view management:**

* In `AnalogAudioView::on_modulation_changed`, replaced direct calls to `baseband::spectrum_streaming_stop()` and `baseband::spectrum_streaming_start()` with calls to `waterfall.stop()` and `waterfall.start()`, delegating responsibility for spectrum streaming control to the `WaterfallView`.

**Robustness improvements in `WaterfallView`:**

* Updated message handlers in `WaterfallView` to early-return if the view is not running, preventing updates to internal state when the view is inactive.
* In `WaterfallView::stop()`, set `channel_fifo` and `audio_spectrum_data` pointers to `nullptr` to ensure proper cleanup and avoid dangling pointers.

Closes #3110 