### PR TITLE
Hard reset app

### DIFF
--- a/firmware/application/external/external.cmake
+++ b/firmware/application/external/external.cmake
@@ -357,7 +357,11 @@ set(EXTCPPSRC
 
 	#two_tone_rx
 	external/two_tone_rx/main.cpp
-	external/two_tone_rx/ui_two_tone_rx.cpp 
+	external/two_tone_rx/ui_two_tone_rx.cpp
+
+	#hard_reset
+	external/hard_reset/main.cpp
+	external/hard_reset/ui_hard_reset.cpp
 )
 
 set(EXTAPPLIST
@@ -446,6 +450,7 @@ set(EXTAPPLIST
 	p25_tx
 	two_tone_pager
 	two_tone_rx
+	hard_reset
 )
 
 # sdusb has type conflicts with PRALINE (HackRF Pro) - add only for non-PRALINE builds

--- a/firmware/application/external/external.ld
+++ b/firmware/application/external/external.ld
@@ -109,6 +109,7 @@ MEMORY
     ram_external_app_two_tone_pager        (rwx) : org = 0xAE040000, len = 32k
     ram_external_app_two_tone_rx           (rwx) : org = 0xAE050000, len = 32k
     ram_external_app_flex_tx               (rwx) : org = 0xAE060000, len = 32k
+    ram_external_app_hard_reset            (rwx) : org = 0xAE070000, len = 32k
 }
 
 SECTIONS
@@ -628,4 +629,10 @@ SECTIONS
         KEEP(*(.external_app.app_flex_tx.application_information));
         *(*ui*external_app*flex_tx*);
     } > ram_external_app_flex_tx
+
+    .external_app_hard_reset : ALIGN(4) SUBALIGN(4)
+    {
+        KEEP(*(.external_app.app_hard_reset.application_information));
+        *(*ui*external_app*hard_reset*);
+    } > ram_external_app_hard_reset
 }

--- a/firmware/application/external/hard_reset/main.cpp
+++ b/firmware/application/external/hard_reset/main.cpp
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2026 Pezsma
+ *
+ * This file is part of PortaPack.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#include "ui.hpp"
+#include "ui_hard_reset.hpp"
+#include "ui_navigation.hpp"
+#include "external_app.hpp"
+
+namespace ui::external_app::hard_reset {
+
+void initialize_app(NavigationView& nav) {
+    nav.push<HardResetView>();
+}
+
+}  // namespace ui::external_app::hard_reset
+
+extern "C" {
+
+__attribute__((section(".external_app.app_hard_reset.application_information"), used))
+application_information_t _application_information_hard_reset = {
+    /*.memory_location = */ (uint8_t*)0x00000000,
+    /*.externalAppEntry = */ ui::external_app::hard_reset::initialize_app,
+    /*.header_version = */ CURRENT_HEADER_VERSION,
+    /*.app_version = */ VERSION_MD5,
+
+    /*.app_name = */ "Hard Reset",
+    /*.bitmap_data = */ {
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0xC0,
+        0x01,
+        0xFF,
+        0x7F,
+        0xFF,
+        0x7F,
+        0x56,
+        0x35,
+        0x56,
+        0x35,
+        0x56,
+        0x35,
+        0x56,
+        0x35,
+        0x56,
+        0x35,
+        0x56,
+        0x35,
+        0x56,
+        0x35,
+        0x56,
+        0x35,
+        0xFE,
+        0x3F,
+        0xFE,
+        0x3F,
+        0x00,
+        0x00,
+    },
+    /*.icon_color = */ ui::Color::dark_cyan().v,
+    /*.menu_location = */ app_location_t::SETTINGS,
+    /*.desired_menu_position = */ -1,
+
+    /*.m4_app_tag = portapack::spi_flash::image_tag_none */ {0, 0, 0, 0},
+    /*.m4_app_offset = */ 0x00000000,  // will be filled at compile time
+};
+
+}  // extern "C"

