### PR TITLE
Add device subdirectory support for APPS layout in firmware

### DIFF
--- a/.github/workflows/create_nightly_release.yml
+++ b/.github/workflows/create_nightly_release.yml
@@ -35,14 +35,17 @@ jobs:
             device_name: HackRF
             cmake_args: ""
             artifact_suffix: "_hackrf"
+            device_subdir: hackrf
           - device: portarf
             device_name: PortaRF
-            cmake_args: "-DFLASH_MB_SIZE=2 -DFLASH_MB_LIMIT_SIZE=2"
+            cmake_args: "-DFLASH_MB_SIZE=2 -DFLASH_MB_LIMIT_SIZE=2 -DDEVICE_SUBDIR=portarf"
             artifact_suffix: "_portarf"
+            device_subdir: portarf
           - device: hpro
             device_name: HackRF Pro
             cmake_args: "-DBOARD=PRALINE"
             artifact_suffix: "_hpro"
+            device_subdir: hpro
     steps:
       - name: Get version date
         id: version_date
@@ -63,7 +66,7 @@ jobs:
         run: docker run -e VERSION_STRING=${{ steps.version_date.outputs.date }} -i -v ${{ github.workspace }}:/havoc portapack-dev ${{ matrix.cmake_args }}
       - name: Create Small SD Card ZIP - No World Map
         run: |
-          mkdir -p sdcard/FIRMWARE && cp build/firmware/portapack-mayhem-firmware.bin sdcard/FIRMWARE/portapack-mayhem_${{ steps.version_date.outputs.date }}.bin && cp build/firmware/portapack-mayhem_OCI.ppfw.tar sdcard/FIRMWARE/mayhem_nightly_${{ steps.version_date.outputs.date }}${{ matrix.artifact_suffix }}_OCI.ppfw.tar && mkdir -p sdcard/APPS && cp build/firmware/application/*.ppma sdcard/APPS && cp build/firmware/standalone/*/*.ppmp sdcard/APPS && cd sdcard && zip -r ../sdcard-no-map.zip . && cd ..
+          mkdir -p sdcard/FIRMWARE && cp build/firmware/portapack-mayhem-firmware.bin sdcard/FIRMWARE/portapack-mayhem_${{ steps.version_date.outputs.date }}${{ matrix.artifact_suffix }}.bin && cp build/firmware/portapack-mayhem_OCI.ppfw.tar sdcard/FIRMWARE/mayhem_nightly_${{ steps.version_date.outputs.date }}${{ matrix.artifact_suffix }}_OCI.ppfw.tar && mkdir -p sdcard/APPS/${{ matrix.device_subdir }} && cp build/firmware/application/*.ppma sdcard/APPS/${{ matrix.device_subdir }} && cp build/firmware/standalone/*/*.ppmp sdcard/APPS/${{ matrix.device_subdir }} && cd sdcard && zip -r ../sdcard-no-map.zip . && cd ..
       - name: Download world map
         run: |
           wget https://github.com/portapack-mayhem/mayhem-firmware/releases/download/world_map/world_map.zip
@@ -78,7 +81,7 @@ jobs:
           zip -j firmware.zip build/firmware/portapack-mayhem-firmware.bin && cd flashing && zip -r ../firmware.zip *
       - name: Create SD Card ZIP
         run: |
-          mkdir -p sdcard/FIRMWARE && cp build/firmware/portapack-mayhem-firmware.bin sdcard/FIRMWARE/portapack-mayhem_${{ steps.version_date.outputs.date }}.bin && cp build/firmware/portapack-mayhem_OCI.ppfw.tar sdcard/FIRMWARE/mayhem_nightly_${{ steps.version_date.outputs.date }}${{ matrix.artifact_suffix }}_OCI.ppfw.tar && mkdir -p sdcard/APPS && cp build/firmware/application/*.ppma sdcard/APPS && cp build/firmware/standalone/*/*.ppmp sdcard/APPS && cd sdcard && zip -r ../sdcard.zip . && cd ..
+          mkdir -p sdcard/FIRMWARE && cp build/firmware/portapack-mayhem-firmware.bin sdcard/FIRMWARE/portapack-mayhem_${{ steps.version_date.outputs.date }}${{ matrix.artifact_suffix }}.bin && cp build/firmware/portapack-mayhem_OCI.ppfw.tar sdcard/FIRMWARE/mayhem_nightly_${{ steps.version_date.outputs.date }}${{ matrix.artifact_suffix }}_OCI.ppfw.tar && mkdir -p sdcard/APPS/${{ matrix.device_subdir }} && cp build/firmware/application/*.ppma sdcard/APPS/${{ matrix.device_subdir }} && cp build/firmware/standalone/*/*.ppmp sdcard/APPS/${{ matrix.device_subdir }} && cd sdcard && zip -r ../sdcard.zip . && cd ..
       - name: Upload firmware zip artifact
         uses: actions/upload-artifact@v4
         with:
