### PR TITLE
fix missing header

### DIFF
--- a/firmware/baseband/sd_over_usb/scsi.c
+++ b/firmware/baseband/sd_over_usb/scsi.c
@@ -27,6 +27,7 @@
 #include <libopencm3/lpc43xx/rgu.h>
 #include <libopencm3/lpc43xx/wwdt.h>
 #include "delay.h"
+#include "string.h"
 
 volatile bool usb_bulk_block_done = false;
 


### PR DESCRIPTION
<!--
👋 Thank you for your contribution!

⚠️ Before you start, please review our Contributing Guidelines:
https://github.com/portapack-mayhem/mayhem-firmware/wiki/Contributing-Guidelines
-->

## Brief description of what you did

Fix compilation warning:

`portapack-mayhem/firmware/baseband/sd_over_usb/scsi.c: In function 'usb_send_csw':
portapack-mayhem/firmware/baseband/sd_over_usb/scsi.c:73:5: warning: implicit declaration of function 'memcpy' [-Wimplicit-function-declaration]
   73 |     memcpy(&usb_bulk_buffer[0], &csw, sizeof(msd_csw_t));
      |     ^~~~~~
portapack-mayhem/firmware/baseband/sd_over_usb/scsi.c:73:5: warning: incompatible implicit declaration of built-in function 'memcpy'
portapack-mayhem/firmware/baseband/sd_over_usb/scsi.c:30:1: note: include '<string.h>' or provide a declaration of 'memcpy'
   29 | #include "delay.h"
  +++ |+#include <string.h>
   30 | 
portapack-mayhem/firmware/baseband/sd_over_usb/scsi.c: In function 'handle_inquiry':
portapack-mayhem/firmware/baseband/sd_over_usb/scsi.c:93:5: warning: incompatible implicit declaration of built-in function 'memcpy'
   93 |     memcpy(&usb_bulk_buffer[0], &ret, sizeof(scsi_inquiry_response_t));
      |     ^~~~~~
portapack-mayhem/firmware/baseband/sd_over_usb/scsi.c:93:5: note: include '<string.h>' or provide a declaration of 'memcpy'
portapack-mayhem/firmware/baseband/sd_over_usb/scsi.c: In function 'handle_inquiry_serial_number':
portapack-mayhem/firmware/baseband/sd_over_usb/scsi.c:109:5: warning: incompatible implicit declaration of built-in function 'memcpy'
  109 |     memcpy(&usb_bulk_buffer[0], &ret, sizeof(scsi_unit_serial_number_inquiry_response_t));
      |     ^~~~~~
portapack-mayhem/firmware/baseband/sd_over_usb/scsi.c:109:5: note: include '<string.h>' or provide a declaration of 'memcpy'
portapack-mayhem/firmware/baseband/sd_over_usb/scsi.c: In function 'read_format_capacities':
portapack-mayhem/firmware/baseband/sd_over_usb/scsi.c:127:9: warning: incompatible implicit declaration of built-in function 'memcpy'
  127 |         memcpy(&usb_bulk_buffer[0], &ret, sizeof(scsi_read_format_capacities_response_t));
      |         ^~~~~~
portapack-mayhem/firmware/baseband/sd_over_usb/scsi.c:127:9: note: include '<string.h>' or provide a declaration of 'memcpy'
portapack-mayhem/firmware/baseband/sd_over_usb/scsi.c: In function 'read_capacity10':
portapack-mayhem/firmware/baseband/sd_over_usb/scsi.c:143:5: warning: incompatible implicit declaration of built-in function 'memcpy'
  143 |     memcpy(&usb_bulk_buffer[0], &ret, sizeof(scsi_read_capacity10_response_t));
      |     ^~~~~~
portapack-mayhem/firmware/baseband/sd_over_usb/scsi.c:143:5: note: include '<string.h>' or provide a declaration of 'memcpy'
portapack-mayhem/firmware/baseband/sd_over_usb/scsi.c: In function 'request_sense':
portapack-mayhem/firmware/baseband/sd_over_usb/scsi.c:159:5: warning: incompatible implicit declaration of built-in function 'memcpy'
  159 |     memcpy(&usb_bulk_buffer[0], &ret, sizeof(scsi_sense_response_t));
      |     ^~~~~~
portapack-mayhem/firmware/baseband/sd_over_usb/scsi.c:159:5: note: include '<string.h>' or provide a declaration of 'memcpy'
portapack-mayhem/firmware/baseband/sd_over_usb/scsi.c: In function 'mode_sense6':
portapack-mayhem/firmware/baseband/sd_over_usb/scsi.c:175:5: warning: incompatible implicit declaration of built-in function 'memcpy'
  175 |     memcpy(&usb_bulk_buffer[0], &ret, sizeof(scsi_mode_sense6_response_t));
      |     ^~~~~~
portapack-mayhem/firmware/baseband/sd_over_usb/scsi.c:175:5: note: include '<string.h>' or provide a declaration of 'memcpy'
portapack-mayhem/firmware/baseband/sd_over_usb/scsi.c: In function 'mode_sense10':
portapack-mayhem/firmware/baseband/sd_over_usb/scsi.c:191:5: warning: incompatible implicit declaration of built-in function 'memcpy'
  191 |     memcpy(&usb_bulk_buffer[0], &ret, sizeof(scsi_mode_sense10_response_t));
      |     ^~~~~~
portapack-mayhem/firmware/baseband/sd_over_usb/scsi.c:191:5: note: include '<string.h>' or provide a declaration of 'memcpy'
portapack-mayhem/firmware/baseband/sd_over_usb/scsi.c: In function 'decode_data_request':
portapack-mayhem/firmware/baseband/sd_over_usb/scsi.c:202:5: warning: incompatible implicit declaration of built-in function 'memcpy'
  202 |     memcpy(&lba, &cmd[2], sizeof(lba));
      |     ^~~~~~
portapack-mayhem/firmware/baseband/sd_over_usb/scsi.c:202:5: note: include '<string.h>' or provide a declaration of 'memcpy'
`

---

## Proof that your changes work

I tested it.

### 🖥️ Proof it compiles

Space remaining in flash ROM: 20064 bytes ( 1.9 %)

## Checklist

- [X] Kept changes minimal and limited to necessary files
- [X] Verified functionality remains intact and code compiles
- [X] Attached proof that the code compiles successfully *(or marked N/A as a trusted contributor)*
- [ ] Attached proof of testing on real PortaPack hardware *(or marked N/A as a trusted contributor)*
- [ ] Attached proof of testing against a real emitter/receiver (if RF-related), or marked N/A with justification
- [X] I understand that by getting this PR merged, I am implicitly agreeing to create or update the corresponding wiki page (including a main-screen screenshot, description, controls, and limitations)
- [X] Reviewed the [Contributing Guidelines](https://github.com/portapack-mayhem/mayhem-firmware/wiki/Contributing-Guidelines)