### PR TITLE
remove some bluffing text from fpv detect app

### DIFF
--- a/firmware/application/external/fpv_detect/ui_fpv_detect.cpp
+++ b/firmware/application/external/fpv_detect/ui_fpv_detect.cpp
@@ -3,13 +3,11 @@
 /*
  * FPV RX — how frequency search and lock work
  *
- * 1. Power metric: We use channelized power (baseband IQ magnitude² in the
- *    capture bandwidth), not raw RF RSSI. Stats come from ChannelStatsCollector
- *    over filtered IQ, so we see power in the tuned channel, not wideband.
+ * 1. Power metric: We use channelized power that portapack RSSI algo included.
  *
  * 2. Scanning: We step through FPV bands/channels (A/B/E/F/R, 8 ch each). When
  *    power on the current channel exceeds the detect threshold, we enter
- *    "Candidate" and run verification — we do not lock on a single peak.
+ *    "Candidate" and run verification - with some edge detecting algo.
  *
  * 3. Verification (making sure the drone is on that freq):
  *    - Multiple samples: verify_hits / verify_misses over several updates.
@@ -177,7 +175,7 @@ void FpvDetectView::reset_detector(bool retune_current) {
     }
 }
 
-bool FpvDetectView::is_possible_analog_carrier(const ChannelStatistics& statistics) const {
+bool FpvDetectView::is_possible_freq_spike(const ChannelStatistics& statistics) const {
     return statistics.max_db >= detect_threshold_db();
 }
 
@@ -392,17 +390,17 @@ void FpvDetectView::update_state_badge() {
             text_state.set("SCANNING");
             break;
         case DetectState::Candidate:
-            text_state.set("VERIFY FPV");
+            text_state.set("CHECKING");
             break;
         case DetectState::Locked:
-            text_state.set("DRONE FOUND");
+            text_state.set("FREQ FOUND");
             break;
     }
 }
 
 void FpvDetectView::update_confidence_text() {
     char buf[16];
-    std::snprintf(buf, sizeof(buf), "Conf %u%%", static_cast<unsigned>(candidate_confidence_));
+    std::snprintf(buf, sizeof(buf), "Posi %u%%", static_cast<unsigned>(candidate_confidence_));
     text_confidence.set(buf);
 }
 
@@ -412,21 +410,21 @@ void FpvDetectView::update_status_text() {
     switch (detect_state_) {
         case DetectState::Scanning:
             if (band_mode < FPV_NUM_BANDS) {
-                std::snprintf(buf, sizeof(buf), "Scanning band %c for analog FPV", band_labels[band_mode]);
+                std::snprintf(buf, sizeof(buf), "Scanning band %c", band_labels[band_mode]);
             } else {
-                std::snprintf(buf, sizeof(buf), "Scanning all FPV bands");
+                std::snprintf(buf, sizeof(buf), "Scanning all from list");
             }
             break;
 
         case DetectState::Candidate:
-            std::snprintf(buf, sizeof(buf), "VERIFYING %c%d  %ld MHz",
+            std::snprintf(buf, sizeof(buf), "CHKING %c%d  %ld MHz",
                           band_labels[candidate_band_],
                           static_cast<int>(candidate_ch_ + 1),
                           static_cast<long>(fpv_frequencies[candidate_band_][candidate_ch_] / 1000000LL));
             break;
 
         case DetectState::Locked:
-            std::snprintf(buf, sizeof(buf), "!!! DRONE FOUND !!! %c%d  %ld",
+            std::snprintf(buf, sizeof(buf), "FREQ FOUND %c%d  %ld",
                           band_labels[candidate_band_],
                           static_cast<int>(candidate_ch_ + 1),
                           static_cast<long>(fpv_frequencies[candidate_band_][candidate_ch_] / 1000000LL));
@@ -453,7 +451,7 @@ void FpvDetectView::update_detail_text() {
             break;
 
         case DetectState::Locked:
-            std::snprintf(buf, sizeof(buf), "LOCKED %c%d  conf %u%%  hold %u",
+            std::snprintf(buf, sizeof(buf), "LOCKED %c%d  posi %u%%  hold %u",
                           band_labels[candidate_band_],
                           static_cast<int>(candidate_ch_ + 1),
                           static_cast<unsigned>(candidate_confidence_),
@@ -605,7 +603,7 @@ void FpvDetectView::on_statistics_update(const ChannelStatistics& statistics) {
 
     switch (detect_state_) {
         case DetectState::Scanning:
-            if (is_possible_analog_carrier(statistics)) {
+            if (is_possible_freq_spike(statistics)) {
                 enter_candidate(statistics);
             }
             break;

--- a/firmware/application/external/fpv_detect/ui_fpv_detect.hpp
+++ b/firmware/application/external/fpv_detect/ui_fpv_detect.hpp
@@ -72,7 +72,7 @@ class FpvDetectView : public View {
     void step_scan();
     void reset_detector(bool retune_current);
 
-    bool is_possible_analog_carrier(const ChannelStatistics& statistics) const;
+    bool is_possible_freq_spike(const ChannelStatistics& statistics) const;
     void enter_candidate(const ChannelStatistics& statistics);
     void evaluate_candidate_sample(const ChannelStatistics& statistics);
     void enter_lock();
@@ -162,7 +162,7 @@ class FpvDetectView : public View {
     Text text_freq{{UI_POS_X_RIGHT(20), UI_POS_Y(1), UI_POS_WIDTH(20), UI_POS_DEFAULT_HEIGHT}, ""};
 
     Text text_state{{UI_POS_X(0), UI_POS_Y(2), UI_POS_WIDTH(12), UI_POS_DEFAULT_HEIGHT}, "SCANNING"};
-    Text text_confidence{{UI_POS_X(12), UI_POS_Y(2), UI_POS_WIDTH(8), UI_POS_DEFAULT_HEIGHT}, "Conf 0%"};
+    Text text_confidence{{UI_POS_X(12), UI_POS_Y(2), UI_POS_WIDTH(8), UI_POS_DEFAULT_HEIGHT}, "Posi 0%"};
     Text text_detect_label{{UI_POS_X_RIGHT(10), UI_POS_Y(2), UI_POS_WIDTH(5), UI_POS_DEFAULT_HEIGHT}, "Thr>"};
 
     NumberField field_detect_threshold{
@@ -176,8 +176,8 @@ class FpvDetectView : public View {
     Text freq_stats_rssi{{UI_POS_X(0), UI_POS_Y(3), UI_POS_WIDTH(15), UI_POS_DEFAULT_HEIGHT}, "RSSI 0/0/0"};
     Text freq_stats_db{{UI_POS_X_RIGHT(14), UI_POS_Y(3), UI_POS_WIDTH(14), UI_POS_DEFAULT_HEIGHT}, "PWR -120 dB"};
 
-    Text text_status{{UI_POS_X(0), UI_POS_Y(4), UI_POS_WIDTH(30), UI_POS_DEFAULT_HEIGHT}, "SCANNING FOR ANALOG FPV"};
-    Text text_detail{{UI_POS_X(0), UI_POS_Y(5), UI_POS_WIDTH(30), UI_POS_DEFAULT_HEIGHT}, "Waiting for FPV-like carrier"};
+    Text text_status{{UI_POS_X(0), UI_POS_Y(4), UI_POS_WIDTH(30), UI_POS_DEFAULT_HEIGHT}, "SCANNING FOR FREQS"};
+    Text text_detail{{UI_POS_X(0), UI_POS_Y(5), UI_POS_WIDTH(30), UI_POS_DEFAULT_HEIGHT}, "Waiting for FPV FREQ"};
 
     RSSIGraph rssi_graph{{UI_POS_X(0), UI_POS_Y(6), UI_POS_WIDTH_REMAINING(5), UI_POS_HEIGHT_REMAINING(7)}};
     RSSI rssi{{UI_POS_X_RIGHT(5), UI_POS_Y(6), UI_POS_WIDTH(5), UI_POS_HEIGHT_REMAINING(7)}};


### PR DESCRIPTION
<!--
👋 Thank you for your contribution!

⚠️ To help avoid extensive change requests or potential rejection, please review our simple Contributing Guidelines before you start coding: https://github.com/portapack-mayhem/mayhem-firmware/wiki/Contributing-Guidelines.

Thank you again for contributing!
-->

## Brief description what you did
<!-- Describe your changes in detail here. What problem does this PR solve? What features does it add or fix? -->

Sorry that when i approved this app, I was just checking if it contains something that can impact things outside of this app. 

I didn't see it contains so many bluffing text/UI element/hints that claiming something it didn't actually implement.

So this PR removed those bluffing context to prevent confusing users, since this app seems not quite even a valid PoC and still needs a lot of work to do on.


## Checklist
- [ ] Kept changes minimal and limited to necessary files
- [ ] Verified functionality remains intact and code compiles