@@ -145,6 +148,21 @@ jobs:
           mv firmware_combined_hpro/hackrf_usb.dfu firmware_combined/firmware/hackrf_hpro_usb.dfu
           mv firmware_combined_hpro/hackrf_usb.bin firmware_combined/firmware/hackrf_hpro_usb.bin
           cd firmware_combined && zip -r ../firmware_all_devices.zip . && cd ..
+      - name: Create Combined SD Card ZIPs
+        run: |
+          VER="${{ steps.version_date.outputs.date }}"
+          # Combine all 3 device sdcard artifacts into one (with world map)
+          mkdir -p combined_sdcard
+          unzip -o artifacts/sdcard-default/sdcard.zip -d combined_sdcard
+          unzip -o artifacts/sdcard-portarf/sdcard.zip -d combined_sdcard
+          unzip -o artifacts/sdcard-hpro/sdcard.zip -d combined_sdcard
+          cd combined_sdcard && zip -r ../sdcard-combined.zip . && cd ..
+          # Combine all 3 device sdcard artifacts into one (no world map)
+          mkdir -p combined_sdcard_no_map
+          unzip -o artifacts/sdcard-no-map-default/sdcard-no-map.zip -d combined_sdcard_no_map
+          unzip -o artifacts/sdcard-no-map-portarf/sdcard-no-map.zip -d combined_sdcard_no_map
+          unzip -o artifacts/sdcard-no-map-hpro/sdcard-no-map.zip -d combined_sdcard_no_map
+          cd combined_sdcard_no_map && zip -r ../sdcard-combined-no-map.zip . && cd ..
       - name: Prepare release assets
         run: |
           VER="${{ steps.version_date.outputs.date }}"
@@ -155,13 +173,9 @@ jobs:
           cp artifacts/oci-tar-hpro/portapack-mayhem_OCI.ppfw.tar "release_assets/OCI_hpro_mayhem_nightly_${VER}.ppfw.tar"
           # Combined firmware
           cp firmware_all_devices.zip "release_assets/FIRMWARE_mayhem_nightly_${VER}.zip"
-          # SD card assets
-          cp artifacts/sdcard-default/sdcard.zip "release_assets/COPY_TO_SDCARD_hackrf_mayhem_nightly_${VER}.zip"
-          cp artifacts/sdcard-no-map-default/sdcard-no-map.zip "release_assets/COPY_TO_SDCARD_hackrf_mayhem_nightly_${VER}-no-world-map.zip"
-          cp artifacts/sdcard-portarf/sdcard.zip "release_assets/COPY_TO_SDCARD_portarf_mayhem_nightly_${VER}.zip"
-          cp artifacts/sdcard-no-map-portarf/sdcard-no-map.zip "release_assets/COPY_TO_SDCARD_portarf_mayhem_nightly_${VER}-no-world-map.zip"
-          cp artifacts/sdcard-hpro/sdcard.zip "release_assets/COPY_TO_SDCARD_hpro_mayhem_nightly_${VER}.zip"
-          cp artifacts/sdcard-no-map-hpro/sdcard-no-map.zip "release_assets/COPY_TO_SDCARD_hpro_mayhem_nightly_${VER}-no-world-map.zip"
+          # Combined SD card assets (2 zips instead of 6)
+          cp sdcard-combined.zip "release_assets/COPY_TO_SDCARD_mayhem_nightly_${VER}.zip"
+          cp sdcard-combined-no-map.zip "release_assets/COPY_TO_SDCARD_mayhem_nightly_${VER}-no-world-map.zip"
       - name: Create Release
         uses: softprops/action-gh-release@v2
         with:

--- a/.github/workflows/create_stable_release.yml
+++ b/.github/workflows/create_stable_release.yml
@@ -15,14 +15,17 @@ jobs:
             device_name: HackRF
             cmake_args: ""
             artifact_suffix: "_hackrf"
+            device_subdir: hackrf
           - device: portarf
             device_name: PortaRF
-            cmake_args: "-DFLASH_MB_SIZE=2 -DFLASH_MB_LIMIT_SIZE=2"
+            cmake_args: "-DFLASH_MB_SIZE=2 -DFLASH_MB_LIMIT_SIZE=2 -DDEVICE_SUBDIR=portarf"
             artifact_suffix: "_portarf"
+            device_subdir: portarf
           - device: hpro
             device_name: HackRF Pro
             cmake_args: "-DBOARD=PRALINE"
             artifact_suffix: "_hpro"
+            device_subdir: hpro
     steps:
       - name: Get current date
         id: date
@@ -46,7 +49,7 @@ jobs:
         run: docker run -e VERSION_STRING=${{ steps.version.outputs.version }} -i -v ${{ github.workspace }}:/havoc portapack-dev ${{ matrix.cmake_args }}
       - name: Create Small SD Card ZIP - No World Map
         run: |
-          mkdir -p sdcard/FIRMWARE && cp build/firmware/portapack-mayhem-firmware.bin sdcard/FIRMWARE/portapack-mayhem_${{ steps.version.outputs.version }}.bin && cp build/firmware/portapack-mayhem_OCI.ppfw.tar sdcard/FIRMWARE/mayhem_${{ steps.version.outputs.version }}${{ matrix.artifact_suffix }}_OCI.ppfw.tar && mkdir -p sdcard/APPS && cp build/firmware/application/*.ppma sdcard/APPS && cp build/firmware/standalone/*/*.ppmp sdcard/APPS && cd sdcard && zip -r ../sdcard-no-map.zip . && cd ..
+          mkdir -p sdcard/FIRMWARE && cp build/firmware/portapack-mayhem-firmware.bin sdcard/FIRMWARE/portapack-mayhem_${{ steps.version.outputs.version }}${{ matrix.artifact_suffix }}.bin && cp build/firmware/portapack-mayhem_OCI.ppfw.tar sdcard/FIRMWARE/mayhem_${{ steps.version.outputs.version }}${{ matrix.artifact_suffix }}_OCI.ppfw.tar && mkdir -p sdcard/APPS/${{ matrix.device_subdir }} && cp build/firmware/application/*.ppma sdcard/APPS/${{ matrix.device_subdir }} && cp build/firmware/standalone/*/*.ppmp sdcard/APPS/${{ matrix.device_subdir }} && cd sdcard && zip -r ../sdcard-no-map.zip . && cd ..
       - name: Download world map
         run: |
           wget https://github.com/portapack-mayhem/mayhem-firmware/releases/download/world_map/world_map.zip
@@ -61,7 +64,7 @@ jobs:
           zip -j firmware.zip build/firmware/portapack-mayhem-firmware.bin && cd flashing && zip -r ../firmware.zip *
       - name: Create SD Card ZIP
         run: |
-          mkdir -p sdcard/FIRMWARE && cp build/firmware/portapack-mayhem-firmware.bin sdcard/FIRMWARE/portapack-mayhem_${{ steps.version.outputs.version }}.bin && cp build/firmware/portapack-mayhem_OCI.ppfw.tar sdcard/FIRMWARE/mayhem_${{ steps.version.outputs.version }}${{ matrix.artifact_suffix }}_OCI.ppfw.tar && mkdir -p sdcard/APPS && cp build/firmware/application/*.ppma sdcard/APPS && cp build/firmware/standalone/*/*.ppmp sdcard/APPS && cd sdcard && zip -r ../sdcard.zip . && cd ..
+          mkdir -p sdcard/FIRMWARE && cp build/firmware/portapack-mayhem-firmware.bin sdcard/FIRMWARE/portapack-mayhem_${{ steps.version.outputs.version }}${{ matrix.artifact_suffix }}.bin && cp build/firmware/portapack-mayhem_OCI.ppfw.tar sdcard/FIRMWARE/mayhem_${{ steps.version.outputs.version }}${{ matrix.artifact_suffix }}_OCI.ppfw.tar && mkdir -p sdcard/APPS/${{ matrix.device_subdir }} && cp build/firmware/application/*.ppma sdcard/APPS/${{ matrix.device_subdir }} && cp build/firmware/standalone/*/*.ppmp sdcard/APPS/${{ matrix.device_subdir }} && cd sdcard && zip -r ../sdcard.zip . && cd ..
       - name: Upload firmware zip artifact
         uses: actions/upload-artifact@v4
         with:
@@ -131,6 +134,21 @@ jobs:
           mv firmware_combined_hpro/hackrf_usb.dfu firmware_combined/firmware/hackrf_hpro_usb.dfu
           mv firmware_combined_hpro/hackrf_usb.bin firmware_combined/firmware/hackrf_hpro_usb.bin
           cd firmware_combined && zip -r ../firmware_all_devices.zip . && cd ..
+      - name: Create Combined SD Card ZIPs
+        run: |
+          VER="${{ steps.version.outputs.version }}"
+          # Combine all 3 device sdcard artifacts into one (with world map)
+          mkdir -p combined_sdcard
+          unzip -o artifacts/sdcard-default/sdcard.zip -d combined_sdcard
+          unzip -o artifacts/sdcard-portarf/sdcard.zip -d combined_sdcard
+          unzip -o artifacts/sdcard-hpro/sdcard.zip -d combined_sdcard
+          cd combined_sdcard && zip -r ../sdcard-combined.zip . && cd ..
+          # Combine all 3 device sdcard artifacts into one (no world map)
+          mkdir -p combined_sdcard_no_map
+          unzip -o artifacts/sdcard-no-map-default/sdcard-no-map.zip -d combined_sdcard_no_map
+          unzip -o artifacts/sdcard-no-map-portarf/sdcard-no-map.zip -d combined_sdcard_no_map
+          unzip -o artifacts/sdcard-no-map-hpro/sdcard-no-map.zip -d combined_sdcard_no_map
+          cd combined_sdcard_no_map && zip -r ../sdcard-combined-no-map.zip . && cd ..
       - name: Prepare release assets
         run: |
           VER="${{ steps.version.outputs.version }}"
@@ -141,13 +159,9 @@ jobs:
           cp artifacts/oci-tar-hpro/portapack-mayhem_OCI.ppfw.tar "release_assets/OCI_hpro_mayhem_${VER}.ppfw.tar"
           # Combined firmware
           cp firmware_all_devices.zip "release_assets/FIRMWARE_mayhem_${VER}.zip"
-          # SD card assets
-          cp artifacts/sdcard-default/sdcard.zip "release_assets/COPY_TO_SDCARD_hackrf_mayhem_${VER}.zip"
-          cp artifacts/sdcard-no-map-default/sdcard-no-map.zip "release_assets/COPY_TO_SDCARD_hackrf_mayhem_${VER}-no-world-map.zip"
-          cp artifacts/sdcard-portarf/sdcard.zip "release_assets/COPY_TO_SDCARD_portarf_mayhem_${VER}.zip"
-          cp artifacts/sdcard-no-map-portarf/sdcard-no-map.zip "release_assets/COPY_TO_SDCARD_portarf_mayhem_${VER}-no-world-map.zip"
-          cp artifacts/sdcard-hpro/sdcard.zip "release_assets/COPY_TO_SDCARD_hpro_mayhem_${VER}.zip"
-          cp artifacts/sdcard-no-map-hpro/sdcard-no-map.zip "release_assets/COPY_TO_SDCARD_hpro_mayhem_${VER}-no-world-map.zip"
+          # Combined SD card assets (2 zips instead of 6)
+          cp sdcard-combined.zip "release_assets/COPY_TO_SDCARD_mayhem_${VER}.zip"
+          cp sdcard-combined-no-map.zip "release_assets/COPY_TO_SDCARD_mayhem_${VER}-no-world-map.zip"
       - name: Create Release
         uses: softprops/action-gh-release@v2
         with:

--- a/firmware/CMakeLists.txt
+++ b/firmware/CMakeLists.txt
@@ -110,23 +110,33 @@ add_custom_target(
 	DEPENDS firmware ${FIRMWARE_FILENAME}
 )
 
