### PR TITLE
Reduce OOK baseband size

### DIFF
--- a/firmware/baseband/proc_ook.cpp
+++ b/firmware/baseband/proc_ook.cpp
@@ -22,25 +22,19 @@
 
 #include "proc_ook.hpp"
 #include "portapack_shared_memory.hpp"
-#include "sine_table_int8.hpp"
 #include "event_m4.hpp"
 
 #include <cstdint>
 
 inline void OOKProcessor::write_sample(const buffer_c8_t& buffer, uint8_t bit_value, size_t i) {
     int8_t re, im;
-
     if (bit_value) {
-        phase = (phase + 200);  // What ?
-        sphase = phase + (64 << 18);
-
-        re = (sine_table_i8[(sphase & 0x03FC0000) >> 18]);
-        im = (sine_table_i8[(phase & 0x03FC0000) >> 18]);
+        re = INT8_MAX;
+        im = 0;
     } else {
         re = 0;
         im = 0;
     }
-
     buffer.p[i] = {re, im};
 }
 
@@ -125,11 +119,8 @@ inline size_t OOKProcessor::duval_algo_step() {
 void OOKProcessor::scan_process(const buffer_c8_t& buffer) {
     size_t buf_ptr = 0;
 
-    // transmit any leftover bits from previous step
-    if (!scan_encode(buffer, buf_ptr))
-        return;
-
-    while (1) {
+    // Encode the sequence into required format. First call transmits any leftover bits from previous step
+    while (scan_encode(buffer, buf_ptr)) {
         // calculate next chunk of deBruijn sequence
         duval_length = duval_algo_step();
 
@@ -151,10 +142,6 @@ void OOKProcessor::scan_process(const buffer_c8_t& buffer) {
         duval_bit = 0;
         duval_sample_bit = 0;
         duval_symbol = 0;
-
-        // encode the sequence into required format
-        if (!scan_encode(buffer, buf_ptr))
-            break;
     }
 }
 

--- a/firmware/baseband/proc_ook.hpp
+++ b/firmware/baseband/proc_ook.hpp
@@ -46,8 +46,6 @@ class OOKProcessor : public BasebandProcessor {
     uint16_t bit_pos{0};
     uint8_t cur_bit{0};
     uint32_t sample_count{0};
-    uint32_t tone_phase{0}, phase{0}, sphase{0};
-    int32_t tone_sample{0}, sig{0}, frq{0};
 
     TXProgressMessage txprogress_message{};
 

--- a/firmware/common/sine_table_int8.hpp
+++ b/firmware/common/sine_table_int8.hpp
@@ -23,9 +23,9 @@
 #ifndef __SINE_TABLE_I8_H__
 #define __SINE_TABLE_I8_H__
 
-#include <cmath>
+#include <cstdint>
 
-static const int8_t sine_table_i8[256] = {
+static constexpr int8_t sine_table_i8[256] = {
     0, 2, 5, 8, 12, 15, 18, 21, 24, 27, 30, 33, 36, 39, 42, 45,
     48, 51, 54, 57, 59, 62, 65, 67, 70, 73, 75, 78, 80, 83, 85, 87,
     90, 92, 94, 96, 98, 100, 102, 104, 105, 107, 109, 110, 112, 113, 115, 116,


### PR DESCRIPTION
## Brief description of what you did

Currently, to transmit a `1` bit, `OOKProcessor` uses a complex sinusoid that slowly changes after each transmitted `1`. But it updates so slowly that the I and Q values are basically the same for thousands of `1`s. The function generates `{127, 0}` for the first 1310 `1`s. It takes 5243 `1`s before the real component drops to 126. So the I and Q values are constant except for very long transmissions.

Removed use of `sine_table_i8` from proc_ook.cpp.
Removed unused variables from OOKProcessor.
Made `sine_table_i8` `constexpr` instead of `const` (no size change, but better in theory).

Saves 372 bytes in total.

---

## Proof that your changes work

### 🖥️ Proof it compiles
```
[ 97%] Generating POOK.bin, baseband_ook.img
Compressed 9844 bytes into 8227 bytes ==> 83.57%
...
Space remaining in flash ROM: 11392 bytes ( 1.1 %)
```

### 📱 Proof of testing on a real device


https://github.com/user-attachments/assets/3316cfa8-b627-421c-8484-0f2a664aab7d



### 📡 Proof against a real emitter/receiver (if applicable)
<!--
1. If your PR involves RX/TX, protocol decoding, signal generation, or any RF-related functionality, you **must** demonstrate it working against a real emitter or receiver. Include photos, videos, logs, or waterfall/spectrum screenshots.
2. If this section does not apply to your PR, write `N/A` below and briefly explain why.
3. Paste RF evidence, or write N/A with a short justification 
-->

Playing the recording back in protocol viewer, the recorded pulses still look like OOK.

https://github.com/user-attachments/assets/da23b06f-a67a-44f3-8c5f-4151eb3d442e


---

## 📚 Wiki documentation commitment
<!--
By submitting this PR, you acknowledge that once it is merged you are responsible for creating or updating the corresponding page on the project wiki(https://github.com/portapack-mayhem/mayhem-firmware/wiki).
Your wiki article should include:
- A screenshot of the main app screen (strongly recommended)
- A clear description of what the app does
- An explanation of the controls and UI elements
- Any known limitations, quirks, or caveats
- Anything else a user should know to use the app effectively (dependencies, required hardware, file formats, etc.)
- If you are modifying an existing app, make sure the wiki page reflects your changes.
-->


- [X] I will (or already) create(d) wiki document for my newly added feature


---

## Checklist

- [x] Kept changes minimal and limited to necessary files
- [x] Verified functionality remains intact and code compiles
- [x] Attached proof that the code compiles successfully *(or marked N/A as a trusted contributor)*
- [x] Attached proof of testing on real PortaPack hardware *(or marked N/A as a trusted contributor)*
- [x] Attached proof of testing against a real emitter/receiver (if RF-related), or marked N/A with justification
- [x] I understand that by getting this PR merged, I am implicitly agreeing to create or update the corresponding wiki page (including a main-screen screenshot, description, controls, and limitations)
- [x] I own all rights to this code (i.e., all code contained in this PR), including compliant usage rights for third-party libraries, and I agree that this code is licensed under the license of this project (GPL-3.0). 
- [x] If any third-party libraries are used, I confirm that their licenses comply with the requirements for contributing to this repository.
- [x] Reviewed the [Contributing Guidelines](https://github.com/portapack-mayhem/mayhem-firmware/wiki/Contributing-Guidelines)
