### PR TITLE
GeoMap: add 24-slot LRU cache for OSM raster tiles

### DIFF
--- a/firmware/application/CMakeLists.txt
+++ b/firmware/application/CMakeLists.txt
@@ -267,6 +267,7 @@ set(CPPSRC
 	ui/ui_font_fixed_5x8.cpp
 	ui/ui_font_fixed_8x16.cpp
 	ui/ui_geomap.cpp
+	ui/tile_cache.cpp
 	ui/ui_qrcode.cpp
 	ui/ui_menu.cpp
 	ui/ui_btngrid.cpp

--- a/firmware/application/ui/tile_cache.cpp
+++ b/firmware/application/ui/tile_cache.cpp
@@ -1,0 +1,105 @@
+/*
+ * Copyright (C) 2026 jrlynx13
+ * Co-authored with Grok (xAI) via design dialog 2026-05-31
+ *
+ * This file is part of PortaPack.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#include "tile_cache.hpp"
+
+namespace ui {
+
+TileCache::TileCache() {
+    // slots_ are already default-constructed (BMPFile default ctor is trivial)
+}
+
+TileCache::~TileCache() {
+    clear();
+}
+
+BMPFile* TileCache::find(const TileKey& key) {
+    for (size_t i = 0; i < MAX_SLOTS; ++i) {
+        if (slots_[i].valid &&
+            slots_[i].key.zoom == key.zoom &&
+            slots_[i].key.x == key.x &&
+            slots_[i].key.y == key.y) {
+            slots_[i].last_access_tick = ++current_tick_;
+            return &slots_[i].bmp;
+        }
+    }
+    return nullptr;
+}
+
+TileCache::CachedTile* TileCache::insert_or_replace(const TileKey& key) {
+    int idx = find_slot_index(key);
+    if (idx < 0) {
+        idx = evict_oldest();
+    }
+
+    auto& slot = slots_[idx];
+    slot.key = key;
+    slot.last_access_tick = ++current_tick_;
+    slot.valid = true;
+
+    return &slot;
+}
+
+void TileCache::clear() {
+    for (auto& slot : slots_) {
+        if (slot.valid) {
+            slot.bmp.close();
+        }
+        slot.valid = false;
+        slot.last_access_tick = 0;
+    }
+    current_tick_ = 0;
+}
+
+int TileCache::find_slot_index(const TileKey& key) const {
+    for (size_t i = 0; i < MAX_SLOTS; ++i) {
+        if (slots_[i].valid &&
+            slots_[i].key.zoom == key.zoom &&
+            slots_[i].key.x == key.x &&
+            slots_[i].key.y == key.y) {
+            return static_cast<int>(i);
+        }
+    }
+    return -1;
+}
+
+int TileCache::evict_oldest() {
+    int oldest_idx = 0;
+    uint32_t oldest_tick = slots_[0].last_access_tick;
+
+    for (size_t i = 1; i < MAX_SLOTS; ++i) {
+        if (!slots_[i].valid) {
+            return static_cast<int>(i);
+        }
+        if (slots_[i].last_access_tick < oldest_tick) {
+            oldest_tick = slots_[i].last_access_tick;
+            oldest_idx = static_cast<int>(i);
+        }
+    }
+
+    if (slots_[oldest_idx].valid) {
+        slots_[oldest_idx].bmp.close();
+    }
+    return oldest_idx;
+}
+
+}  // namespace ui

--- a/firmware/application/ui/tile_cache.hpp
+++ b/firmware/application/ui/tile_cache.hpp
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2026 jrlynx13
+ * Co-authored with Grok (xAI) via design dialog 2026-05-31
+ *
+ * This file is part of PortaPack.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#ifndef __TILE_CACHE_H__
+#define __TILE_CACHE_H__
+
+#include <cstdint>
+#include <cstddef>
+
+#include "bmpfile.hpp"
+
+namespace ui {
+
+class TileCache {
+   public:
+    static constexpr size_t MAX_SLOTS = 24;
+
+    struct TileKey {
+        int8_t zoom;
+        int16_t x;
+        int16_t y;
+    };
+
+    struct CachedTile {
+        TileKey key{};
+        uint32_t last_access_tick{0};
+        bool valid{false};
+        BMPFile bmp{};
+    };
+
+    TileCache();
+    ~TileCache();
+
+    BMPFile* find(const TileKey& key);
+    CachedTile* insert_or_replace(const TileKey& key);
+    void clear();
+
+   private:
+    CachedTile slots_[MAX_SLOTS];
+    uint32_t current_tick_{0};
+
+    int find_slot_index(const TileKey& key) const;
+    int evict_oldest();
+};
+
+}  // namespace ui
+
+#endif

--- a/firmware/application/ui/ui_geomap.cpp
+++ b/firmware/application/ui/ui_geomap.cpp
@@ -415,8 +415,27 @@ bool GeoMap::draw_osm_file(int zoom, int tile_x, int tile_y, int relative_x, int
         return true;
     }
 
-    BMPFile bmp{};
-    bmp.open("/OSM/" + to_string_dec_int(zoom) + "/" + to_string_dec_int(tile_x) + "/" + to_string_dec_int(tile_y) + ".bmp", true);
+    // === Cache-aware tile load ===
+    ui::TileCache::TileKey key{
+        static_cast<int8_t>(zoom),
+        static_cast<int16_t>(tile_x),
+        static_cast<int16_t>(tile_y)};
+
+    BMPFile* bmp = tile_cache_.find(key);
+
+    if (bmp == nullptr) {
+        auto* slot = tile_cache_.insert_or_replace(key);
+        std::string path = "/OSM/" + to_string_dec_int(zoom) + "/" +
+                           to_string_dec_int(tile_x) + "/" +
+                           to_string_dec_int(tile_y) + ".bmp";
+        slot->bmp.open(path, true);
+        if (!slot->bmp.is_loaded()) {
+            slot->valid = false;
+        }
+        bmp = &slot->bmp;
+    }
+    // === end cache-aware tile load ===
+
     // 1. Define the source and destination areas, starting with the full tile.
     int src_x = 0;
     int src_y = 0;
@@ -449,7 +468,7 @@ bool GeoMap::draw_osm_file(int zoom, int tile_x, int tile_y, int relative_x, int
         return true;
     }
 
-    if (!bmp.is_loaded()) {
+    if (!bmp->is_loaded()) {
         // Draw an error rectangle using the calculated clipped dimensions
         ui::Rect error_rect{{dest_x + r.left(), dest_y + r.top()}, {clip_w, clip_h}};
         display.fill_rectangle(error_rect, Theme::getInstance()->bg_darkest->background);
@@ -458,20 +477,20 @@ bool GeoMap::draw_osm_file(int zoom, int tile_x, int tile_y, int relative_x, int
 
     map_line_buffer.resize(clip_w);
 
-    if (bmp.is_bottomup()) {
+    if (bmp->is_bottomup()) {
         for (int y = clip_h - 1; y >= 0; --y) {
             int source_row = src_y + y;
             int dest_row = dest_y + y;
-            bmp.seek(src_x, source_row);
-            bmp.read_next_px_cnt(map_line_buffer.data(), clip_w, false);
+            bmp->seek(src_x, source_row);
+            bmp->read_next_px_cnt(map_line_buffer.data(), clip_w, false);
             display.draw_pixels({dest_x + r.left(), dest_row + r.top(), clip_w, 1}, map_line_buffer);
         }
     } else {
         for (int y = 0; y < clip_h; ++y) {
             int source_row = src_y + y;
             int dest_row = dest_y + y;
-            bmp.seek(src_x, source_row);
-            bmp.read_next_px_cnt(map_line_buffer.data(), clip_w, false);
+            bmp->seek(src_x, source_row);
+            bmp->read_next_px_cnt(map_line_buffer.data(), clip_w, false);
             display.draw_pixels({dest_x + r.left(), dest_row + r.top(), clip_w, 1}, map_line_buffer);
         }
     }

--- a/firmware/application/ui/ui_geomap.hpp
+++ b/firmware/application/ui/ui_geomap.hpp
@@ -28,6 +28,7 @@
 #include "file.hpp"
 #include "ui_navigation.hpp"
 #include "bmpfile.hpp"
+#include "tile_cache.hpp"
 #include "mathdef.hpp"
 
 #include "portapack.hpp"
@@ -304,6 +305,8 @@ class GeoMap : public Widget {
     bool redraw_map{true};
     bool use_osm{false};
     bool has_osm{false};
+
+    ui::TileCache tile_cache_{};
 };
 
 class GeoMapView : public View {


### PR DESCRIPTION
### Summary

This change adds a small LRU cache for the OSM raster tile path used by ADS-B and other GeoMap consumers. It eliminates repeated expensive `BMPFile::open()` calls on cache hits while leaving behavior, APIs, and display output unchanged. The binary `world_map.bin` path is unaffected.

### The Problem

The current `draw_osm_file()` implementation (in `firmware/application/ui/ui_geomap.cpp`) constructs a fresh `BMPFile` and calls `open()` for every visible tile on every paint. Because iteration is tile-major, this means:

- Every paint walks the tile grid and calls `draw_osm_file()` once per tile.
- `BMPFile::open()` ultimately calls `File::open()` → FatFS `f_open()`, which performs a directory walk.
- For a typical viewport this is ~9 tiles per paint. Even when the same tiles were loaded a frame ago, the full open cost is paid again.

On SD cards this directory traversal is the dominant cost per tile. The result is unnecessary I/O on every redraw (marker updates, banner refreshes, slow panning, BIN/OSM toggles, etc.).

### The Fix

A 24-slot LRU cache (`firmware/application/ui/tile_cache.hpp` and `.cpp`) now holds live `BMPFile` instances keyed by `(zoom, tile_x, tile_y)`.

- `find(key)` returns a `BMPFile*` on hit — the caller uses the already-open handle directly.
- `insert_or_replace(key)` returns a slot pointer; the caller then calls `slot->bmp.open(path)`. The `BMPFile::open()` implementation already calls `close()` on any previous handle (bmpfile.cpp:98), so reuse is clean.
- The cache lives as a `GeoMap` member (`ui_geomap.hpp`). Its destructor calls `clear()` to release any open handles.
- Path string construction (`std::string`) is now lazy — it only happens on cache miss.

The integration lives entirely inside `draw_osm_file()`. The `paint()` loop is unchanged.

### Why 24 Slots

A 320×240 viewport needs roughly 9 visible tiles at any zoom. 24 slots gives ~2.5× headroom so short panning movements and small zoom steps stay warm without thrashing. This size was verified against the M4 RAM budget in prior analysis and fits comfortably as static storage.

### Why No Copy/Move of BMPFile

`File` (file.hpp:330-331) deletes its copy constructor. `BMPFile` therefore cannot be copied. The design avoids the issue entirely by default-constructing all slots in place at `TileCache` startup and mutating them via `open()` on miss. No copy or move of `BMPFile` ever occurs.

### What's NOT in This PR

- Cache pre-warm scan — natural warming during the first real paint is sufficient; can be revisited if profiling shows cold-paint stalls.
- Replacement of `map_line_buffer` `std::vector` with a static array — separate cleanup (matches PR1/PR2 style but orthogonal).
- Vector tile rendering path — longer-term R&D, not part of this raster-path improvement.
- Deep discussion of `BMPFile` destructor/copy semantics — kept in design notes, not the PR body.

### Testing

Tested on H4M + HackRF Pro (Praline board) running Mayhem n_260530 with a custom 32K cartographic OSM bin. Cache behavior verified by:
- Panning at fixed zoom (subsequent paints visibly faster once warm).
- Zoom in/out cycles (eviction works as expected).
- Removing a tile mid-session (open failure path correctly invalidates the slot and falls back to error rectangle).
