### PR TITLE
FLEX TX: fix stop button not stopping transmission (fixes #3135)

### DIFF
--- a/firmware/application/external/flex_tx/ui_flex_tx.cpp
+++ b/firmware/application/external/flex_tx/ui_flex_tx.cpp
@@ -673,6 +673,7 @@ void FlexTXView::on_serial_msg(const FlexTosendMessage data) {
 
 void FlexTXView::on_tx_progress(const uint32_t progress, const bool done) {
     if (done) {
+        if (tx_phase_ == 0) return;  // stopped by user
         int ers_n = tx_steps_total_ - 2;
         if (tx_phase_ == 1 && ers_remaining_ > 0) {
             tx_step_++;
@@ -705,7 +706,8 @@ void FlexTXView::on_tx_progress(const uint32_t progress, const bool done) {
             set_dirty();  // repaint capcode info
         }
     } else {
-        progressbar.set_value(progress);
+        if (tx_phase_ != 0)
+            progressbar.set_value(progress);
     }
 }
 
@@ -890,8 +892,11 @@ FlexTXView::FlexTXView(NavigationView& nav)
     };
 
     tx_view.on_stop = [this]() {
+        tx_phase_ = 0;
         tx_view.set_transmitting(false);
         transmitter_model.disable();
+        progressbar.set_value(0);
+        set_dirty();  // repaint capcode info
     };
 }
 


### PR DESCRIPTION
Reset tx_phase_ to 0 on stop so on_tx_progress does not restart the next phase. Reset progress bar and repaint capcode info.

<!--
👋 Thank you for your contribution!

⚠️ To help avoid extensive change requests or potential rejection, please review our simple Contributing Guidelines before you start coding: https://github.com/portapack-mayhem/mayhem-firmware/wiki/Contributing-Guidelines.

Thank you again for contributing!
-->

## Brief description what you did
<!-- Describe your changes in detail here. What problem does this PR solve? What features does it add or fix? -->


## Checklist
- [x] Kept changes minimal and limited to necessary files
- [x] Verified functionality remains intact and code compiles