--- a/firmware/application/external/hard_reset/main.cpp
+++ b/firmware/application/external/hard_reset/main.cpp
@@ -76,7 +76,7 @@ application_information_t _application_information_hard_reset = {
         0x00,
         0x00,
     },
-    /*.icon_color = */ ui::Color::dark_cyan().v,
+    /*.icon_color = */ ui::Color::red().v,
     /*.menu_location = */ app_location_t::SETTINGS,
     /*.desired_menu_position = */ -1,
 

--- a/firmware/application/external/hard_reset/ui_hard_reset.cpp
+++ b/firmware/application/external/hard_reset/ui_hard_reset.cpp
@@ -1,9 +1,32 @@
+/*
+ * Copyright (C) 2026 Pezsma
+ *
+ * This file is part of PortaPack.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
 #include "ui_hard_reset.hpp"
 
 #include "portapack.hpp"
 #include "file.hpp"
 #include "file_path.hpp"
 #include "ui_touch_calibration.hpp"
+#include "ui_external_items_menu_loader.hpp"
+#include "app_settings.hpp"
 
 using namespace portapack;
 namespace pmem = portapack::persistent_memory;
@@ -11,44 +34,204 @@ namespace pmem = portapack::persistent_memory;
 namespace ui::external_app::hard_reset {
 HardResetView::HardResetView(ui::NavigationView& nav)
     : nav_(nav) {
-    add_children({&btn_yes,
+    add_children({&chk_settings_file,
+                  &chk_bad_apps,
+                  &chk_pmem,
+                  &txt_settings_file_count,
+                  &txt_bad_apps_count,
+                  &btn_yes,
                   &btn_no,
-                  &console_text});
+                  &text,
+                  &txt_wait});
 
-    btn_yes.on_select = [&nav, this](Button&) {
-        pmem::cache::defaults();
-        clear_settings_folder();
-        nav.push<TouchCalibrationView>();
-        // nav_.pop();
+    txt_wait.set_style(Theme::getInstance()->warning_dark);
+
+    btn_yes.on_select = [this](Button&) {
+        {  // to  free painter after draw
+            Painter painter;
+            txt_wait.hidden(false);
+            text.hidden(true);
+            painter.fill_rectangle(text.screen_rect(), this->style().background);
+            txt_wait.paint(painter);
+        }
+        if (chk_settings_file.value()) {
+            clear_settings_folder();
+        }
+        if (chk_bad_apps.value()) {
+            delete_bad_apps(apps_dir);
+        }
+        if (chk_pmem.value()) {
+            pmem::cache::defaults();
+            nav_.replace<TouchCalibrationView>();
+        } else {
+            nav_.pop();
+        }
     };
 
-    btn_no.on_select = [&nav, this](Button&) {
+    btn_no.on_select = [this](Button&) {
         nav_.pop();
+    };
+    txt_settings_file_count.set_style(Theme::getInstance()->fg_magenta);
+    txt_bad_apps_count.set_style(Theme::getInstance()->fg_magenta);
+
+    signal_token_tick_second = rtc_time::signal_tick_second += [this]() {
+        this->calculate();
+        rtc_time::signal_tick_second -= signal_token_tick_second;
     };
 }
 
 HardResetView::~HardResetView() {
+    rtc_time::signal_tick_second -= signal_token_tick_second;
 }
 
-void HardResetView::on_show() {
-    console_text.write("Warning! All app settings and P.Mem will be erased. After   the operation, the touchscreen must be recalibrated.");
+void HardResetView::calculate() {
+    settings_file_count = count_ini_files_in_directory(settings_dir);
+    txt_settings_file_count.set(to_string_dec_uint(settings_file_count));
+
+    bad_apps_count = count_bad_apps(apps_dir);
+    txt_bad_apps_count.set(to_string_dec_uint(bad_apps_count));
+
+    if (settings_file_count > 0) {
+        chk_settings_file.set_value(true);
+    }
+    if (bad_apps_count > 0) {
+        chk_bad_apps.set_value(true);
+    }
+    chk_pmem.set_value(true);
+    txt_wait.hidden(true);
+    text.set("Warning! Checked items will\nbe erased (bad apps, P.Mem,\nsettings). Uncheck to keep.\nTouch calibration is required only if P.Mem is reset.");
 }
 
 void HardResetView::focus() {
     btn_no.focus();
 }
 
-void HardResetView::delete_all_files_in_directory(const std::filesystem::path& dir_path) {
-    for (const auto& entry : std::filesystem::directory_iterator(dir_path, u"*")) {
+uint16_t HardResetView::count_ini_files_in_directory(const std::filesystem::path& dir_path) {
+    int count = 0;
+    for (const auto& entry : std::filesystem::directory_iterator(dir_path, u"*.ini")) {
         if (std::filesystem::is_regular_file(entry.status())) {
-            auto full_path = dir_path / entry.path().filename();
-            delete_file(full_path);
+            count++;
         }
     }
+    return count;
+}
+
+void HardResetView::delete_ini_files_in_directory(const std::filesystem::path& dir_path) {
+    bool found_and_deleted;
+    do {
+        found_and_deleted = false;
+        for (const auto& entry : std::filesystem::directory_iterator(dir_path, u"*.ini")) {
+            if (std::filesystem::is_regular_file(entry.status())) {
+                auto full_path = dir_path / entry.path().filename();
+                delete_file(full_path);
+                found_and_deleted = true;
+                break;  // iterator can become invalid if the dir is modified, so break and restart the loop after deletion
+            }
+        }
+    } while (found_and_deleted);
 }
 
 void HardResetView::clear_settings_folder() {
-    delete_all_files_in_directory(settings_dir);
+    delete_ini_files_in_directory(settings_dir);
+}
+
+bool HardResetView::is_bad_app(const std::filesystem::path& file_path, bool is_ppma) {
+    File app;
+    if (app.open(file_path)) {
+        return true;
+    }
+    bool is_bad = false;
+    if (is_ppma) {
+        application_information_t app_info = {};
+        auto readResult = app.read(&app_info, sizeof(application_information_t));
+        if (!readResult || readResult.value() != sizeof(application_information_t)) {
+            is_bad = true;
+        } else if (app_info.header_version != CURRENT_HEADER_VERSION) {
+            is_bad = true;
+        } else if (VERSION_MD5 != app_info.app_version) {
+            is_bad = true;
+        } else {
+            // --- CHECKSUM VALIDATION ---
+            // Similar to run_external_app: read through the file and calculate the checksum
+            app.seek(0);
+            uint32_t checksum = 0;
+            uint8_t buffer[512];  // 512-byte buffer to conserve RAM
+
+            while (true) {
+                auto res = app.read(buffer, sizeof(buffer));
+                if (!res) break;
+                checksum += simple_checksum((uint32_t)buffer, res.value());
+                if (res.value() < sizeof(buffer)) break;  // End of file
+            }
+
+            if (checksum != EXT_APP_EXPECTED_CHECKSUM) {
+                is_bad = true;  // The file body is corrupted / truncated!
+            }
+        }
+    } else {
+        // PPMP validation
+        standalone_application_information_t app_info = {};
+        auto readResult = app.read(&app_info, sizeof(standalone_application_information_t));
+        if (!readResult || readResult.value() != sizeof(standalone_application_information_t)) {
+            is_bad = true;
+        } else if (app_info.header_version > CURRENT_STANDALONE_APPLICATION_API_VERSION) {
+            is_bad = true;
+        }
+    }
+
+    app.close();
+    return is_bad;
+}
+
+uint16_t HardResetView::count_bad_apps(const std::filesystem::path& apps_dir) {
+    int bad_count = 0;
+
+    // Check .ppma files
+    for (const auto& entry : std::filesystem::directory_iterator(apps_dir, u"*.ppma")) {
+        auto file_path = apps_dir / entry.path();
+        if (is_bad_app(file_path, true)) {
+            bad_count++;
+        }
+    }
+
+    // Check .ppmp files
+    for (const auto& entry : std::filesystem::directory_iterator(apps_dir, u"*.ppmp")) {
+        auto file_path = apps_dir / entry.path();
+        if (is_bad_app(file_path, false)) {
+            bad_count++;
+        }
+    }
+
+    return bad_count;
+}
+
+void HardResetView::delete_bad_apps(const std::filesystem::path& apps_dir) {
+    // Delete bad .ppma files
+    bool deleted_something;
+    do {
+        deleted_something = false;
+        for (const auto& entry : std::filesystem::directory_iterator(apps_dir, u"*.ppma")) {
+            auto file_path = apps_dir / entry.path();
+            if (is_bad_app(file_path, true)) {
+                delete_file(file_path);
+                deleted_something = true;
+                break;
+            }
+        }
+    } while (deleted_something);
+
+    // Delete bad .ppmp files
+    do {
+        deleted_something = false;
+        for (const auto& entry : std::filesystem::directory_iterator(apps_dir, u"*.ppmp")) {
+            auto file_path = apps_dir / entry.path();
+            if (is_bad_app(file_path, false)) {
+                delete_file(file_path);
+                deleted_something = true;
+                break;
+            }
+        }
+    } while (deleted_something);
 }
 
 }  // namespace ui::external_app::hard_reset

--- a/firmware/application/external/hard_reset/ui_hard_reset.cpp
+++ b/firmware/application/external/hard_reset/ui_hard_reset.cpp
@@ -62,6 +62,8 @@ HardResetView::HardResetView(ui::NavigationView& nav)
         }
         if (chk_pmem.value()) {
             pmem::cache::defaults();
+            StatusRefreshMessage message{};
+            EventDispatcher::send_message(message);
             nav_.replace<TouchCalibrationView>();
         } else {
             nav_.pop();

--- a/firmware/application/external/hard_reset/ui_hard_reset.cpp
+++ b/firmware/application/external/hard_reset/ui_hard_reset.cpp
@@ -1,0 +1,54 @@
+#include "ui_hard_reset.hpp"
+
+#include "portapack.hpp"
+#include "file.hpp"
+#include "file_path.hpp"
+#include "ui_touch_calibration.hpp"
+
+using namespace portapack;
+namespace pmem = portapack::persistent_memory;
+
+namespace ui::external_app::hard_reset {
+HardResetView::HardResetView(ui::NavigationView& nav)
+    : nav_(nav) {
+    add_children({&btn_yes,
+                  &btn_no,
+                  &console_text});
+
+    btn_yes.on_select = [&nav, this](Button&) {
+        pmem::cache::defaults();
+        clear_settings_folder();
+        nav.push<TouchCalibrationView>();
+        // nav_.pop();
+    };
+
+    btn_no.on_select = [&nav, this](Button&) {
+        nav_.pop();
+    };
+}
+
+HardResetView::~HardResetView() {
+}
+
+void HardResetView::on_show() {
+    console_text.write("Warning! All app settings and P.Mem will be erased. After   the operation, the touchscreen must be recalibrated.");
+}
+
+void HardResetView::focus() {
+    btn_no.focus();
+}
+
+void HardResetView::delete_all_files_in_directory(const std::filesystem::path& dir_path) {
+    for (const auto& entry : std::filesystem::directory_iterator(dir_path, u"*")) {
+        if (std::filesystem::is_regular_file(entry.status())) {
+            auto full_path = dir_path / entry.path().filename();
+            delete_file(full_path);
+        }
+    }
+}
+
+void HardResetView::clear_settings_folder() {
+    delete_all_files_in_directory(settings_dir);
+}
+
+}  // namespace ui::external_app::hard_reset

--- a/firmware/application/external/hard_reset/ui_hard_reset.cpp
+++ b/firmware/application/external/hard_reset/ui_hard_reset.cpp
@@ -99,7 +99,7 @@ void HardResetView::calculate() {
     }
     chk_pmem.set_value(true);
     txt_wait.hidden(true);
-    text.set("Warning! Checked items will\nbe erased (bad apps, P.Mem,\nsettings). Uncheck to keep.\nTouch calibration is required only if P.Mem is reset.");
+    text.set("Warning! Checked items will beerased (bad apps, P.Mem,      settings). Uncheck to keep.   Touch calibration is required only if P.Mem is reset.");
 }
 
 void HardResetView::focus() {

--- a/firmware/application/external/hard_reset/ui_hard_reset.hpp
+++ b/firmware/application/external/hard_reset/ui_hard_reset.hpp
@@ -19,8 +19,8 @@
  * Boston, MA 02110-1301, USA.
  */
 
