### PR TITLE
ui_geomap: lift MAP_ZOOM_RESOLUTION_LIMIT gate via horizontal linear interpolation

### DIFF
--- a/firmware/application/ui/ui_geomap.cpp
+++ b/firmware/application/ui/ui_geomap.cpp
@@ -217,7 +217,14 @@ bool GeoMap::on_encoder(const EncoderEvent delta) {
         return false;
     }
 
-    map_visible = map_opened && (map_zoom <= MAP_ZOOM_RESOLUTION_LIMIT);
+    // USE_IMPROVED_UPSCALING (ui_geomap.hpp): when true, the binary-path
+    // renderer interpolates instead of pixel-replicating, so the old
+    // MAP_ZOOM_RESOLUTION_LIMIT-based black-screen cap no longer applies.
+    if (USE_IMPROVED_UPSCALING) {
+        map_visible = map_opened;
+    } else {
+        map_visible = map_opened && (map_zoom <= MAP_ZOOM_RESOLUTION_LIMIT);
+    }
     if (use_osm) {
         map_visible = true;
         zoom_pixel_offset = 0;
@@ -237,17 +244,61 @@ void GeoMap::map_read_line_bin(ui::Color* buffer, uint16_t pixels) {
     if (map_zoom == 1) {
         map_file.read(buffer, pixels << 1);
     } else if (map_zoom > 1) {
-        map_file.read(buffer, (pixels / map_zoom) << 1);
+        if (USE_IMPROVED_UPSCALING) {
+            // Horizontal linear interpolation upscaling.
+            //
+            // The original code below replicated each source pixel `map_zoom`
+            // times. That works only when `width % map_zoom == 0`; the
+            // surrounding logic (see MAP_ZOOM_RESOLUTION_LIMIT in
+            // ui_geomap.hpp) used to refuse to render past zoom 5 in part
+            // because of this divisibility constraint. With per-pixel linear
+            // interpolation that constraint goes away, so the visibility gate
+            // can be relaxed for arbitrary zoom levels (see on_encoder).
+            //
+            // src_pixels_needed shrinks monotonically as map_zoom grows
+            // (256/2=128 at zoom 2, 1 at zoom 320), so a buffer the width of
+            // the widest shipped display (320) covers every case. Function-
+            // static BSS allocation matches the pattern used by the zoom-out
+            // scratch buffer in this same function — no stack or heap
+            // pressure inside the paint() loop.
+            static ui::Color src_buffer[320];
+            constexpr size_t kSrcCapacity = sizeof(src_buffer) / sizeof(src_buffer[0]);
 
-        // Zoom in: Expand each pixel to "map_zoom" number of pixels.
-        // Future TODO:  Add dithering to smooth out the pixelation.
-        // As long as MOD(width,map_zoom)==0 then we don't need to check buffer overflow case when stretching last pixel;
-        // For 240 width, than means no check is needed for map_zoom values up to 6.
-        // (Rectangle height must also divide evenly into map_zoom or we get black lines at end of screen)
-        // Note that zooming in results in a map offset of (1/map_zoom) pixels to the right & downward directions (see zoom_pixel_offset).
-        for (int i = (width / map_zoom) - 1; i >= 0; i--) {
-            for (int j = 0; j < map_zoom; j++) {
-                buffer[(i * map_zoom) + j] = buffer[i];
+            uint16_t src_pixels_needed = (pixels + map_zoom - 1) / map_zoom;
+            if (src_pixels_needed == 0) src_pixels_needed = 1;
+            if (src_pixels_needed > kSrcCapacity) src_pixels_needed = kSrcCapacity;
+
+            map_file.read(src_buffer, src_pixels_needed << 1);
+
+            for (uint16_t dst = 0; dst < pixels; ++dst) {
+                float src_pos = static_cast<float>(dst) / map_zoom;
+                int i0 = static_cast<int>(src_pos);
+                int i1 = i0 + 1;
+                if (i1 > static_cast<int>(src_pixels_needed) - 1) i1 = static_cast<int>(src_pixels_needed) - 1;
+                float frac = src_pos - static_cast<float>(i0);
+
+                ui::Color c0 = src_buffer[i0];
+                ui::Color c1 = src_buffer[i1];
+
+                uint8_t r = static_cast<uint8_t>((static_cast<float>(c0.r()) * (1.0f - frac) + static_cast<float>(c1.r()) * frac) + 0.5f);
+                uint8_t g = static_cast<uint8_t>((static_cast<float>(c0.g()) * (1.0f - frac) + static_cast<float>(c1.g()) * frac) + 0.5f);
+                uint8_t b = static_cast<uint8_t>((static_cast<float>(c0.b()) * (1.0f - frac) + static_cast<float>(c1.b()) * frac) + 0.5f);
+
+                buffer[dst] = ui::Color(r, g, b);
+            }
+        } else {
+            map_file.read(buffer, (pixels / map_zoom) << 1);
+
+            // Legacy pixel replication (kept behind USE_IMPROVED_UPSCALING).
+            // Zoom in: Expand each pixel to "map_zoom" number of pixels.
+            // As long as MOD(width,map_zoom)==0 then we don't need to check buffer overflow case when stretching last pixel;
+            // For 240 width, than means no check is needed for map_zoom values up to 6.
+            // (Rectangle height must also divide evenly into map_zoom or we get black lines at end of screen)
+            // Note that zooming in results in a map offset of (1/map_zoom) pixels to the right & downward directions (see zoom_pixel_offset).
+            for (int i = (width / map_zoom) - 1; i >= 0; i--) {
+                for (int j = 0; j < map_zoom; j++) {
+                    buffer[(i * map_zoom) + j] = buffer[i];
+                }
             }
         }
     } else {

--- a/firmware/application/ui/ui_geomap.hpp
+++ b/firmware/application/ui/ui_geomap.hpp
@@ -38,6 +38,12 @@ namespace ui {
 #define MAX_MAP_ZOOM_OUT 10
 #define MAP_ZOOM_RESOLUTION_LIMIT 5  // Max zoom-in to show map; rect height & width must divide into this evenly
 
+// When true, GeoMap uses horizontal linear interpolation for zoom-in on the
+// binary world_map.bin path and lifts the MAP_ZOOM_RESOLUTION_LIMIT-based
+// visibility gate, so the map continues to render past the old hard cap.
+// Set to false to fall back to the legacy pixel-replication renderer.
+constexpr bool USE_IMPROVED_UPSCALING = true;
+
 #define INVALID_LAT_LON 200
 #define INVALID_ANGLE 400
 


### PR DESCRIPTION
## Summary

The practical zoom-in limit users hit on the binary `world_map.bin` path is not `MAX_MAP_ZOOM_IN` (4000) but **`MAP_ZOOM_RESOLUTION_LIMIT`** (5). Past zoom level 5 the renderer flipped `map_visible` to false and drew nothing — even when a high-detail `world_map.bin` had real content to display. This shows up as the famous *zoom-in past 5x = black screen with maybe a faint grid* on a custom-built world map.

The reason the gate existed was the old upscaler in `map_read_line_bin()` simply replicated each source pixel `map_zoom` times, which only works when `width % map_zoom == 0`. Past zoom 5 on 240/320-wide displays the divisibility constraint stopped holding cleanly, and the renderer was gated off to avoid showing partial rows.

This change:

- Introduces a **horizontal linear interpolation pass** in `map_read_line_bin()` for `map_zoom > 1`. Per-output-pixel, lerp between the two nearest source pixels.
- **Lifts the visibility gate** when the new path is active so the renderer keeps drawing past zoom 5.
- Uses a **function-static BSS scratch buffer** to keep the per-line work off both stack and heap, matching the pattern from PR #3202 (the zoom-out VLA fix).
- Adds a **compile-time switch** (`USE_IMPROVED_UPSCALING`, default `true`) so the legacy replication path stays available for fallback or comparison.

## Behavioral changes for users

- Zoom-in past level 5 now renders interpolated map content instead of going black, on the binary `world_map.bin` path.
- Past the point where the source map has no usable detail at the current view, the rendered image becomes increasingly blurry, but the renderer never silently stops drawing.

## Out of scope (handled elsewhere)

- No change to zoom-out (handled in #3202).
- No change to the OSM / tiled (`use_osm`) path — that's the subject of a planned PR3.
- No change to `on_encoder()` zoom-stepping logic.
- Aircraft / marker position math is unchanged.

## Tested on

PortaPack H4M + HackRF Pro running Mayhem nightly **n_260530**, with a custom 32K×32K cartographic world_map.bin (Carto `voyager_nolabels` + an Erie ROI overlay). The pre-patch behavior reproducibly went black above zoom 5; the patched behavior continues to draw, with the expected progressive blur as the source map runs out of detail per display pixel.

Build verified locally on a PRoot Ubuntu (Snapdragon 8 Elite) docker-free toolchain. No new compiler warnings introduced.

## Related

Part 2 of a small series targeting the GeoMap renderer:

- ✅ **#3202** — zoom-out VLA fix (M0 stack overflow).
- 🟡 **This PR (#2)** — lift the zoom-in resolution gate with linear interpolation on the binary path.
- ⏳ **Upcoming PR3** — promote the experimental tiled (`use_osm`) path to a production multi-zoom renderer with a small in-RAM tile cache, so high-detail tiles in a region of interest unlock real zoom-in beyond the binary path's smearing-blur ceiling.

Reported-by: @jrlynx13
Co-authored-by: Grok (xAI) <design contribution via the bridge folder dialog G2-G6>