### PR TITLE
Fix MAX17055 false re-init and broken dPAcc seed

### DIFF
--- a/firmware/common/i2cdev_max17055.cpp
+++ b/firmware/common/i2cdev_max17055.cpp
@@ -253,9 +253,8 @@ bool I2cDev_MAX17055::initialize_custom_parameters() {
     if (!write_register(0x1E, 0x03C0)) return false;                                  // IChgTerm
     if (!write_register(0x3A, 0x9661)) return false;                                  // VEmpty
     if (!write_register(0x60, 0x0090)) return false;                                  // Unknown register
-    if (!write_register(0x46, ((designcap / 32) * 44138) * designcap)) return false;  // dPAcc
+    if (!write_register(0x46, ((designcap / 32) * 44138) / designcap)) return false;  // dPAcc = dQAcc * 44138 / DesignCap (Maxim EZ config)
     if (!write_register(0xDB, 0x8000)) return false;                                  // ModelCfg  --we should wait till it loads here. While (ReadRegister(0xDB)&0x8000) Wait(10)；//do not continue until ModelCFG.Refresh == 0
-    if (!write_register(0x40, 0x0001)) return false;                                  // Set user mem to 1
     return true;
 }
 
@@ -284,12 +283,10 @@ bool I2cDev_MAX17055::clear_por() {
 }
 
 bool I2cDev_MAX17055::needsInitialization() {
-    uint16_t UserMem1 = read_register(0x40);
-
-    if (UserMem1 == 0) {
-        return true;
-    }
-    return false;
+    // Status.POR (bit 1) is set by hardware on power-on-reset and stays set
+    // until cleared by clear_por(). It's the only reliable signal that the
+    // IC has lost its learned parameters and needs re-initialization.
+    return (read_register(0x00) & 0x0002) != 0;
 }
 
 void I2cDev_MAX17055::partialInit() {


### PR DESCRIPTION
## Summary

Two bugs in the MAX17055 fuel gauge driver caused inaccurate battery
percentages and an apparent "factory reset" of learned parameters after a
few charge/discharge cycles.

### Bug 1: spurious full re-init wipes learned parameters

`needsInitialization()` checked `UserMem1` (register 0x40) as the
"already initialized" marker. `UserMem1` is volatile — it clears to 0 on
any power-on-reset, hibernate-exit glitch, or stray write. When that
happened, the driver ran `full_reset_and_init()` and wiped all the
parameters the chip had learned (RComp0, TempCo, FullCapNom, QRTable,
Cycles, dQAcc/dPAcc), making the gauge behave as if the battery had
just been swapped.

Fixed by checking `Status.POR` (register 0x00, bit 1) instead. POR is
the hardware signal for "this IC just came up cold" and stays latched
until `clear_por()` clears it — which the driver already does at the
end of init. The CR2032 keeps pmem alive but does not power the
MAX17055, so a pmem-side flag would have made the problem worse on
real battery removals.

### Bug 2: dPAcc seed value overflowed (The main issue)

The EZ-config seed for `dPAcc` (register 0x46) was written as:

    ((designcap / 32) * 44138) * designcap

Maxim's formula is `dPAcc = dQAcc * 44138 / DesignCap` — the trailing
operator should be `/`, not `*`. The previous expression overflowed a
uint16 and wrote garbage, corrupting the SOC learning curve from the
very first init. Bug 1 masked this because every spurious re-init
re-corrupted dPAcc the same way, so the model never had a chance to
converge.

Also dropped the now-dead `write_register(0x40, 0x0001)` line that
seeded the old `UserMem1` marker.