-#ifndef __HARD_RESET_H__
-#define __HARD_RESET_H__
+#ifndef __UI_HARD_RESET_H__
+#define __UI_HARD_RESET_H__
 
 #include "ui_navigation.hpp"
 #include "signal.hpp"
@@ -66,4 +66,4 @@ class HardResetView : public ui::View {
 
 }  // namespace ui::external_app::hard_reset
 
-#endif  // __HARD_RESET_H__
+#endif  // __UI_HARD_RESET_H__

--- a/firmware/application/external/hard_reset/ui_hard_reset.hpp
+++ b/firmware/application/external/hard_reset/ui_hard_reset.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 Pezsma
+ * Copyright (C) 2026 Pezsma
  *
  * This file is part of PortaPack.
  *
@@ -23,6 +23,8 @@
 #define __HARD_RESET_H__
 
 #include "ui_navigation.hpp"
+#include "signal.hpp"
+using namespace ui;
 
 namespace ui::external_app::hard_reset {
 
@@ -33,16 +35,33 @@ class HardResetView : public ui::View {
 
     std::string title() const override { return "Hard Reset"; }
     void focus() override;
-    void on_show() override;
 
    private:
     ui::NavigationView& nav_;
-    ui::Button btn_yes{{UI_POS_X(1), UI_POS_Y_BOTTOM(4), UI_POS_WIDTH(10), UI_POS_HEIGHT(2)}, "Erase All"};
-    ui::Button btn_no{{UI_POS_X_RIGHT(11), UI_POS_Y_BOTTOM(4), UI_POS_WIDTH(10), UI_POS_HEIGHT(2)}, "No"};
-    ui::Console console_text{{UI_POS_X(0), UI_POS_Y(2), UI_POS_MAXWIDTH, UI_POS_HEIGHT_REMAINING(6)}};
 
-    void delete_all_files_in_directory(const std::filesystem::path& dir_path);
+    SignalToken signal_token_tick_second{};
+    ui::Button btn_yes{{UI_POS_X(1), UI_POS_Y_BOTTOM(4), UI_POS_WIDTH(11), UI_POS_HEIGHT(2)}, "Erase sel."};
+    ui::Button btn_no{{UI_POS_X_RIGHT(11), UI_POS_Y_BOTTOM(4), UI_POS_WIDTH(10), UI_POS_HEIGHT(2)}, "No"};
+    ui::Text text{{UI_POS_X(0), UI_POS_Y(6), UI_POS_MAXWIDTH, UI_POS_HEIGHT(5)}, ""};
+    Checkbox chk_settings_file{{UI_POS_X(1), UI_POS_Y(1)}, 14, "Settings file:", true};
+    Checkbox chk_bad_apps{{UI_POS_X(1), UI_POS_Y(2.5)}, 9, "Bad apps:", true};
+    Checkbox chk_pmem{{UI_POS_X(1), UI_POS_Y(4)}, 11, "P.mem reset", true};
+
+    Text txt_settings_file_count{{UI_POS_X(19), UI_POS_Y(1), UI_POS_WIDTH(5), UI_POS_HEIGHT(1)}, "?"};
+    Text txt_bad_apps_count{{UI_POS_X(14), UI_POS_Y(2.5), UI_POS_WIDTH(5), UI_POS_HEIGHT(1)}, "?"};
+
+    Text txt_wait{{UI_POS_X_CENTER(14), UI_POS_Y(8), UI_POS_WIDTH(14), UI_POS_HEIGHT(1)}, "Please wait..."};
+
+    uint16_t count_ini_files_in_directory(const std::filesystem::path& dir_path);
+    void delete_ini_files_in_directory(const std::filesystem::path& dir_path);
     void clear_settings_folder();
+    void calculate();
+    bool is_bad_app(const std::filesystem::path& file_path, bool is_ppma);
+    uint16_t count_bad_apps(const std::filesystem::path& apps_dir);
+    void delete_bad_apps(const std::filesystem::path& apps_dir);
+
+    uint16_t settings_file_count = 0;
+    uint16_t bad_apps_count = 0;
 };
 
 }  // namespace ui::external_app::hard_reset

