### PR TITLE
ui_geomap: replace zoom-out VLA with static BSS buffer (fixes M0 stack overflow)

### DIFF
--- a/firmware/application/ui/ui_geomap.cpp
+++ b/firmware/application/ui/ui_geomap.cpp
@@ -251,8 +251,35 @@ void GeoMap::map_read_line_bin(ui::Color* buffer, uint16_t pixels) {
             }
         }
     } else {
-        ui::Color zoom_out_buffer[(pixels * (-map_zoom))];
-        map_file.read(zoom_out_buffer, (pixels * (-map_zoom)) << 1);
+        // The original code here used a runtime-sized stack array:
+        //
+        //     ui::Color zoom_out_buffer[(pixels * (-map_zoom))];
+        //
+        // With a full 32768x32768 world_map.bin and a deeply negative
+        // map_zoom (up to -MAX_MAP_ZOOM_OUT = -10), that VLA can grow to
+        // pixels * 10 * sizeof(ui::Color) bytes — large enough on some
+        // displays to exceed the available stack budget and trigger a hard
+        // fault (Guru Meditation, "Stack Overflow") when the user zooms
+        // out aggressively.
+        //
+        // Fix: bound the buffer with a function-static (BSS) allocation
+        // sized for the worst case. screen_width is currently 320 across
+        // all shipped PortaPack hardware; MAX_MAP_ZOOM_OUT is 10. That
+        // gives 3200 ui::Color entries = 6400 bytes, which lives in BSS
+        // and never touches the stack. If a future variant ships a wider
+        // display, raise kMaxBufPixels to match.
+        static constexpr size_t kMaxBufPixels = 320 * MAX_MAP_ZOOM_OUT;
+        static ui::Color zoom_out_buffer[kMaxBufPixels];
+
+        const size_t needed = static_cast<size_t>(pixels) * static_cast<size_t>(-map_zoom);
+        if (needed > kMaxBufPixels) {
+            // Defensive: shouldn't trigger under current hardware caps.
+            // If it does, render the line blank rather than corrupt the
+            // stack like the old VLA would have.
+            return;
+        }
+
+        map_file.read(zoom_out_buffer, needed << 1);
         // Zoom out:  Collapse each group of "-map_zoom" pixels into one pixel.
         // Future TODO: Average each group of pixels (in both X & Y directions if possible).
         for (int i = 0; i < width; i++) {


### PR DESCRIPTION
## Summary

`GeoMap::map_read_line_bin()` allocates the zoom-out scratch buffer as a runtime-sized stack VLA:

```cpp
ui::Color zoom_out_buffer[(pixels * (-map_zoom))];
```

With a full 32768×32768 `world_map.bin` and a deeply negative `map_zoom` (up to `-MAX_MAP_ZOOM_OUT = -10`), this VLA grows to ~6400 bytes on a 320-wide display. That alone is small, but combined with the rest of the application thread's stack frame during `paint()`, it exceeds the available stack budget and triggers a hard fault — Guru Meditation, "Stack Overflow".

## Repro

PortaPack H4M + HackRF Pro, Mayhem nightly **n_260530**, custom 32K × 32K `world_map.bin`. Open ADS-B RX, zoom out several notches from the default. 100% reproducible.

## Fix

Replace the VLA with a function-static array sized for the worst case (`kMaxBufPixels = 320 * MAX_MAP_ZOOM_OUT = 3200 ui::Color` entries = 6400 bytes). Lives in BSS, never touches the stack.

Adds a defensive bounds check so that if a future hardware variant ships with a wider display before `kMaxBufPixels` is updated, the function renders the line blank rather than corrupting the stack the way the original VLA would have.

**No behavior change** for any zoom level that previously worked.

## Tested on

PortaPack H4M + HackRF Pro running Mayhem **n_260530**. After patch, the same zoom-out sequence that previously crashed renders cleanly.

Build verified locally on a PRoot Ubuntu (Snapdragon 8 Elite) docker-free toolchain; no compiler warnings introduced.

## Related

Part 1 of a small series planned for the GeoMap renderer:

- **PR #1 (this one)** — fix the M0 stack overflow on extreme zoom-out.
- **PR #2 (upcoming)** — raise / parameterize `MAX_MAP_ZOOM_IN` and replace pixel replication with bilinear upscaling on the binary path.
- **PR #3 (upcoming, larger)** — promote the tiled `use_osm` path to a production-quality multi-zoom renderer with an in-RAM tile cache, so high-detail tiles in a region of interest unlock real zoom-in beyond the binary path's cap.

Reported-by: @jrlynx13