### PR TITLE
ISSUE-3135: FLEX TX: fix stop button not halting transmission (#3135)

### DIFF
--- a/firmware/application/external/flex_tx/ui_flex_tx.cpp
+++ b/firmware/application/external/flex_tx/ui_flex_tx.cpp
@@ -672,6 +672,8 @@ void FlexTXView::on_serial_msg(const FlexTosendMessage data) {
 // ===== TX =====
 
 void FlexTXView::on_tx_progress(const uint32_t progress, const bool done) {
+    if (tx_phase_ == 0)
+        return;
     if (done) {
         int ers_n = tx_steps_total_ - 2;
         if (tx_phase_ == 1 && ers_remaining_ > 0) {
@@ -890,6 +892,7 @@ FlexTXView::FlexTXView(NavigationView& nav)
     };
 
     tx_view.on_stop = [this]() {
+        tx_phase_ = 0;
         tx_view.set_transmitting(false);
         transmitter_model.disable();
     };


### PR DESCRIPTION
## Description

The FLEX TX app cannot be stopped once a transmission is in progress. Pressing the Stop button appears to have no effect because the multi-phase TX state machine immediately re-triggers the next phase from a stale baseband `done` callback.

The root cause is that `on_stop` disables the transmitter but never resets `tx_phase_`, so when the baseband fires a final `TXProgress` message with `done=true`, `on_tx_progress` sees a non-zero phase and kicks off the next transmission step — effectively ignoring the stop request.

## Implementation Details

- **`firmware/application/external/flex_tx/ui_flex_tx.cpp`**
  - Reset `tx_phase_` to `0` in the `tx_view.on_stop` handler before disabling the transmitter, so no further TX phases can be initiated.
  - Add an early-return guard at the top of `on_tx_progress`: if `tx_phase_ == 0`, discard the callback immediately. This prevents any stale or in-flight baseband messages from re-entering the state machine after the user has stopped.

## Testing/Documentation

- Open the FLEX TX app, configure a message, and start transmission.
- Press Stop during any phase (ERS burst, frame 1, or frame 2) and confirm TX halts immediately.
- Verify the progress bar resets and the UI returns to the idle state.
- Confirm that starting a new transmission after stopping works correctly (no stuck state).

Fixes https://github.com/portapack-mayhem/mayhem-firmware/issues/3135