--- a/firmware/application/external/hard_reset/ui_hard_reset.hpp
+++ b/firmware/application/external/hard_reset/ui_hard_reset.hpp
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2025 Pezsma
+ *
+ * This file is part of PortaPack.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#ifndef __HARD_RESET_H__
+#define __HARD_RESET_H__
+
+#include "ui_navigation.hpp"
+
+namespace ui::external_app::hard_reset {
+
+class HardResetView : public ui::View {
+   public:
+    HardResetView(ui::NavigationView& nav);
+    ~HardResetView();
+
+    std::string title() const override { return "Hard Reset"; }
+    void focus() override;
+    void on_show() override;
+
+   private:
+    ui::NavigationView& nav_;
+    ui::Button btn_yes{{UI_POS_X(1), UI_POS_Y_BOTTOM(4), UI_POS_WIDTH(10), UI_POS_HEIGHT(2)}, "Erase All"};
+    ui::Button btn_no{{UI_POS_X_RIGHT(11), UI_POS_Y_BOTTOM(4), UI_POS_WIDTH(10), UI_POS_HEIGHT(2)}, "No"};
+    ui::Console console_text{{UI_POS_X(0), UI_POS_Y(2), UI_POS_MAXWIDTH, UI_POS_HEIGHT_REMAINING(6)}};
+
+    void delete_all_files_in_directory(const std::filesystem::path& dir_path);
+    void clear_settings_folder();
+};
+
+}  // namespace ui::external_app::hard_reset
+
+#endif  // __HARD_RESET_H__