+# Determine device subdirectory for per-device APPS layout
+if(BOARD STREQUAL "PRALINE")
+	set(DEVICE_SUBDIR "hpro")
+else()
+	if(NOT DEFINED DEVICE_SUBDIR)
+		set(DEVICE_SUBDIR "hackrf")
+	endif()
+endif()
+message("Using DEVICE_SUBDIR=${DEVICE_SUBDIR}")
+
 add_custom_target(
 	program-external-apps
 	WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-	COMMAND ${PROJECT_SOURCE_DIR}/tools/copy_external_apps.sh
+	COMMAND ${CMAKE_COMMAND} -E env DEVICE_SUBDIR=${DEVICE_SUBDIR} ${PROJECT_SOURCE_DIR}/tools/copy_external_apps.sh
 	DEPENDS program standalone_apps
 )
 
 add_custom_command(
 	OUTPUT ${PPFW_FILENAME}
-	
+
 	COMMAND rm -rf firmware_tar
 	COMMAND mkdir -p firmware_tar/FIRMWARE
 	# Using VERSION_NOHASH to avoid dev builds piling up in the FIRMWARE folder of the sd card of testers in #test-drive
 	COMMAND cp ${FIRMWARE_FILENAME} firmware_tar/FIRMWARE/portapack-mayhem_${VERSION_NOHASH}.bin
-	COMMAND mkdir -p firmware_tar/APPS
-	COMMAND cp application/*.ppma firmware_tar/APPS
-	COMMAND cp standalone/*/*.ppmp firmware_tar/APPS
+	COMMAND mkdir -p firmware_tar/APPS/${DEVICE_SUBDIR}
+	COMMAND cp application/*.ppma firmware_tar/APPS/${DEVICE_SUBDIR}
+	COMMAND cp standalone/*/*.ppmp firmware_tar/APPS/${DEVICE_SUBDIR}
 	COMMAND cd firmware_tar && tar -cvaf ../${PPFW_FILENAME} *
 	DEPENDS firmware ${FIRMWARE_FILENAME} standalone_apps
 	# Dont use VERBATIM here as it prevents usage of globbing (*)

--- a/firmware/application/file_path.cpp
+++ b/firmware/application/file_path.cpp
@@ -21,10 +21,23 @@
 
 #include "file_path.hpp"
 #include "file.hpp"
+#include "portapack_io.hpp"
 
 const std::filesystem::path adsb_dir = u"ADSB";
 const std::filesystem::path ais_dir = u"AIS";
-const std::filesystem::path apps_dir = u"APPS";
+std::filesystem::path apps_dir = u"APPS";
+
+void init_apps_dir() {
+#ifdef PRALINE
+    apps_dir = u"APPS/hpro";
+#else
+    if (portapack::device_type == portapack::DEV_PORTARF)
+        apps_dir = u"APPS/portarf";
+    else
+        apps_dir = u"APPS/hackrf";
+#endif
+}
+
 const std::filesystem::path aprs_dir = u"APRS";
 const std::filesystem::path audio_dir = u"AUDIO";
 const std::filesystem::path blerx_dir = u"BLERX";

--- a/firmware/application/file_path.hpp
+++ b/firmware/application/file_path.hpp
@@ -26,7 +26,8 @@
 
 extern const std::filesystem::path adsb_dir;
 extern const std::filesystem::path ais_dir;
-extern const std::filesystem::path apps_dir;
+extern std::filesystem::path apps_dir;
+void init_apps_dir();
 extern const std::filesystem::path aprs_dir;
 extern const std::filesystem::path audio_dir;
 extern const std::filesystem::path blerx_dir;

--- a/firmware/application/main.cpp
+++ b/firmware/application/main.cpp
@@ -137,6 +137,7 @@ Continuous (Fox-oring)
 #include "gcc.hpp"
 
 #include "sd_card.hpp"
+#include "file_path.hpp"
 
 #include <string.h>
 #include "i2cdevmanager.hpp"
@@ -199,6 +200,7 @@ int main(void) {
 
         case portapack::init_status_t::INIT_SUCCESS:
 
+            init_apps_dir();
             config_mode_clear();
 
             lcd_frame_sync_configure();

--- a/firmware/tools/copy_external_apps.sh
+++ b/firmware/tools/copy_external_apps.sh
@@ -41,10 +41,11 @@ do
         mountpoint=$(findmnt -f -o TARGET --noheadings $part)
         if [[ ! -z "$mountpoint" ]]; then
 
-            echo "Copying external applications to" $mountpoint
-            mkdir -p $mountpoint/APPS
-            cp application/*.ppma $mountpoint/APPS
-            cp standalone/*/*.ppmp $mountpoint/APPS
+            SUBDIR=${DEVICE_SUBDIR:-hackrf}
+            echo "Copying external applications to $mountpoint/APPS/$SUBDIR"
+            mkdir -p $mountpoint/APPS/$SUBDIR
+            cp application/*.ppma $mountpoint/APPS/$SUBDIR
+            cp standalone/*/*.ppmp $mountpoint/APPS/$SUBDIR
 
             echo "Unmounting" $mountpoint
             umount $mountpoint

--- a/firmware/tools/fast_flash_pp_and_copy_apps.py
+++ b/firmware/tools/fast_flash_pp_and_copy_apps.py
@@ -204,7 +204,8 @@ def run():
         print(f"find pp sd: {mount_point}")
 
         # worker 5: copy ppma and ppmp apps
-        apps_dir = os.path.join(mount_point, 'APPS')
+        device_subdir = os.environ.get('DEVICE_SUBDIR', 'hackrf')
+        apps_dir = os.path.join(mount_point, 'APPS', device_subdir)
         if not os.path.exists(apps_dir):
             os.makedirs(apps_dir)
 


### PR DESCRIPTION
### **Summary**
This PR optimizes the release workflow by consolidating device-specific SD card assets into a single "universal" ZIP file. It also introduces a structured directory layout for external applications (`.ppma`/`.ppmp`), ensuring that different hardware targets (HackRF, PortaRF, HackRF Pro) load the correct binaries from dedicated subdirectories on the SD card.

---

### **Key Changes**

#### **1. Workflow & Release Optimization**
* **Asset Consolidation**: Replaced the generation of 6 individual SD card ZIPs (3 devices × 2 map variants) with **2 consolidated ZIPs** (Standard and No-World-Map). 
* **Multi-Device Bundle**: The CI now unzips and merges the artifacts for HackRF, PortaRF, and HackRF Pro into a single distribution, reducing clutter in the GitHub Releases page.
* **Matrix Enhancements**: Added `device_subdir` to the build matrix to facilitate organized file placement during the build process.

#### **2. Firmware & App Directory Logic**
* **Namespaced Apps**: External applications are now stored in `APPS/<device_subdir>/` (e.g., `APPS/hackrf`, `APPS/portarf`, or `APPS/hpro`) instead of a flat `APPS/` root. 
* **Dynamic Path Resolution**: 
    * Added `init_apps_dir()` in `file_path.cpp` to detect the hardware at runtime and point the `apps_dir` path to the correct subdirectory.
    * Modified `main.cpp` to initialize these paths immediately after successful hardware initialization.
* **Build System Updates**: `CMakeLists.txt` and internal helper scripts (`copy_external_apps.sh`, `fast_flash_pp_and_copy_apps.py`) now respect the `DEVICE_SUBDIR` environment variable.

#### **3. Build System Improvements**
* **Unified OCI/PPFW**: Firmware naming now includes the `artifact_suffix` consistently across nightly and stable workflows to prevent binary collisions when creating combined archives.

---

### **Technical Details**

| Feature | Old Behavior | New Behavior |
| :--- | :--- | :--- |
| **SD Card Layout** | `/APPS/*.ppma` | `/APPS/<device>/*.ppma` |
| **Release Assets** | 6 separate ZIP files for SD cards | 2 "All-in-one" ZIP files |
| **App Loading** | Hardcoded to `/APPS` | Runtime detection based on `portapack::device_type` |
| **CI Complexity** | Uploaded multiple redundant artifacts | Merges device artifacts into a single combined release |

---

### **Impact**
* **Users**: Can now use a single "Copy to SD Card" ZIP that works across all supported Mayhem hardware variants.
* **Developers**: Cleaner release page and more robust handling of device-specific binary requirements.

---
> [!IMPORTANT]
> Ensure that existing users are informed to move their custom apps to the new subdirectories or perform a clean install from the new consolidated SD card ZIP to ensure apps remain visible in the UI.