### PR TITLE
Increase text length to avoid cutoff

### DIFF
--- a/firmware/application/apps/ui_battinfo.hpp
+++ b/firmware/application/apps/ui_battinfo.hpp
@@ -69,29 +69,29 @@ class BattinfoView : public View {
     };
 
     Text text_percent{
-        {UI_POS_X(13), UI_POS_Y(1), UI_POS_WIDTH(10), UI_POS_HEIGHT(1)},
+        {UI_POS_X(13), UI_POS_Y(1), UI_POS_WIDTH(11), UI_POS_HEIGHT(1)},
         "-"};
     Text text_voltage{
-        {UI_POS_X(13), UI_POS_Y(2), UI_POS_WIDTH(10), UI_POS_HEIGHT(1)},
+        {UI_POS_X(13), UI_POS_Y(2), UI_POS_WIDTH(11), UI_POS_HEIGHT(1)},
         "-"};
     Text text_method{
-        {UI_POS_X(13), UI_POS_Y(3), UI_POS_WIDTH(10), UI_POS_HEIGHT(1)},
+        {UI_POS_X(13), UI_POS_Y(3), UI_POS_WIDTH(11), UI_POS_HEIGHT(1)},
         "-"};
     Text text_capacity{
-        {UI_POS_X(13), UI_POS_Y(4), UI_POS_WIDTH(10), UI_POS_HEIGHT(1)},
+        {UI_POS_X(13), UI_POS_Y(4), UI_POS_WIDTH(11), UI_POS_HEIGHT(1)},
         "-"};
     Text text_current{
-        {UI_POS_X(13), UI_POS_Y(5), UI_POS_WIDTH(10), UI_POS_HEIGHT(1)},
+        {UI_POS_X(13), UI_POS_Y(5), UI_POS_WIDTH(11), UI_POS_HEIGHT(1)},
         "-"};
     Text text_charge{
-        {UI_POS_X(13), UI_POS_Y(6), UI_POS_WIDTH(10), UI_POS_HEIGHT(1)},
+        {UI_POS_X(13), UI_POS_Y(6), UI_POS_WIDTH(11), UI_POS_HEIGHT(1)},
         "-"};
     Text text_ttef{
-        {UI_POS_X(13), UI_POS_Y(7), UI_POS_WIDTH(10), UI_POS_HEIGHT(1)},
+        {UI_POS_X(13), UI_POS_Y(7), UI_POS_WIDTH(11), UI_POS_HEIGHT(1)},
         "-"};
 
     /* Text text_cycles{
-        {UI_POS_X(13), UI_POS_Y(8), UI_POS_WIDTH(10), UI_POS_HEIGHT(1)},
+        {UI_POS_X(13), UI_POS_Y(8), UI_POS_WIDTH(11), UI_POS_HEIGHT(1)},
         "-"};
 
     Text text_warn{


### PR DESCRIPTION
## Brief description of what you did

The Battery info screen shows `Charge:    Dischargin` which looks like a typo. I increased the width of the `text_charge` element to 11 to prevent cutting off the 'g' and make it show "Discharging". Increased the other Text element widths to 11 for consistency.

---

## Proof that your changes work

### 🖥️ Proof it compiles

<details><summary>Compilation log</summary>
Suffix successfully added to file
[ 83%] Built target hackrf_usb.dfu
[ 83%] Building CXX object firmware/application/CMakeFiles/application.elf.dir/ui_navigation.cpp.obj
[ 83%] Building CXX object firmware/application/CMakeFiles/application.elf.dir/apps/ui_battinfo.cpp.obj
[ 83%] Linking CXX executable application.elf
Memory region         Used Size  Region Size  %age Used
           flash:      694456 B         1 MB     66.23%
             ram:       22344 B        64 KB     34.09%
       ram_local:          0 GB         0 GB      -nan%
ram_external_app_afsk_rx:        3788 B        32 KB     11.56%
ram_external_app_calculator:       10208 B        32 KB     31.15%
ram_external_app_font_viewer:        1904 B        32 KB      5.81%
ram_external_app_blespam:        8800 B        32 KB     26.86%
ram_external_app_analogtv:        5928 B        32 KB     18.09%
ram_external_app_nrf_rx:        2480 B        32 KB      7.57%
ram_external_app_coasterp:        2480 B        32 KB      7.57%
ram_external_app_lge:        6236 B        32 KB     19.03%
ram_external_app_lcr:        7844 B        32 KB     23.94%
ram_external_app_jammer:        9408 B        32 KB     28.71%
ram_external_app_gpssim:        4148 B        32 KB     12.66%
ram_external_app_spainter:        8256 B        32 KB     25.20%
ram_external_app_keyfob:        3556 B        32 KB     10.85%
ram_external_app_tetris:        6032 B        32 KB     18.41%
ram_external_app_extsensors:        2992 B        32 KB      9.13%
ram_external_app_foxhunt_rx:        3104 B        32 KB      9.47%
ram_external_app_audio_test:        2740 B        32 KB      8.36%
ram_external_app_wardrivemap:        4160 B        32 KB     12.70%
ram_external_app_tpmsrx:        9784 B        32 KB     29.86%
ram_external_app_protoview:        4600 B        32 KB     14.04%
ram_external_app_adsbtx:        6768 B        32 KB     20.65%
ram_external_app_morse_tx:          0 GB        32 KB      0.00%
ram_external_app_sstvtx:        4672 B        32 KB     14.26%
ram_external_app_random_password:       10728 B        32 KB     32.74%
ram_external_app_acars_rx:        4164 B        32 KB     12.71%
ram_external_app_shoppingcart_lock:        5768 B        32 KB     17.60%
ram_external_app_cvs_spam:        5908 B        32 KB     18.03%
ram_external_app_ookbrute:        4604 B        32 KB     14.05%
ram_external_app_flippertx:        4484 B        32 KB     13.68%
ram_external_app_ook_editor:       10104 B        32 KB     30.83%
ram_external_app_remote:       13160 B        32 KB     40.16%
ram_external_app_mcu_temperature:        1872 B        32 KB      5.71%
ram_external_app_fmradio:        9648 B        32 KB     29.44%
ram_external_app_tuner:        5180 B        32 KB     15.81%
ram_external_app_metronome:        4752 B        32 KB     14.50%
ram_external_app_app_manager:        5416 B        32 KB     16.53%
ram_external_app_hopper:        8832 B        32 KB     26.95%
ram_external_app_antenna_length:        5300 B        32 KB     16.17%
ram_external_app_view_wav:        8068 B        32 KB     24.62%
ram_external_app_sd_wipe:        1452 B        32 KB      4.43%
ram_external_app_playlist_editor:        8396 B        32 KB     25.62%
ram_external_app_snake:        3148 B        32 KB      9.61%
ram_external_app_stopwatch:        3888 B        32 KB     11.87%
ram_external_app_wefax_rx:        4504 B        32 KB     13.75%
ram_external_app_breakout:        7196 B        32 KB     21.96%
ram_external_app_doom:       17704 B        32 KB     54.03%
ram_external_app_debug_pmem:       11084 B        32 KB     33.83%
ram_external_app_scanner:       12840 B        32 KB     39.18%
ram_external_app_level:        8252 B        32 KB     25.18%
ram_external_app_gfxeq:        4940 B        32 KB     15.08%
ram_external_app_noaaapt_rx:          4 KB        32 KB     12.50%
ram_external_app_detector_rx:        6840 B        32 KB     20.87%
ram_external_app_dinogame:       24400 B        32 KB     74.46%
ram_external_app_spaceinv:        9664 B        32 KB     29.49%
ram_external_app_blackjack:       10512 B        32 KB     32.08%
ram_external_app_battleship:       13968 B        32 KB     42.63%
ram_external_app_ert:        2940 B        32 KB      8.97%
ram_external_app_epirb_rx:       10160 B        32 KB     31.01%
ram_external_app_soundboard:        6460 B        32 KB     19.71%
ram_external_app_game2048:        3468 B        32 KB     10.58%
ram_external_app_bht_tx:        6948 B        32 KB     21.20%
ram_external_app_morse_practice:        7336 B        32 KB     22.39%
ram_external_app_adult_toys_controller:        8516 B        32 KB     25.99%
ram_external_app_flex_rx:        5704 B        32 KB     17.41%
ram_external_app_sstvrx:        6496 B        32 KB     19.82%
ram_external_app_subcarrx:        9624 B        32 KB     29.37%
ram_external_app_siggen:        4268 B        32 KB     13.02%
ram_external_app_sdusb:        1476 B        32 KB      4.50%
ram_external_app_morse_radio:       11168 B        32 KB     34.08%
ram_external_app_waterfall_designer:       10568 B        32 KB     32.25%
ram_external_app_morseradiotx:       13692 B        32 KB     41.78%
ram_external_app_keeloqtx:        6392 B        32 KB     19.51%
ram_external_app_rtty_rx:        2676 B        32 KB      8.17%
ram_external_app_rtty_tx:        5000 B        32 KB     15.26%
ram_external_app_tpmstx:        9736 B        32 KB     29.71%
ram_external_app_pocsag_tx:        4972 B        32 KB     15.17%
ram_external_app_time_sink:        5428 B        32 KB     16.56%
ram_external_app_same_tx:        4056 B        32 KB     12.38%
ram_external_app_kiss_tnc:        4056 B        32 KB     12.38%
ram_external_app_mdc_tx:        4220 B        32 KB     12.88%
ram_external_app_epirb_tx:       16216 B        32 KB     49.49%
ram_external_app_fpv_detect:        7120 B        32 KB     21.73%
ram_external_app_p25_tx:        4000 B        32 KB     12.21%
ram_external_app_two_tone_pager:        9724 B        32 KB     29.68%
ram_external_app_two_tone_rx:        9572 B        32 KB     29.21%
ram_external_app_flex_tx:       14520 B        32 KB     44.31%
[100%] Built target application.elf
[100%] Generating application.bin
copy from `application.elf' [elf32-littlearm] to `application.bin' [binary]
Creating external application image for afsk_rx
copy from `/havoc/build/firmware/application/application.elf' [elf32-littlearm] to `/havoc/build/firmware/application/external_app_afsk_rx.himg' [binary]
b'PAFR'
PAFR
/havoc/build/firmware/application/../baseband/PAFR.bin
Creating external application image for calculator
copy from `/havoc/build/firmware/application/application.elf' [elf32-littlearm] to `/havoc/build/firmware/application/external_app_calculator.himg' [binary]
Creating external application image for font_viewer
copy from `/havoc/build/firmware/application/application.elf' [elf32-littlearm] to `/havoc/build/firmware/application/external_app_font_viewer.himg' [binary]
Creating external application image for blespam
copy from `/havoc/build/firmware/application/application.elf' [elf32-littlearm] to `/havoc/build/firmware/application/external_app_blespam.himg' [binary]
b'PBTT'
PBTT
/havoc/build/firmware/application/../baseband/PBTT.bin
WARNING: External code address 0xae032710 at offset 0x288 in /havoc/build/firmware/application/external_app_blespam.himg
Creating external application image for analogtv
copy from `/havoc/build/firmware/application/application.elf' [elf32-littlearm] to `/havoc/build/firmware/application/external_app_analogtv.himg' [binary]
b'PAMT'
PAMT
/havoc/build/firmware/application/../baseband/PAMT.bin
Creating external application image for nrf_rx
copy from `/havoc/build/firmware/application/application.elf' [elf32-littlearm] to `/havoc/build/firmware/application/external_app_nrf_rx.himg' [binary]
b'PNRR'
PNRR
/havoc/build/firmware/application/../baseband/PNRR.bin
Creating external application image for coasterp
copy from `/havoc/build/firmware/application/application.elf' [elf32-littlearm] to `/havoc/build/firmware/application/external_app_coasterp.himg' [binary]
b'PFSK'
PFSK
/havoc/build/firmware/application/../baseband/PFSK.bin
Creating external application image for lge
copy from `/havoc/build/firmware/application/application.elf' [elf32-littlearm] to `/havoc/build/firmware/application/external_app_lge.himg' [binary]
b'PFSK'
PFSK
/havoc/build/firmware/application/../baseband/PFSK.bin
WARNING: External code address 0xae034b1a at offset 0xa24 in /havoc/build/firmware/application/external_app_lge.himg
Creating external application image for lcr
copy from `/havoc/build/firmware/application/application.elf' [elf32-littlearm] to `/havoc/build/firmware/application/external_app_lcr.himg' [binary]
b'PAFT'
PAFT
/havoc/build/firmware/application/../baseband/PAFT.bin
Creating external application image for jammer
copy from `/havoc/build/firmware/application/application.elf' [elf32-littlearm] to `/havoc/build/firmware/application/external_app_jammer.himg' [binary]
b'PJAM'
PJAM
/havoc/build/firmware/application/../baseband/PJAM.bin
Creating external application image for gpssim
copy from `/havoc/build/firmware/application/application.elf' [elf32-littlearm] to `/havoc/build/firmware/application/external_app_gpssim.himg' [binary]
b'PGPS'
PGPS
/havoc/build/firmware/application/../baseband/PGPS.bin
Creating external application image for spainter
copy from `/havoc/build/firmware/application/application.elf' [elf32-littlearm] to `/havoc/build/firmware/application/external_app_spainter.himg' [binary]
b'PSPT'
PSPT
/havoc/build/firmware/application/../baseband/PSPT.bin
Creating external application image for keyfob
copy from `/havoc/build/firmware/application/application.elf' [elf32-littlearm] to `/havoc/build/firmware/application/external_app_keyfob.himg' [binary]
b'POOK'
POOK
/havoc/build/firmware/application/../baseband/POOK.bin
Creating external application image for tetris
copy from `/havoc/build/firmware/application/application.elf' [elf32-littlearm] to `/havoc/build/firmware/application/external_app_tetris.himg' [binary]
Creating external application image for extsensors
copy from `/havoc/build/firmware/application/application.elf' [elf32-littlearm] to `/havoc/build/firmware/application/external_app_extsensors.himg' [binary]
Creating external application image for foxhunt_rx
copy from `/havoc/build/firmware/application/application.elf' [elf32-littlearm] to `/havoc/build/firmware/application/external_app_foxhunt_rx.himg' [binary]
b'PAMA'
PAMA
/havoc/build/firmware/application/../baseband/PAMA.bin
Creating external application image for audio_test
copy from `/havoc/build/firmware/application/application.elf' [elf32-littlearm] to `/havoc/build/firmware/application/external_app_audio_test.himg' [binary]
b'PABP'
PABP
/havoc/build/firmware/application/../baseband/PABP.bin
Creating external application image for wardrivemap
copy from `/havoc/build/firmware/application/application.elf' [elf32-littlearm] to `/havoc/build/firmware/application/external_app_wardrivemap.himg' [binary]
Creating external application image for tpmsrx
copy from `/havoc/build/firmware/application/application.elf' [elf32-littlearm] to `/havoc/build/firmware/application/external_app_tpmsrx.himg' [binary]
b'PTPM'
PTPM
/havoc/build/firmware/application/../baseband/PTPM.bin
WARNING: External code address 0xae022500 at offset 0x638 in /havoc/build/firmware/application/external_app_tpmsrx.himg
Creating external application image for tpmstx
copy from `/havoc/build/firmware/application/application.elf' [elf32-littlearm] to `/havoc/build/firmware/application/external_app_tpmstx.himg' [binary]
b'POOK'
POOK
/havoc/build/firmware/application/../baseband/POOK.bin
Creating external application image for protoview
copy from `/havoc/build/firmware/application/application.elf' [elf32-littlearm] to `/havoc/build/firmware/application/external_app_protoview.himg' [binary]
b'PPVW'
PPVW
/havoc/build/firmware/application/../baseband/PPVW.bin
Creating external application image for adsbtx
copy from `/havoc/build/firmware/application/application.elf' [elf32-littlearm] to `/havoc/build/firmware/application/external_app_adsbtx.himg' [binary]
b'PADT'
PADT
/havoc/build/firmware/application/../baseband/PADT.bin
WARNING: External code address 0xae044b27 at offset 0xd44 in /havoc/build/firmware/application/external_app_adsbtx.himg
Creating external application image for sstvtx
copy from `/havoc/build/firmware/application/application.elf' [elf32-littlearm] to `/havoc/build/firmware/application/external_app_sstvtx.himg' [binary]
b'PSTX'
PSTX
/havoc/build/firmware/application/../baseband/PSTX.bin
Creating external application image for same_tx
copy from `/havoc/build/firmware/application/application.elf' [elf32-littlearm] to `/havoc/build/firmware/application/external_app_same_tx.himg' [binary]
b'PAFT'
PAFT
/havoc/build/firmware/application/../baseband/PAFT.bin
Creating external application image for mdc_tx
copy from `/havoc/build/firmware/application/application.elf' [elf32-littlearm] to `/havoc/build/firmware/application/external_app_mdc_tx.himg' [binary]
b'PAFT'
PAFT
/havoc/build/firmware/application/../baseband/PAFT.bin
Creating external application image for sstvrx
copy from `/havoc/build/firmware/application/application.elf' [elf32-littlearm] to `/havoc/build/firmware/application/external_app_sstvrx.himg' [binary]
b'PSRX'
PSRX
/havoc/build/firmware/application/../baseband/PSRX.bin
Creating external application image for random_password
copy from `/havoc/build/firmware/application/application.elf' [elf32-littlearm] to `/havoc/build/firmware/application/external_app_random_password.himg' [binary]
b'PAFR'
PAFR
/havoc/build/firmware/application/../baseband/PAFR.bin
Creating external application image for acars_rx
copy from `/havoc/build/firmware/application/application.elf' [elf32-littlearm] to `/havoc/build/firmware/application/external_app_acars_rx.himg' [binary]
b'PACA'
PACA
/havoc/build/firmware/application/../baseband/PACA.bin
Creating external application image for wefax_rx
copy from `/havoc/build/firmware/application/application.elf' [elf32-littlearm] to `/havoc/build/firmware/application/external_app_wefax_rx.himg' [binary]
b'PWFX'
PWFX
/havoc/build/firmware/application/../baseband/PWFX.bin
Creating external application image for noaaapt_rx
copy from `/havoc/build/firmware/application/application.elf' [elf32-littlearm] to `/havoc/build/firmware/application/external_app_noaaapt_rx.himg' [binary]
b'PNOA'
PNOA
/havoc/build/firmware/application/../baseband/PNOA.bin
Creating external application image for shoppingcart_lock
copy from `/havoc/build/firmware/application/application.elf' [elf32-littlearm] to `/havoc/build/firmware/application/external_app_shoppingcart_lock.himg' [binary]
b'PATX'
PATX
/havoc/build/firmware/application/../baseband/PATX.bin
Creating external application image for ookbrute
copy from `/havoc/build/firmware/application/application.elf' [elf32-littlearm] to `/havoc/build/firmware/application/external_app_ookbrute.himg' [binary]
b'POOK'
POOK
/havoc/build/firmware/application/../baseband/POOK.bin
Creating external application image for ook_editor
copy from `/havoc/build/firmware/application/application.elf' [elf32-littlearm] to `/havoc/build/firmware/application/external_app_ook_editor.himg' [binary]
b'POOK'
POOK
/havoc/build/firmware/application/../baseband/POOK.bin
Creating external application image for cvs_spam
copy from `/havoc/build/firmware/application/application.elf' [elf32-littlearm] to `/havoc/build/firmware/application/external_app_cvs_spam.himg' [binary]
b'PREP'
PREP
/havoc/build/firmware/application/../baseband/PREP.bin
Creating external application image for flippertx
copy from `/havoc/build/firmware/application/application.elf' [elf32-littlearm] to `/havoc/build/firmware/application/external_app_flippertx.himg' [binary]
b'POSK'
POSK
/havoc/build/firmware/application/../baseband/POSK.bin
Creating external application image for remote
copy from `/havoc/build/firmware/application/application.elf' [elf32-littlearm] to `/havoc/build/firmware/application/external_app_remote.himg' [binary]
b'PREP'
PREP
/havoc/build/firmware/application/../baseband/PREP.bin
Creating external application image for mcu_temperature
copy from `/havoc/build/firmware/application/application.elf' [elf32-littlearm] to `/havoc/build/firmware/application/external_app_mcu_temperature.himg' [binary]
Creating external application image for fmradio
copy from `/havoc/build/firmware/application/application.elf' [elf32-littlearm] to `/havoc/build/firmware/application/external_app_fmradio.himg' [binary]
b'PWFM'
PWFM
/havoc/build/firmware/application/../baseband/PWFM.bin
Creating external application image for tuner
copy from `/havoc/build/firmware/application/application.elf' [elf32-littlearm] to `/havoc/build/firmware/application/external_app_tuner.himg' [binary]
b'PABP'
PABP
/havoc/build/firmware/application/../baseband/PABP.bin
Creating external application image for metronome
copy from `/havoc/build/firmware/application/application.elf' [elf32-littlearm] to `/havoc/build/firmware/application/external_app_metronome.himg' [binary]
b'PABP'
PABP
/havoc/build/firmware/application/../baseband/PABP.bin
Creating external application image for app_manager
copy from `/havoc/build/firmware/application/application.elf' [elf32-littlearm] to `/havoc/build/firmware/application/external_app_app_manager.himg' [binary]
Creating external application image for hopper
copy from `/havoc/build/firmware/application/application.elf' [elf32-littlearm] to `/havoc/build/firmware/application/external_app_hopper.himg' [binary]
b'PJAM'
PJAM
/havoc/build/firmware/application/../baseband/PJAM.bin
Creating external application image for antenna_length
copy from `/havoc/build/firmware/application/application.elf' [elf32-littlearm] to `/havoc/build/firmware/application/external_app_antenna_length.himg' [binary]
Creating external application image for view_wav
copy from `/havoc/build/firmware/application/application.elf' [elf32-littlearm] to `/havoc/build/firmware/application/external_app_view_wav.himg' [binary]
b'PATX'
PATX
/havoc/build/firmware/application/../baseband/PATX.bin
Creating external application image for sd_wipe
copy from `/havoc/build/firmware/application/application.elf' [elf32-littlearm] to `/havoc/build/firmware/application/external_app_sd_wipe.himg' [binary]
Creating external application image for playlist_editor
copy from `/havoc/build/firmware/application/application.elf' [elf32-littlearm] to `/havoc/build/firmware/application/external_app_playlist_editor.himg' [binary]
Creating external application image for snake
copy from `/havoc/build/firmware/application/application.elf' [elf32-littlearm] to `/havoc/build/firmware/application/external_app_snake.himg' [binary]
Creating external application image for stopwatch
copy from `/havoc/build/firmware/application/application.elf' [elf32-littlearm] to `/havoc/build/firmware/application/external_app_stopwatch.himg' [binary]
Creating external application image for breakout
copy from `/havoc/build/firmware/application/application.elf' [elf32-littlearm] to `/havoc/build/firmware/application/external_app_breakout.himg' [binary]
b'PABP'
PABP
/havoc/build/firmware/application/../baseband/PABP.bin
Creating external application image for dinogame
copy from `/havoc/build/firmware/application/application.elf' [elf32-littlearm] to `/havoc/build/firmware/application/external_app_dinogame.himg' [binary]
Creating external application image for doom
copy from `/havoc/build/firmware/application/application.elf' [elf32-littlearm] to `/havoc/build/firmware/application/external_app_doom.himg' [binary]
Creating external application image for debug_pmem
copy from `/havoc/build/firmware/application/application.elf' [elf32-littlearm] to `/havoc/build/firmware/application/external_app_debug_pmem.himg' [binary]
Creating external application image for scanner
copy from `/havoc/build/firmware/application/application.elf' [elf32-littlearm] to `/havoc/build/firmware/application/external_app_scanner.himg' [binary]
b'PWFM'
PWFM
/havoc/build/firmware/application/../baseband/PWFM.bin
Creating external application image for level
copy from `/havoc/build/firmware/application/application.elf' [elf32-littlearm] to `/havoc/build/firmware/application/external_app_level.himg' [binary]
b'PWFM'
PWFM
/havoc/build/firmware/application/../baseband/PWFM.bin
Creating external application image for gfxeq
copy from `/havoc/build/firmware/application/application.elf' [elf32-littlearm] to `/havoc/build/firmware/application/external_app_gfxeq.himg' [binary]
b'PWFM'
PWFM
/havoc/build/firmware/application/../baseband/PWFM.bin
Creating external application image for waterfall_designer
copy from `/havoc/build/firmware/application/application.elf' [elf32-littlearm] to `/havoc/build/firmware/application/external_app_waterfall_designer.himg' [binary]
b'PCAP'
PCAP
/havoc/build/firmware/application/../baseband/PCAP.bin
Creating external application image for detector_rx
copy from `/havoc/build/firmware/application/application.elf' [elf32-littlearm] to `/havoc/build/firmware/application/external_app_detector_rx.himg' [binary]
b'PWFM'
PWFM
/havoc/build/firmware/application/../baseband/PWFM.bin
Creating external application image for fpv_detect
copy from `/havoc/build/firmware/application/application.elf' [elf32-littlearm] to `/havoc/build/firmware/application/external_app_fpv_detect.himg' [binary]
b'PWFM'
PWFM
/havoc/build/firmware/application/../baseband/PWFM.bin
Creating external application image for spaceinv
copy from `/havoc/build/firmware/application/application.elf' [elf32-littlearm] to `/havoc/build/firmware/application/external_app_spaceinv.himg' [binary]
Creating external application image for blackjack
copy from `/havoc/build/firmware/application/application.elf' [elf32-littlearm] to `/havoc/build/firmware/application/external_app_blackjack.himg' [binary]
Creating external application image for battleship
copy from `/havoc/build/firmware/application/application.elf' [elf32-littlearm] to `/havoc/build/firmware/application/external_app_battleship.himg' [binary]
b'PPO2'
PPO2
/havoc/build/firmware/application/../baseband/PPO2.bin
Creating external application image for ert
copy from `/havoc/build/firmware/application/application.elf' [elf32-littlearm] to `/havoc/build/firmware/application/external_app_ert.himg' [binary]
b'PERT'
PERT
/havoc/build/firmware/application/../baseband/PERT.bin
Creating external application image for epirb_rx
copy from `/havoc/build/firmware/application/application.elf' [elf32-littlearm] to `/havoc/build/firmware/application/external_app_epirb_rx.himg' [binary]
b'PEPI'
PEPI
/havoc/build/firmware/application/../baseband/PEPI.bin
WARNING: External code address 0xae022500 at offset 0x440 in /havoc/build/firmware/application/external_app_epirb_rx.himg
Creating external application image for epirb_tx
copy from `/havoc/build/firmware/application/application.elf' [elf32-littlearm] to `/havoc/build/firmware/application/external_app_epirb_tx.himg' [binary]
b'PEPT'
PEPT
/havoc/build/firmware/application/../baseband/PEPT.bin
Creating external application image for soundboard
copy from `/havoc/build/firmware/application/application.elf' [elf32-littlearm] to `/havoc/build/firmware/application/external_app_soundboard.himg' [binary]
b'PATX'
PATX
/havoc/build/firmware/application/../baseband/PATX.bin
Creating external application image for game2048
copy from `/havoc/build/firmware/application/application.elf' [elf32-littlearm] to `/havoc/build/firmware/application/external_app_game2048.himg' [binary]
Creating external application image for bht_tx
copy from `/havoc/build/firmware/application/application.elf' [elf32-littlearm] to `/havoc/build/firmware/application/external_app_bht_tx.himg' [binary]
b'PTON'
PTON
/havoc/build/firmware/application/../baseband/PTON.bin
Creating external application image for morse_practice
copy from `/havoc/build/firmware/application/application.elf' [elf32-littlearm] to `/havoc/build/firmware/application/external_app_morse_practice.himg' [binary]
b'PABP'
PABP
/havoc/build/firmware/application/../baseband/PABP.bin
Creating external application image for adult_toys_controller
copy from `/havoc/build/firmware/application/application.elf' [elf32-littlearm] to `/havoc/build/firmware/application/external_app_adult_toys_controller.himg' [binary]
b'PBTT'
PBTT
/havoc/build/firmware/application/../baseband/PBTT.bin
Creating external application image for flex_rx
copy from `/havoc/build/firmware/application/application.elf' [elf32-littlearm] to `/havoc/build/firmware/application/external_app_flex_rx.himg' [binary]
b'PFLX'
PFLX
/havoc/build/firmware/application/../baseband/PFLX.bin
Creating external application image for subcarrx
copy from `/havoc/build/firmware/application/application.elf' [elf32-littlearm] to `/havoc/build/firmware/application/external_app_subcarrx.himg' [binary]
b'PSCD'
PSCD
/havoc/build/firmware/application/../baseband/PSCD.bin
Creating external application image for siggen
copy from `/havoc/build/firmware/application/application.elf' [elf32-littlearm] to `/havoc/build/firmware/application/external_app_siggen.himg' [binary]
b'PSIG'
PSIG
/havoc/build/firmware/application/../baseband/PSIG.bin
Creating external application image for morse_radio
copy from `/havoc/build/firmware/application/application.elf' [elf32-littlearm] to `/havoc/build/firmware/application/external_app_morse_radio.himg' [binary]
b'PMRS'
PMRS
/havoc/build/firmware/application/../baseband/PMRS.bin
Creating external application image for morseradiotx
copy from `/havoc/build/firmware/application/application.elf' [elf32-littlearm] to `/havoc/build/firmware/application/external_app_morseradiotx.himg' [binary]
b'PMRT'
PMRT
/havoc/build/firmware/application/../baseband/PMRT.bin
Creating external application image for keeloqtx
copy from `/havoc/build/firmware/application/application.elf' [elf32-littlearm] to `/havoc/build/firmware/application/external_app_keeloqtx.himg' [binary]
b'POOK'
POOK
/havoc/build/firmware/application/../baseband/POOK.bin
Creating external application image for rtty_rx
copy from `/havoc/build/firmware/application/application.elf' [elf32-littlearm] to `/havoc/build/firmware/application/external_app_rtty_rx.himg' [binary]
b'PRTR'
PRTR
/havoc/build/firmware/application/../baseband/PRTR.bin
Creating external application image for rtty_tx
copy from `/havoc/build/firmware/application/application.elf' [elf32-littlearm] to `/havoc/build/firmware/application/external_app_rtty_tx.himg' [binary]
b'PRTT'
PRTT
/havoc/build/firmware/application/../baseband/PRTT.bin
Creating external application image for pocsag_tx
copy from `/havoc/build/firmware/application/application.elf' [elf32-littlearm] to `/havoc/build/firmware/application/external_app_pocsag_tx.himg' [binary]
b'PFSK'
PFSK
/havoc/build/firmware/application/../baseband/PFSK.bin
Creating external application image for flex_tx
copy from `/havoc/build/firmware/application/application.elf' [elf32-littlearm] to `/havoc/build/firmware/application/external_app_flex_tx.himg' [binary]
b'PFSK'
PFSK
/havoc/build/firmware/application/../baseband/PFSK.bin
Creating external application image for time_sink
copy from `/havoc/build/firmware/application/application.elf' [elf32-littlearm] to `/havoc/build/firmware/application/external_app_time_sink.himg' [binary]
b'PTSK'
PTSK
/havoc/build/firmware/application/../baseband/PTSK.bin
Creating external application image for kiss_tnc
copy from `/havoc/build/firmware/application/application.elf' [elf32-littlearm] to `/havoc/build/firmware/application/external_app_kiss_tnc.himg' [binary]
b'PAPR'
PAPR
/havoc/build/firmware/application/../baseband/PAPR.bin
Creating external application image for p25_tx
copy from `/havoc/build/firmware/application/application.elf' [elf32-littlearm] to `/havoc/build/firmware/application/external_app_p25_tx.himg' [binary]
b'P25T'
P25T
/havoc/build/firmware/application/../baseband/P25T.bin
Creating external application image for two_tone_pager
copy from `/havoc/build/firmware/application/application.elf' [elf32-littlearm] to `/havoc/build/firmware/application/external_app_two_tone_pager.himg' [binary]
b'PTON'
PTON
/havoc/build/firmware/application/../baseband/PTON.bin
Creating external application image for two_tone_rx
copy from `/havoc/build/firmware/application/application.elf' [elf32-littlearm] to `/havoc/build/firmware/application/external_app_two_tone_rx.himg' [binary]
b'PTNE'
PTNE
/havoc/build/firmware/application/../baseband/PTNE.bin
Creating external application image for sdusb
copy from `/havoc/build/firmware/application/application.elf' [elf32-littlearm] to `/havoc/build/firmware/application/external_app_sdusb.himg' [binary]
b'PUSB'
PUSB
/havoc/build/firmware/application/../baseband/PUSB.bin
[100%] Built target application
[100%] Generating portapack-mayhem-firmware.bin

check gcc versions from all elf target

gcc version of application.elf is (GNU Tools for Arm Embedded Processors 9-2019-q4-major) 9.2.1 20191025 (release) [ARM/arm-9-branch revision 277599]
gcc version of baseband_rds.elf is (GNU Tools for Arm Embedded Processors 9-2019-q4-major) 9.2.1 20191025 (release) [ARM/arm-9-branch revision 277599]
gcc version of baseband_wfm_audio.elf is (GNU Tools for Arm Embedded Processors 9-2019-q4-major) 9.2.1 20191025 (release) [ARM/arm-9-branch revision 277599]
gcc version of baseband_tonedetect.elf is (GNU Tools for Arm Embedded Processors 9-2019-q4-major) 9.2.1 20191025 (release) [ARM/arm-9-branch revision 277599]
gcc version of baseband_acars.elf is (GNU Tools for Arm Embedded Processors 9-2019-q4-major) 9.2.1 20191025 (release) [ARM/arm-9-branch revision 277599]
gcc version of baseband_morsetx.elf is (GNU Tools for Arm Embedded Processors 9-2019-q4-major) 9.2.1 20191025 (release) [ARM/arm-9-branch revision 277599]
gcc version of baseband_adsbrx.elf is (GNU Tools for Arm Embedded Processors 9-2019-q4-major) 9.2.1 20191025 (release) [ARM/arm-9-branch revision 277599]
gcc version of baseband_protoview.elf is (GNU Tools for Arm Embedded Processors 9-2019-q4-major) 9.2.1 20191025 (release) [ARM/arm-9-branch revision 277599]
gcc version of baseband_nfm_audio.elf is (GNU Tools for Arm Embedded Processors 9-2019-q4-major) 9.2.1 20191025 (release) [ARM/arm-9-branch revision 277599]
gcc version of baseband_flash_utility.elf is (GNU Tools for Arm Embedded Processors 9-2019-q4-major) 9.2.1 20191025 (release) [ARM/arm-9-branch revision 277599]
gcc version of baseband_rtty_rx.elf is (GNU Tools for Arm Embedded Processors 9-2019-q4-major) 9.2.1 20191025 (release) [ARM/arm-9-branch revision 277599]
gcc version of baseband_epirb_tx.elf is (GNU Tools for Arm Embedded Processors 9-2019-q4-major) 9.2.1 20191025 (release) [ARM/arm-9-branch revision 277599]
gcc version of baseband_audio_beep.elf is (GNU Tools for Arm Embedded Processors 9-2019-q4-major) 9.2.1 20191025 (release) [ARM/arm-9-branch revision 277599]
gcc version of baseband_tpms.elf is (GNU Tools for Arm Embedded Processors 9-2019-q4-major) 9.2.1 20191025 (release) [ARM/arm-9-branch revision 277599]
gcc version of baseband_morse.elf is (GNU Tools for Arm Embedded Processors 9-2019-q4-major) 9.2.1 20191025 (release) [ARM/arm-9-branch revision 277599]
gcc version of baseband_ais.elf is (GNU Tools for Arm Embedded Processors 9-2019-q4-major) 9.2.1 20191025 (release) [ARM/arm-9-branch revision 277599]
gcc version of baseband_pocsag2.elf is (GNU Tools for Arm Embedded Processors 9-2019-q4-major) 9.2.1 20191025 (release) [ARM/arm-9-branch revision 277599]
gcc version of baseband_btlerx.elf is (GNU Tools for Arm Embedded Processors 9-2019-q4-major) 9.2.1 20191025 (release) [ARM/arm-9-branch revision 277599]
gcc version of baseband_btletx.elf is (GNU Tools for Arm Embedded Processors 9-2019-q4-major) 9.2.1 20191025 (release) [ARM/arm-9-branch revision 277599]
gcc version of baseband_flex.elf is (GNU Tools for Arm Embedded Processors 9-2019-q4-major) 9.2.1 20191025 (release) [ARM/arm-9-branch revision 277599]
gcc version of baseband_subcar.elf is (GNU Tools for Arm Embedded Processors 9-2019-q4-major) 9.2.1 20191025 (release) [ARM/arm-9-branch revision 277599]
gcc version of baseband_afsktx.elf is (GNU Tools for Arm Embedded Processors 9-2019-q4-major) 9.2.1 20191025 (release) [ARM/arm-9-branch revision 277599]
gcc version of baseband_mic_tx.elf is (GNU Tools for Arm Embedded Processors 9-2019-q4-major) 9.2.1 20191025 (release) [ARM/arm-9-branch revision 277599]
gcc version of baseband_bintstream.elf is (GNU Tools for Arm Embedded Processors 9-2019-q4-major) 9.2.1 20191025 (release) [ARM/arm-9-branch revision 277599]
gcc version of baseband_rtty_tx.elf is (GNU Tools for Arm Embedded Processors 9-2019-q4-major) 9.2.1 20191025 (release) [ARM/arm-9-branch revision 277599]
gcc version of baseband_subghzd.elf is (GNU Tools for Arm Embedded Processors 9-2019-q4-major) 9.2.1 20191025 (release) [ARM/arm-9-branch revision 277599]
gcc version of baseband_afskrx.elf is (GNU Tools for Arm Embedded Processors 9-2019-q4-major) 9.2.1 20191025 (release) [ARM/arm-9-branch revision 277599]
gcc version of baseband_am_tv.elf is (GNU Tools for Arm Embedded Processors 9-2019-q4-major) 9.2.1 20191025 (release) [ARM/arm-9-branch revision 277599]
gcc version of baseband_jammer.elf is (GNU Tools for Arm Embedded Processors 9-2019-q4-major) 9.2.1 20191025 (release) [ARM/arm-9-branch revision 277599]
gcc version of baseband_aprsrx.elf is (GNU Tools for Arm Embedded Processors 9-2019-q4-major) 9.2.1 20191025 (release) [ARM/arm-9-branch revision 277599]
gcc version of baseband_gps_sim.elf is (GNU Tools for Arm Embedded Processors 9-2019-q4-major) 9.2.1 20191025 (release) [ARM/arm-9-branch revision 277599]
gcc version of baseband_wefaxrx.elf is (GNU Tools for Arm Embedded Processors 9-2019-q4-major) 9.2.1 20191025 (release) [ARM/arm-9-branch revision 277599]
gcc version of baseband_fsktx.elf is (GNU Tools for Arm Embedded Processors 9-2019-q4-major) 9.2.1 20191025 (release) [ARM/arm-9-branch revision 277599]
gcc version of baseband_ert.elf is (GNU Tools for Arm Embedded Processors 9-2019-q4-major) 9.2.1 20191025 (release) [ARM/arm-9-branch revision 277599]
gcc version of baseband_sstvrx.elf is (GNU Tools for Arm Embedded Processors 9-2019-q4-major) 9.2.1 20191025 (release) [ARM/arm-9-branch revision 277599]
gcc version of baseband_noaaapt_rx.elf is (GNU Tools for Arm Embedded Processors 9-2019-q4-major) 9.2.1 20191025 (release) [ARM/arm-9-branch revision 277599]
gcc version of baseband_sonde.elf is (GNU Tools for Arm Embedded Processors 9-2019-q4-major) 9.2.1 20191025 (release) [ARM/arm-9-branch revision 277599]
gcc version of baseband_siggen.elf is (GNU Tools for Arm Embedded Processors 9-2019-q4-major) 9.2.1 20191025 (release) [ARM/arm-9-branch revision 277599]
gcc version of baseband_wideband_spectrum.elf is (GNU Tools for Arm Embedded Processors 9-2019-q4-major) 9.2.1 20191025 (release) [ARM/arm-9-branch revision 277599]
gcc version of baseband_adsbtx.elf is (GNU Tools for Arm Embedded Processors 9-2019-q4-major) 9.2.1 20191025 (release) [ARM/arm-9-branch revision 277599]
gcc version of baseband_p25_tx.elf is (GNU Tools for Arm Embedded Processors 9-2019-q4-major) 9.2.1 20191025 (release) [ARM/arm-9-branch revision 277599]
gcc version of baseband_spectrum_painter.elf is (GNU Tools for Arm Embedded Processors 9-2019-q4-major) 9.2.1 20191025 (release) [ARM/arm-9-branch revision 277599]
gcc version of baseband_tones.elf is (GNU Tools for Arm Embedded Processors 9-2019-q4-major) 9.2.1 20191025 (release) [ARM/arm-9-branch revision 277599]
gcc version of baseband_epirb_rx.elf is (GNU Tools for Arm Embedded Processors 9-2019-q4-major) 9.2.1 20191025 (release) [ARM/arm-9-branch revision 277599]
gcc version of baseband_weather.elf is (GNU Tools for Arm Embedded Processors 9-2019-q4-major) 9.2.1 20191025 (release) [ARM/arm-9-branch revision 277599]
gcc version of baseband_sstvtx.elf is (GNU Tools for Arm Embedded Processors 9-2019-q4-major) 9.2.1 20191025 (release) [ARM/arm-9-branch revision 277599]
gcc version of baseband_capture.elf is (GNU Tools for Arm Embedded Processors 9-2019-q4-major) 9.2.1 20191025 (release) [ARM/arm-9-branch revision 277599]
gcc version of baseband_test.elf is (GNU Tools for Arm Embedded Processors 9-2019-q4-major) 9.2.1 20191025 (release) [ARM/arm-9-branch revision 277599]
gcc version of baseband_fskrx.elf is (GNU Tools for Arm Embedded Processors 9-2019-q4-major) 9.2.1 20191025 (release) [ARM/arm-9-branch revision 277599]
gcc version of baseband_replay.elf is (GNU Tools for Arm Embedded Processors 9-2019-q4-major) 9.2.1 20191025 (release) [ARM/arm-9-branch revision 277599]
gcc version of baseband_nrfrx.elf is (GNU Tools for Arm Embedded Processors 9-2019-q4-major) 9.2.1 20191025 (release) [ARM/arm-9-branch revision 277599]
gcc version of baseband_am_audio.elf is (GNU Tools for Arm Embedded Processors 9-2019-q4-major) 9.2.1 20191025 (release) [ARM/arm-9-branch revision 277599]
gcc version of baseband_ook.elf is (GNU Tools for Arm Embedded Processors 9-2019-q4-major) 9.2.1 20191025 (release) [ARM/arm-9-branch revision 277599]
gcc version of baseband_audio_tx.elf is (GNU Tools for Arm Embedded Processors 9-2019-q4-major) 9.2.1 20191025 (release) [ARM/arm-9-branch revision 277599]
gcc version of baseband_time_sink.elf is (GNU Tools for Arm Embedded Processors 9-2019-q4-major) 9.2.1 20191025 (release) [ARM/arm-9-branch revision 277599]
gcc version of baseband_sd_over_usb.elf is (GNU Tools for Arm Embedded Processors 9-2019-q4-major) 9.2.1 20191025 (release) [ARM/arm-9-branch revision 277599]




checking 86 external apps address memory regions
external app addr seems correct, pass
WARNING: Possible external code address 0xae016825 at offset 0x1bd0c in portapack-mayhem-firmware.bin
WARNING: Possible external code address 0xae011812 at offset 0x446d0 in portapack-mayhem-firmware.bin
WARNING: Possible external code address 0xae030020 at offset 0x6236c in portapack-mayhem-firmware.bin
WARNING: Possible external code address 0xae046a03 at offset 0x6c7bc in portapack-mayhem-firmware.bin
WARNING: Possible external code address 0xae056820 at offset 0x76790 in portapack-mayhem-firmware.bin
WARNING: Possible external code address 0xae0569c2 at offset 0x826d4 in portapack-mayhem-firmware.bin
WARNING: Possible external code address 0xae006cb1 at offset 0xb5c14 in portapack-mayhem-firmware.bin
WARNING: Possible external code address 0xadf00146 at offset 0xb5c9c in portapack-mayhem-firmware.bin
WARNING: Possible external code address 0xae044604 at offset 0xbeb1c in portapack-mayhem-firmware.bin
WARNING: Possible external code address 0xae0001b0 at offset 0xc9824 in portapack-mayhem-firmware.bin
WARNING: Possible external code address 0xadb96ef0 at offset 0xcbf64 in portapack-mayhem-firmware.bin
WARNING: Possible external code address 0xae0003fe at offset 0xcd6e4 in portapack-mayhem-firmware.bin
WARNING: Possible external code address 0xae00355c at offset 0xe54d4 in portapack-mayhem-firmware.bin
WARNING: Possible external code address 0xadf00021 at offset 0xec64c in portapack-mayhem-firmware.bin
WARNING: Possible external code address 0xadd114a8 at offset 0xf5eec in portapack-mayhem-firmware.bin
WARNING: Possible external code address 0xae000000 at offset 0xfae3c in portapack-mayhem-firmware.bin
Space remaining in flash ROM: 19592 bytes ( 1.9 %)
[100%] Built target firmware
[100%] Generating portapack-mayhem_OCI.ppfw.tar
APPS/
APPS/tpmstx.ppma
APPS/doom.ppma
APPS/soundboard.ppma
APPS/gfxeq.ppma
APPS/spaceinv.ppma
APPS/breakout.ppma
APPS/hopper.ppma
APPS/ert.ppma
APPS/rtty_rx.ppma
APPS/same_tx.ppma
APPS/pacman_app.ppmp
APPS/analogtv.ppma
APPS/wardrivemap.ppma
APPS/jammer.ppma
APPS/protoview.ppma
APPS/debug_pmem.ppma
APPS/nrf_rx.ppma
APPS/waterfall_designer.ppma
APPS/morseradiotx.ppma
APPS/flex_rx.ppma
APPS/blackjack.ppma
APPS/level.ppma
APPS/gpssim.ppma
APPS/noaaapt_rx.ppma
APPS/bht_tx.ppma
APPS/tuner.ppma
APPS/remote.ppma
APPS/sdusb.ppma
APPS/morse_practice.ppma
APPS/epirb_tx.ppma
APPS/epirb_rx.ppma
APPS/two_tone_rx.ppma
APPS/foxhunt_rx.ppma
APPS/view_wav.ppma
APPS/ook_editor.ppma
APPS/pocsag_tx.ppma
APPS/tetris.ppma
APPS/wefax_rx.ppma
APPS/p25_tx.ppma
APPS/mdc_tx.ppma
APPS/flex_tx.ppma
APPS/app_manager.ppma
APPS/adsbtx.ppma
APPS/tpmsrx.ppma
APPS/acars_rx.ppma
APPS/detector_rx.ppma
APPS/rtty_tx.ppma
APPS/audio_test.ppma
APPS/lcr.ppma
APPS/sd_wipe.ppma
APPS/mcu_temperature.ppma
APPS/morse_radio.ppma
APPS/siggen.ppma
APPS/font_viewer.ppma
APPS/subcarrx.ppma
APPS/fmradio.ppma
APPS/keeloqtx.ppma
APPS/calculator.ppma
APPS/flippertx.ppma
APPS/digitalrain_app.ppmp
APPS/sstvtx.ppma
APPS/coasterp.ppma
APPS/battleship.ppma
APPS/game2048.ppma
APPS/playlist_editor.ppma
APPS/stopwatch.ppma
APPS/adult_toys_controller.ppma
APPS/two_tone_pager.ppma
APPS/snake.ppma
APPS/dinogame.ppma
APPS/kiss_tnc.ppma
APPS/lge.ppma
APPS/spainter.ppma
APPS/blespam.ppma
APPS/afsk_rx.ppma
APPS/ookbrute.ppma
APPS/sstvrx.ppma
APPS/shoppingcart_lock.ppma
APPS/keyfob.ppma
APPS/metronome.ppma
APPS/scanner.ppma
APPS/cvs_spam.ppma
APPS/random_password.ppma
APPS/fpv_detect.ppma
APPS/extsensors.ppma
APPS/antenna_length.ppma
APPS/time_sink.ppma
FIRMWARE/
FIRMWARE/portapack-mayhem_dev.bin
[100%] Built target ppfw
</details>

<!-- Paste log below -->

### 📱 Proof of testing on a real device

Attach photos, screenshots, or a short video of your changes running on actual PortaPack hardware. **Emulator or simulator output is not a substitute for real-device testing.**

<!-- Paste photo / video / screenshot below -->

https://github.com/user-attachments/assets/7ca05d0d-9e17-4d58-b7d2-e88751c62176

### 📡 Proof against a real emitter/receiver (if applicable)

N/A, this is purely a UI change.

---

## 📚 Wiki documentation commitment

**By submitting this PR, you acknowledge that once it is merged you are responsible for creating or updating the corresponding page on the [project wiki](https://github.com/portapack-mayhem/mayhem-firmware/wiki).**

Your wiki article should include:

- A **screenshot of the main app screen** (strongly recommended)
- A clear **description** of what the app does
- An explanation of the **controls** and UI elements
- Any known **limitations**, quirks, or caveats
- Anything else a user should know to use the app effectively (dependencies, required hardware, file formats, etc.)

If you are modifying an existing app, make sure the wiki page reflects your changes.

---

## Checklist

- [x] Kept changes minimal and limited to necessary files
- [x] Verified functionality remains intact and code compiles
- [x] Attached proof that the code compiles successfully *(or marked N/A as a trusted contributor)*
- [x] Attached proof of testing on real PortaPack hardware *(or marked N/A as a trusted contributor)*
- [x] Attached proof of testing against a real emitter/receiver (if RF-related), or marked N/A with justification
- [x] I understand that by getting this PR merged, I am implicitly agreeing to create or update the corresponding wiki page (including a main-screen screenshot, description, controls, and limitations)
- [x] Reviewed the [Contributing Guidelines](https://github.com/portapack-mayhem/mayhem-firmware/wiki/Contributing-Guidelines)