### PR DESCRIPTION
# Hard Reset

The Hard Reset application is a system utility designed to clean up corrupted files, clear stored configurations, and reset the device's persistent memory to factory defaults. 

When you launch the app, it automatically scans your SD card to count existing settings files and detect any corrupted or incompatible external applications.

<img width="1052" height="324" alt="image" src="https://github.com/user-attachments/assets/2a13474c-25b9-4674-8857-5d79190d7fd5" />

<img width="327" height="415" alt="image" src="https://github.com/user-attachments/assets/7ec8dd01-b1ce-4fd4-8663-047950b0e5e6" />


## Checklist

- [x] Kept changes minimal and limited to necessary files
- [x] Verified functionality remains intact and code compiles
- [x] Attached proof that the code compiles successfully *(or marked N/A as a trusted contributor)*
- [x] Attached proof of testing on real PortaPack hardware *(or marked N/A as a trusted contributor)*
- [ ] Attached proof of testing against a real emitter/receiver (if RF-related), or marked N/A with justification
- [x] I understand that by getting this PR merged, I am implicitly agreeing to create or update the corresponding wiki page (including a main-screen screenshot, description, controls, and limitations)
- [x] I own all rights to this code (i.e., all code contained in this PR), including compliant usage rights for third-party libraries, and I agree that this code is licensed under the license of this project (GPL-3.0). 
- [ ] If any third-party libraries are used, I confirm that their licenses comply with the requirements for contributing to this repository.
- [x] Reviewed the [Contributing Guidelines](https://github.com/portapack-mayhem/mayhem-firmware/wiki/Contributing-Guidelines)
