### PR TITLE
Add power off command to I2cDev_PPmod class

### DIFF
--- a/firmware/common/i2cdev_ppmod.cpp
+++ b/firmware/common/i2cdev_ppmod.cpp
@@ -246,7 +246,7 @@ bool I2cDev_PPmod::send_poweroff_command() {
     if (isLocked()) return false;  // device is busy
     Command cmd = Command::COMMAND_POWER_OFF;
     uint8_t tmp = 0;  // result of the ack. 0 = no, 1 = ok
-    i2c_write((uint8_t*)&cmd, 2, &tmp, 1);
+    i2c_read((uint8_t*)&cmd, 2, &tmp, 1);
     return (tmp == 1);
 }
 

--- a/firmware/common/i2cdev_ppmod.cpp
+++ b/firmware/common/i2cdev_ppmod.cpp
@@ -242,4 +242,10 @@ std::vector<uint8_t> I2cDev_PPmod::downloadStandaloneApp(uint32_t index, size_t 
     return ret;
 }
 
+void I2cDev_PPmod::send_poweroff_command() {
+    if (isLocked()) return;  // device is busy
+    Command cmd = Command::COMMAND_POWER_OFF;
+    i2c_read(nullptr, 0, (uint8_t*)&cmd, 2);
+}
+
 }  // namespace i2cdev

--- a/firmware/common/i2cdev_ppmod.cpp
+++ b/firmware/common/i2cdev_ppmod.cpp
@@ -242,10 +242,12 @@ std::vector<uint8_t> I2cDev_PPmod::downloadStandaloneApp(uint32_t index, size_t 
     return ret;
 }
 
-void I2cDev_PPmod::send_poweroff_command() {
-    if (isLocked()) return;  // device is busy
+bool I2cDev_PPmod::send_poweroff_command() {
+    if (isLocked()) return false;  // device is busy
     Command cmd = Command::COMMAND_POWER_OFF;
-    i2c_write((uint8_t*)&cmd, 2);
+    uint8_t tmp = 0;  // result of the ack. 0 = no, 1 = ok
+    i2c_write((uint8_t*)&cmd, 2, &tmp, 1);
+    return (tmp == 1);
 }
 
 }  // namespace i2cdev

--- a/firmware/common/i2cdev_ppmod.cpp
+++ b/firmware/common/i2cdev_ppmod.cpp
@@ -245,7 +245,7 @@ std::vector<uint8_t> I2cDev_PPmod::downloadStandaloneApp(uint32_t index, size_t 
 void I2cDev_PPmod::send_poweroff_command() {
     if (isLocked()) return;  // device is busy
     Command cmd = Command::COMMAND_POWER_OFF;
-    i2c_read(nullptr, 0, (uint8_t*)&cmd, 2);
+    i2c_write((uint8_t*)&cmd, 2);
 }
 
 }  // namespace i2cdev

--- a/firmware/common/i2cdev_ppmod.hpp
+++ b/firmware/common/i2cdev_ppmod.hpp
@@ -93,7 +93,7 @@ class I2cDev_PPmod : public I2cDev {
     uint16_t get_shell_buffer_bytes();
     bool get_shell_get_buffer_data(uint8_t* buff, size_t len);
 
-    void send_poweroff_command();  // sends the command to power off the device. Restarting the app needs a full power cycle!
+    bool send_poweroff_command();  // sends the command to power off the device. Restarting the esp needs a full power cycle!
 
    private:
     uint8_t self_timer = 0;

--- a/firmware/common/i2cdev_ppmod.hpp
+++ b/firmware/common/i2cdev_ppmod.hpp
@@ -59,7 +59,8 @@ class I2cDev_PPmod : public I2cDev {
         COMMAND_SHELL_PPTOMOD_DATA,       // pp shell to esp. size not defined
         COMMAND_SHELL_MODTOPP_DATA_SIZE,  // how many bytes the esp has to send to pp's shell
         COMMAND_SHELL_MODTOPP_DATA,       // the actual bytes sent by esp. 1st byte's 1st bit is the "hasmore" flag, the remaining 7 bits are the size of the data. exactly 64 byte follows.
-
+        // poweroff command
+        COMMAND_POWER_OFF,  // requests power off from the esp, and after it needs a full power cycle to get it back again
     };
 
     typedef struct {
@@ -91,6 +92,8 @@ class I2cDev_PPmod : public I2cDev {
     std::optional<uint16_t> get_light_data();
     uint16_t get_shell_buffer_bytes();
     bool get_shell_get_buffer_data(uint8_t* buff, size_t len);
+
+    void send_poweroff_command();  // sends the command to power off the device. Restarting the app needs a full power cycle!
 
    private:
     uint8_t self_timer = 0;


### PR DESCRIPTION
Self describing pr. This is a requirement for the portarf power manager pr.



This pull request adds support for powering off the device via a new command in the `I2cDev_PPmod` class. The main changes introduce a `COMMAND_POWER_OFF` command and a corresponding method to send the power-off command to the device.

**Power management enhancements:**

* Added a new `COMMAND_POWER_OFF` value to the `Command` enum, allowing the device to be powered off via command.
* Implemented the `send_poweroff_command()` method in `I2cDev_PPmod`, which sends the power-off command to the device and requires a full power cycle to restart. [[1]](diffhunk://#diff-8f271d61dc3f29d204b6ffa86dd616e5256b50853d2f89719c3e5d9d5d3b6beeR245-R250) [[2]](diffhunk://#diff-5bd6ce59053279f4973c5f071f0b5a82113d954eb828329d8ccbebc178dcd10dR96-R97)