### PR TITLE
Add support for larger battery capacities

### DIFF
--- a/firmware/common/portapack_persistent_memory.hpp
+++ b/firmware/common/portapack_persistent_memory.hpp
@@ -47,7 +47,7 @@
 
 // to check battery mins and maxes in pmem, and validity
 #define BATT_18650_MIN_MAH 1000
-#define BATT_18650_MAX_MAH 5000
+#define BATT_18650_MAX_MAH 20000
 
 using namespace modems;
 using namespace serializer;


### PR DESCRIPTION

Adds support for higher-capacity Li-ion battery configurations by adjusting MAX17055 fuel gauge battery capacity handling.

This fixes incorrect battery percentage/runtime estimation when using large custom battery packs (tested with 7Ah and 20Ah 1S Li-ion configurations on PortaPack/HackRF builds).

The modification allows Mayhem to correctly report battery state-of-charge and remaining runtime for non-stock battery capacities.

Tested on real hardware with successful firmware flashing and matching `.ppma` external app builds.

---

Successful build using Docker on Arch Linux.

Final Flash output:

File size 1048576 bytes.
Checking target device compatibility
Erasing SPI flash.
Writing 1048576 bytes at 0x000000.

Firmware and matching `.ppma` files compiled successfully and flashed to hardware.

### 📱 Proof of testing on a real device

Tested successfully on:

* HackRF One
* PortaPack H4M
 with Mayhem nightly build
* custom 7Ah and 20Ah 1S Li-ion battery packs

Verified:

* successful boot
* battery percentage reporting
* runtime estimation
* charging/discharging behavior
* no instability observed

<img width="3000" height="4000" alt="20260508_220615" src="https://github.com/user-attachments/assets/338fcc7e-04b3-4ced-bc73-957a28eb1755" />


(attach photos/screenshots here)

---

## 📚 Wiki documentation commitment

I understand that if this PR is merged, I am responsible for updating the relevant wiki documentation.

---

## Checklist

* [x] Kept changes minimal and limited to necessary files
* [x] Verified functionality remains intact and code compiles
* [x] Attached proof that the code compiles successfully
* [x] Attached proof of testing on real PortaPack hardware
* [x] Attached proof of testing against a real emitter/receiver (if RF-related), or marked N/A with justification
* [x] I understand that by getting this PR merged, I am implicitly agreeing to create or update the corresponding wiki page
* [x] Reviewed the Contributing Guidelines
