### PR TITLE
Use gradient for level view, fix height scaling

### DIFF
--- a/firmware/application/apps/ui_looking_glass_app.cpp
+++ b/firmware/application/apps/ui_looking_glass_app.cpp
@@ -31,6 +31,7 @@
 using namespace portapack;
 
 namespace ui {
+
 void GlassView::focus() {
     range_presets.focus();
 }
@@ -43,7 +44,7 @@ GlassView::~GlassView() {
 }
 
 // Function to map the value from one range to another
-static constexpr int32_t map(int32_t value, int32_t fromLow, int32_t fromHigh, int32_t toLow, int32_t toHigh) {
+int32_t GlassView::map(int32_t value, int32_t fromLow, int32_t fromHigh, int32_t toLow, int32_t toHigh) {
     return toLow + ((value - fromLow) * (toHigh - toLow) + (fromHigh - fromLow) / 2) / (fromHigh - fromLow);
 }
 
@@ -128,8 +129,9 @@ void GlassView::reset_live_view() {
     max_freq_power = -1000;
 
     // Clear screen in peak mode.
+    const int spectrum_height = screen_height - spectrum_y;
     if (live_frequency_view == 2)
-        display.fill_rectangle({{0, 108 + 16}, {screen_width, screen_height - (108 + 16)}}, {0, 0, 0});
+        display.fill_rectangle({{0, spectrum_y}, {screen_width, spectrum_height}}, {0, 0, 0});
 }
 
 void GlassView::add_spectrum_pixel(uint8_t power) {
@@ -146,6 +148,7 @@ void GlassView::add_spectrum_pixel(uint8_t power) {
             constexpr float adc_voltage_max = 3.3;
             constexpr int raw_min = 0.5f + rssi_sample_range * rssi_voltage_min / adc_voltage_max;
             constexpr int raw_max = 0.5f + rssi_sample_range * rssi_voltage_max / adc_voltage_max;
+            const int spectrum_height = screen_height - spectrum_y;
             // drawing and keeping track of max freq
             for (uint16_t xpos = 0; xpos < screen_width; xpos++) {
                 // save max powerwull freq
@@ -153,16 +156,16 @@ void GlassView::add_spectrum_pixel(uint8_t power) {
                     max_freq_power = spectrum_data[xpos];
                     max_freq_hold = get_freq_from_bin_pos(xpos);
                 }
-                int16_t point = map(spectrum_data[xpos], 0, 255, 0, 196);
+                int16_t point = map(spectrum_data[xpos], 0, 255, 0, spectrum_height);
                 // clear if not in peak view
                 if (live_frequency_view != 2) {
-                    display.fill_rectangle({{xpos, 108 + 16}, {1, screen_height - point}}, {0, 0, 0});
+                    display.fill_rectangle({{xpos, spectrum_y}, {1, screen_height - point}}, {0, 0, 0});
                 }
                 display.fill_rectangle({{xpos, screen_height - point}, {1, point}}, gradient.lut[spectrum_data[xpos]]);
             }
             // indicate RSSI min and max power
-            display.fill_rectangle({{0, screen_height - map(raw_min, 0, 255, 0, 196)}, {screen_width, 1}}, -gradient.lut[raw_min]);
-            display.fill_rectangle({{0, screen_height - map(raw_max, 0, 255, 0, 196)}, {screen_width, 1}}, -gradient.lut[raw_max]);
+            display.fill_rectangle({{0, screen_height - map(raw_min, 0, 255, 0, spectrum_height)}, {screen_width, 1}}, -gradient.lut[raw_min]);
+            display.fill_rectangle({{0, screen_height - map(raw_max, 0, 255, 0, spectrum_height)}, {screen_width, 1}}, -gradient.lut[raw_max]);
             if (last_max_freq != max_freq_hold) {
                 last_max_freq = max_freq_hold;
                 freq_stats.set("MAX HOLD: " + to_string_short_freq(max_freq_hold));

--- a/firmware/application/apps/ui_looking_glass_app.cpp
+++ b/firmware/application/apps/ui_looking_glass_app.cpp
@@ -44,7 +44,7 @@ GlassView::~GlassView() {
 
 // Function to map the value from one range to another
 int32_t GlassView::map(int32_t value, int32_t fromLow, int32_t fromHigh, int32_t toLow, int32_t toHigh) {
-    return toLow + (value - fromLow) * (toHigh - toLow) / (fromHigh - fromLow);
+    return toLow + ((value - fromLow) * (toHigh - toLow) + (fromHigh - fromLow) / 2) / (fromHigh - fromLow);
 }
 
 void GlassView::update_display_beep() {
@@ -140,15 +140,6 @@ void GlassView::add_spectrum_pixel(uint8_t power) {
     if (pixel_index == screen_width)  // got an entire waterfall line
     {
         if (live_frequency_view > 0) {
-            constexpr int rssi_sample_range = SPEC_NB_BINS;
-            constexpr float rssi_voltage_min = 0.4;
-            constexpr float rssi_voltage_max = 2.2;
-            constexpr float adc_voltage_max = 3.3;
-            constexpr int raw_min = rssi_sample_range * rssi_voltage_min / adc_voltage_max;
-            constexpr int raw_max = rssi_sample_range * rssi_voltage_max / adc_voltage_max;
-            constexpr int raw_delta = raw_max - raw_min;
-            const range_t<int> y_max_range{0, screen_height - (108 + 16)};
-
             // drawing and keeping track of max freq
             for (uint16_t xpos = 0; xpos < screen_width; xpos++) {
                 // save max powerwull freq
@@ -156,13 +147,12 @@ void GlassView::add_spectrum_pixel(uint8_t power) {
                     max_freq_power = spectrum_data[xpos];
                     max_freq_hold = get_freq_from_bin_pos(xpos);
                 }
-                int16_t point = y_max_range.clip(((spectrum_data[xpos] - raw_min) * (screen_height - (108 + 16))) / raw_delta);
-                uint8_t color_gradient = (point * 255) / 212;
+                int16_t point = map(spectrum_data[xpos], 0, 255, 0, 196);
                 // clear if not in peak view
                 if (live_frequency_view != 2) {
                     display.fill_rectangle({{xpos, 108 + 16}, {1, screen_height - point}}, {0, 0, 0});
                 }
-                display.fill_rectangle({{xpos, screen_height - point}, {1, point}}, {color_gradient, 0, uint8_t(255 - color_gradient)});
+                display.fill_rectangle({{xpos, screen_height - point}, {1, point}}, gradient.lut[spectrum_data[xpos]]);
             }
             if (last_max_freq != max_freq_hold) {
                 last_max_freq = max_freq_hold;

--- a/firmware/application/apps/ui_looking_glass_app.cpp
+++ b/firmware/application/apps/ui_looking_glass_app.cpp
@@ -43,7 +43,7 @@ GlassView::~GlassView() {
 }
 
 // Function to map the value from one range to another
-int32_t GlassView::map(int32_t value, int32_t fromLow, int32_t fromHigh, int32_t toLow, int32_t toHigh) {
+static constexpr int32_t map(int32_t value, int32_t fromLow, int32_t fromHigh, int32_t toLow, int32_t toHigh) {
     return toLow + ((value - fromLow) * (toHigh - toLow) + (fromHigh - fromLow) / 2) / (fromHigh - fromLow);
 }
 
@@ -140,6 +140,12 @@ void GlassView::add_spectrum_pixel(uint8_t power) {
     if (pixel_index == screen_width)  // got an entire waterfall line
     {
         if (live_frequency_view > 0) {
+            constexpr int rssi_sample_range = SPEC_NB_BINS;
+            constexpr float rssi_voltage_min = 0.4;
+            constexpr float rssi_voltage_max = 2.2;
+            constexpr float adc_voltage_max = 3.3;
+            constexpr int raw_min = 0.5f + rssi_sample_range * rssi_voltage_min / adc_voltage_max;
+            constexpr int raw_max = 0.5f + rssi_sample_range * rssi_voltage_max / adc_voltage_max;
             // drawing and keeping track of max freq
             for (uint16_t xpos = 0; xpos < screen_width; xpos++) {
                 // save max powerwull freq
@@ -154,6 +160,9 @@ void GlassView::add_spectrum_pixel(uint8_t power) {
                 }
                 display.fill_rectangle({{xpos, screen_height - point}, {1, point}}, gradient.lut[spectrum_data[xpos]]);
             }
+            // indicate RSSI min and max power
+            display.fill_rectangle({{0, screen_height - map(raw_min, 0, 255, 0, 196)}, {screen_width, 1}}, -gradient.lut[raw_min]);
+            display.fill_rectangle({{0, screen_height - map(raw_max, 0, 255, 0, 196)}, {screen_width, 1}}, -gradient.lut[raw_max]);
             if (last_max_freq != max_freq_hold) {
                 last_max_freq = max_freq_hold;
                 freq_stats.set("MAX HOLD: " + to_string_short_freq(max_freq_hold));

--- a/firmware/application/apps/ui_looking_glass_app.hpp
+++ b/firmware/application/apps/ui_looking_glass_app.hpp
@@ -104,6 +104,8 @@ class GlassView : public View {
     };
 
     void on_freqchg(int64_t freq);
+    // Function to map the value from one range to another
+    int32_t map(int32_t value, int32_t fromLow, int32_t fromHigh, int32_t toLow, int32_t toHigh);
     std::vector<preset_entry> presets_db{};
     void manage_beep_audio();
     void update_display_beep();
@@ -162,6 +164,9 @@ class GlassView : public View {
     uint8_t bin_length = screen_width;
     uint8_t offset = 0;
     uint8_t ignore_dc = 0;
+
+    // start of spectrum area
+    static constexpr int spectrum_y = (108 + 16);
 
     Labels labels{
         {{0, UI_POS_Y(0)}, "MIN:     MAX:     LNA   VGA  ", Theme::getInstance()->fg_light->foreground},

--- a/firmware/application/apps/ui_looking_glass_app.hpp
+++ b/firmware/application/apps/ui_looking_glass_app.hpp
@@ -104,7 +104,6 @@ class GlassView : public View {
     };
 
     void on_freqchg(int64_t freq);
-    int32_t map(int32_t value, int32_t fromLow, int32_t fromHigh, int32_t toLow, int32_t toHigh);
     std::vector<preset_entry> presets_db{};
     void manage_beep_audio();
     void update_display_beep();


### PR DESCRIPTION
## Brief description of what you did

Made Looking Glass level/peak view use the same gradient as the waterfall view.

Changed the scaling calculation for level view line height so that lines only reach the top at max power. Then added lines to indicate the RSSI power levels.

---

## Proof that your changes work

### 🖥️ Proof it compiles

`Space remaining in flash ROM: 19800 bytes ( 1.9 %)`

### 📱 Proof of testing on a real device

Attach photos, screenshots, or a short video of your changes running on actual PortaPack hardware. **Emulator or simulator output is not a substitute for real-device testing.**

<img width="240" height="320" alt="image" src="https://github.com/user-attachments/assets/c5b15e0b-6ddc-49a5-9146-790d370a2aa0" />

Notice the max-power DC spike reaches the top, while lower-power lines do not.
<img width="240" height="320" alt="image" src="https://github.com/user-attachments/assets/00aab01f-b33e-490c-97dd-ee49de836f86" />

RSSI power indicators:
<img width="240" height="320" alt="image" src="https://github.com/user-attachments/assets/387310d9-163c-4ff1-a21c-702a54127f38" />

start 94Mhz, LNA24 VGA62 AMP 0 Fast Scan INT x1

|RANGE | MODE  |RES |M0 CPU% (mine) |M0 CPU% (next) |
|------|-------|----|-----|-----|
|1     | LEVEL |2   |85   |86   |
|1     | PEAK  |2   |71   |70   |
|1     | LEVEL |128 |28   |28   |
|1     | PEAK  |128 |16   |18   |
|20    | LEVEL |2   |91   |93   |
|20    | PEAK  |2   |75   |83   |
|20    | LEVEL |128 |85   |85   |
|20    | PEAK  |128 |76   |78   |
|100   | LEVEL |2   |54   |55   |
|100   | PEAK  |2   |36   |41   |
|100   | LEVEL |128 |49   |49   |
|100   | PEAK  |128 |33   |34   |
|1000  | LEVEL |2   |18   |17   |
|1000  | PEAK  |2   |15   |16   |
|1000  | LEVEL |128 |13   |17   |
|1000  | PEAK  |128 |10   |10   |
|5000 | * | *     | ~7  | ~7 |
|Everything above 1000 is roughly the same cpu usage.|||||

### 📡 Proof against a real emitter/receiver (if applicable)

N/A

---

## 📚 Wiki documentation commitment

I can update the Looking Glass wiki page if needed, the screenshots look a little out of date.

---

## Checklist

- [X] Kept changes minimal and limited to necessary files
- [X] Verified functionality remains intact and code compiles
- [X] Attached proof that the code compiles successfully *(or marked N/A as a trusted contributor)*
- [X] Attached proof of testing on real PortaPack hardware *(or marked N/A as a trusted contributor)*
- [X] Attached proof of testing against a real emitter/receiver (if RF-related), or marked N/A with justification
- [X] I understand that by getting this PR merged, I am implicitly agreeing to create or update the corresponding wiki page (including a main-screen screenshot, description, controls, and limitations)
- [X] Reviewed the [Contributing Guidelines](https://github.com/portapack-mayhem/mayhem-firmware/wiki/Contributing-Guidelines)
