### PR TITLE
Gpio modify v3

### DIFF
--- a/firmware/application/clock_manager.cpp
+++ b/firmware/application/clock_manager.cpp
@@ -443,11 +443,6 @@ void ClockManager::portapack_tcxo_disable() {
 using namespace hackrf::one;
 
 void ClockManager::init_clock_generator() {
-    if (hackrf_r9) {
-        gpio_r9_mcu_clk_en.output();
-        gpio_r9_mcu_clk_en.write(1);
-    }
-
     clock_generator.reset();
     clock_generator.set_crystal_internal_load_capacitance(CrystalInternalLoadCapacitance::XTAL_CL_8pF);
     clock_generator.enable_fanout();
@@ -685,7 +680,7 @@ ClockManager::Reference ClockManager::choose_reference() {
     }
 #else
     if (hackrf_r9) {
-        gpio_r9_clkin_en.write(1);
+        gpio_control::r9_clkin_en.setActive();
         volatile uint32_t delay = 240000 + 24000;
         while (delay--);
     }
@@ -700,7 +695,7 @@ ClockManager::Reference ClockManager::choose_reference() {
     }
 
     if (hackrf_r9) {
-        gpio_r9_clkin_en.write(0);
+        gpio_control::r9_clkin_en.setInactive();
     }
 #endif
 
@@ -1187,8 +1182,7 @@ void ClockManager::enable_clock_output(bool enable) {
     }
 #else
     if (hackrf_r9) {
-        gpio_r9_clkout_en.output();
-        gpio_r9_clkout_en.write(enable);
+        gpio_control::r9_clkout_en.setState(enable);
 
         // NOTE: RETURNING HERE IF HACKRF_R9 TO PREVENT CLK2 FROM BEING DISABLED OR FREQ MODIFIED SINCE CLK2 ON R9 IS
         // USED FOR BOTH CLKOUT AND FOR THE MCU_CLOCK (== GP_CLKIN) WHICH OTHER LP43XX CLOCKS CURRENTLY RELY ON.

--- a/firmware/application/radio.cpp
+++ b/firmware/application/radio.cpp
@@ -151,10 +151,6 @@ void init() {
     /* PRALINE uses MAX2831 transceiver */
     second_if = (max283x::MAX283x*)&second_if_max2831;
 #else
-    if (hackrf_r9) {
-        gpio_r9_not_ant_pwr.write(1);
-        gpio_r9_not_ant_pwr.output();
-    }
     second_if = hackrf_r9
                     ? (max283x::MAX283x*)&second_if_max2839
                     : (max283x::MAX283x*)&second_if_max2837;
@@ -398,7 +394,7 @@ void set_antenna_bias(const bool on) {
     rf_path.set_ant_bias(on);
 #else
     if (hackrf_r9) {
-        gpio_r9_not_ant_pwr.write(on ? 0 : 1);
+        rf_path.set_ant_bias(on);
     } else {
         first_if.set_gpo1(on ? 0 : 1);
     }

--- a/firmware/application/rf_path.cpp
+++ b/firmware/application/rf_path.cpp
@@ -65,11 +65,13 @@ struct Config {
     bool amp_bypass_en;
     bool tx_amp_en;
     bool rx_amp_en;
+    bool ant_bias_en;
 
     constexpr Config(
         const Direction direction,
         const Band band,
-        const bool amplify)
+        const bool amplify,
+        const bool ant_bias)
         : tx(direction == Direction::Transmit),
           rx(direction == Direction::Receive),
           mix_bypass_en(band == Band::Mid),
@@ -79,7 +81,8 @@ struct Config {
           lpf_en(band == Band::Low),
           amp_bypass_en(!amplify),
           tx_amp_en((direction == Direction::Transmit) && amplify),
-          rx_amp_en((direction == Direction::Receive) && amplify) {
+          rx_amp_en((direction == Direction::Receive) && amplify),
+          ant_bias_en(ant_bias) {
     }
 
     void apply() const {
@@ -107,6 +110,7 @@ struct Config {
         tx_mix_bypass.setState(mix_bypass_en);
         tx_amp_pwr.setState(tx_amp_en);
         rx_amp_pwr.setState(rx_amp_en);
+        ant_bias.setState(ant_bias_en);
     }
 };
 
@@ -182,7 +186,7 @@ void Path::update() {
     config.apply();
 #else
     /* HackRF One RF path control - On the fly calculation */
-    Config config(direction, band, rf_amp);
+    Config config(direction, band, rf_amp, ant_bias);
     config.apply();
 #endif
 }

--- a/firmware/application/rf_path.cpp
+++ b/firmware/application/rf_path.cpp
@@ -68,10 +68,6 @@ bool Path::get_ant_bias() const {
 }
 
 void Path::update() {
-    /* 0 ^ 0 => 0 & 0 = 0 ^ 0 = 0 (no change)
-     * 0 ^ 1 => 1 & 0 = 0 ^ 0 = 0 (ignore change to 1)
-     * 1 ^ 0 => 1 & 1 = 1 ^ 1 = 0 (allow change to 0)
-     * 1 ^ 1 => 0 & 1 = 0 ^ 1 = 1 (no change) */
     const bool is_tx = (direction == Direction::Transmit);
 
 #ifdef PRALINE
@@ -125,7 +121,9 @@ void Path::update() {
     tx_amp_pwr.setState(is_tx && amplify);
     rx_amp_pwr.setState(is_rx && amplify);
 
-    ant_bias.setState(ant_bias_en);
+    if (hackrf_r9) {
+        ant_bias.setState(ant_bias_en);
+    }
 #endif
 }
 

--- a/firmware/application/rf_path.cpp
+++ b/firmware/application/rf_path.cpp
@@ -22,11 +22,8 @@
 #include "rf_path.hpp"
 #include "platform.hpp"
 
-#include <array>
-#include <initializer_list>
-
-#include "hackrf_gpio.hpp"
-using namespace hackrf::one;
+#include "gpio.hpp"
+using namespace gpio_control;
 
 #include "utility.hpp"
 
@@ -41,63 +38,33 @@ namespace {
  */
 struct PralineConfig {
     bool tx_en;
-    bool mix_bypass;  // RF path mixer bypass (GPIO3[2])
+    bool mix_bypass_en;  // RF path mixer bypass (GPIO3[2])
     bool lpf_en;
     bool rf_amp_en;
-    bool ant_bias_en_n;  // Inverted: 0 = bias enabled
+    bool ant_bias_en;
 
     void apply() const {
-        gpio_tx_enable.write(tx_en);
-        gpio_mix_bypass.write(mix_bypass);  // Control RF path mixer
-        gpio_lpf_enable.write(lpf_en);
-        gpio_rf_amp_enable.write(rf_amp_en);
-        gpio_ant_bias_disable.write(ant_bias_en_n);
+        tx_enable.setState(tx_en);
+        mix_bypass.setState(mix_bypass_en);
+        lpf.setState(lpf_en);
+        rf_amp_enable.setState(rf_amp_en);
+        ant_bias.setState(ant_bias_en);
     }
 };
-
 #else
-/* HackRF One uses 11 GPIOs for RF path control */
-using GPIOs = std::array<GPIO, 11>;
 
-/* TODO: ARM GCC 4.8 2014q3 doesn't like this array inside struct Config.
- * No idea why.
- */
-constexpr GPIOs gpios{
-    gpio_mix_bypass,
-    gpio_not_mix_bypass,
-    gpio_tx_mix_bp,
-    gpio_rx_mix_bp,
-    gpio_hp,
-    gpio_lp,
-    gpio_amp_bypass,
-    gpio_tx_amp,
-    gpio_not_tx_amp_pwr,
-    gpio_rx_amp,
-    gpio_not_rx_amp_pwr,
-};
-
-/* HackRF One Config struct - not used on PRALINE */
+/* HackRF One uses GPIOs for RF path control, simplified for PortaPack internal use */
 struct Config {
-    using base_type = uint16_t;
-
-    union {
-        struct {
-            bool tx : 1;
-            bool rx : 1;
-            bool mix_bypass : 1;
-            bool not_mix_bypass : 1;
-            bool tx_mix_bp : 1;
-            bool rx_mix_bp : 1;
-            bool hp : 1;
-            bool lp : 1;
-            bool amp_bypass : 1;
-            bool tx_amp : 1;
-            bool not_tx_amp : 1;
-            bool rx_amp : 1;
-            bool not_rx_amp : 1;
-        };
-        base_type w;
-    };
+    bool tx;
+    bool rx;
+    bool mix_bypass_en;
+    bool tx_mix_bp_en;
+    bool rx_mix_bp_en;
+    bool hpf_en;
+    bool lpf_en;
+    bool amp_bypass_en;
+    bool tx_amp_en;
+    bool rx_amp_en;
 
     constexpr Config(
         const Direction direction,
@@ -105,118 +72,44 @@ struct Config {
         const bool amplify)
         : tx(direction == Direction::Transmit),
           rx(direction == Direction::Receive),
-          mix_bypass(band == Band::Mid),
-          not_mix_bypass(band != Band::Mid),
-          tx_mix_bp((direction == Direction::Transmit) && (band == Band::Mid)),
-          rx_mix_bp((direction == Direction::Receive) && (band == Band::Mid)),
-          hp(band == Band::High),
-          lp(band == Band::Low),
-          amp_bypass(!amplify),
-          tx_amp((direction == Direction::Transmit) && amplify),
-          not_tx_amp(!tx_amp),
-          rx_amp((direction == Direction::Receive) && amplify),
-          not_rx_amp(!rx_amp) {
-    }
-
-    constexpr Config()
-        : Config(Direction::Receive, Band::Mid, false) {
-    }
-
-    constexpr Config(
-        const base_type w)
-        : w(w) {
-    }
-
-    constexpr Config operator^(const Config& r) const {
-        return w ^ r.w;
-    }
-
-    constexpr Config operator&(const Config& r) const {
-        return w & r.w;
-    }
-
-    constexpr bool operator[](const size_t n) const {
-        return (w >> n) & 1;
-    }
-
-    static void gpio_init() {
-        if (hackrf_r9) {
-            gpio_r9_rx.output();
-        } else {
-            gpio_og_tx.output();
-            gpio_og_rx.output();
-        }
-        for (auto gpio : gpios) {
-            gpio.output();
-        }
+          mix_bypass_en(band == Band::Mid),
+          tx_mix_bp_en((direction == Direction::Transmit) && (band == Band::Mid)),
+          rx_mix_bp_en((direction == Direction::Receive) && (band == Band::Mid)),
+          hpf_en(band == Band::High),
+          lpf_en(band == Band::Low),
+          amp_bypass_en(!amplify),
+          tx_amp_en((direction == Direction::Transmit) && amplify),
+          rx_amp_en((direction == Direction::Receive) && amplify) {
     }
 
     void apply() const {
-        /* NOTE: Assumes order in gpios[] and Config bitfield match,
-         * after the 'tx' and 'rx' fields which are handled specially. */
-        for (size_t n = 0; n < gpios.size() + 2; n++) {
-            bool value = (*this)[n];
-            switch (n) {
-                case 0:
-                    if (!hackrf_r9) {
-                        gpio_og_tx.write(value);
-                    }
-                    break;
-                case 1:
-                    if (hackrf_r9) {
-                        gpio_r9_rx.write(value);
-                    } else {
-                        gpio_og_rx.write(value);
-                    }
-                    break;
-                default:
-                    gpios[n - 2].write(value);
-                    break;
-            }
+        // TX/RX primary switches
+        if (!hackrf_r9) {
+            og_tx.setState(tx);
         }
+
+        if (hackrf_r9) {
+            r9_rx.setState(rx);
+        } else {
+            og_rx.setState(rx);
+        }
+
+        // Apply primary RF path states
+        rx_mix_bypass.setState(mix_bypass_en);
+        tx_mix_bp.setState(tx_mix_bp_en);
+        rx_mix_bp.setState(rx_mix_bp_en);
+        hpf.setState(hpf_en);
+        lpf.setState(lpf_en);
+        amp_bypass.setState(amp_bypass_en);
+        tx_amp.setState(tx_amp_en);
+        rx_amp.setState(rx_amp_en);
+
+        tx_mix_bypass.setState(mix_bypass_en);
+        tx_amp_pwr.setState(tx_amp_en);
+        rx_amp_pwr.setState(rx_amp_en);
     }
 };
 
-/* HackRF One config table - not used on PRALINE */
-using ConfigAmp = std::array<Config, 2>;
-using ConfigDirection = std::array<ConfigAmp, 2>;
-using ConfigBand = std::array<ConfigDirection, 3>;
-
-constexpr ConfigAmp config_amp(
-    const Direction direction,
-    const Band band) {
-    return {{
-        Config(direction, band, false),
-        Config(direction, band, true),
-    }};
-}
-
-constexpr ConfigDirection config_rx_tx(
-    const Band band) {
-    return {
-        config_amp(Direction::Receive, band),
-        config_amp(Direction::Transmit, band),
-    };
-}
-
-constexpr ConfigBand config_band() {
-    return {
-        config_rx_tx(Band::Low),
-        config_rx_tx(Band::Mid),
-        config_rx_tx(Band::High),
-    };
-}
-
-constexpr ConfigBand config_table = config_band();
-
-static_assert(sizeof(config_table) == sizeof(Config::base_type) * 3 * 2 * 2, "rf path config table unexpected size");
-
-constexpr Config get_config(
-    const Direction direction,
-    const Band band,
-    const bool amplify) {
-    return config_table[toUType(band)][toUType(direction)][amplify ? 1 : 0];
-}
 #endif /* PRALINE */
 
 } /* namespace */
@@ -226,15 +119,13 @@ void Path::init() {
     /* Set safe initial state: RX mode, mixer enabled, LPF on, amp off, no bias */
     PralineConfig config = {
         .tx_en = false,
-        .mix_bypass = false,   // RF path mixer bypass (GPIO3[2])
-        .lpf_en = true,        // LPF on for low band
-        .rf_amp_en = false,    // Amp off
-        .ant_bias_en_n = true  // Bias off (inverted)
-    };
+        .mix_bypass_en = true,
+        .lpf_en = true,
+        .rf_amp_en = false,
+        .ant_bias_en = false};
     config.apply();
 #else
     update();
-    Config::gpio_init();
 #endif
 }
 
@@ -268,47 +159,30 @@ void Path::update() {
      * 0 ^ 1 => 1 & 0 = 0 ^ 0 = 0 (ignore change to 1)
      * 1 ^ 0 => 1 & 1 = 1 ^ 1 = 0 (allow change to 0)
      * 1 ^ 1 => 0 & 1 = 0 ^ 1 = 1 (no change) */
-
 #ifdef PRALINE
     /* PRALINE RF path control:
      * - tx_en: 1 for TX, 0 for RX
-     * - mix_bypass: 0 to enable RF path mixer bypass (GPIO3[2])
+     * - mix_bypass: 1 to enable RF path mixer bypass (GPIO3[2])
      * - lpf_en: 1 for low band (< 2.4 GHz), 0 for high band
      * - rf_amp_en: 1 to enable RF amplifier
-     * - ant_bias_en_n: 0 to enable antenna bias (inverted)
      */
-    // const Config changed = _config ^ config_next;
-    // const Config turned_off = _config & changed;
 
     PralineConfig config;
 
-    /* In transition, ignore the bits that are turning on. So this transition phase
-     * only turns off signals. It doesn't turn on signals.
-     */
-    // const Config transition_config = _config ^ turned_off;
-    // update_signals(transition_config);
-
     config.tx_en = (direction == Direction::Transmit);
 
-    // RF path mixer bypass: 0=enabled, 1=bypassed
-    config.mix_bypass = (band == Band::Mid);
-
-    /* Move to the final state by turning on required signals. */
-    /* LPF for low band */
+    /* BUGFIX: PRALINE enables mixer on Low band! */
+    config.mix_bypass_en = (band == Band::Low);
 
     config.lpf_en = (band == Band::Low);
-
-    /* RF amp when amplification requested */
     config.rf_amp_en = rf_amp;
 
-    /* Antenna bias */
-    config.ant_bias_en_n = !ant_bias;
+    config.ant_bias_en = ant_bias;
 
     config.apply();
-
 #else
-    /* HackRF One RF path control */
-    const auto config = get_config(direction, band, rf_amp);
+    /* HackRF One RF path control - On the fly calculation */
+    Config config(direction, band, rf_amp);
     config.apply();
 #endif
 }

--- a/firmware/application/rf_path.cpp
+++ b/firmware/application/rf_path.cpp
@@ -21,116 +21,26 @@
 
 #include "rf_path.hpp"
 #include "platform.hpp"
-
+#include "utility.hpp"
 #include "gpio.hpp"
 using namespace gpio_control;
-
-#include "utility.hpp"
 
 namespace rf {
 namespace path {
 
-namespace {
-
-#ifdef PRALINE
-/* PRALINE uses a simplified RF path with only 5 control signals.
- * The RF path architecture is completely different from HackRF One.
- */
-struct PralineConfig {
-    bool tx_en;
-    bool mix_bypass_en;  // RF path mixer bypass (GPIO3[2])
-    bool lpf_en;
-    bool rf_amp_en;
-    bool ant_bias_en;
-
-    void apply() const {
-        tx_enable.setState(tx_en);
-        mix_bypass.setState(mix_bypass_en);
-        lpf.setState(lpf_en);
-        rf_amp_enable.setState(rf_amp_en);
-        ant_bias.setState(ant_bias_en);
-    }
-};
-#else
-
-/* HackRF One uses GPIOs for RF path control, simplified for PortaPack internal use */
-struct Config {
-    bool tx;
-    bool rx;
-    bool mix_bypass_en;
-    bool tx_mix_bp_en;
-    bool rx_mix_bp_en;
-    bool hpf_en;
-    bool lpf_en;
-    bool amp_bypass_en;
-    bool tx_amp_en;
-    bool rx_amp_en;
-    bool ant_bias_en;
-
-    constexpr Config(
-        const Direction direction,
-        const Band band,
-        const bool amplify,
-        const bool ant_bias)
-        : tx(direction == Direction::Transmit),
-          rx(direction == Direction::Receive),
-          mix_bypass_en(band == Band::Mid),
-          tx_mix_bp_en((direction == Direction::Transmit) && (band == Band::Mid)),
-          rx_mix_bp_en((direction == Direction::Receive) && (band == Band::Mid)),
-          hpf_en(band == Band::High),
-          lpf_en(band == Band::Low),
-          amp_bypass_en(!amplify),
-          tx_amp_en((direction == Direction::Transmit) && amplify),
-          rx_amp_en((direction == Direction::Receive) && amplify),
-          ant_bias_en(ant_bias) {
-    }
-
-    void apply() const {
-        // TX/RX primary switches
-        if (!hackrf_r9) {
-            og_tx.setState(tx);
-        }
-
-        if (hackrf_r9) {
-            r9_rx.setState(rx);
-        } else {
-            og_rx.setState(rx);
-        }
-
-        // Apply primary RF path states
-        rx_mix_bypass.setState(mix_bypass_en);
-        tx_mix_bp.setState(tx_mix_bp_en);
-        rx_mix_bp.setState(rx_mix_bp_en);
-        hpf.setState(hpf_en);
-        lpf.setState(lpf_en);
-        amp_bypass.setState(amp_bypass_en);
-        tx_amp.setState(tx_amp_en);
-        rx_amp.setState(rx_amp_en);
-
-        tx_mix_bypass.setState(mix_bypass_en);
-        tx_amp_pwr.setState(tx_amp_en);
-        rx_amp_pwr.setState(rx_amp_en);
-        ant_bias.setState(ant_bias_en);
-    }
-};
-
-#endif /* PRALINE */
-
-} /* namespace */
-
 void Path::init() {
+    /* Set safe initial default states */
+    direction = Direction::Receive;
+    rf_amp_en = false;
+    ant_bias_en = false;
+
 #ifdef PRALINE
-    /* Set safe initial state: RX mode, mixer enabled, LPF on, amp off, no bias */
-    PralineConfig config = {
-        .tx_en = false,
-        .mix_bypass_en = true,
-        .lpf_en = true,
-        .rf_amp_en = false,
-        .ant_bias_en = false};
-    config.apply();
+    band = Band::Low;
 #else
-    update();
+    band = Band::Mid;
 #endif
+
+    update();
 }
 
 void Path::set_direction(const Direction new_direction) {
@@ -140,22 +50,21 @@ void Path::set_direction(const Direction new_direction) {
 
 void Path::set_band(const Band new_band) {
     band = new_band;
-    _band = new_band;
     update();
 }
 
 void Path::set_rf_amp(const bool new_rf_amp) {
-    rf_amp = new_rf_amp;
+    rf_amp_en = new_rf_amp;
     update();
 }
 
 void Path::set_ant_bias(const bool new_ant_bias) {
-    ant_bias = new_ant_bias;
+    ant_bias_en = new_ant_bias;
     update();
 }
 
 bool Path::get_ant_bias() const {
-    return ant_bias;
+    return ant_bias_en;
 }
 
 void Path::update() {
@@ -163,31 +72,60 @@ void Path::update() {
      * 0 ^ 1 => 1 & 0 = 0 ^ 0 = 0 (ignore change to 1)
      * 1 ^ 0 => 1 & 1 = 1 ^ 1 = 0 (allow change to 0)
      * 1 ^ 1 => 0 & 1 = 0 ^ 1 = 1 (no change) */
+    const bool is_tx = (direction == Direction::Transmit);
+
 #ifdef PRALINE
-    /* PRALINE RF path control:
-     * - tx_en: 1 for TX, 0 for RX
-     * - mix_bypass: 1 to enable RF path mixer bypass (GPIO3[2])
-     * - lpf_en: 1 for low band (< 2.4 GHz), 0 for high band
-     * - rf_amp_en: 1 to enable RF amplifier
-     */
+    // PRALINE specific RF path control directly applied to pins.
+    // Active-low pin inversion is handled internally inside setState().
 
-    PralineConfig config;
+    tx_enable.setState(is_tx);
 
-    config.tx_en = (direction == Direction::Transmit);
+    // On the PRALINE board, the mixer is used ONLY on the Low band.
+    // Since setState() internally handles the active-low (MIX_ENABLE_N) hardware inversion,
+    // we simply pass 'true' to enable the mixer on Low band, and 'false' for Mid/High bands.
 
-    /* BUGFIX: PRALINE enables mixer on Low band! */
-    config.mix_bypass_en = (band == Band::Low);
+    mix_bypass.setState(band == Band::Low);
 
-    config.lpf_en = (band == Band::Low);
-    config.rf_amp_en = rf_amp;
+    lpf.setState(band == Band::Low);
+    rf_amp_enable.setState(rf_amp_en);
+    ant_bias.setState(ant_bias_en);
 
-    config.ant_bias_en = ant_bias;
-
-    config.apply();
 #else
-    /* HackRF One RF path control - On the fly calculation */
-    Config config(direction, band, rf_amp, ant_bias);
-    config.apply();
+
+    const bool is_rx = (direction == Direction::Receive);
+
+    // HackRF One (OG & R9) RF path control
+    const bool mix_bypass_en = (band == Band::Mid);
+    const bool amplify = rf_amp_en;
+
+    // Primary TX/RX routing switches
+    if (!hackrf_r9) {
+        og_tx.setState(is_tx);
+    }
+
+    if (hackrf_r9) {
+        r9_rx.setState(is_rx);  // Single pin handles directional switching on R9
+    } else {
+        og_rx.setState(is_rx);
+    }
+
+    // RF path switch configuration matrix
+    rx_mix_bypass.setState(mix_bypass_en);
+    tx_mix_bp.setState(is_tx && mix_bypass_en);
+    rx_mix_bp.setState(is_rx && mix_bypass_en);
+
+    hpf.setState(band == Band::High);
+    lpf.setState(band == Band::Low);
+
+    amp_bypass.setState(!amplify);
+    tx_amp.setState(is_tx && amplify);
+    rx_amp.setState(is_rx && amplify);
+
+    tx_mix_bypass.setState(mix_bypass_en);
+    tx_amp_pwr.setState(is_tx && amplify);
+    rx_amp_pwr.setState(is_rx && amplify);
+
+    ant_bias.setState(ant_bias_en);
 #endif
 }
 

--- a/firmware/application/rf_path.hpp
+++ b/firmware/application/rf_path.hpp
@@ -41,13 +41,13 @@ namespace path {
 
 #ifdef PRALINE
 /* PRALINE: MAX2831 direct path is 2320-2740 MHz */
-constexpr Frequency MAX2831_TRANSITION = 2320'000'000;
+constexpr Frequency TRANSITION = 2320'000'000;
 #else
 /* HackRF One: Original band boundaries */
-constexpr Frequency MAX2831_TRANSITION = 2170'000'000;
+constexpr Frequency TRANSITION = 2170'000'000;
 #endif
 
-constexpr FrequencyRange band_low{0, MAX2831_TRANSITION};
+constexpr FrequencyRange band_low{0, TRANSITION};
 constexpr FrequencyRange band_high{2740'000'000, 7250'000'000};
 constexpr FrequencyRange band_mid{band_low.maximum, band_high.minimum};
 

--- a/firmware/application/rf_path.hpp
+++ b/firmware/application/rf_path.hpp
@@ -41,15 +41,15 @@ namespace path {
 
 #ifdef PRALINE
 /* PRALINE: MAX2831 direct path is 2320-2740 MHz */
-constexpr FrequencyRange band_low{0, 2320'000'000};
-constexpr FrequencyRange band_high{2740'000'000, 7250'000'000};
-constexpr FrequencyRange band_mid{band_low.maximum, band_high.minimum};
+constexpr Frequency MAX2831_TRANSITION = 2320'000'000;
 #else
 /* HackRF One: Original band boundaries */
-constexpr FrequencyRange band_low{0, 2170'000'000};
+constexpr Frequency MAX2831_TRANSITION = 2170'000'000;
+#endif
+
+constexpr FrequencyRange band_low{0, MAX2831_TRANSITION};
 constexpr FrequencyRange band_high{2740'000'000, 7250'000'000};
 constexpr FrequencyRange band_mid{band_low.maximum, band_high.minimum};
-#endif
 
 enum class Band {
     /* Zero-based, used as index into frequency_bands table */
@@ -61,23 +61,20 @@ enum class Band {
 class Path {
    public:
     void init();
-
     void set_direction(const Direction direction);
     void set_band(const Band band);
     void set_rf_amp(const bool rf_amp);
     void set_ant_bias(const bool ant_bias);
     bool get_ant_bias() const;
-    Band get_band() const { return _band; }  //_band is used solely for debugging purposes.
+    Band get_band() const { return band; }
 
    private:
     Direction direction{Direction::Receive};
     Band band{Band::Mid};
-    bool rf_amp{false};
-    bool ant_bias{false};
+    bool rf_amp_en{false};
+    bool ant_bias_en{false};
 
     void update();
-
-    Band _band{Band::Mid};  //_band is solely used of debugging purposes
 };
 
 }  // namespace path

--- a/firmware/chibios-portapack/boards/PORTAPACK_APPLICATION/board.cpp
+++ b/firmware/chibios-portapack/boards/PORTAPACK_APPLICATION/board.cpp
@@ -70,8 +70,6 @@ const PALConfig pal_default_config = {
               | boot_bit(sgpio_12, 0)    // P1_18: SGPIO12, HOST_Q_INVERT
               | boot_bit(sgpio_11, 0)    // P1_17: SGPIO11, HOST_DIRECTION, Praline: FPGA HOST_DIRECTION
               | (1 << 10)                // P1_3:  SSP1_MISO
-              | (0 << 9)                 // P1_2:  Varies by revision, float until detection
-              | (0 << 8)                 // P1_1:  Varies by revision, float until detection
               | (0 << 6)                 // P3_6:  SPIFI_MISO
               | boot_bit(sgpio_5, 1)     // P6_6:  SGPIO5, HOST_DATA5, Praline: FPGA HOST_DATA5
               | boot_bit(sgpio_7, 1)     // P1_0:  SGPIO7, HOST_DATA7, Praline: FPGA HOST_DATA7
@@ -175,9 +173,9 @@ const PALConfig pal_default_config = {
                     | (1 << 13)               // P5_4:  MIXER_ENX, 10K PU
                     | boot_bit(rx_mix_bp, 1)  // P5_3:  RX_MIX_BP
                     | boot_bit(tx_mix_bp, 0)  // P5_2:  TX_MIX_BP
-                    | boot_bit(lpf, 0)        // P5_1:  LP
+                    | boot_bit(lpf, 0)        // P5_1:  LPF
                     | (0 << 9)                // P5_0:  Varies by revision
-                    | boot_bit(hpf, 0)        // P4_0:  HP
+                    | boot_bit(hpf, 0)        // P4_0:  HPF
                     | boot_bit(sgpio_9, 1)    // P4_3:  SGPIO9, HOST_CAPTURE
                     | (0 << 6)                // P4_6:  XCVR_EN, 10K PD
                     | boot_bit(led_tx, 0)     // P6_12: LED3 (TX)
@@ -207,7 +205,7 @@ const PALConfig pal_default_config = {
                 | boot_bit(tx_mix_bp, 1)  // P5_2:  TX_MIX_BP
                 | boot_bit(lpf, 1)        // P5_1:  LPF
                 | (0 << 9)                // P5_0:  Varies by revision
-                | boot_bit(hpf, 1)        // P4_0:  HP
+                | boot_bit(hpf, 1)        // P4_0:  HPF
                 | boot_bit(sgpio_9, 0)    // P4_3:  SGPIO9, HOST_CAPTURE
                 | (1 << 6)                // P4_6:  XCVR_EN, 10K PD
 #endif
@@ -565,8 +563,7 @@ const PALConfig pal_default_config = {
         {11, 2, scu_config_normal_drive_t{.mode = 4, .epd = 1, .epun = 1, .ehs = 0, .ezi = 1, .zif = 0}},  // PB_2: Unused IN
         {11, 4, scu_config_normal_drive_t{.mode = 4, .epd = 1, .epun = 1, .ehs = 0, .ezi = 1, .zif = 0}},  // PB_4: Unused IN
 #else
-        {map_og_rx.scu_port, map_og_rx.scu_pin, scu_config_normal_drive_t{.mode = map_og_rx.gpio_mode, .epd = 0, .epun = 1, .ehs = 0, .ezi = 0, .zif = 0}},  // P2_5
-        {4, 8, scu_config_normal_drive_t{.mode = 0, .epd = 0, .epun = 1, .ehs = 0, .ezi = 0, .zif = 0}},                                                     // P4_8
+        {4, 8, scu_config_normal_drive_t{.mode = 0, .epd = 0, .epun = 1, .ehs = 0, .ezi = 0, .zif = 0}},  // P4_8
 #endif
 
         // PORTAPACK SPECIFIC & JTAG (CPLD, UI, Audio, SD)
@@ -677,17 +674,17 @@ static const std::array<gpio_setup_t, 6> gpio_setup_r9{{
 }};
 
 /* Additional SCU configuration for HackRF OG */
-static const std::array<scu_setup_t, 6> pins_setup_og{{
+static const std::array<scu_setup_t, 7> pins_setup_og{{
 
     /* Power control */
     {map_og_VAA_en.scu_port, map_og_VAA_en.scu_pin, scu_config_normal_drive_t{.mode = map_og_VAA_en.gpio_mode, .epd = 0, .epun = 1, .ehs = 0, .ezi = 0, .zif = 0}}, /* !VAA_ENABLE: 10K PU, Q3.G(I), power to VAA */
     {map_og_1v8_en.scu_port, map_og_1v8_en.scu_pin, scu_config_normal_drive_t{.mode = map_og_1v8_en.gpio_mode, .epd = 0, .epun = 1, .ehs = 0, .ezi = 0, .zif = 0}}, /* EN1V8/P70: 10K PD, TPS62410.EN2(I), 1V8LED.A(I) */
 
     /* Radio section control */
-    {2, 5, scu_config_normal_drive_t{.mode = 4, .epd = 0, .epun = 1, .ehs = 0, .ezi = 0, .zif = 0}},                                                    /* RX/P43: U7.VCTL1(I), U10.VCTL1(I), U2.VCTL1(I) */
-    {4, 4, scu_config_normal_drive_t{.mode = 0, .epd = 0, .epun = 1, .ehs = 0, .ezi = 0, .zif = 0}},                                                    /* TXENABLE/P55: MAX2837.TXENABLE(I) */
-    {map_og_tx.scu_port, map_og_tx.scu_pin, scu_config_normal_drive_t{.mode = map_og_tx.gpio_mode, .epd = 0, .epun = 1, .ehs = 0, .ezi = 0, .zif = 0}}, /* TX/P42: U7.VCTL2(I), U10.VCTL2(I), U2.VCTL2(I) */
-
+    {2, 5, scu_config_normal_drive_t{.mode = 4, .epd = 0, .epun = 1, .ehs = 0, .ezi = 0, .zif = 0}},                                                     /* RX/P43: U7.VCTL1(I), U10.VCTL1(I), U2.VCTL1(I) */
+    {4, 4, scu_config_normal_drive_t{.mode = 0, .epd = 0, .epun = 1, .ehs = 0, .ezi = 0, .zif = 0}},                                                     /* TXENABLE/P55: MAX2837.TXENABLE(I) */
+    {map_og_tx.scu_port, map_og_tx.scu_pin, scu_config_normal_drive_t{.mode = map_og_tx.gpio_mode, .epd = 0, .epun = 1, .ehs = 0, .ezi = 0, .zif = 0}},  /* TX/P42: U7.VCTL2(I), U10.VCTL2(I), U2.VCTL2(I) */
+    {map_og_rx.scu_port, map_og_rx.scu_pin, scu_config_normal_drive_t{.mode = map_og_rx.gpio_mode, .epd = 0, .epun = 1, .ehs = 0, .ezi = 0, .zif = 0}},  // P2_5
     /* SGPIO for sample transfer interface to HackRF CPLD. */
     {map_sgpio_13.scu_port, map_sgpio_13.scu_pin, scu_config_normal_drive_t{.mode = map_sgpio_13.gpio_mode, .epd = 1, .epun = 1, .ehs = 0, .ezi = 0, .zif = 0}}, /* SGPIO13/BANK2F3M2: CPLD.90/HOST_SYNC_EN(I) */
 }};

--- a/firmware/chibios-portapack/boards/PORTAPACK_APPLICATION/board.cpp
+++ b/firmware/chibios-portapack/boards/PORTAPACK_APPLICATION/board.cpp
@@ -63,8 +63,8 @@ const PALConfig pal_default_config = {
               | boot_bit(p1_ctrl0, 0)    // P2_10: P1_CTRL0, start low
               | boot_bit(clkin_ctrl, 0)  // P1_20: CLKIN_CTRL - start low
 #else
-            = (1 << 14)    // P2_10: AMP_BYPASS
-              | (1 << 15)  // P1_20: CS_XCVR
+            = boot_bit(amp_bypass, 1)  // P2_10: AMP_BYPASS
+              | (1 << 15)              // P1_20: CS_XCVR
 #endif
               | (1 << 11)              // P1_4:  SSP1_MOSI
               | boot_bit(sgpio_12, 0)  // P1_18: SGPIO12, HOST_Q_INVERT
@@ -72,7 +72,6 @@ const PALConfig pal_default_config = {
               | (1 << 10)              // P1_3:  SSP1_MISO
               | (0 << 9)               // P1_2:  Varies by revision, float until detection
               | (0 << 8)               // P1_1:  Varies by revision, float until detection
-              | (0 << 7)               // P2_7:  Varies by revision, float until detection
               | (0 << 6)               // P3_6:  SPIFI_MISO
               | boot_bit(sgpio_5, 1)   // P6_6:  SGPIO5, HOST_DATA5, Praline: FPGA HOST_DATA5
               | boot_bit(sgpio_7, 1)   // P1_0:  SGPIO7, HOST_DATA7, Praline: FPGA HOST_DATA7
@@ -89,8 +88,8 @@ const PALConfig pal_default_config = {
               | boot_bit(p1_ctrl0, 1)    // P2_10: P1_CTRL0
               | boot_bit(clkin_ctrl, 1)  // P1_20: CLKIN_CTRL
 #else
-            = (1 << 14)    // P2_10: AMP_BYPASS
-              | (1 << 15)  // P1_20: CS_XCVR
+            = boot_bit(amp_bypass, 1)  // P2_10: AMP_BYPASS
+              | (1 << 15)              // P1_20: CS_XCVR
 #endif
               | (0 << 11)              // P1_4:  SSP1_MOSI
               | boot_bit(sgpio_12, 1)  // P1_18: SGPIO12, HOST_Q_INVERT
@@ -98,7 +97,6 @@ const PALConfig pal_default_config = {
               | (0 << 10)              // P1_3:  SSP1_MISO
               | (0 << 9)               // P1_2:  Varies by revision, float until detection
               | (0 << 8)               // P1_1:  Varies by revision, float until detection
-              | (0 << 7)               // P2_7:  Varies by revision, float until detection
               | (0 << 6)               // P3_6:  SPIFI_MISO
               | boot_bit(sgpio_5, 1)   // P6_6:  SGPIO5, HOST_DATA5
               | boot_bit(sgpio_7, 1)   // P1_0:  SGPIO7, HOST_DATA7
@@ -113,15 +111,15 @@ const PALConfig pal_default_config = {
                     | (1 << 14)  // P3_4:  SPIFI_SIO3
                     | (1 << 13)  // P2_13: PortaPack DIR
 #ifdef PRALINE
-                    | (1 << 12)           // P2_12: BIAS_EN
-                    | (0 << 11)           // P2_11: BIAS_OC
-                    | boot_bit(aa_en, 0)  // P1_14: AA_EN
-                    | (0 << 0)            // P1_7:  Output GND
+                    | boot_bit(ant_bias, 1)  // P2_12: !BIAS_EN
+                    | (0 << 11)              // P2_11: BIAS_OC
+                    | boot_bit(aa_en, 0)     // P1_14: AA_EN
+                    | (0 << 0)               // P1_7:  Output GND
 #else
-                    | (1 << 12)              // P2_12: !RX_AMP_PWR
-                    | (0 << 11)              // P2_11: RX_AMP
-                    | boot_bit(sgpio_10, 1)  // P1_14: SGPIO10, HOST_DISABLE
-                    | (0 << 0)               // P1_7:  !MIX_BYPASS
+                    | boot_bit(rx_amp_pwr, 1)     // P2_12: !RX_AMP_PWR
+                    | boot_bit(rx_amp, 0)         // P2_11: RX_AMP
+                    | boot_bit(sgpio_10, 1)       // P1_14: SGPIO10, HOST_DISABLE
+                    | boot_bit(tx_mix_bypass, 1)  // P1_7:  !TX MIX BYPASS
 #endif
                     | (0 << 10)  // P2_9:  10K PD, BOOT3, PortaPack LCD_WRX
                     | (1 << 9)   // P1_6:  SD_CMD
@@ -137,15 +135,15 @@ const PALConfig pal_default_config = {
                    | (0 << 14)  // P3_4:  SPIFI_SIO3
                    | (1 << 13)  // P2_13: PortaPack DIR
 #ifdef PRALINE
-                   | (1 << 12)           // P2_12: !BIAS_EN
-                   | (0 << 11)           // P2_11: BIAS_OC
-                   | boot_bit(aa_en, 1)  // P1_14: AA_EN
-                   | (1 << 0)            // P1_7:  Output
+                   | boot_bit(ant_bias, 1)  // P2_12: !BIAS_EN
+                   | (0 << 11)              // P2_11: BIAS_OC
+                   | boot_bit(aa_en, 1)     // P1_14: AA_EN
+                   | (1 << 0)               // P1_7:  Output
 #else
-                   | (1 << 12)              // P2_12: !RX_AMP_PWR
-                   | (1 << 11)              // P2_11: RX_AMP
-                   | boot_bit(sgpio_10, 0)  // P1_14: SGPIO10, HOST_DISABLE
-                   | (1 << 0)               // P1_7:  !MIX_BYPASS
+                   | boot_bit(rx_amp_pwr, 1)     // P2_12: !RX_AMP_PWR
+                   | boot_bit(rx_amp, 1)         // P2_11: RX_AMP
+                   | boot_bit(sgpio_10, 0)       // P1_14: SGPIO10, HOST_DISABLE
+                   | boot_bit(tx_mix_bypass, 1)  // P1_7:  !TX MIX BYPASS
 #endif
                    | (1 << 10)  // P2_9:  10K PD, BOOT3, PortaPack LCD_WRX
                    | (0 << 9)   // P1_6:  SD_CMD
@@ -159,9 +157,9 @@ const PALConfig pal_default_config = {
         },
         {
             // GPIO2
-            .data = (0 << 15)    // P5_6:  TX_AMP, unused on PRALINE
-                    | (1 << 14)  // P5_5:  MIXER_RESETX, 10K PU
+            .data = (1 << 14)  // P5_5:  MIXER_RESETX, 10K PU
 #ifdef PRALINE
+                    | (0 << 15)             // P5_6:  unused on PRALINE
                     | (1 << 13)             // P5_4:  RFFC5072 ENX
                     | (0 << 12)             // P5_3:  unused on PRALINE
                     | (0 << 11)             // P5_2:  FPGA_CRESET
@@ -175,51 +173,52 @@ const PALConfig pal_default_config = {
                     | boot_bit(led_rx, 1)   // P4_2:  LED2 (RX)
                     | boot_bit(led_usb, 1)  // P4_1:  LED1 (USB)
 #else
-                    | (1 << 13)             // P5_4:  MIXER_ENX, 10K PU
-                    | (1 << 12)             // P5_3:  RX_MIX_BP
-                    | (0 << 11)             // P5_2:  TX_MIX_BP
-                    | (0 << 10)             // P5_1:  LP
-                    | (0 << 4)              // P4_4:  Varies by revision
-                    | (0 << 9)              // P5_0:  Varies by revision
-                    | (1 << 0)              // P4_0:  HP
-                    | boot_bit(sgpio_9, 1)  // P4_3:  SGPIO9, HOST_CAPTURE
-                    | (0 << 6)              // P4_6:  XCVR_EN, 10K PD
-                    | boot_bit(led_tx, 0)   // P6_12: LED3 (TX)
-                    | boot_bit(led_rx, 0)   // P4_2:  LED2 (RX)
-                    | boot_bit(led_usb, 0)  // P4_1:  LED1 (USB)
+                    | boot_bit(tx_amp, 1)     // P5_6:  TX_AMP
+                    | (1 << 13)               // P5_4:  MIXER_ENX, 10K PU
+                    | boot_bit(rx_mix_bp, 1)  // P5_3:  RX_MIX_BP
+                    | boot_bit(tx_mix_bp, 0)  // P5_2:  TX_MIX_BP
+                    | boot_bit(lpf, 0)        // P5_1:  LP
+                    | (0 << 9)                // P5_0:  Varies by revision
+                    | boot_bit(hpf, 0)        // P4_0:  HP
+                    | boot_bit(sgpio_9, 1)    // P4_3:  SGPIO9, HOST_CAPTURE
+                    | (0 << 6)                // P4_6:  XCVR_EN, 10K PD
+                    | boot_bit(led_tx, 0)     // P6_12: LED3 (TX)
+                    | boot_bit(led_rx, 0)     // P4_2:  LED2 (RX)
+                    | boot_bit(led_usb, 0)    // P4_1:  LED1 (USB)
 #endif
 
                     | (1 << 7)  // P5_7:  CS_AD
                     | (0 << 5)  // P4_5:  RXENABLE
             ,
-            .dir = (1 << 15)  // P5_6:  TX_AMP, unused on PRALINE
+            .dir =
 #ifdef PRALINE
-                   | (1 << 13)  // P5_4:  RFFC5072 ENX
-                   | (1 << 12)  // P5_3:  unused on PRALINE
-                   | (1 << 11)  // P5_2:  FPGA_CRESET
-                   | (1 << 10)  // P5_1:  FPGA_SPI_CS
-                   | (1 << 4)   // P4_4:  unused on PRALINE
-                   | (1 << 9)   // P5_0:  unused on PRALINE
-                   | (1 << 0)   // P4_0:  unused on PRALINE
-                   | (0 << 3)   // P4_3:  VBUSCTRL input
-                   | (0 << 6)   // P4_6:  Input
+                (1 << 15)    // P5_6:  unused on PRALINE
+                | (1 << 13)  // P5_4:  RFFC5072 ENX
+                | (1 << 12)  // P5_3:  unused on PRALINE
+                | (1 << 11)  // P5_2:  FPGA_CRESET
+                | (1 << 10)  // P5_1:  FPGA_SPI_CS
+                | (1 << 4)   // P4_4:  unused on PRALINE
+                | (1 << 9)   // P5_0:  unused on PRALINE
+                | (1 << 0)   // P4_0:  unused on PRALINE
+                | (0 << 3)   // P4_3:  VBUSCTRL input
+                | (0 << 6)   // P4_6:  Input
 #else
-                   | (1 << 13)             // P5_4:  MIXER_ENX, 10K PU
-                   | (1 << 12)             // P5_3:  RX_MIX_BP
-                   | (1 << 11)             // P5_2:  TX_MIX_BP
-                   | (1 << 10)             // P5_1:  LP
-                   | (0 << 4)              // P4_4:  Varies by revision
-                   | (0 << 9)              // P5_0:  Varies by revision
-                   | (1 << 0)              // P4_0:  HP
-                   | boot_bit(sgpio_9, 0)  // P4_3:  SGPIO9, HOST_CAPTURE
-                   | (1 << 6)              // P4_6:  XCVR_EN, 10K PD
+                boot_bit(tx_amp, 1)       // P5_6:  TX_AMP
+                | (1 << 13)               // P5_4:  MIXER_ENX, 10K PU
+                | boot_bit(rx_mix_bp, 1)  // P5_3:  RX_MIX_BP
+                | boot_bit(tx_mix_bp, 1)  // P5_2:  TX_MIX_BP
+                | boot_bit(lpf, 1)        // P5_1:  LPF
+                | (0 << 9)                // P5_0:  Varies by revision
+                | boot_bit(hpf, 1)        // P4_0:  HP
+                | boot_bit(sgpio_9, 0)    // P4_3:  SGPIO9, HOST_CAPTURE
+                | (1 << 6)                // P4_6:  XCVR_EN, 10K PD
 #endif
-                   | (1 << 14)             // P5_5:  MIXER_RESETX, 10K PU
-                   | boot_bit(led_tx, 1)   // P6_12: LED3 (TX)
-                   | (1 << 7)              // P5_7:  CS_AD
-                   | (1 << 5)              // P4_5:  RXENABLE
-                   | boot_bit(led_rx, 1)   // P4_2:  LED2 (RX)
-                   | boot_bit(led_usb, 1)  // P4_1:  LED1 (USB)
+                | (1 << 14)             // P5_5:  MIXER_RESETX, 10K PU
+                | boot_bit(led_tx, 1)   // P6_12: LED3 (TX)
+                | (1 << 7)              // P5_7:  CS_AD
+                | (1 << 5)              // P4_5:  RXENABLE
+                | boot_bit(led_rx, 1)   // P4_2:  LED2 (RX)
+                | boot_bit(led_usb, 1)  // P4_1:  LED1 (USB)
         },
         {
             // GPIO3
@@ -232,16 +231,16 @@ const PALConfig pal_default_config = {
                     | (1 << 9)   // P7_1:  PortaPack GPIO3_9(IO)
                     | (1 << 8)   // P7_0:  PortaPack GPIO3_8(IO)
 #ifdef PRALINE
-                    | (0 << 4)               // P6_5:  TX_ENABLE
-                    | (1 << 2)               // P6_3:  MIX_ENABLE_N
-                    | (0 << 6)               // P6_10: unused on PRALINE
-                    | boot_bit(p1_ctrl2, 0)  // P6_9:  P1_CTRL2
+                    | boot_bit(tx_enable, 0)   // P6_5:  TX_ENABLE
+                    | boot_bit(mix_bypass, 1)  // P6_3:  MIX_ENABLE_N
+                    | (0 << 6)                 // P6_10: unused on PRALINE
+                    | boot_bit(p1_ctrl2, 0)    // P6_9:  P1_CTRL2
 #else
-                    | (1 << 4)               // P6_5:  HackRF CPLD.TMS(I)
-                    | boot_bit(vregmode, 1)  // P6_11: VREGMODE
-                    | (0 << 6)               // P6_10: Varies by revision
-                    | (1 << 2)               // P6_3:  SGPIO4
-                    | (1 << 5)               // P6_9:  !TX_AMP_PWR, 10K PU
+                    | (1 << 4)                 // P6_5:  HackRF CPLD.TMS(I)
+                    | boot_bit(vregmode, 1)    // P6_11: VREGMODE
+                    | (0 << 6)                 // P6_10: Varies by revision
+                    | (1 << 2)                 // P6_3:  SGPIO4
+                    | boot_bit(tx_amp_pwr, 1)  // P6_9:  !TX_AMP_PWR, 10K PU
 #endif
                     | (1 << 3)  // P6_4:  MIXER_SDATA
                     | (1 << 1)  // P6_2:  HackRF CPLD.TDI(I)
@@ -256,16 +255,16 @@ const PALConfig pal_default_config = {
                    | (1 << 9)   // P7_1:  PortaPack GPIO3_9(IO)
                    | (1 << 8)   // P7_0:  PortaPack GPIO3_8(IO)
 #ifdef PRALINE
-                   | (0 << 7)               // P6_11: 3V3AUX_OC
-                   | (1 << 4)               // P6_5:  TX_ENABLE
-                   | (1 << 2)               // P6_3:  MIX_ENABLE_N
-                   | (0 << 6)               // P6_10: unused on PRALINE
-                   | boot_bit(p1_ctrl2, 1)  // P6_9:  P1_CTRL2
+                   | (0 << 7)                 // P6_11: 3V3AUX_OC
+                   | boot_bit(tx_enable, 1)   // P6_5:  TX_ENABLE
+                   | boot_bit(mix_bypass, 1)  // P6_3:  MIX_ENABLE_N
+                   | (0 << 6)                 // P6_10: unused on PRALINE
+                   | boot_bit(p1_ctrl2, 1)    // P6_9:  P1_CTRL2
 #else
-                   | boot_bit(vregmode, 1)  // P6_11: VREGMODE
-                   | (0 << 6)               // P6_10: Varies by revision
-                   | (0 << 2)               // P6_3:  SGPIO4
-                   | (1 << 5)               // P6_9:  !TX_AMP_PWR, 10K PU
+                   | boot_bit(vregmode, 1)    // P6_11: VREGMODE
+                   | (0 << 6)                 // P6_10: Varies by revision
+                   | (0 << 2)                 // P6_3:  SGPIO4
+                   | boot_bit(tx_amp_pwr, 1)  // P6_9:  !TX_AMP_PWR, 10K PU
 #endif
                    | (0 << 4)  // P6_5:  HackRF CPLD.TMS(I)
                    | (0 << 3)  // P6_4:  MIXER_SDATA
@@ -277,8 +276,8 @@ const PALConfig pal_default_config = {
             .data =
                 boot_bit(sgpio_8, 0)  // P9_6: SGPIO8, SGPIO_CLK, PRALINE: P8_0
 #ifdef PRALINE
-                | (0 << 9)                    // PA_2: RF_AMP_EN
-                | (0 << 8)                    // PA_1: LPF_EN
+                | boot_bit(rf_amp_enable, 0)  // PA_2: RF_AMP_EN
+                | boot_bit(lpf, 0)            // PA_1: LPF_EN
                 | boot_bit(en_1v2, 0)         // P8_7: EN_1V2
                 | boot_bit(led_mcu, 1)        // P8_6: LED4
                 | boot_bit(sgpio_10, 1)       // P8_2: SGPIO10, HOST_DISABLE
@@ -297,8 +296,8 @@ const PALConfig pal_default_config = {
             .dir =
                 boot_bit(sgpio_8, 0)  // P9_6: SGPIO8, SGPIO_CLK, PRALINE: P8_0
 #ifdef PRALINE
-                | (1 << 9)                    // PA_2: RF_AMP_EN
-                | (1 << 8)                    // PA_1: LPF_EN
+                | boot_bit(rf_amp_enable, 1)  // PA_2: RF_AMP_EN
+                | boot_bit(lpf, 1)            // PA_1: LPF_EN
                 | boot_bit(en_1v2, 1)         // P8_7: EN_1V2
                 | boot_bit(led_mcu, 1)        // P8_6: LED4
                 | boot_bit(sgpio_10, 0)       // P8_2: SGPIO10, HOST_DISABLE
@@ -335,14 +334,12 @@ const PALConfig pal_default_config = {
                 | (0 << 12)                 // P4_8: Output GND
                 | boot_bit(vregmode, 1)     // P4_9: TPS62410 VREGMODE
 #else
-                (1 << 18)    // P9_5: HackRF CPLD.TDO(O)
-                | (0 << 6)   // P2_6: MIXER_SCLK
-                | (1 << 14)  // P4_10: SGPIO15, CPLD (unused)
-                | (0 << 15)  // P6_7: Varies by revision
-                | (0 << 5)   // P2_5: Varies by revision
-                | (1 << 16)  // P6_8: MIX_BYPASS
-                | (1 << 13)  // P4_9: SGPIO14, CPLD (unused)
-                | (0 << 12)  // P4_8: Varies by revision
+                (1 << 18)                     // P9_5: HackRF CPLD.TDO(O)
+                | (0 << 6)                    // P2_6: MIXER_SCLK
+                | (1 << 14)                   // P4_10: SGPIO15, CPLD (unused)
+                | boot_bit(rx_mix_bypass, 1)  // P6_8: RX MIX BYPASS
+                | (1 << 13)                   // P4_9: SGPIO14, CPLD (unused)
+                | (0 << 12)                   // P4_8: Varies by revision
 #endif
                 | (1 << 11)             // P3_8: SPIFI_CS
                 | (1 << 10)             // P3_7: SPIFI_MOSI
@@ -374,14 +371,12 @@ const PALConfig pal_default_config = {
                 | (1 << 12)                 // P4_8: Output
                 | boot_bit(vregmode, 1)     // P4_9: TPS62410 VREGMODE
 #else
-                (0 << 18)    // P9_5: HackRF CPLD.TDO(O)
-                | (1 << 6)   // P2_6: MIXER_SCLK
-                | (0 << 14)  // P4_10: SGPIO15, CPLD
-                | (0 << 15)  // P6_7: Varies by revision
-                | (0 << 5)   // P2_5: Varies by revision
-                | (1 << 16)  // P6_8: MIX_BYPASS
-                | (0 << 13)  // P4_9: SGPIO14, CPLD
-                | (0 << 12)  // P4_8: Varies by revision
+                (0 << 18)                     // P9_5: HackRF CPLD.TDO(O)
+                | (1 << 6)                    // P2_6: MIXER_SCLK
+                | (0 << 14)                   // P4_10: SGPIO15, CPLD
+                | boot_bit(rx_mix_bypass, 1)  // P6_8: RX MIX BYPASS
+                | (0 << 13)                   // P4_9: SGPIO14, CPLD
+                | (0 << 12)                   // P4_8: Varies by revision
 #endif
                 | (0 << 11)             // P3_8: SPIFI_CS
                 | (0 << 10)             // P3_7: SPIFI_MOSI
@@ -459,6 +454,7 @@ const PALConfig pal_default_config = {
         {map_p1_ctrl2.scu_port, map_p1_ctrl2.scu_pin, scu_config_normal_drive_t{.mode = map_p1_ctrl2.gpio_mode, .epd = 0, .epun = 0, .ehs = 0, .ezi = 0, .zif = 0}},  // P6_9: P1_CTRL2 (Output VCC, PU ON,)
         {map_p2_ctrl0.scu_port, map_p2_ctrl0.scu_pin, scu_config_normal_drive_t{.mode = map_p2_ctrl0.gpio_mode, .epd = 1, .epun = 1, .ehs = 0, .ezi = 0, .zif = 0}},  // PE_3: P2_CTRL0
         {map_p2_ctrl1.scu_port, map_p2_ctrl1.scu_pin, scu_config_normal_drive_t{.mode = map_p2_ctrl1.gpio_mode, .epd = 1, .epun = 1, .ehs = 0, .ezi = 0, .zif = 0}},  // PE_4: P2_CTRL1
+        {map_ant_bias.scu_port, map_ant_bias.scu_pin, scu_config_normal_drive_t{.mode = map_ant_bias.gpio_mode, .epd = 0, .epun = 1, .ehs = 0, .ezi = 0, .zif = 0}},  // P2_12: !ANT BIAS
 #endif
 
         /* HackRF: I2C0 */
@@ -503,27 +499,26 @@ const PALConfig pal_default_config = {
         {map_trigger_in.scu_port, map_trigger_in.scu_pin, scu_config_normal_drive_t{.mode = map_trigger_in.gpio_mode, .epd = 1, .epun = 1, .ehs = 0, .ezi = 1, .zif = 0}},     // PD_12: TRIGGER IN (Input GND, Mode 4)
         {map_trigger_out.scu_port, map_trigger_out.scu_pin, scu_config_normal_drive_t{.mode = map_trigger_out.gpio_mode, .epd = 0, .epun = 1, .ehs = 1, .ezi = 0, .zif = 0}},  // P2_6: TRIGGER
         {2, 5, scu_config_normal_drive_t{.mode = 4, .epd = 1, .epun = 1, .ehs = 0, .ezi = 1, .zif = 0}},
-        {gpio_control::map_clkin_ctrl.scu_port, gpio_control::map_clkin_ctrl.scu_pin, scu_config_normal_drive_t{.mode = 0, .epd = 0, .epun = 1, .ehs = 0, .ezi = 0, .zif = 0}},  // P1_20  CLKIN_ctrl
+        {map_clkin_ctrl.scu_port, map_clkin_ctrl.scu_pin, scu_config_normal_drive_t{.mode = map_clkin_ctrl.gpio_mode, .epd = 0, .epun = 1, .ehs = 0, .ezi = 0, .zif = 0}},  // P1_20  CLKIN_ctrl
 #else
 
-        {4, 9, scu_config_normal_drive_t{.mode = 7, .epd = 0, .epun = 0, .ehs = 0, .ezi = 0, .zif = 0}},   // SGPIO14/BANK2F3M4: CPLD_P81
-        {4, 10, scu_config_normal_drive_t{.mode = 7, .epd = 0, .epun = 0, .ehs = 0, .ezi = 0, .zif = 0}},  // SGPIO15/BANK2F3M6: CPLD_P78
-        {2, 6, scu_config_normal_drive_t{.mode = 4, .epd = 0, .epun = 1, .ehs = 0, .ezi = 0, .zif = 1}},   // MIXER_SCLK/P31: 33pF, RFFC5072.SCLK(I)
-        {4, 5, scu_config_normal_drive_t{.mode = 0, .epd = 0, .epun = 1, .ehs = 0, .ezi = 0, .zif = 0}},   // RXENABLE
-        {4, 6, scu_config_normal_drive_t{.mode = 0, .epd = 0, .epun = 1, .ehs = 0, .ezi = 0, .zif = 0}},   // XCVR_EN: 10K PD
-        {1, 20, scu_config_normal_drive_t{.mode = 0, .epd = 0, .epun = 1, .ehs = 0, .ezi = 0, .zif = 0}},  // P1_20 CS_XCVR: MAX2837.CS(I)
+        {4, 9, scu_config_normal_drive_t{.mode = 7, .epd = 0, .epun = 0, .ehs = 0, .ezi = 0, .zif = 0}},                                                                    // SGPIO14/BANK2F3M4: CPLD_P81
+        {4, 10, scu_config_normal_drive_t{.mode = 7, .epd = 0, .epun = 0, .ehs = 0, .ezi = 0, .zif = 0}},                                                                   // SGPIO15/BANK2F3M6: CPLD_P78
+        {2, 6, scu_config_normal_drive_t{.mode = 4, .epd = 0, .epun = 1, .ehs = 0, .ezi = 0, .zif = 1}},                                                                    // MIXER_SCLK/P31: 33pF, RFFC5072.SCLK(I)
+        {4, 5, scu_config_normal_drive_t{.mode = 0, .epd = 0, .epun = 1, .ehs = 0, .ezi = 0, .zif = 0}},                                                                    // RXENABLE
+        {4, 6, scu_config_normal_drive_t{.mode = 0, .epd = 0, .epun = 1, .ehs = 0, .ezi = 0, .zif = 0}},                                                                    // XCVR_EN: 10K PD
+        {1, 20, scu_config_normal_drive_t{.mode = 0, .epd = 0, .epun = 1, .ehs = 0, .ezi = 0, .zif = 0}},                                                                   // P1_20 CS_XCVR: MAX2837.CS(I)
+        {map_hpf.scu_port, map_hpf.scu_pin, scu_config_normal_drive_t{.mode = map_hpf.gpio_mode, .epd = 0, .epun = 1, .ehs = 0, .ezi = 0, .zif = 0}},                       // P4_0 HPF
+        {map_rx_amp.scu_port, map_rx_amp.scu_pin, scu_config_normal_drive_t{.mode = map_rx_amp.gpio_mode, .epd = 0, .epun = 1, .ehs = 0, .ezi = 0, .zif = 0}},              // P2_11 RX_AMP
+        {map_rx_amp_pwr.scu_port, map_rx_amp_pwr.scu_pin, scu_config_normal_drive_t{.mode = map_rx_amp_pwr.gpio_mode, .epd = 0, .epun = 1, .ehs = 0, .ezi = 0, .zif = 0}},  // P2_12 !RX_AMP_PWR
+        {map_tx_mix_bp.scu_port, map_tx_mix_bp.scu_pin, scu_config_normal_drive_t{.mode = map_tx_mix_bp.gpio_mode, .epd = 0, .epun = 1, .ehs = 0, .ezi = 0, .zif = 0}},     // P5_2 TX_MIX_BP
 #endif
 
         // RADIO & RF PATH (MAX2831, RFFC5072, Mixers, Switches, Amps)
-        {1, 3, scu_config_normal_drive_t{.mode = 5, .epd = 0, .epun = 0, .ehs = 0, .ezi = 1, .zif = 0}},   // P1_3 SSP1_MISO: MAX2837.DOUT(O)
-        {1, 4, scu_config_normal_drive_t{.mode = 5, .epd = 0, .epun = 0, .ehs = 0, .ezi = 0, .zif = 0}},   // P1_4 SSP1_MOSI: MAX2837.DIN(I)
-        {1, 19, scu_config_normal_drive_t{.mode = 1, .epd = 0, .epun = 0, .ehs = 0, .ezi = 1, .zif = 1}},  // P1_19 SSP1_SCK: MAX2837.SCLK(I)
-        {2, 11, scu_config_normal_drive_t{.mode = 0, .epd = 0, .epun = 1, .ehs = 0, .ezi = 0, .zif = 0}},  // P2_11 RX_AMP
-        {2, 12, scu_config_normal_drive_t{.mode = 0, .epd = 0, .epun = 1, .ehs = 0, .ezi = 0, .zif = 0}},  // P2_12 !RX_AMP_PWR
-        {4, 0, scu_config_normal_drive_t{.mode = 0, .epd = 0, .epun = 1, .ehs = 0, .ezi = 0, .zif = 0}},   // P4_0 HP
-        {5, 1, scu_config_normal_drive_t{.mode = 0, .epd = 0, .epun = 1, .ehs = 0, .ezi = 0, .zif = 0}},   // P5_1 LP
-        {5, 2, scu_config_normal_drive_t{.mode = 0, .epd = 0, .epun = 1, .ehs = 0, .ezi = 0, .zif = 0}},   // P5_2 TX_MIX_BP
-
+        {1, 3, scu_config_normal_drive_t{.mode = 5, .epd = 0, .epun = 0, .ehs = 0, .ezi = 1, .zif = 0}},                                               // P1_3 SSP1_MISO: MAX2837.DOUT(O)
+        {1, 4, scu_config_normal_drive_t{.mode = 5, .epd = 0, .epun = 0, .ehs = 0, .ezi = 0, .zif = 0}},                                               // P1_4 SSP1_MOSI: MAX2837.DIN(I)
+        {1, 19, scu_config_normal_drive_t{.mode = 1, .epd = 0, .epun = 0, .ehs = 0, .ezi = 1, .zif = 1}},                                              // P1_19 SSP1_SCK: MAX2837.SCLK(I)
+        {map_lpf.scu_port, map_lpf.scu_pin, scu_config_normal_drive_t{.mode = map_lpf.gpio_mode, .epd = 0, .epun = 1, .ehs = 0, .ezi = 0, .zif = 0}},  // P5_1 LPF
 #ifdef PRALINE
         {5, 4, scu_config_normal_drive_t{.mode = 0, .epd = 0, .epun = 0, .ehs = 0, .ezi = 0, .zif = 0}},                                                                             // P5_4: RFFC ENX
         {5, 5, scu_config_normal_drive_t{.mode = 0, .epd = 0, .epun = 0, .ehs = 0, .ezi = 0, .zif = 0}},                                                                             // P5_5: RFFC RESETX
@@ -535,25 +530,26 @@ const PALConfig pal_default_config = {
         {13, 16, scu_config_normal_drive_t{.mode = 4, .epd = 0, .epun = 1, .ehs = 1, .ezi = 0, .zif = 0}},                                                                           // PD_16: MAX5864 CS
         {14, 1, scu_config_normal_drive_t{.mode = 4, .epd = 0, .epun = 1, .ehs = 1, .ezi = 0, .zif = 0}},                                                                            // PE_1: MAX2831 !SHDN
         {14, 2, scu_config_normal_drive_t{.mode = 4, .epd = 0, .epun = 1, .ehs = 1, .ezi = 1, .zif = 1}},                                                                            // PE_2: MAX2831 RXTX
-        {6, 3, scu_config_normal_drive_t{.mode = 0, .epd = 0, .epun = 0, .ehs = 1, .ezi = 0, .zif = 0}},                                                                             // P6_3: MIX_ENABLE_N
         {map_p1_ctrl1.scu_port, map_p1_ctrl1.scu_pin, scu_config_normal_drive_t{.mode = map_p1_ctrl1.gpio_mode, .epd = 0, .epun = 1, .ehs = 0, .ezi = 0, .zif = 0}},                 // P6_8 P1_CTRL1 (Output GND, Mode 4)
         {map_aa_en.scu_port, map_aa_en.scu_pin, scu_config_normal_drive_t{.mode = map_aa_en.gpio_mode, .epd = 0, .epun = 1, .ehs = 1, .ezi = 1, .zif = 0}},                          // P1_14: AA_EN
         {map_rf5072_mix_en.scu_port, map_rf5072_mix_en.scu_pin, scu_config_normal_drive_t{.mode = map_rf5072_mix_en.gpio_mode, .epd = 1, .epun = 1, .ehs = 0, .ezi = 0, .zif = 0}},  // P9_0: RF5072 MIX EN
         {9, 6, scu_config_normal_drive_t{.mode = 0, .epd = 0, .epun = 0, .ehs = 0, .ezi = 0, .zif = 0}},                                                                             // P9_6: MAX2831 LD Input
-        {6, 5, scu_config_normal_drive_t{.mode = 0, .epd = 0, .epun = 1, .ehs = 1, .ezi = 0, .zif = 0}},                                                                             // P6_5: TX enable
+        {map_tx_enable.scu_port, map_tx_enable.scu_pin, scu_config_normal_drive_t{.mode = map_tx_enable.gpio_mode, .epd = 0, .epun = 1, .ehs = 1, .ezi = 0, .zif = 0}},              // P6_5: TX enable
         {10, 1, scu_config_normal_drive_t{.mode = 0, .epd = 0, .epun = 1, .ehs = 1, .ezi = 0, .zif = 0}},                                                                            // PA_1: LPF enable
         {10, 2, scu_config_normal_drive_t{.mode = 0, .epd = 0, .epun = 1, .ehs = 1, .ezi = 0, .zif = 0}},                                                                            // PA_2: RF amp enable
+        {map_mix_bypass.scu_port, map_mix_bypass.scu_pin, scu_config_normal_drive_t{.mode = map_mix_bypass.gpio_mode, .epd = 0, .epun = 0, .ehs = 1, .ezi = 0, .zif = 0}},           // P6_8 P6_3: MIX_ENABLE_N
+        {map_rf_amp_enable.scu_port, map_rf_amp_enable.scu_pin, scu_config_normal_drive_t{.mode = map_rf_amp_enable.gpio_mode, .epd = 0, .epun = 1, .ehs = 0, .ezi = 0, .zif = 0}},  // PA_2 RF_AMP_EN
 #else
-        {5, 3, scu_config_normal_drive_t{.mode = 0, .epd = 0, .epun = 1, .ehs = 0, .ezi = 0, .zif = 0}},   // P5_3 RX_MIX_BP
-        {5, 4, scu_config_normal_drive_t{.mode = 0, .epd = 0, .epun = 1, .ehs = 0, .ezi = 0, .zif = 0}},   // MIXER_ENX
-        {5, 6, scu_config_normal_drive_t{.mode = 0, .epd = 0, .epun = 1, .ehs = 0, .ezi = 0, .zif = 0}},   // P5_6 TX_AMP
-        {5, 7, scu_config_normal_drive_t{.mode = 0, .epd = 0, .epun = 1, .ehs = 0, .ezi = 0, .zif = 0}},   // P5_7 CS_AD, PRALINE: RFFC5072 CS
-        {5, 5, scu_config_normal_drive_t{.mode = 0, .epd = 0, .epun = 1, .ehs = 0, .ezi = 0, .zif = 0}},   // MIXER_RESETX
-        {6, 4, scu_config_normal_drive_t{.mode = 0, .epd = 0, .epun = 0, .ehs = 0, .ezi = 1, .zif = 0}},   // MIXER_SDATA
-        {1, 7, scu_config_normal_drive_t{.mode = 0, .epd = 0, .epun = 1, .ehs = 0, .ezi = 0, .zif = 0}},   // !MIX_BYPASS
-        {2, 10, scu_config_normal_drive_t{.mode = 0, .epd = 0, .epun = 1, .ehs = 0, .ezi = 0, .zif = 0}},  // AMP_BYPASS
-        {6, 8, scu_config_normal_drive_t{.mode = 4, .epd = 0, .epun = 1, .ehs = 0, .ezi = 0, .zif = 0}},   // P6_8 MIX_BYPASS
-        {6, 9, scu_config_normal_drive_t{.mode = 0, .epd = 0, .epun = 1, .ehs = 0, .ezi = 0, .zif = 0}},   // !TX_AMP_PWR
+        {map_rx_mix_bp.scu_port, map_rx_mix_bp.scu_pin, scu_config_normal_drive_t{.mode = map_rx_mix_bp.gpio_mode, .epd = 0, .epun = 1, .ehs = 0, .ezi = 0, .zif = 0}},              // P5_3 RX_MIX_BP
+        {5, 4, scu_config_normal_drive_t{.mode = 0, .epd = 0, .epun = 1, .ehs = 0, .ezi = 0, .zif = 0}},                                                                             // MIXER_ENX
+        {map_tx_amp.scu_port, map_tx_amp.scu_pin, scu_config_normal_drive_t{.mode = map_tx_amp.gpio_mode, .epd = 0, .epun = 1, .ehs = 0, .ezi = 0, .zif = 0}},                       // P5_6 TX_AMP
+        {5, 7, scu_config_normal_drive_t{.mode = 0, .epd = 0, .epun = 1, .ehs = 0, .ezi = 0, .zif = 0}},                                                                             // P5_7 CS_AD, PRALINE: RFFC5072 CS
+        {5, 5, scu_config_normal_drive_t{.mode = 0, .epd = 0, .epun = 1, .ehs = 0, .ezi = 0, .zif = 0}},                                                                             // MIXER_RESETX
+        {6, 4, scu_config_normal_drive_t{.mode = 0, .epd = 0, .epun = 0, .ehs = 0, .ezi = 1, .zif = 0}},                                                                             // MIXER_SDATA
+        {map_tx_mix_bypass.scu_port, map_tx_mix_bypass.scu_pin, scu_config_normal_drive_t{.mode = map_tx_mix_bypass.gpio_mode, .epd = 0, .epun = 1, .ehs = 0, .ezi = 0, .zif = 0}},  // P6_8 !TX MIX BYPASS
+        {map_amp_bypass.scu_port, map_amp_bypass.scu_pin, scu_config_normal_drive_t{.mode = map_amp_bypass.gpio_mode, .epd = 0, .epun = 1, .ehs = 0, .ezi = 0, .zif = 0}},           // P2_10 AMP_BYPASS
+        {map_tx_amp_pwr.scu_port, map_tx_amp_pwr.scu_pin, scu_config_normal_drive_t{.mode = map_tx_amp_pwr.gpio_mode, .epd = 0, .epun = 1, .ehs = 0, .ezi = 0, .zif = 0}},           // !TX_AMP_PWR
+        {map_rx_mix_bypass.scu_port, map_rx_mix_bypass.scu_pin, scu_config_normal_drive_t{.mode = map_rx_mix_bypass.gpio_mode, .epd = 0, .epun = 0, .ehs = 1, .ezi = 0, .zif = 0}},  // P6_8 RX MIX BYPASS
 #endif
 
 // SAFE TERMINATION (Unused pins grounded to prevent noise & save power)
@@ -571,11 +567,10 @@ const PALConfig pal_default_config = {
         {11, 2, scu_config_normal_drive_t{.mode = 4, .epd = 1, .epun = 1, .ehs = 0, .ezi = 1, .zif = 0}},  // PB_2: Unused IN
         {11, 4, scu_config_normal_drive_t{.mode = 4, .epd = 1, .epun = 1, .ehs = 0, .ezi = 1, .zif = 0}},  // PB_4: Unused IN
 #else
-        {1, 1, scu_config_normal_drive_t{.mode = 0, .epd = 0, .epun = 1, .ehs = 0, .ezi = 0, .zif = 0}},  // P1_1
-        {1, 2, scu_config_normal_drive_t{.mode = 0, .epd = 0, .epun = 1, .ehs = 0, .ezi = 0, .zif = 0}},  // P1_2
-        {2, 5, scu_config_normal_drive_t{.mode = 0, .epd = 0, .epun = 1, .ehs = 0, .ezi = 0, .zif = 0}},  // P2_5
-        {2, 7, scu_config_normal_drive_t{.mode = 0, .epd = 0, .epun = 1, .ehs = 0, .ezi = 0, .zif = 0}},  // P2_7
-        {4, 8, scu_config_normal_drive_t{.mode = 0, .epd = 0, .epun = 1, .ehs = 0, .ezi = 0, .zif = 0}},  // P4_8
+        {1, 1, scu_config_normal_drive_t{.mode = 0, .epd = 0, .epun = 1, .ehs = 0, .ezi = 0, .zif = 0}},                                                     // P1_1
+        {1, 2, scu_config_normal_drive_t{.mode = 0, .epd = 0, .epun = 1, .ehs = 0, .ezi = 0, .zif = 0}},                                                     // P1_2
+        {map_og_rx.scu_port, map_og_rx.scu_pin, scu_config_normal_drive_t{.mode = map_og_rx.gpio_mode, .epd = 0, .epun = 1, .ehs = 0, .ezi = 0, .zif = 0}},  // P2_5                                                  // P2_7
+        {4, 8, scu_config_normal_drive_t{.mode = 0, .epd = 0, .epun = 1, .ehs = 0, .ezi = 0, .zif = 0}},                                                     // P4_8
 #endif
 
         // PORTAPACK SPECIFIC & JTAG (CPLD, UI, Audio, SD)
@@ -630,13 +625,13 @@ static const std::array<gpio_setup_t, 6> gpio_setup_og{{
      .dir = 0},
     {
         // GPIO5
-        .data = (0 << 15)                // P6_7:  TX
+        .data = boot_bit(og_tx, 0)       // P6_7:  TX
                 | boot_bit(sgpio_13, 0)  // P4_8:  SGPIO13, HOST_SYNC_EN
-                | (1 << 5)               // P2_5:  RX
+                | boot_bit(og_rx, 1)     // P2_5:  RX
         ,
-        .dir = (1 << 15)                // P6_7:  TX
+        .dir = boot_bit(og_tx, 1)       // P6_7:  TX
                | boot_bit(sgpio_13, 0)  // P4_8:  SGPIO13, HOST_SYNC_EN
-               | (1 << 5)               // P2_5:  RX
+               | boot_bit(og_rx, 1)     // P2_5:  RX
     },
 
 }};
@@ -645,24 +640,24 @@ static const std::array<gpio_setup_t, 6> gpio_setup_og{{
 static const std::array<gpio_setup_t, 6> gpio_setup_r9{{
     {
         // GPIO0
-        .data = (0 << 9)    // P1_2:  10K PD, BOOT1, CLKOUT_EN
-                | (1 << 8)  // P1_1:  10K PU, BOOT0, MCU_CLK_EN
-                | (1 << 7)  // P2_7:  10K PU, ISP, RX
+        .data = (0 << 9)              // P1_2:  10K PD, BOOT1, CLKOUT_EN
+                | (1 << 8)            // P1_1:  10K PU, BOOT0, MCU_CLK_EN
+                | boot_bit(r9_rx, 1)  // P2_7:  10K PU, ISP, RX
         ,
-        .dir = (0 << 9)    // P1_2:  10K PD, BOOT1, CLKOUT_EN
-               | (0 << 8)  // P1_1:  10K PU, BOOT0, MCU_CLK_EN
-               | (0 << 7)  // P2_7:  10K PU, ISP, RX
+        .dir = (0 << 9)              // P1_2:  10K PD, BOOT1, CLKOUT_EN
+               | (0 << 8)            // P1_1:  10K PU, BOOT0, MCU_CLK_EN
+               | boot_bit(r9_rx, 1)  // P2_7:  10K PU, ISP, RX
     },
     {// GPIO1
      .data = 0,
      .dir = 0},
     {
         // GPIO2
-        .data = boot_bit(r9_1v8_en, 0)  // P5_0:  EN1V8, 10K PD
-                | (1 << 4)              // P4_4:  !ANT_BIAS
+        .data = boot_bit(r9_1v8_en, 0)   // P5_0:  EN1V8, 10K PD
+                | boot_bit(ant_bias, 1)  // P4_4:  !ANT_BIAS
         ,
-        .dir = boot_bit(r9_1v8_en, 1)  // P5_0:  EN1V8, 10K PD
-               | (1 << 4)              // P4_4:  !ANT_BIAS
+        .dir = boot_bit(r9_1v8_en, 1)   // P5_0:  EN1V8, 10K PD
+               | boot_bit(ant_bias, 1)  // P4_4:  !ANT_BIAS
     },
     {
         // GPIO3
@@ -693,9 +688,9 @@ static const std::array<scu_setup_t, 9> pins_setup_og{{
     {map_og_1v8_en.scu_port, map_og_1v8_en.scu_pin, scu_config_normal_drive_t{.mode = map_og_1v8_en.gpio_mode, .epd = 0, .epun = 1, .ehs = 0, .ezi = 0, .zif = 0}}, /* EN1V8/P70: 10K PD, TPS62410.EN2(I), 1V8LED.A(I) */
 
     /* Radio section control */
-    {2, 5, scu_config_normal_drive_t{.mode = 4, .epd = 0, .epun = 1, .ehs = 0, .ezi = 0, .zif = 0}}, /* RX/P43: U7.VCTL1(I), U10.VCTL1(I), U2.VCTL1(I) */
-    {4, 4, scu_config_normal_drive_t{.mode = 0, .epd = 0, .epun = 1, .ehs = 0, .ezi = 0, .zif = 0}}, /* TXENABLE/P55: MAX2837.TXENABLE(I) */
-    {6, 7, scu_config_normal_drive_t{.mode = 4, .epd = 0, .epun = 1, .ehs = 0, .ezi = 0, .zif = 0}}, /* TX/P42: U7.VCTL2(I), U10.VCTL2(I), U2.VCTL2(I) */
+    {2, 5, scu_config_normal_drive_t{.mode = 4, .epd = 0, .epun = 1, .ehs = 0, .ezi = 0, .zif = 0}},                                                    /* RX/P43: U7.VCTL1(I), U10.VCTL1(I), U2.VCTL1(I) */
+    {4, 4, scu_config_normal_drive_t{.mode = 0, .epd = 0, .epun = 1, .ehs = 0, .ezi = 0, .zif = 0}},                                                    /* TXENABLE/P55: MAX2837.TXENABLE(I) */
+    {map_og_tx.scu_port, map_og_tx.scu_pin, scu_config_normal_drive_t{.mode = map_og_tx.gpio_mode, .epd = 0, .epun = 1, .ehs = 0, .ezi = 0, .zif = 0}}, /* TX/P42: U7.VCTL2(I), U10.VCTL2(I), U2.VCTL2(I) */
 
     /* SGPIO for sample transfer interface to HackRF CPLD. */
     {map_sgpio_13.scu_port, map_sgpio_13.scu_pin, scu_config_normal_drive_t{.mode = map_sgpio_13.gpio_mode, .epd = 1, .epun = 1, .ehs = 0, .ezi = 0, .zif = 0}}, /* SGPIO13/BANK2F3M2: CPLD.90/HOST_SYNC_EN(I) */
@@ -713,8 +708,8 @@ static const std::array<scu_setup_t, 9> pins_setup_r9{{
     {map_r9_1v8_en.scu_port, map_r9_1v8_en.scu_pin, scu_config_normal_drive_t{.mode = map_r9_1v8_en.gpio_mode, .epd = 0, .epun = 1, .ehs = 0, .ezi = 0, .zif = 0}}, /* EN1V8: 10K PD, TPS62410.EN2(I), 1V8LED.A(I) */
 
     /* Radio section control */
-    {2, 7, scu_config_normal_drive_t{.mode = 0, .epd = 0, .epun = 1, .ehs = 0, .ezi = 0, .zif = 0}}, /* RX/ISP/P96: U7.VCTL(I), U10.VCTL(I), U2.VCTL(I) */
-    {4, 4, scu_config_normal_drive_t{.mode = 0, .epd = 0, .epun = 1, .ehs = 0, .ezi = 0, .zif = 0}}, /* !ANT_BIAS: 10K PU, Q4.G(I) */
+    {map_r9_rx.scu_port, map_r9_rx.scu_pin, scu_config_normal_drive_t{.mode = map_r9_rx.gpio_mode, .epd = 0, .epun = 1, .ehs = 0, .ezi = 0, .zif = 0}},          /* RX/ISP/P96: U7.VCTL(I), U10.VCTL(I), U2.VCTL(I) */
+    {map_ant_bias.scu_port, map_ant_bias.scu_pin, scu_config_normal_drive_t{.mode = map_ant_bias.gpio_mode, .epd = 0, .epun = 1, .ehs = 0, .ezi = 0, .zif = 0}}, /* !ANT_BIAS: 10K PU, Q4.G(I) */
 
     /* SGPIO for sample transfer interface to HackRF CPLD. */
     {2, 5, scu_config_normal_drive_t{.mode = 4, .epd = 1, .epun = 1, .ehs = 0, .ezi = 0, .zif = 0}}, /* BANK2F3M2: CPLD.90/HOST_SYNC_EN(I) */

--- a/firmware/chibios-portapack/boards/PORTAPACK_APPLICATION/board.cpp
+++ b/firmware/chibios-portapack/boards/PORTAPACK_APPLICATION/board.cpp
@@ -169,7 +169,8 @@ const PALConfig pal_default_config = {
                     | boot_bit(led_rx, 1)   // P4_2:  LED2 (RX)
                     | boot_bit(led_usb, 1)  // P4_1:  LED1 (USB)
 #else
-                    | boot_bit(tx_amp, 0)     // P5_6:  TX_AMP
+                    | boot_bit(tx_amp, 0)     // P5_6:  TX_AMP
+
                     | (1 << 13)               // P5_4:  MIXER_ENX, 10K PU
                     | boot_bit(rx_mix_bp, 1)  // P5_3:  RX_MIX_BP
                     | boot_bit(tx_mix_bp, 0)  // P5_2:  TX_MIX_BP
@@ -536,7 +537,7 @@ const PALConfig pal_default_config = {
         {map_tx_enable.scu_port, map_tx_enable.scu_pin, scu_config_normal_drive_t{.mode = map_tx_enable.gpio_mode, .epd = 0, .epun = 1, .ehs = 1, .ezi = 0, .zif = 0}},              // P6_5: TX enable
         {10, 1, scu_config_normal_drive_t{.mode = 0, .epd = 0, .epun = 1, .ehs = 1, .ezi = 0, .zif = 0}},                                                                            // PA_1: LPF enable
         {10, 2, scu_config_normal_drive_t{.mode = 0, .epd = 0, .epun = 1, .ehs = 1, .ezi = 0, .zif = 0}},                                                                            // PA_2: RF amp enable
-        {map_mix_bypass.scu_port, map_mix_bypass.scu_pin, scu_config_normal_drive_t{.mode = map_mix_bypass.gpio_mode, .epd = 0, .epun = 0, .ehs = 1, .ezi = 0, .zif = 0}},           // P6_8 P6_3: MIX_ENABLE_N
+        {map_mix_bypass.scu_port, map_mix_bypass.scu_pin, scu_config_normal_drive_t{.mode = map_mix_bypass.gpio_mode, .epd = 0, .epun = 0, .ehs = 1, .ezi = 0, .zif = 0}},           // P6_3: MIX_ENABLE_N
         {map_rf_amp_enable.scu_port, map_rf_amp_enable.scu_pin, scu_config_normal_drive_t{.mode = map_rf_amp_enable.gpio_mode, .epd = 0, .epun = 1, .ehs = 0, .ezi = 0, .zif = 0}},  // PA_2 RF_AMP_EN
 #else
         {map_rx_mix_bp.scu_port, map_rx_mix_bp.scu_pin, scu_config_normal_drive_t{.mode = map_rx_mix_bp.gpio_mode, .epd = 0, .epun = 1, .ehs = 0, .ezi = 0, .zif = 0}},              // P5_3 RX_MIX_BP

--- a/firmware/chibios-portapack/boards/PORTAPACK_APPLICATION/board.cpp
+++ b/firmware/chibios-portapack/boards/PORTAPACK_APPLICATION/board.cpp
@@ -57,53 +57,51 @@ const PALConfig pal_default_config = {
             // GPIO0
             .data
 #ifdef PRALINE
-            = (0 << 7)                   // P2_7:  Input GND
-              | (0 << 8)                 // P1_1:  Input GND
-              | (1 << 9)                 // P1_2:  Input VCC
-              | boot_bit(p1_ctrl0, 0)    // P2_10: P1_CTRL0, start low
+            = boot_bit(p1_ctrl0, 0)      // P2_10: P1_CTRL0, start low
               | boot_bit(clkin_ctrl, 0)  // P1_20: CLKIN_CTRL - start low
 #else
             = boot_bit(amp_bypass, 1)  // P2_10: AMP_BYPASS
               | (1 << 15)              // P1_20: CS_XCVR
 #endif
-              | (1 << 11)              // P1_4:  SSP1_MOSI
-              | boot_bit(sgpio_12, 0)  // P1_18: SGPIO12, HOST_Q_INVERT
-              | boot_bit(sgpio_11, 0)  // P1_17: SGPIO11, HOST_DIRECTION, Praline: FPGA HOST_DIRECTION
-              | (1 << 10)              // P1_3:  SSP1_MISO
-              | (0 << 9)               // P1_2:  Varies by revision, float until detection
-              | (0 << 8)               // P1_1:  Varies by revision, float until detection
-              | (0 << 6)               // P3_6:  SPIFI_MISO
-              | boot_bit(sgpio_5, 1)   // P6_6:  SGPIO5, HOST_DATA5, Praline: FPGA HOST_DATA5
-              | boot_bit(sgpio_7, 1)   // P1_0:  SGPIO7, HOST_DATA7, Praline: FPGA HOST_DATA7
-              | boot_bit(sgpio_3, 1)   // P1_16: SGPIO3, HOST_DATA3, Praline: FPGA HOST_DATA3
-              | boot_bit(sgpio_2, 1)   // P1_15: SGPIO2, HOST_DATA2, Praline: FPGA HOST_DATA2
-              | boot_bit(sgpio_1, 1)   // P0_1:  SGPIO1, HOST_DATA1, Praline: FPGA HOST_DATA1
-              | boot_bit(sgpio_0, 1)   // P0_0:  SGPIO0, HOST_DATA0, Praline: FPGA HOST_DATA0
+              | boot_bit(dfu_boot_0, 0)  // P1_1:  10K PU, BOOT0
+              | boot_bit(dfu_boot_1, 0)  // P1_2:  10K PD, BOOT1
+              | boot_bit(dfu_isp, 0)     // P2_7:  10K PU, ISP
+              | (1 << 11)                // P1_4:  SSP1_MOSI
+              | boot_bit(sgpio_12, 0)    // P1_18: SGPIO12, HOST_Q_INVERT
+              | boot_bit(sgpio_11, 0)    // P1_17: SGPIO11, HOST_DIRECTION, Praline: FPGA HOST_DIRECTION
+              | (1 << 10)                // P1_3:  SSP1_MISO
+              | (0 << 9)                 // P1_2:  Varies by revision, float until detection
+              | (0 << 8)                 // P1_1:  Varies by revision, float until detection
+              | (0 << 6)                 // P3_6:  SPIFI_MISO
+              | boot_bit(sgpio_5, 1)     // P6_6:  SGPIO5, HOST_DATA5, Praline: FPGA HOST_DATA5
+              | boot_bit(sgpio_7, 1)     // P1_0:  SGPIO7, HOST_DATA7, Praline: FPGA HOST_DATA7
+              | boot_bit(sgpio_3, 1)     // P1_16: SGPIO3, HOST_DATA3, Praline: FPGA HOST_DATA3
+              | boot_bit(sgpio_2, 1)     // P1_15: SGPIO2, HOST_DATA2, Praline: FPGA HOST_DATA2
+              | boot_bit(sgpio_1, 1)     // P0_1:  SGPIO1, HOST_DATA1, Praline: FPGA HOST_DATA1
+              | boot_bit(sgpio_0, 1)     // P0_0:  SGPIO0, HOST_DATA0, Praline: FPGA HOST_DATA0
             ,
             .dir
 #ifdef PRALINE
-            = (0 << 7)                   // P2_7:  Input
-              | (0 << 8)                 // P1_1:  Input
-              | (0 << 9)                 // P1_2:  Input
-              | boot_bit(p1_ctrl0, 1)    // P2_10: P1_CTRL0
+            = boot_bit(p1_ctrl0, 1)      // P2_10: P1_CTRL0
               | boot_bit(clkin_ctrl, 1)  // P1_20: CLKIN_CTRL
 #else
             = boot_bit(amp_bypass, 1)  // P2_10: AMP_BYPASS
               | (1 << 15)              // P1_20: CS_XCVR
 #endif
-              | (0 << 11)              // P1_4:  SSP1_MOSI
-              | boot_bit(sgpio_12, 1)  // P1_18: SGPIO12, HOST_Q_INVERT
-              | boot_bit(sgpio_11, 0)  // P1_17: SGPIO11, HOST_DIRECTION, Praline: FPGA HOST_DIRECTION
-              | (0 << 10)              // P1_3:  SSP1_MISO
-              | (0 << 9)               // P1_2:  Varies by revision, float until detection
-              | (0 << 8)               // P1_1:  Varies by revision, float until detection
-              | (0 << 6)               // P3_6:  SPIFI_MISO
-              | boot_bit(sgpio_5, 1)   // P6_6:  SGPIO5, HOST_DATA5
-              | boot_bit(sgpio_7, 1)   // P1_0:  SGPIO7, HOST_DATA7
-              | boot_bit(sgpio_3, 0)   // P1_16: SGPIO3, HOST_DATA3
-              | boot_bit(sgpio_2, 0)   // P1_15: SGPIO2, HOST_DATA2
-              | boot_bit(sgpio_1, 0)   // P0_1:  SGPIO1, HOST_DATA1
-              | boot_bit(sgpio_0, 0)   // P0_0:  SGPIO0, HOST_DATA0
+              | boot_bit(dfu_boot_0, 0)  // P1_1:  10K PU, BOOT0
+              | boot_bit(dfu_boot_1, 0)  // P1_2:  10K PD, BOOT1
+              | boot_bit(dfu_isp, 0)     // P2_7:  10K PU, ISP
+              | (0 << 10)                // P1_3:  SSP1_MISO
+              | (0 << 11)                // P1_4:  SSP1_MOSI
+              | boot_bit(sgpio_12, 1)    // P1_18: SGPIO12, HOST_Q_INVERT
+              | boot_bit(sgpio_11, 0)    // P1_17: SGPIO11, HOST_DIRECTION, Praline: FPGA HOST_DIRECTION
+              | (0 << 6)                 // P3_6:  SPIFI_MISO
+              | boot_bit(sgpio_5, 1)     // P6_6:  SGPIO5, HOST_DATA5
+              | boot_bit(sgpio_7, 1)     // P1_0:  SGPIO7, HOST_DATA7
+              | boot_bit(sgpio_3, 0)     // P1_16: SGPIO3, HOST_DATA3
+              | boot_bit(sgpio_2, 0)     // P1_15: SGPIO2, HOST_DATA2
+              | boot_bit(sgpio_1, 0)     // P0_1:  SGPIO1, HOST_DATA1
+              | boot_bit(sgpio_0, 0)     // P0_0:  SGPIO0, HOST_DATA0
         },
         {
             // GPIO1
@@ -111,49 +109,49 @@ const PALConfig pal_default_config = {
                     | (1 << 14)  // P3_4:  SPIFI_SIO3
                     | (1 << 13)  // P2_13: PortaPack DIR
 #ifdef PRALINE
-                    | boot_bit(ant_bias, 1)  // P2_12: !BIAS_EN
-                    | (0 << 11)              // P2_11: BIAS_OC
-                    | boot_bit(aa_en, 0)     // P1_14: AA_EN
-                    | (0 << 0)               // P1_7:  Output GND
+                    | boot_bit(ant_bias, 1)     // P2_12: !BIAS_EN
+                    | boot_bit(ant_bias_oc, 0)  // P2_11: BIAS_OC
+                    | boot_bit(aa_en, 0)        // P1_14: AA_EN
+                    | (0 << 0)                  // P1_7:  Output GND
 #else
                     | boot_bit(rx_amp_pwr, 1)     // P2_12: !RX_AMP_PWR
                     | boot_bit(rx_amp, 0)         // P2_11: RX_AMP
                     | boot_bit(sgpio_10, 1)       // P1_14: SGPIO10, HOST_DISABLE
                     | boot_bit(tx_mix_bypass, 1)  // P1_7:  !TX MIX BYPASS
 #endif
-                    | (0 << 10)  // P2_9:  10K PD, BOOT3, PortaPack LCD_WRX
-                    | (1 << 9)   // P1_6:  SD_CMD
-                    | (1 << 8)   // P1_5:  SD_POW, PortaPack CPLD.TDO(O)
-                    | (1 << 6)   // P1_13: SD_CD
-                    | (1 << 5)   // P1_12: SD_DAT3
-                    | (1 << 4)   // P1_11: SD_DAT2
-                    | (1 << 3)   // P1_10: SD_DAT1
-                    | (1 << 2)   // P1_9:  SD_DAT0
-                    | (1 << 1)   // P1_8:  PortaPack CPLD.TMS(I)
+                    | boot_bit(lcd_wrx, 0)  // P2_9:  10K PD, BOOT3, PortaPack LCD_WRX
+                    | (1 << 9)              // P1_6:  SD_CMD
+                    | (1 << 8)              // P1_5:  SD_POW, PortaPack CPLD.TDO(O)
+                    | (1 << 6)              // P1_13: SD_CD
+                    | (1 << 5)              // P1_12: SD_DAT3
+                    | (1 << 4)              // P1_11: SD_DAT2
+                    | (1 << 3)              // P1_10: SD_DAT1
+                    | (1 << 2)              // P1_9:  SD_DAT0
+                    | (1 << 1)              // P1_8:  PortaPack CPLD.TMS(I)
             ,
             .dir = (0 << 15)    // P3_5:  SPIFI_SIO2
                    | (0 << 14)  // P3_4:  SPIFI_SIO3
                    | (1 << 13)  // P2_13: PortaPack DIR
 #ifdef PRALINE
-                   | boot_bit(ant_bias, 1)  // P2_12: !BIAS_EN
-                   | (0 << 11)              // P2_11: BIAS_OC
-                   | boot_bit(aa_en, 1)     // P1_14: AA_EN
-                   | (1 << 0)               // P1_7:  Output
+                   | boot_bit(ant_bias, 1)     // P2_12: !BIAS_EN
+                   | boot_bit(ant_bias_oc, 0)  // P2_11: BIAS_OC
+                   | boot_bit(aa_en, 1)        // P1_14: AA_EN
+                   | (1 << 0)                  // P1_7:  Output
 #else
                    | boot_bit(rx_amp_pwr, 1)     // P2_12: !RX_AMP_PWR
                    | boot_bit(rx_amp, 1)         // P2_11: RX_AMP
                    | boot_bit(sgpio_10, 0)       // P1_14: SGPIO10, HOST_DISABLE
                    | boot_bit(tx_mix_bypass, 1)  // P1_7:  !TX MIX BYPASS
 #endif
-                   | (1 << 10)  // P2_9:  10K PD, BOOT3, PortaPack LCD_WRX
-                   | (0 << 9)   // P1_6:  SD_CMD
-                   | (0 << 8)   // P1_5:  SD_POW, PortaPack CPLD.TDO(O)
-                   | (0 << 6)   // P1_13: SD_CD
-                   | (0 << 5)   // P1_12: SD_DAT3
-                   | (0 << 4)   // P1_11: SD_DAT2
-                   | (0 << 3)   // P1_10: SD_DAT1
-                   | (0 << 2)   // P1_9:  SD_DAT0
-                   | (0 << 1)   // P1_8:  PortaPack CPLD.TMS(I)
+                   | boot_bit(lcd_wrx, 1)  // P2_9:  10K PD, BOOT3, PortaPack LCD_WRX
+                   | (0 << 9)              // P1_6:  SD_CMD
+                   | (0 << 8)              // P1_5:  SD_POW, PortaPack CPLD.TDO(O)
+                   | (0 << 6)              // P1_13: SD_CD
+                   | (0 << 5)              // P1_12: SD_DAT3
+                   | (0 << 4)              // P1_11: SD_DAT2
+                   | (0 << 3)              // P1_10: SD_DAT1
+                   | (0 << 2)              // P1_9:  SD_DAT0
+                   | (0 << 1)              // P1_8:  PortaPack CPLD.TMS(I)
         },
         {
             // GPIO2
@@ -231,15 +229,16 @@ const PALConfig pal_default_config = {
                     | (1 << 9)   // P7_1:  PortaPack GPIO3_9(IO)
                     | (1 << 8)   // P7_0:  PortaPack GPIO3_8(IO)
 #ifdef PRALINE
-                    | boot_bit(tx_enable, 0)   // P6_5:  TX_ENABLE
-                    | boot_bit(mix_bypass, 1)  // P6_3:  MIX_ENABLE_N
-                    | (0 << 6)                 // P6_10: unused on PRALINE
-                    | boot_bit(p1_ctrl2, 0)    // P6_9:  P1_CTRL2
+                    | boot_bit(tx_enable, 0)     // P6_5:  TX_ENABLE
+                    | boot_bit(mix_bypass, 1)    // P6_3:  MIX_ENABLE_N
+                    | (0 << 6)                   // P6_10: unused on PRALINE
+                    | boot_bit(p1_ctrl2, 0)      // P6_9:  P1_CTRL2
+                    | boot_bit(aux_power_oc, 0)  // P6_11: AUX overcurrent
 #else
                     | (1 << 4)                 // P6_5:  HackRF CPLD.TMS(I)
                     | boot_bit(vregmode, 1)    // P6_11: VREGMODE
                     | (0 << 6)                 // P6_10: Varies by revision
-                    | (1 << 2)                 // P6_3:  SGPIO4
+                    | boot_bit(sgpio_4, 1)     // P6_3:  SGPIO4
                     | boot_bit(tx_amp_pwr, 1)  // P6_9:  !TX_AMP_PWR, 10K PU
 #endif
                     | (1 << 3)  // P6_4:  MIXER_SDATA
@@ -255,15 +254,15 @@ const PALConfig pal_default_config = {
                    | (1 << 9)   // P7_1:  PortaPack GPIO3_9(IO)
                    | (1 << 8)   // P7_0:  PortaPack GPIO3_8(IO)
 #ifdef PRALINE
-                   | (0 << 7)                 // P6_11: 3V3AUX_OC
-                   | boot_bit(tx_enable, 1)   // P6_5:  TX_ENABLE
-                   | boot_bit(mix_bypass, 1)  // P6_3:  MIX_ENABLE_N
-                   | (0 << 6)                 // P6_10: unused on PRALINE
-                   | boot_bit(p1_ctrl2, 1)    // P6_9:  P1_CTRL2
+                   | boot_bit(aux_power_oc, 0)  // P6_11: AUX overcurrent
+                   | boot_bit(tx_enable, 1)     // P6_5:  TX_ENABLE
+                   | boot_bit(mix_bypass, 1)    // P6_3:  MIX_ENABLE_N
+                   | (0 << 6)                   // P6_10: unused on PRALINE
+                   | boot_bit(p1_ctrl2, 1)      // P6_9:  P1_CTRL2
 #else
                    | boot_bit(vregmode, 1)    // P6_11: VREGMODE
                    | (0 << 6)                 // P6_10: Varies by revision
-                   | (0 << 2)                 // P6_3:  SGPIO4
+                   | boot_bit(sgpio_4, 0)     // P6_3:  SGPIO4
                    | boot_bit(tx_amp_pwr, 1)  // P6_9:  !TX_AMP_PWR, 10K PU
 #endif
                    | (0 << 4)  // P6_5:  HackRF CPLD.TMS(I)
@@ -317,22 +316,22 @@ const PALConfig pal_default_config = {
             // GPIO5
             .data =
 #ifdef PRALINE
-                (0 << 18)                   // P9_5: RFF5072 SCLK
-                | boot_bit(trigger_out, 0)  // P2_6: Trigger out
-                | (0 << 14)                 // P4_10: FPGA CDONE
-                | (1 << 15)                 // P6_7: 3V3 AUX_ENABLE
-                | boot_bit(p1_ctrl1, 0)     // P6_8: P1_CTRL1
-                | boot_bit(sgpio_4, 1)      // P9_4: FPGA SGPIO4
-                | (0 << 19)                 // PA_4: Output GND
-                | (0 << 20)                 // PB_0: Output GND
-                | (0 << 21)                 // PB_1: Output GND
-                | (0 << 22)                 // PB_2: Unused IN
-                | (0 << 23)                 // PB_3: Output GND
-                | (0 << 24)                 // PB_4: Unused IN
-                | (0 << 25)                 // PB_5: Output GND
-                | (0 << 5)                  // P2_5: PPS OUT/IN
-                | (0 << 12)                 // P4_8: Output GND
-                | boot_bit(vregmode, 1)     // P4_9: TPS62410 VREGMODE
+                (0 << 18)                        // P9_5: RFF5072 SCLK
+                | boot_bit(trigger_out, 0)       // P2_6: Trigger out
+                | (0 << 14)                      // P4_10: FPGA CDONE
+                | boot_bit(aux_power_enable, 1)  // P6_7: !3V3 AUX_ENABLE
+                | boot_bit(p1_ctrl1, 0)          // P6_8: P1_CTRL1
+                | boot_bit(sgpio_4, 1)           // P9_4: FPGA SGPIO4
+                | (0 << 19)                      // PA_4: Output GND
+                | (0 << 20)                      // PB_0: Output GND
+                | (0 << 21)                      // PB_1: Output GND
+                | (0 << 22)                      // PB_2: Unused IN
+                | (0 << 23)                      // PB_3: Output GND
+                | (0 << 24)                      // PB_4: Unused IN
+                | (0 << 25)                      // PB_5: Output GND
+                | boot_bit(pps_in_out, 0)        // P2_5: PPS OUT/IN
+                | (0 << 12)                      // P4_8: Output GND
+                | boot_bit(vregmode, 1)          // P4_9: TPS62410 VREGMODE
 #else
                 (1 << 18)                     // P9_5: HackRF CPLD.TDO(O)
                 | (0 << 6)                    // P2_6: MIXER_SCLK
@@ -341,35 +340,35 @@ const PALConfig pal_default_config = {
                 | (1 << 13)                   // P4_9: SGPIO14, CPLD (unused)
                 | (0 << 12)                   // P4_8: Varies by revision
 #endif
-                | (1 << 11)             // P3_8: SPIFI_CS
-                | (1 << 10)             // P3_7: SPIFI_MOSI
-                | (1 << 9)              // P3_2: I2S0_RX_SDA
-                | (1 << 8)              // P3_1: I2S0_RX_WS
-                | (0 << 7)              // P2_8: BOOT2
-                | (1 << 4)              // P2_4: PortaPack LCD_RDX
-                | (0 << 3)              // P2_3: PortaPack LCD_TE
-                | boot_bit(sgpio_6, 1)  // P2_2: SGPIO6, HOST_DATA6
-                | (1 << 1)              // P2_1: PortaPack ADDR
-                | (1 << 0)              // P2_0: PortaPack IO_STBX
+                | (1 << 11)                // P3_8: SPIFI_CS
+                | (1 << 10)                // P3_7: SPIFI_MOSI
+                | (1 << 9)                 // P3_2: I2S0_RX_SDA
+                | (1 << 8)                 // P3_1: I2S0_RX_WS
+                | boot_bit(dfu_button, 0)  // P2_8: 10K PD, BOOT2, DFU button
+                | (1 << 4)                 // P2_4: PortaPack LCD_RDX
+                | (0 << 3)                 // P2_3: PortaPack LCD_TE
+                | boot_bit(sgpio_6, 1)     // P2_2: SGPIO6, HOST_DATA6
+                | (1 << 1)                 // P2_1: PortaPack ADDR
+                | (1 << 0)                 // P2_0: PortaPack IO_STBX
             ,
             .dir =
 #ifdef PRALINE
-                (1 << 18)                   // P9_5: RFF5072 SCLK
-                | boot_bit(trigger_out, 1)  // P2_6: Trigger out
-                | (0 << 14)                 // P4_10: FPGA CDONE
-                | (1 << 15)                 // P6_7: 3V3 AUX_ENABLE
-                | boot_bit(p1_ctrl1, 1)     // P6_8: P1_CTRL1
-                | boot_bit(sgpio_4, 0)      // P9_4: FPGA SGPIO
-                | (1 << 19)                 // PA_4: Output
-                | (1 << 20)                 // PB_0: Output GND
-                | (1 << 21)                 // PB_1: Output GND
-                | (0 << 22)                 // PB_2: Unused
-                | (1 << 23)                 // PB_3: Output
-                | (0 << 24)                 // PB_4: Unused
-                | (1 << 25)                 // PB_5: Output
-                | (0 << 5)                  // P2_5: PPS (Bidirectional)
-                | (1 << 12)                 // P4_8: Output
-                | boot_bit(vregmode, 1)     // P4_9: TPS62410 VREGMODE
+                (1 << 18)                        // P9_5: RFF5072 SCLK
+                | boot_bit(trigger_out, 1)       // P2_6: Trigger out
+                | (0 << 14)                      // P4_10: FPGA CDONE
+                | boot_bit(aux_power_enable, 1)  // P6_7: !3V3 AUX_ENABLE
+                | boot_bit(p1_ctrl1, 1)          // P6_8: P1_CTRL1
+                | boot_bit(sgpio_4, 0)           // P9_4: FPGA SGPIO
+                | (1 << 19)                      // PA_4: Output
+                | (1 << 20)                      // PB_0: Output GND
+                | (1 << 21)                      // PB_1: Output GND
+                | (0 << 22)                      // PB_2: Unused
+                | (1 << 23)                      // PB_3: Output
+                | (0 << 24)                      // PB_4: Unused
+                | (1 << 25)                      // PB_5: Output
+                | boot_bit(pps_in_out, 0)        // P2_5: PPS (Bidirectional)
+                | (1 << 12)                      // P4_8: Output
+                | boot_bit(vregmode, 1)          // P4_9: TPS62410 VREGMODE
 #else
                 (0 << 18)                     // P9_5: HackRF CPLD.TDO(O)
                 | (1 << 6)                    // P2_6: MIXER_SCLK
@@ -378,16 +377,16 @@ const PALConfig pal_default_config = {
                 | (0 << 13)                   // P4_9: SGPIO14, CPLD
                 | (0 << 12)                   // P4_8: Varies by revision
 #endif
-                | (0 << 11)             // P3_8: SPIFI_CS
-                | (0 << 10)             // P3_7: SPIFI_MOSI
-                | (0 << 9)              // P3_2: I2S0_RX_SDA
-                | (0 << 8)              // P3_1: I2S0_RX_WS
-                | (0 << 7)              // P2_8: BOOT2
-                | (0 << 4)              // P2_4: PortaPack LCD_RDX
-                | (0 << 3)              // P2_3: PortaPack LCD_TE
-                | boot_bit(sgpio_6, 0)  // P2_2: SGPIO6, HOST_DATA6
-                | (0 << 1)              // P2_1: PortaPack ADDR
-                | (0 << 0)              // P2_0: PortaPack IO_STBX
+                | (0 << 11)                // P3_8: SPIFI_CS
+                | (0 << 10)                // P3_7: SPIFI_MOSI
+                | (0 << 9)                 // P3_2: I2S0_RX_SDA
+                | (0 << 8)                 // P3_1: I2S0_RX_WS
+                | boot_bit(dfu_button, 0)  // P2_8: 10K PD, BOOT2, DFU button
+                | (0 << 4)                 // P2_4: PortaPack LCD_RDX
+                | (0 << 3)                 // P2_3: PortaPack LCD_TE
+                | boot_bit(sgpio_6, 0)     // P2_2: SGPIO6, HOST_DATA6
+                | (0 << 1)                 // P2_1: PortaPack ADDR
+                | (0 << 0)                 // P2_0: PortaPack IO_STBX
         },
         {
 // GPIO6
@@ -444,17 +443,19 @@ const PALConfig pal_default_config = {
 
         {map_vregmode.scu_port, map_vregmode.scu_pin, scu_config_normal_drive_t{.mode = map_vregmode.gpio_mode, .epd = 0, .epun = 1, .ehs = 0, .ezi = 0, .zif = 0}},  // VREGMODE: TPS62410
 #ifdef PRALINE
-        {map_VAA_en.scu_port, map_VAA_en.scu_pin, scu_config_normal_drive_t{.mode = map_VAA_en.gpio_mode, .epd = 0, .epun = 1, .ehs = 0, .ezi = 0, .zif = 0}},        // P8_1: !VAA_EN
-        {8, 4, scu_config_normal_drive_t{.mode = 0, .epd = 0, .epun = 1, .ehs = 0, .ezi = 0, .zif = 0}},                                                              // P8_4: VBUS_IN_EN
-        {8, 5, scu_config_normal_drive_t{.mode = 0, .epd = 0, .epun = 1, .ehs = 0, .ezi = 0, .zif = 0}},                                                              // P8_5: VIN_IN_EN
-        {map_en_1v2.scu_port, map_en_1v2.scu_pin, scu_config_normal_drive_t{.mode = map_en_1v2.gpio_mode, .epd = 0, .epun = 1, .ehs = 0, .ezi = 0, .zif = 0}},        // P8_7: EN_1V2
-        {6, 7, scu_config_normal_drive_t{.mode = 4, .epd = 0, .epun = 1, .ehs = 0, .ezi = 0, .zif = 0}},                                                              // P6_7: 3.3V Aux Enable
-        {4, 9, scu_config_normal_drive_t{.mode = 4, .epd = 0, .epun = 1, .ehs = 0, .ezi = 0, .zif = 0}},                                                              // P4_9: TPS62410 mode
-        {map_p1_ctrl0.scu_port, map_p1_ctrl0.scu_pin, scu_config_normal_drive_t{.mode = map_p1_ctrl0.gpio_mode, .epd = 1, .epun = 1, .ehs = 0, .ezi = 0, .zif = 0}},  // P2_10: P1_CTRL0
-        {map_p1_ctrl2.scu_port, map_p1_ctrl2.scu_pin, scu_config_normal_drive_t{.mode = map_p1_ctrl2.gpio_mode, .epd = 0, .epun = 0, .ehs = 0, .ezi = 0, .zif = 0}},  // P6_9: P1_CTRL2 (Output VCC, PU ON,)
-        {map_p2_ctrl0.scu_port, map_p2_ctrl0.scu_pin, scu_config_normal_drive_t{.mode = map_p2_ctrl0.gpio_mode, .epd = 1, .epun = 1, .ehs = 0, .ezi = 0, .zif = 0}},  // PE_3: P2_CTRL0
-        {map_p2_ctrl1.scu_port, map_p2_ctrl1.scu_pin, scu_config_normal_drive_t{.mode = map_p2_ctrl1.gpio_mode, .epd = 1, .epun = 1, .ehs = 0, .ezi = 0, .zif = 0}},  // PE_4: P2_CTRL1
-        {map_ant_bias.scu_port, map_ant_bias.scu_pin, scu_config_normal_drive_t{.mode = map_ant_bias.gpio_mode, .epd = 0, .epun = 1, .ehs = 0, .ezi = 0, .zif = 0}},  // P2_12: !ANT BIAS
+        {map_VAA_en.scu_port, map_VAA_en.scu_pin, scu_config_normal_drive_t{.mode = map_VAA_en.gpio_mode, .epd = 0, .epun = 1, .ehs = 0, .ezi = 0, .zif = 0}},                                // P8_1: !VAA_EN
+        {8, 4, scu_config_normal_drive_t{.mode = 0, .epd = 0, .epun = 1, .ehs = 0, .ezi = 0, .zif = 0}},                                                                                      // P8_4: VBUS_IN_EN
+        {8, 5, scu_config_normal_drive_t{.mode = 0, .epd = 0, .epun = 1, .ehs = 0, .ezi = 0, .zif = 0}},                                                                                      // P8_5: VIN_IN_EN
+        {map_en_1v2.scu_port, map_en_1v2.scu_pin, scu_config_normal_drive_t{.mode = map_en_1v2.gpio_mode, .epd = 0, .epun = 1, .ehs = 0, .ezi = 0, .zif = 0}},                                // P8_7: EN_1V2
+        {map_aux_power_enable.scu_port, map_aux_power_enable.scu_pin, scu_config_normal_drive_t{.mode = map_aux_power_enable.gpio_mode, .epd = 0, .epun = 1, .ehs = 0, .ezi = 0, .zif = 0}},  // P6_7: !3.3V Aux Enable
+        {map_aux_power_oc.scu_port, map_aux_power_oc.scu_pin, scu_config_normal_drive_t{.mode = map_aux_power_oc.gpio_mode, .epd = 0, .epun = 0, .ehs = 0, .ezi = 1, .zif = 0}},              // P6_11: !3.3V Aux overcurrent input
+        {4, 9, scu_config_normal_drive_t{.mode = 4, .epd = 0, .epun = 1, .ehs = 0, .ezi = 0, .zif = 0}},                                                                                      // P4_9: TPS62410 mode
+        {map_p1_ctrl0.scu_port, map_p1_ctrl0.scu_pin, scu_config_normal_drive_t{.mode = map_p1_ctrl0.gpio_mode, .epd = 1, .epun = 1, .ehs = 0, .ezi = 0, .zif = 0}},                          // P2_10: P1_CTRL0
+        {map_p1_ctrl2.scu_port, map_p1_ctrl2.scu_pin, scu_config_normal_drive_t{.mode = map_p1_ctrl2.gpio_mode, .epd = 0, .epun = 0, .ehs = 0, .ezi = 0, .zif = 0}},                          // P6_9: P1_CTRL2 (Output VCC, PU ON,)
+        {map_p2_ctrl0.scu_port, map_p2_ctrl0.scu_pin, scu_config_normal_drive_t{.mode = map_p2_ctrl0.gpio_mode, .epd = 1, .epun = 1, .ehs = 0, .ezi = 0, .zif = 0}},                          // PE_3: P2_CTRL0
+        {map_p2_ctrl1.scu_port, map_p2_ctrl1.scu_pin, scu_config_normal_drive_t{.mode = map_p2_ctrl1.gpio_mode, .epd = 1, .epun = 1, .ehs = 0, .ezi = 0, .zif = 0}},                          // PE_4: P2_CTRL1
+        {map_ant_bias.scu_port, map_ant_bias.scu_pin, scu_config_normal_drive_t{.mode = map_ant_bias.gpio_mode, .epd = 0, .epun = 1, .ehs = 0, .ezi = 0, .zif = 0}},                          // P2_12: !ANT BIAS
+        {map_ant_bias_oc.scu_port, map_ant_bias_oc.scu_pin, scu_config_normal_drive_t{.mode = map_ant_bias_oc.gpio_mode, .epd = 0, .epun = 0, .ehs = 0, .ezi = 1, .zif = 0}},                 // P2_11: !ANT BIAS overcurrent input
 #endif
 
         /* HackRF: I2C0 */
@@ -498,8 +499,8 @@ const PALConfig pal_default_config = {
         {4, 10, scu_config_normal_drive_t{.mode = 7, .epd = 1, .epun = 1, .ehs = 0, .ezi = 1, .zif = 0}},                                                                      // P4_10: FPGA Config Done (Input GND)
         {map_trigger_in.scu_port, map_trigger_in.scu_pin, scu_config_normal_drive_t{.mode = map_trigger_in.gpio_mode, .epd = 1, .epun = 1, .ehs = 0, .ezi = 1, .zif = 0}},     // PD_12: TRIGGER IN (Input GND, Mode 4)
         {map_trigger_out.scu_port, map_trigger_out.scu_pin, scu_config_normal_drive_t{.mode = map_trigger_out.gpio_mode, .epd = 0, .epun = 1, .ehs = 1, .ezi = 0, .zif = 0}},  // P2_6: TRIGGER
-        {2, 5, scu_config_normal_drive_t{.mode = 4, .epd = 1, .epun = 1, .ehs = 0, .ezi = 1, .zif = 0}},
-        {map_clkin_ctrl.scu_port, map_clkin_ctrl.scu_pin, scu_config_normal_drive_t{.mode = map_clkin_ctrl.gpio_mode, .epd = 0, .epun = 1, .ehs = 0, .ezi = 0, .zif = 0}},  // P1_20  CLKIN_ctrl
+        {map_pps_in_out.scu_port, map_pps_in_out.scu_pin, scu_config_normal_drive_t{.mode = map_pps_in_out.gpio_mode, .epd = 0, .epun = 0, .ehs = 1, .ezi = 1, .zif = 0}},     // P2_5 PPS bidirectional
+        {map_clkin_ctrl.scu_port, map_clkin_ctrl.scu_pin, scu_config_normal_drive_t{.mode = map_clkin_ctrl.gpio_mode, .epd = 0, .epun = 1, .ehs = 0, .ezi = 0, .zif = 0}},     // P1_20  CLKIN_ctrl
 #else
 
         {4, 9, scu_config_normal_drive_t{.mode = 7, .epd = 0, .epun = 0, .ehs = 0, .ezi = 0, .zif = 0}},                                                                    // SGPIO14/BANK2F3M4: CPLD_P81
@@ -555,9 +556,6 @@ const PALConfig pal_default_config = {
 // SAFE TERMINATION (Unused pins grounded to prevent noise & save power)
 
 #ifdef PRALINE
-        {1, 1, scu_config_normal_drive_t{.mode = 0, .epd = 1, .epun = 1, .ehs = 0, .ezi = 1, .zif = 0}},   // P1_1: Input GND
-        {2, 7, scu_config_normal_drive_t{.mode = 0, .epd = 1, .epun = 1, .ehs = 0, .ezi = 1, .zif = 0}},   // P2_7: Input GND
-        {1, 2, scu_config_normal_drive_t{.mode = 0, .epd = 0, .epun = 0, .ehs = 0, .ezi = 1, .zif = 0}},   // P1_2: Input VCC
         {4, 6, scu_config_normal_drive_t{.mode = 0, .epd = 0, .epun = 0, .ehs = 0, .ezi = 1, .zif = 0}},   // P4_6: Input VCC
         {6, 10, scu_config_normal_drive_t{.mode = 0, .epd = 1, .epun = 1, .ehs = 0, .ezi = 0, .zif = 0}},  // P6_10: Output GND
         {4, 8, scu_config_normal_drive_t{.mode = 4, .epd = 1, .epun = 1, .ehs = 0, .ezi = 0, .zif = 0}},   // P4_8: Output GND
@@ -567,9 +565,7 @@ const PALConfig pal_default_config = {
         {11, 2, scu_config_normal_drive_t{.mode = 4, .epd = 1, .epun = 1, .ehs = 0, .ezi = 1, .zif = 0}},  // PB_2: Unused IN
         {11, 4, scu_config_normal_drive_t{.mode = 4, .epd = 1, .epun = 1, .ehs = 0, .ezi = 1, .zif = 0}},  // PB_4: Unused IN
 #else
-        {1, 1, scu_config_normal_drive_t{.mode = 0, .epd = 0, .epun = 1, .ehs = 0, .ezi = 0, .zif = 0}},                                                     // P1_1
-        {1, 2, scu_config_normal_drive_t{.mode = 0, .epd = 0, .epun = 1, .ehs = 0, .ezi = 0, .zif = 0}},                                                     // P1_2
-        {map_og_rx.scu_port, map_og_rx.scu_pin, scu_config_normal_drive_t{.mode = map_og_rx.gpio_mode, .epd = 0, .epun = 1, .ehs = 0, .ezi = 0, .zif = 0}},  // P2_5                                                  // P2_7
+        {map_og_rx.scu_port, map_og_rx.scu_pin, scu_config_normal_drive_t{.mode = map_og_rx.gpio_mode, .epd = 0, .epun = 1, .ehs = 0, .ezi = 0, .zif = 0}},  // P2_5
         {4, 8, scu_config_normal_drive_t{.mode = 0, .epd = 0, .epun = 1, .ehs = 0, .ezi = 0, .zif = 0}},                                                     // P4_8
 #endif
 
@@ -587,6 +583,12 @@ const PALConfig pal_default_config = {
         {6, 1, scu_config_normal_drive_t{.mode = 0, .epd = 0, .epun = 1, .ehs = 0, .ezi = 0, .zif = 0}},  // CPLD_TCK: PortaPack CPLD.TCK(I)
         {6, 2, scu_config_normal_drive_t{.mode = 0, .epd = 0, .epun = 1, .ehs = 0, .ezi = 1, .zif = 0}},  // CPLD_TDI: PortaPack CPLD.TDI(I)
 
+        {map_isp.scu_port, map_isp.scu_pin, scu_config_normal_drive_t{.mode = map_isp.gpio_mode, .epd = 0, .epun = 1, .ehs = 0, .ezi = 0, .zif = 0}},                       // P2_7: ISP: 10K PU, Unused
+        {map_dfu_boot_0.scu_port, map_dfu_boot_0.scu_pin, scu_config_normal_drive_t{.mode = map_dfu_boot_0.gpio_mode, .epd = 0, .epun = 1, .ehs = 0, .ezi = 0, .zif = 0}},  // P1_1: 10K PU, BOOT0
+        {map_dfu_boot_1.scu_port, map_dfu_boot_1.scu_pin, scu_config_normal_drive_t{.mode = map_dfu_boot_1.gpio_mode, .epd = 0, .epun = 1, .ehs = 0, .ezi = 0, .zif = 0}},  // P1_2: 10K PD, BOOT1
+        {map_dfu_button.scu_port, map_dfu_button.scu_pin, scu_config_normal_drive_t{.mode = map_dfu_button.gpio_mode, .epd = 0, .epun = 0, .ehs = 0, .ezi = 1, .zif = 1}},  // P2_8: 10K PD, BOOT2, DFU button
+        {map_lcd_wrx.scu_port, map_lcd_wrx.scu_pin, scu_config_normal_drive_t{.mode = map_lcd_wrx.gpio_mode, .epd = 0, .epun = 1, .ehs = 0, .ezi = 1, .zif = 0}},           // P2_9: 10K PD, BOOT3, PortaPack LCD_WRX
+
     }};
 
 #ifndef PRALINE
@@ -595,14 +597,8 @@ static const std::array<gpio_setup_t, 6> gpio_setup_og{{
     {
 
         // GPIO0
-        .data = (0 << 9)    // P1_2:  10K PD, BOOT1
-                | (1 << 8)  // P1_1:  10K PU, BOOT0
-                | (1 << 7)  // P2_7:  10K PU, ISP
-        ,
-        .dir = (0 << 9)    // P1_2:  10K PD, BOOT1
-               | (0 << 8)  // P1_1:  10K PU, BOOT0
-               | (0 << 7)  // P2_7:  10K PU, ISP
-    },
+        .data = 0,
+        .dir = 0},
     {// GPIO1
      .data = 0,
      .dir = 0},
@@ -640,13 +636,13 @@ static const std::array<gpio_setup_t, 6> gpio_setup_og{{
 static const std::array<gpio_setup_t, 6> gpio_setup_r9{{
     {
         // GPIO0
-        .data = (0 << 9)              // P1_2:  10K PD, BOOT1, CLKOUT_EN
-                | (1 << 8)            // P1_1:  10K PU, BOOT0, MCU_CLK_EN
-                | boot_bit(r9_rx, 1)  // P2_7:  10K PU, ISP, RX
+        .data = boot_bit(r9_clkout_en, 0)     // P1_2:  10K PD, BOOT1, CLKOUT_EN
+                | boot_bit(r9_mcu_clk_en, 1)  // P1_1:  10K PU, BOOT0, MCU_CLK_EN
+                | boot_bit(r9_rx, 1)          // P2_7:  10K PU, ISP, RX
         ,
-        .dir = (0 << 9)              // P1_2:  10K PD, BOOT1, CLKOUT_EN
-               | (0 << 8)            // P1_1:  10K PU, BOOT0, MCU_CLK_EN
-               | boot_bit(r9_rx, 1)  // P2_7:  10K PU, ISP, RX
+        .dir = boot_bit(r9_clkout_en, 1)     // P1_2:  10K PD, BOOT1, CLKOUT_EN
+               | boot_bit(r9_mcu_clk_en, 1)  // P1_1:  10K PU, BOOT0, MCU_CLK_EN
+               | boot_bit(r9_rx, 1)          // P2_7:  10K PU, ISP, RX
     },
     {// GPIO1
      .data = 0,
@@ -670,18 +666,18 @@ static const std::array<gpio_setup_t, 6> gpio_setup_r9{{
      .dir = 0},
     {
         // GPIO5
-        .data = (0 << 15)    // P6_7:  CLKIN_EN
-                | (0 << 12)  // P4_8:  CLKIN_DETECT
-                | (0 << 5)   // P2_5:  HOST_SYNC_EN
+        .data = boot_bit(r9_clkin_en, 0)  // P6_7:  CLKIN_EN
+                | (0 << 12)               // P4_8:  CLKIN_DETECT
+                | (0 << 5)                // P2_5:  HOST_SYNC_EN
         ,
-        .dir = (1 << 15)    // P6_7:  CLKIN_EN
-               | (0 << 12)  // P4_8:  CLKIN_DETECT
-               | (0 << 5)   // P2_5:  HOST_SYNC_EN
+        .dir = boot_bit(r9_clkin_en, 1)  // P6_7:  CLKIN_EN
+               | (0 << 12)               // P4_8:  CLKIN_DETECT
+               | (0 << 5)                // P2_5:  HOST_SYNC_EN
     },
 }};
 
 /* Additional SCU configuration for HackRF OG */
-static const std::array<scu_setup_t, 9> pins_setup_og{{
+static const std::array<scu_setup_t, 6> pins_setup_og{{
 
     /* Power control */
     {map_og_VAA_en.scu_port, map_og_VAA_en.scu_pin, scu_config_normal_drive_t{.mode = map_og_VAA_en.gpio_mode, .epd = 0, .epun = 1, .ehs = 0, .ezi = 0, .zif = 0}}, /* !VAA_ENABLE: 10K PU, Q3.G(I), power to VAA */
@@ -694,30 +690,25 @@ static const std::array<scu_setup_t, 9> pins_setup_og{{
 
     /* SGPIO for sample transfer interface to HackRF CPLD. */
     {map_sgpio_13.scu_port, map_sgpio_13.scu_pin, scu_config_normal_drive_t{.mode = map_sgpio_13.gpio_mode, .epd = 1, .epun = 1, .ehs = 0, .ezi = 0, .zif = 0}}, /* SGPIO13/BANK2F3M2: CPLD.90/HOST_SYNC_EN(I) */
-    /* Miscellaneous */
-    {1, 1, scu_config_normal_drive_t{.mode = 0, .epd = 0, .epun = 1, .ehs = 0, .ezi = 0, .zif = 0}}, /* P1_1/P74: 10K PU, BOOT0 */
-    {1, 2, scu_config_normal_drive_t{.mode = 0, .epd = 0, .epun = 1, .ehs = 0, .ezi = 0, .zif = 0}}, /* P1_2/P73: 10K PD, BOOT1 */
-    {2, 7, scu_config_normal_drive_t{.mode = 0, .epd = 0, .epun = 1, .ehs = 0, .ezi = 0, .zif = 0}}, /* ISP: 10K PU, Unused */
-
 }};
 
 /* Additional SCU configuration for HackRF r9 */
 static const std::array<scu_setup_t, 9> pins_setup_r9{{
     /* Power control */
-    {map_r9_VAA_en.scu_port, map_r9_VAA_en.scu_pin, scu_config_normal_drive_t{.mode = map_r9_VAA_en.gpio_mode, .epd = 0, .epun = 1, .ehs = 0, .ezi = 0, .zif = 0}}, /* !VAA_ENABLE: 10K PU, Q3.G(I), power to VAA */
-    {map_r9_1v8_en.scu_port, map_r9_1v8_en.scu_pin, scu_config_normal_drive_t{.mode = map_r9_1v8_en.gpio_mode, .epd = 0, .epun = 1, .ehs = 0, .ezi = 0, .zif = 0}}, /* EN1V8: 10K PD, TPS62410.EN2(I), 1V8LED.A(I) */
+    {map_r9_VAA_en.scu_port, map_r9_VAA_en.scu_pin, scu_config_normal_drive_t{.mode = map_r9_VAA_en.gpio_mode, .epd = 0, .epun = 1, .ehs = 0, .ezi = 0, .zif = 0}},  // !VAA_ENABLE: 10K PU, Q3.G(I), power to VAA
+    {map_r9_1v8_en.scu_port, map_r9_1v8_en.scu_pin, scu_config_normal_drive_t{.mode = map_r9_1v8_en.gpio_mode, .epd = 0, .epun = 1, .ehs = 0, .ezi = 0, .zif = 0}},  // EN1V8: 10K PD, TPS62410.EN2(I), 1V8LED.A(I)
 
     /* Radio section control */
-    {map_r9_rx.scu_port, map_r9_rx.scu_pin, scu_config_normal_drive_t{.mode = map_r9_rx.gpio_mode, .epd = 0, .epun = 1, .ehs = 0, .ezi = 0, .zif = 0}},          /* RX/ISP/P96: U7.VCTL(I), U10.VCTL(I), U2.VCTL(I) */
-    {map_ant_bias.scu_port, map_ant_bias.scu_pin, scu_config_normal_drive_t{.mode = map_ant_bias.gpio_mode, .epd = 0, .epun = 1, .ehs = 0, .ezi = 0, .zif = 0}}, /* !ANT_BIAS: 10K PU, Q4.G(I) */
+    {map_r9_rx.scu_port, map_r9_rx.scu_pin, scu_config_normal_drive_t{.mode = map_r9_rx.gpio_mode, .epd = 0, .epun = 1, .ehs = 0, .ezi = 0, .zif = 0}},           // RX/ISP/P96: U7.VCTL(I), U10.VCTL(I), U2.VCTL(I)
+    {map_ant_bias.scu_port, map_ant_bias.scu_pin, scu_config_normal_drive_t{.mode = map_ant_bias.gpio_mode, .epd = 0, .epun = 1, .ehs = 0, .ezi = 0, .zif = 0}},  // !ANT_BIAS: 10K PU, Q4.G(I)
 
     /* SGPIO for sample transfer interface to HackRF CPLD. */
     {2, 5, scu_config_normal_drive_t{.mode = 4, .epd = 1, .epun = 1, .ehs = 0, .ezi = 0, .zif = 0}}, /* BANK2F3M2: CPLD.90/HOST_SYNC_EN(I) */
 
     /* Clock control */
-    {1, 1, scu_config_normal_drive_t{.mode = 0, .epd = 0, .epun = 1, .ehs = 0, .ezi = 0, .zif = 0}}, /* MCU_CLK_EN/BOOT0: 10K PU, U28.1A(I) */
-    {1, 2, scu_config_normal_drive_t{.mode = 0, .epd = 0, .epun = 1, .ehs = 0, .ezi = 0, .zif = 0}}, /* CLKOUT_EN/BOOT1: 10K PD, U28.2A(I) */
-    {6, 7, scu_config_normal_drive_t{.mode = 4, .epd = 0, .epun = 1, .ehs = 0, .ezi = 0, .zif = 0}}, /* CLKIN_EN: U16.SEL(I), U26.1A(I) */
+    {map_r9_mcu_clk_en.scu_port, map_r9_mcu_clk_en.scu_pin, scu_config_normal_drive_t{.mode = map_r9_mcu_clk_en.gpio_mode, .epd = 0, .epun = 1, .ehs = 0, .ezi = 0, .zif = 0}},  // P1_1: MCU_CLK_EN/BOOT0: 10K PU, U28.1A(I)
+    {map_r9_clkout_en.scu_port, map_r9_clkout_en.scu_pin, scu_config_normal_drive_t{.mode = map_r9_clkout_en.gpio_mode, .epd = 0, .epun = 1, .ehs = 0, .ezi = 0, .zif = 0}},     // P1_2: CLKOUT_EN/BOOT1: 10K PD, U28.2A(I)
+    {map_r9_clkin_en.scu_port, map_r9_clkin_en.scu_pin, scu_config_normal_drive_t{.mode = map_r9_clkin_en.gpio_mode, .epd = 0, .epun = 1, .ehs = 0, .ezi = 0, .zif = 0}},        /* CLKIN_EN: U16.SEL(I), U26.1A(I) */
 
     /* Miscellaneous */
     {4, 8, scu_config_normal_drive_t{.mode = 1, .epd = 1, .epun = 1, .ehs = 0, .ezi = 0, .zif = 0}}, /* CLKIN_DETECT: U26.2Y(O) */
@@ -728,13 +719,11 @@ static const std::array<scu_setup_t, 9> pins_setup_r9{{
 
 #ifdef PRALINE
 
-static const std::array<scu_setup_t, 43> pins_setup_portapack{{
+static const std::array<scu_setup_t, 41> pins_setup_portapack{{
     {2, 0, scu_config_normal_drive_t{.mode = 4, .epd = 0, .epun = 1, .ehs = 0, .ezi = 1, .zif = 0}},  /* U0_TXD: PortaPack P2_0/IO_STBX */
     {2, 1, scu_config_normal_drive_t{.mode = 4, .epd = 0, .epun = 1, .ehs = 0, .ezi = 1, .zif = 0}},  /* U0_RXD: PortaPack P2_1/ADDR */
     {2, 3, scu_config_normal_drive_t{.mode = 4, .epd = 0, .epun = 1, .ehs = 0, .ezi = 1, .zif = 1}},  /* I2C1_SDA: PortaPack P2_3/LCD_TE */
     {2, 4, scu_config_normal_drive_t{.mode = 4, .epd = 0, .epun = 1, .ehs = 0, .ezi = 1, .zif = 1}},  /* I2C1_SCL: PortaPack P2_4/LCD_RDX */
-    {2, 8, scu_config_normal_drive_t{.mode = 1, .epd = 0, .epun = 0, .ehs = 0, .ezi = 1, .zif = 1}},  /* P2_8: 10K PD, BOOT2, DFU switch, PortaPack P2_8/<unused> */
-    {2, 9, scu_config_normal_drive_t{.mode = 0, .epd = 0, .epun = 1, .ehs = 0, .ezi = 1, .zif = 0}},  /* P2_9: 10K PD, BOOT3, PortaPack P2_9/LCD_WRX */
     {2, 13, scu_config_normal_drive_t{.mode = 0, .epd = 0, .epun = 1, .ehs = 0, .ezi = 1, .zif = 0}}, /* P2_13: PortaPack P2_13/DIR */
     {7, 0, scu_config_normal_drive_t{.mode = 0, .epd = 0, .epun = 1, .ehs = 0, .ezi = 1, .zif = 0}},  /* GPIO3_8: PortaPack GPIO3_8(IO) */
     {7, 1, scu_config_normal_drive_t{.mode = 0, .epd = 0, .epun = 1, .ehs = 0, .ezi = 1, .zif = 0}},  /* GPIO3_9: PortaPack GPIO3_9(IO) */
@@ -785,13 +774,11 @@ static const std::array<scu_setup_t, 43> pins_setup_portapack{{
 }};
 
 #else
-static const std::array<scu_setup_t, 26> pins_setup_portapack{{
+static const std::array<scu_setup_t, 24> pins_setup_portapack{{
     {2, 0, scu_config_normal_drive_t{.mode = 4, .epd = 0, .epun = 1, .ehs = 0, .ezi = 1, .zif = 0}},  /* U0_TXD: PortaPack P2_0/IO_STBX */
     {2, 1, scu_config_normal_drive_t{.mode = 4, .epd = 0, .epun = 1, .ehs = 0, .ezi = 1, .zif = 0}},  /* U0_RXD: PortaPack P2_1/ADDR */
     {2, 3, scu_config_normal_drive_t{.mode = 4, .epd = 0, .epun = 1, .ehs = 0, .ezi = 1, .zif = 0}},  /* I2C1_SDA: PortaPack P2_3/LCD_TE */
     {2, 4, scu_config_normal_drive_t{.mode = 4, .epd = 0, .epun = 1, .ehs = 0, .ezi = 1, .zif = 0}},  /* I2C1_SCL: PortaPack P2_4/LCD_RDX */
-    {2, 8, scu_config_normal_drive_t{.mode = 1, .epd = 0, .epun = 0, .ehs = 0, .ezi = 1, .zif = 1}},  /* P2_8: 10K PD, BOOT2, DFU switch, PortaPack P2_8/<unused> */
-    {2, 9, scu_config_normal_drive_t{.mode = 0, .epd = 0, .epun = 1, .ehs = 0, .ezi = 1, .zif = 0}},  /* P2_9: 10K PD, BOOT3, PortaPack P2_9/LCD_WRX */
     {2, 13, scu_config_normal_drive_t{.mode = 0, .epd = 0, .epun = 1, .ehs = 0, .ezi = 1, .zif = 0}}, /* P2_13: PortaPack P2_13/DIR */
     {7, 0, scu_config_normal_drive_t{.mode = 0, .epd = 0, .epun = 1, .ehs = 0, .ezi = 1, .zif = 0}},  /* GPIO3_8: PortaPack GPIO3_8(IO) */
     {7, 1, scu_config_normal_drive_t{.mode = 0, .epd = 0, .epun = 1, .ehs = 0, .ezi = 1, .zif = 0}},  /* GPIO3_9: PortaPack GPIO3_9(IO) */

--- a/firmware/chibios-portapack/boards/PORTAPACK_APPLICATION/board.cpp
+++ b/firmware/chibios-portapack/boards/PORTAPACK_APPLICATION/board.cpp
@@ -169,7 +169,7 @@ const PALConfig pal_default_config = {
                     | boot_bit(led_rx, 1)   // P4_2:  LED2 (RX)
                     | boot_bit(led_usb, 1)  // P4_1:  LED1 (USB)
 #else
-                    | boot_bit(tx_amp, 1)     // P5_6:  TX_AMP
+                    | boot_bit(tx_amp, 0)     // P5_6:  TX_AMP
                     | (1 << 13)               // P5_4:  MIXER_ENX, 10K PU
                     | boot_bit(rx_mix_bp, 1)  // P5_3:  RX_MIX_BP
                     | boot_bit(tx_mix_bp, 0)  // P5_2:  TX_MIX_BP

--- a/firmware/chibios-portapack/os/hal/platforms/LPC43xx/pal_lld.h
+++ b/firmware/chibios-portapack/os/hal/platforms/LPC43xx/pal_lld.h
@@ -52,10 +52,9 @@
  */
 
 #ifdef PRALINE
-// #pragma message "PRALINE DEFINED - SZAMOLJUK AZ ELEMEKET"
 #define SCU_ARRAY_SIZE 80
 #else
-#define SCU_ARRAY_SIZE 58
+#define SCU_ARRAY_SIZE 57
 #endif
 
 typedef struct {

--- a/firmware/chibios-portapack/os/hal/platforms/LPC43xx/pal_lld.h
+++ b/firmware/chibios-portapack/os/hal/platforms/LPC43xx/pal_lld.h
@@ -52,9 +52,10 @@
  */
 
 #ifdef PRALINE
-#define SCU_ARRAY_SIZE 76
+// #pragma message "PRALINE DEFINED - SZAMOLJUK AZ ELEMEKET"
+#define SCU_ARRAY_SIZE 80
 #else
-#define SCU_ARRAY_SIZE 55
+#define SCU_ARRAY_SIZE 58
 #endif
 
 typedef struct {

--- a/firmware/chibios-portapack/os/hal/platforms/LPC43xx/pal_lld.h
+++ b/firmware/chibios-portapack/os/hal/platforms/LPC43xx/pal_lld.h
@@ -52,9 +52,9 @@
  */
 
 #ifdef PRALINE
-#define SCU_ARRAY_SIZE 78
+#define SCU_ARRAY_SIZE 76
 #else
-#define SCU_ARRAY_SIZE 56
+#define SCU_ARRAY_SIZE 55
 #endif
 
 typedef struct {

--- a/firmware/common/gpio.hpp
+++ b/firmware/common/gpio.hpp
@@ -511,7 +511,7 @@ constexpr Pin pin_rf_amp_enable{map_rf_amp_enable.scu_port, map_rf_amp_enable.sc
 constexpr GPIO rf_amp_enable{pin_rf_amp_enable, map_rf_amp_enable.gpio_port, map_rf_amp_enable.gpio_pad, map_rf_amp_enable.gpio_mode};  // GPIO[4]9
 
 constexpr Pin pin_aux_power_enable{map_aux_power_enable.scu_port, map_aux_power_enable.scu_pin};                                                       // SCU: P6_7
-constexpr GPIO aux_power_enable{pin_aux_power_enable, map_aux_power_enable.gpio_port, map_aux_power_enable.gpio_pad, map_aux_power_enable.gpio_mode};  // GPIO[5]15
+constexpr GPIO aux_power_enable{pin_aux_power_enable, map_aux_power_enable.gpio_port, map_aux_power_enable.gpio_pad, map_aux_power_enable.gpio_mode, Polarity::ActiveLow};  // GPIO[5]15
 
 constexpr Pin pin_aux_power_oc{map_aux_power_oc.scu_port, map_aux_power_oc.scu_pin};                                               // SCU: P6_11
 constexpr GPIO aux_power_oc{pin_aux_power_oc, map_aux_power_oc.gpio_port, map_aux_power_oc.gpio_pad, map_aux_power_oc.gpio_mode};  // GPIO[3]7

--- a/firmware/common/gpio.hpp
+++ b/firmware/common/gpio.hpp
@@ -377,15 +377,25 @@ constexpr PinMap map_sgpio_4{9, 4, 5, 17, 6};
 constexpr PinMap map_sgpio_8{8, 0, 4, 0, 4};
 constexpr PinMap map_sgpio_9{9, 3, 4, 15, 6};
 constexpr PinMap map_sgpio_10{8, 2, 4, 2, 4};
-constexpr PinMap map_en_1v2{8, 7, 4, 7, 0};
+
 constexpr PinMap map_vregmode{4, 9, 5, 13, 4};
+constexpr PinMap map_en_1v2{8, 7, 4, 7, 0};
 constexpr PinMap map_VAA_en{8, 1, 4, 1, 0};
+constexpr PinMap map_aux_power_enable{6, 7, 5, 15, 4};
+
+constexpr PinMap map_ant_bias{2, 12, 1, 12, 0};
+
+constexpr PinMap map_ant_bias_oc{2, 11, 1, 11, 0};
+constexpr PinMap map_aux_power_oc{6, 11, 3, 7, 0};
+
 constexpr PinMap map_led_mcu{8, 6, 4, 6, 0};
 constexpr PinMap map_mix_bypass{6, 3, 3, 2, 0};
 constexpr PinMap map_lpf{10, 1, 4, 8, 4};
-constexpr PinMap map_ant_bias{2, 12, 1, 12, 0};
 constexpr PinMap map_tx_enable{6, 5, 3, 4, 0};
 constexpr PinMap map_rf_amp_enable{10, 2, 4, 9, 0};
+constexpr PinMap map_pps_in_out{2, 5, 5, 5, 4};
+// constexpr PinMap map_unused_1{2, 7, 0, 7, 0};
+
 #else
 constexpr PinMap map_sgpio_4{6, 3, 3, 2, 2};
 constexpr PinMap map_sgpio_8{9, 6, 4, 11, 6};
@@ -412,6 +422,9 @@ constexpr PinMap map_rx_amp{2, 11, 1, 11, 0};
 constexpr PinMap map_tx_amp_pwr{6, 9, 3, 5, 0};
 constexpr PinMap map_rx_amp_pwr{2, 12, 1, 12, 0};
 constexpr PinMap map_ant_bias{4, 4, 2, 4, 0};
+constexpr PinMap map_r9_mcu_clk_en{1, 1, 0, 8, 0};
+constexpr PinMap map_r9_clkout_en{1, 2, 0, 9, 0};
+constexpr PinMap map_r9_clkin_en{6, 7, 5, 15, 4};
 #endif
 
 constexpr PinMap map_sgpio_0{0, 0, 0, 0, 3};
@@ -426,6 +439,12 @@ constexpr PinMap map_sgpio_12{1, 18, 0, 13, 0};
 constexpr PinMap map_led_usb{4, 1, 2, 1, 0};
 constexpr PinMap map_led_rx{4, 2, 2, 2, 0};
 constexpr PinMap map_led_tx{6, 12, 2, 8, 0};
+
+constexpr PinMap map_dfu_boot_0{1, 1, 0, 8, 0};
+constexpr PinMap map_dfu_boot_1{1, 2, 0, 9, 0};
+constexpr PinMap map_dfu_button{2, 8, 5, 7, 4};
+constexpr PinMap map_lcd_wrx{2, 9, 1, 10, 0};
+constexpr PinMap map_isp{2, 7, 0, 7, 0};
 #ifdef PRALINE
 
 // P1 Multiplexer control pins
@@ -491,6 +510,18 @@ constexpr GPIO tx_enable{pin_tx_enable, map_tx_enable.gpio_port, map_tx_enable.g
 constexpr Pin pin_rf_amp_enable{map_rf_amp_enable.scu_port, map_rf_amp_enable.scu_pin};                                                 // SCU: PA_2
 constexpr GPIO rf_amp_enable{pin_rf_amp_enable, map_rf_amp_enable.gpio_port, map_rf_amp_enable.gpio_pad, map_rf_amp_enable.gpio_mode};  // GPIO[4]9
 
+constexpr Pin pin_aux_power_enable{map_aux_power_enable.scu_port, map_aux_power_enable.scu_pin};                                                       // SCU: P6_7
+constexpr GPIO aux_power_enable{pin_aux_power_enable, map_aux_power_enable.gpio_port, map_aux_power_enable.gpio_pad, map_aux_power_enable.gpio_mode};  // GPIO[5]15
+
+constexpr Pin pin_aux_power_oc{map_aux_power_oc.scu_port, map_aux_power_oc.scu_pin};                                               // SCU: P6_11
+constexpr GPIO aux_power_oc{pin_aux_power_oc, map_aux_power_oc.gpio_port, map_aux_power_oc.gpio_pad, map_aux_power_oc.gpio_mode};  // GPIO[3]7
+
+constexpr Pin pin_ant_bias_oc{map_ant_bias_oc.scu_port, map_ant_bias_oc.scu_pin};                                                                  // SCU: P2_11
+constexpr GPIO ant_bias_oc{pin_ant_bias_oc, map_ant_bias_oc.gpio_port, map_ant_bias_oc.gpio_pad, map_ant_bias_oc.gpio_mode, Polarity::ActiveLow};  // GPIO[1]11}
+
+constexpr Pin pin_pps_in_out{map_pps_in_out.scu_port, map_pps_in_out.scu_pin};                                           // SCU: P2_5
+constexpr GPIO pps_in_out{pin_pps_in_out, map_pps_in_out.gpio_port, map_pps_in_out.gpio_pad, map_pps_in_out.gpio_mode};  // GPIO[5]5}
+
 #else
 constexpr Pin pin_sgpio_13{map_sgpio_13.scu_port, map_sgpio_13.scu_pin};                                       // SCU: P4_8
 constexpr GPIO sgpio_13{pin_sgpio_13, map_sgpio_13.gpio_port, map_sgpio_13.gpio_pad, map_sgpio_13.gpio_mode};  // GPIO[5]12
@@ -555,6 +586,15 @@ constexpr GPIO tx_amp_pwr{pin_tx_amp_pwr, map_tx_amp_pwr.gpio_port, map_tx_amp_p
 constexpr Pin pin_rx_amp_pwr{map_rx_amp_pwr.scu_port, map_rx_amp_pwr.scu_pin};                                                                // SCU: P2_12
 constexpr GPIO rx_amp_pwr{pin_rx_amp_pwr, map_rx_amp_pwr.gpio_port, map_rx_amp_pwr.gpio_pad, map_rx_amp_pwr.gpio_mode, Polarity::ActiveLow};  // GPIO[1]12
 
+constexpr Pin pin_r9_mcu_clk_en{map_r9_mcu_clk_en.scu_port, map_r9_mcu_clk_en.scu_pin};                                                 // SCU: P1_1
+constexpr GPIO r9_mcu_clk_en{pin_r9_mcu_clk_en, map_r9_mcu_clk_en.gpio_port, map_r9_mcu_clk_en.gpio_pad, map_r9_mcu_clk_en.gpio_mode};  // GPIO[0]8
+
+constexpr Pin pin_r9_clkout_en{map_r9_clkout_en.scu_port, map_r9_clkout_en.scu_pin};                                               // SCU: P1_2
+constexpr GPIO r9_clkout_en{pin_r9_clkout_en, map_r9_clkout_en.gpio_port, map_r9_clkout_en.gpio_pad, map_r9_clkout_en.gpio_mode};  // GPIO[0]9
+
+constexpr Pin pin_r9_clkin_en{map_r9_clkin_en.scu_port, map_r9_clkin_en.scu_pin};                                             // SCU: P6_7
+constexpr GPIO r9_clkin_en{pin_r9_clkin_en, map_r9_clkin_en.gpio_port, map_r9_clkin_en.gpio_pad, map_r9_clkin_en.gpio_mode};  // GPIO[5]15
+
 static const motocon_pwm_resources_t motocon_pwm_resources = {
     .base = {.clk = &LPC_CGU->BASE_APB1_CLK, .stat = &LPC_CCU1->BASE_STAT, .stat_mask = (1 << 1)},
     .branch = {.cfg = &LPC_CCU1->CLK_APB1_MOTOCON_PWM_CFG, .stat = &LPC_CCU1->CLK_APB1_MOTOCON_PWM_STAT},
@@ -615,6 +655,21 @@ constexpr GPIO lpf{pin_lpf, map_lpf.gpio_port, map_lpf.gpio_pad, map_lpf.gpio_mo
 
 constexpr Pin pin_ant_bias{map_ant_bias.scu_port, map_ant_bias.scu_pin};                                                            // SCU: R9: P4_4 , PRALINE: P2_12
 constexpr GPIO ant_bias{pin_ant_bias, map_ant_bias.gpio_port, map_ant_bias.gpio_pad, map_ant_bias.gpio_mode, Polarity::ActiveLow};  // R9: GPIO[2]4, PRALINE: GPIO[1]12}
+
+constexpr Pin pin_dfu_boot_0{map_dfu_boot_0.scu_port, map_dfu_boot_0.scu_pin};                                           // SCU: P1_1
+constexpr GPIO dfu_boot_0{pin_dfu_boot_0, map_dfu_boot_0.gpio_port, map_dfu_boot_0.gpio_pad, map_dfu_boot_0.gpio_mode};  // GPIO[0]8
+
+constexpr Pin pin_dfu_boot_1{map_dfu_boot_1.scu_port, map_dfu_boot_1.scu_pin};                                           // SCU: P1_2
+constexpr GPIO dfu_boot_1{pin_dfu_boot_1, map_dfu_boot_1.gpio_port, map_dfu_boot_1.gpio_pad, map_dfu_boot_1.gpio_mode};  // GPIO[0]9
+
+constexpr Pin pin_dfu_button{map_dfu_button.scu_port, map_dfu_button.scu_pin};                                           // SCU: P2_8
+constexpr GPIO dfu_button{pin_dfu_button, map_dfu_button.gpio_port, map_dfu_button.gpio_pad, map_dfu_button.gpio_mode};  // GPIO[5]7
+
+constexpr Pin pin_lcd_wrx{map_lcd_wrx.scu_port, map_lcd_wrx.scu_pin};                                     // SCU: P2_9
+constexpr GPIO lcd_wrx{pin_lcd_wrx, map_lcd_wrx.gpio_port, map_lcd_wrx.gpio_pad, map_lcd_wrx.gpio_mode};  // GPIO[1]10
+
+constexpr Pin pin_isp{map_isp.scu_port, map_isp.scu_pin};                                 // SCU: P2_7
+constexpr GPIO dfu_isp{pin_isp, map_isp.gpio_port, map_isp.gpio_pad, map_isp.gpio_mode};  // GPIO[0]7
 
 }  // namespace gpio_control
 

--- a/firmware/common/gpio.hpp
+++ b/firmware/common/gpio.hpp
@@ -361,8 +361,8 @@ constexpr PinMap map_p1_ctrl0{2, 10, 0, 14, 0};  // SCU: 2, 10 | GPIO: 0, 14
 constexpr PinMap map_p1_ctrl1{6, 8, 5, 16, 4};
 constexpr PinMap map_p1_ctrl2{6, 9, 3, 5, 0};
 
-constexpr PinMap map_p2_ctrl0{8, 3, 7, 3, 0};
-constexpr PinMap map_p2_ctrl1{8, 4, 7, 4, 0};
+constexpr PinMap map_p2_ctrl0{14, 3, 7, 3, 0};
+constexpr PinMap map_p2_ctrl1{14, 4, 7, 4, 0};
 
 constexpr PinMap map_trigger_out{2, 6, 5, 6, 4};
 constexpr PinMap map_trigger_in{13, 12, 6, 26, 4};
@@ -381,6 +381,11 @@ constexpr PinMap map_en_1v2{8, 7, 4, 7, 0};
 constexpr PinMap map_vregmode{4, 9, 5, 13, 4};
 constexpr PinMap map_VAA_en{8, 1, 4, 1, 0};
 constexpr PinMap map_led_mcu{8, 6, 4, 6, 0};
+constexpr PinMap map_mix_bypass{6, 3, 3, 2, 0};
+constexpr PinMap map_lpf{10, 1, 4, 8, 4};
+constexpr PinMap map_ant_bias{2, 12, 1, 12, 0};
+constexpr PinMap map_tx_enable{6, 5, 3, 4, 0};
+constexpr PinMap map_rf_amp_enable{10, 2, 4, 9, 0};
 #else
 constexpr PinMap map_sgpio_4{6, 3, 3, 2, 2};
 constexpr PinMap map_sgpio_8{9, 6, 4, 11, 6};
@@ -392,6 +397,21 @@ constexpr PinMap map_r9_1v8_en{5, 0, 2, 9, 0};
 constexpr PinMap map_vregmode{6, 11, 3, 7, 0};
 constexpr PinMap map_og_VAA_en{5, 0, 2, 9, 0};
 constexpr PinMap map_r9_VAA_en{6, 10, 3, 6, 0};
+constexpr PinMap map_rx_mix_bypass{6, 8, 5, 16, 4};
+constexpr PinMap map_tx_mix_bp{5, 2, 2, 11, 0};
+constexpr PinMap map_rx_mix_bp{5, 3, 2, 12, 0};
+constexpr PinMap map_tx_mix_bypass{1, 7, 1, 0, 0};
+constexpr PinMap map_og_rx{2, 5, 5, 5, 4};
+constexpr PinMap map_og_tx{6, 7, 5, 15, 4};
+constexpr PinMap map_r9_rx{2, 7, 0, 7, 0};
+constexpr PinMap map_lpf{5, 1, 2, 10, 0};
+constexpr PinMap map_hpf{4, 0, 2, 0, 0};
+constexpr PinMap map_amp_bypass{2, 10, 0, 14, 0};
+constexpr PinMap map_tx_amp{5, 6, 2, 15, 0};
+constexpr PinMap map_rx_amp{2, 11, 1, 11, 0};
+constexpr PinMap map_tx_amp_pwr{6, 9, 3, 5, 0};
+constexpr PinMap map_rx_amp_pwr{2, 12, 1, 12, 0};
+constexpr PinMap map_ant_bias{4, 4, 2, 4, 0};
 #endif
 
 constexpr PinMap map_sgpio_0{0, 0, 0, 0, 3};
@@ -461,6 +481,16 @@ constexpr GPIO led_tx{pin_led_tx, map_led_tx.gpio_port, map_led_tx.gpio_pad, map
 
 constexpr Pin pin_led_mcu{map_led_mcu.scu_port, map_led_mcu.scu_pin};                                                          // SCU: P8_6
 constexpr GPIO led_mcu{pin_led_mcu, map_led_mcu.gpio_port, map_led_mcu.gpio_pad, map_led_mcu.gpio_mode, Polarity::ActiveLow};  // GPIO[4]6
+
+constexpr Pin pin_mix_bypass{map_mix_bypass.scu_port, map_mix_bypass.scu_pin};                                                                // SCU: P6_3
+constexpr GPIO mix_bypass{pin_mix_bypass, map_mix_bypass.gpio_port, map_mix_bypass.gpio_pad, map_mix_bypass.gpio_mode, Polarity::ActiveLow};  // GPIO[3]2
+
+constexpr Pin pin_tx_enable{map_tx_enable.scu_port, map_tx_enable.scu_pin};                                         // SCU: P6_5
+constexpr GPIO tx_enable{pin_tx_enable, map_tx_enable.gpio_port, map_tx_enable.gpio_pad, map_tx_enable.gpio_mode};  // GPIO[3]4
+
+constexpr Pin pin_rf_amp_enable{map_rf_amp_enable.scu_port, map_rf_amp_enable.scu_pin};                                                 // SCU: PA_2
+constexpr GPIO rf_amp_enable{pin_rf_amp_enable, map_rf_amp_enable.gpio_port, map_rf_amp_enable.gpio_pad, map_rf_amp_enable.gpio_mode};  // GPIO[4]9
+
 #else
 constexpr Pin pin_sgpio_13{map_sgpio_13.scu_port, map_sgpio_13.scu_pin};                                       // SCU: P4_8
 constexpr GPIO sgpio_13{pin_sgpio_13, map_sgpio_13.gpio_port, map_sgpio_13.gpio_pad, map_sgpio_13.gpio_mode};  // GPIO[5]12
@@ -485,6 +515,45 @@ constexpr GPIO led_rx{pin_led_rx, map_led_rx.gpio_port, map_led_rx.gpio_pad, map
 
 constexpr Pin pin_led_tx{map_led_tx.scu_port, map_led_tx.scu_pin};                                   // SCU: P6_12
 constexpr GPIO led_tx{pin_led_tx, map_led_tx.gpio_port, map_led_tx.gpio_pad, map_led_tx.gpio_mode};  // GPIO[2]8
+
+constexpr Pin pin_rx_mix_bypass{map_rx_mix_bypass.scu_port, map_rx_mix_bypass.scu_pin};                                                 // SCU: P6_11
+constexpr GPIO rx_mix_bypass{pin_rx_mix_bypass, map_rx_mix_bypass.gpio_port, map_rx_mix_bypass.gpio_pad, map_rx_mix_bypass.gpio_mode};  // GPIO[5]16
+
+constexpr Pin pin_tx_mix_bp{map_tx_mix_bp.scu_port, map_tx_mix_bp.scu_pin};                                         // SCU: P5_2
+constexpr GPIO tx_mix_bp{pin_tx_mix_bp, map_tx_mix_bp.gpio_port, map_tx_mix_bp.gpio_pad, map_tx_mix_bp.gpio_mode};  // GPIO[2]11
+
+constexpr Pin pin_rx_mix_bp{map_rx_mix_bp.scu_port, map_rx_mix_bp.scu_pin};                                         // SCU: P5_2
+constexpr GPIO rx_mix_bp{pin_rx_mix_bp, map_rx_mix_bp.gpio_port, map_rx_mix_bp.gpio_pad, map_rx_mix_bp.gpio_mode};  // GPIO[2]12
+
+constexpr Pin pin_tx_mix_bypass{map_tx_mix_bypass.scu_port, map_tx_mix_bypass.scu_pin};                                                                      // SCU: P1_7
+constexpr GPIO tx_mix_bypass{pin_tx_mix_bypass, map_tx_mix_bypass.gpio_port, map_tx_mix_bypass.gpio_pad, map_tx_mix_bypass.gpio_mode, Polarity::ActiveLow};  // GPIO[1]0
+
+constexpr Pin pin_og_rx{map_og_rx.scu_port, map_og_rx.scu_pin};                                 // SCU: P2_5
+constexpr GPIO og_rx{pin_og_rx, map_og_rx.gpio_port, map_og_rx.gpio_pad, map_og_rx.gpio_mode};  // GPIO[5]5
+
+constexpr Pin pin_og_tx{map_og_tx.scu_port, map_og_tx.scu_pin};                                 // SCU: P6_7
+constexpr GPIO og_tx{pin_og_tx, map_og_tx.gpio_port, map_og_tx.gpio_pad, map_og_tx.gpio_mode};  // GPIO[5]15
+
+constexpr Pin pin_r9_rx{map_r9_rx.scu_port, map_r9_rx.scu_pin};                                 // SCU: P2_7
+constexpr GPIO r9_rx{pin_r9_rx, map_r9_rx.gpio_port, map_r9_rx.gpio_pad, map_r9_rx.gpio_mode};  // GPIO[0]7
+
+constexpr Pin pin_hpf{map_hpf.scu_port, map_hpf.scu_pin};                             // SCU: P4_0
+constexpr GPIO hpf{pin_hpf, map_hpf.gpio_port, map_hpf.gpio_pad, map_hpf.gpio_mode};  // GPIO[2]0
+
+constexpr Pin pin_amp_bypass{map_amp_bypass.scu_port, map_amp_bypass.scu_pin};                                           // SCU: P2_10
+constexpr GPIO amp_bypass{pin_amp_bypass, map_amp_bypass.gpio_port, map_amp_bypass.gpio_pad, map_amp_bypass.gpio_mode};  // GPIO[0]14
+
+constexpr Pin pin_tx_amp{map_tx_amp.scu_port, map_tx_amp.scu_pin};                                   // SCU: P5_6
+constexpr GPIO tx_amp{pin_tx_amp, map_tx_amp.gpio_port, map_tx_amp.gpio_pad, map_tx_amp.gpio_mode};  // GPIO[2]15
+
+constexpr Pin pin_rx_amp{map_rx_amp.scu_port, map_rx_amp.scu_pin};                                   // SCU: P2_11
+constexpr GPIO rx_amp{pin_rx_amp, map_rx_amp.gpio_port, map_rx_amp.gpio_pad, map_rx_amp.gpio_mode};  // GPIO[1]11
+
+constexpr Pin pin_tx_amp_pwr{map_tx_amp_pwr.scu_port, map_tx_amp_pwr.scu_pin};                                                                // SCU: P6_9
+constexpr GPIO tx_amp_pwr{pin_tx_amp_pwr, map_tx_amp_pwr.gpio_port, map_tx_amp_pwr.gpio_pad, map_tx_amp_pwr.gpio_mode, Polarity::ActiveLow};  // GPIO[3]5
+
+constexpr Pin pin_rx_amp_pwr{map_rx_amp_pwr.scu_port, map_rx_amp_pwr.scu_pin};                                                                // SCU: P2_12
+constexpr GPIO rx_amp_pwr{pin_rx_amp_pwr, map_rx_amp_pwr.gpio_port, map_rx_amp_pwr.gpio_pad, map_rx_amp_pwr.gpio_mode, Polarity::ActiveLow};  // GPIO[1]12
 
 static const motocon_pwm_resources_t motocon_pwm_resources = {
     .base = {.clk = &LPC_CGU->BASE_APB1_CLK, .stat = &LPC_CCU1->BASE_STAT, .stat_mask = (1 << 1)},
@@ -540,6 +609,13 @@ constexpr GPIO sgpio_12{pin_sgpio_12, map_sgpio_12.gpio_port, map_sgpio_12.gpio_
 
 constexpr Pin pin_vregmode{map_vregmode.scu_port, map_vregmode.scu_pin};                                       // SCU: P6_11, PRALINE: P4_9
 constexpr GPIO vregmode{pin_vregmode, map_vregmode.gpio_port, map_vregmode.gpio_pad, map_vregmode.gpio_mode};  // GPIO[3]7, PRALINE: GPIO[5]13
+
+constexpr Pin pin_lpf{map_lpf.scu_port, map_lpf.scu_pin};                             // SCU: P5_1, PRALINE: PA_1
+constexpr GPIO lpf{pin_lpf, map_lpf.gpio_port, map_lpf.gpio_pad, map_lpf.gpio_mode};  // GPIO[2]10, PRALINE: GPIO[4]8
+
+constexpr Pin pin_ant_bias{map_ant_bias.scu_port, map_ant_bias.scu_pin};                                                            // SCU: R9: P4_4 , PRALINE: P2_12
+constexpr GPIO ant_bias{pin_ant_bias, map_ant_bias.gpio_port, map_ant_bias.gpio_pad, map_ant_bias.gpio_mode, Polarity::ActiveLow};  // R9: GPIO[2]4, PRALINE: GPIO[1]12}
+
 }  // namespace gpio_control
 
 namespace power_control {

--- a/firmware/common/gpio.hpp
+++ b/firmware/common/gpio.hpp
@@ -517,10 +517,10 @@ constexpr Pin pin_aux_power_oc{map_aux_power_oc.scu_port, map_aux_power_oc.scu_p
 constexpr GPIO aux_power_oc{pin_aux_power_oc, map_aux_power_oc.gpio_port, map_aux_power_oc.gpio_pad, map_aux_power_oc.gpio_mode};  // GPIO[3]7
 
 constexpr Pin pin_ant_bias_oc{map_ant_bias_oc.scu_port, map_ant_bias_oc.scu_pin};                                                                  // SCU: P2_11
-constexpr GPIO ant_bias_oc{pin_ant_bias_oc, map_ant_bias_oc.gpio_port, map_ant_bias_oc.gpio_pad, map_ant_bias_oc.gpio_mode, Polarity::ActiveLow};  // GPIO[1]11}
+constexpr GPIO ant_bias_oc{pin_ant_bias_oc, map_ant_bias_oc.gpio_port, map_ant_bias_oc.gpio_pad, map_ant_bias_oc.gpio_mode, Polarity::ActiveLow};  // GPIO[1]11
 
 constexpr Pin pin_pps_in_out{map_pps_in_out.scu_port, map_pps_in_out.scu_pin};                                           // SCU: P2_5
-constexpr GPIO pps_in_out{pin_pps_in_out, map_pps_in_out.gpio_port, map_pps_in_out.gpio_pad, map_pps_in_out.gpio_mode};  // GPIO[5]5}
+constexpr GPIO pps_in_out{pin_pps_in_out, map_pps_in_out.gpio_port, map_pps_in_out.gpio_pad, map_pps_in_out.gpio_mode};  // GPIO[5]5
 
 #else
 constexpr Pin pin_sgpio_13{map_sgpio_13.scu_port, map_sgpio_13.scu_pin};                                       // SCU: P4_8
@@ -547,13 +547,13 @@ constexpr GPIO led_rx{pin_led_rx, map_led_rx.gpio_port, map_led_rx.gpio_pad, map
 constexpr Pin pin_led_tx{map_led_tx.scu_port, map_led_tx.scu_pin};                                   // SCU: P6_12
 constexpr GPIO led_tx{pin_led_tx, map_led_tx.gpio_port, map_led_tx.gpio_pad, map_led_tx.gpio_mode};  // GPIO[2]8
 
-constexpr Pin pin_rx_mix_bypass{map_rx_mix_bypass.scu_port, map_rx_mix_bypass.scu_pin};                                                 // SCU: P6_11
+constexpr Pin pin_rx_mix_bypass{map_rx_mix_bypass.scu_port, map_rx_mix_bypass.scu_pin};                                                 // SCU: P6_8
 constexpr GPIO rx_mix_bypass{pin_rx_mix_bypass, map_rx_mix_bypass.gpio_port, map_rx_mix_bypass.gpio_pad, map_rx_mix_bypass.gpio_mode};  // GPIO[5]16
 
 constexpr Pin pin_tx_mix_bp{map_tx_mix_bp.scu_port, map_tx_mix_bp.scu_pin};                                         // SCU: P5_2
 constexpr GPIO tx_mix_bp{pin_tx_mix_bp, map_tx_mix_bp.gpio_port, map_tx_mix_bp.gpio_pad, map_tx_mix_bp.gpio_mode};  // GPIO[2]11
 
-constexpr Pin pin_rx_mix_bp{map_rx_mix_bp.scu_port, map_rx_mix_bp.scu_pin};                                         // SCU: P5_2
+constexpr Pin pin_rx_mix_bp{map_rx_mix_bp.scu_port, map_rx_mix_bp.scu_pin};                                         // SCU: P5_3
 constexpr GPIO rx_mix_bp{pin_rx_mix_bp, map_rx_mix_bp.gpio_port, map_rx_mix_bp.gpio_pad, map_rx_mix_bp.gpio_mode};  // GPIO[2]12
 
 constexpr Pin pin_tx_mix_bypass{map_tx_mix_bypass.scu_port, map_tx_mix_bypass.scu_pin};                                                                      // SCU: P1_7
@@ -654,7 +654,7 @@ constexpr Pin pin_lpf{map_lpf.scu_port, map_lpf.scu_pin};                       
 constexpr GPIO lpf{pin_lpf, map_lpf.gpio_port, map_lpf.gpio_pad, map_lpf.gpio_mode};  // GPIO[2]10, PRALINE: GPIO[4]8
 
 constexpr Pin pin_ant_bias{map_ant_bias.scu_port, map_ant_bias.scu_pin};                                                            // SCU: R9: P4_4 , PRALINE: P2_12
-constexpr GPIO ant_bias{pin_ant_bias, map_ant_bias.gpio_port, map_ant_bias.gpio_pad, map_ant_bias.gpio_mode, Polarity::ActiveLow};  // R9: GPIO[2]4, PRALINE: GPIO[1]12}
+constexpr GPIO ant_bias{pin_ant_bias, map_ant_bias.gpio_port, map_ant_bias.gpio_pad, map_ant_bias.gpio_mode, Polarity::ActiveLow};  // R9: GPIO[2]4, PRALINE: GPIO[1]12
 
 constexpr Pin pin_dfu_boot_0{map_dfu_boot_0.scu_port, map_dfu_boot_0.scu_pin};                                           // SCU: P1_1
 constexpr GPIO dfu_boot_0{pin_dfu_boot_0, map_dfu_boot_0.gpio_port, map_dfu_boot_0.gpio_pad, map_dfu_boot_0.gpio_mode};  // GPIO[0]8

--- a/firmware/common/gpio.hpp
+++ b/firmware/common/gpio.hpp
@@ -510,7 +510,7 @@ constexpr GPIO tx_enable{pin_tx_enable, map_tx_enable.gpio_port, map_tx_enable.g
 constexpr Pin pin_rf_amp_enable{map_rf_amp_enable.scu_port, map_rf_amp_enable.scu_pin};                                                 // SCU: PA_2
 constexpr GPIO rf_amp_enable{pin_rf_amp_enable, map_rf_amp_enable.gpio_port, map_rf_amp_enable.gpio_pad, map_rf_amp_enable.gpio_mode};  // GPIO[4]9
 
-constexpr Pin pin_aux_power_enable{map_aux_power_enable.scu_port, map_aux_power_enable.scu_pin};                                                       // SCU: P6_7
+constexpr Pin pin_aux_power_enable{map_aux_power_enable.scu_port, map_aux_power_enable.scu_pin};                                                                            // SCU: P6_7
 constexpr GPIO aux_power_enable{pin_aux_power_enable, map_aux_power_enable.gpio_port, map_aux_power_enable.gpio_pad, map_aux_power_enable.gpio_mode, Polarity::ActiveLow};  // GPIO[5]15
 
 constexpr Pin pin_aux_power_oc{map_aux_power_oc.scu_port, map_aux_power_oc.scu_pin};                                               // SCU: P6_11

--- a/firmware/common/hackrf_gpio.hpp
+++ b/firmware/common/hackrf_gpio.hpp
@@ -33,28 +33,6 @@ namespace one {
 
 /* GPIO */
 
-constexpr GPIO gpio_rx_mix_bp = gpio[GPIO2_12];
-constexpr GPIO gpio_tx_mix_bp = gpio[GPIO2_11];
-#ifdef PRALINE
-constexpr GPIO gpio_mix_bypass = gpio[GPIO3_2];  // P6_3: PRALINE RF path mixer bypass inverted
-// constexpr GPIO gpio_mix_en_n_r1_0 = gpio[GPIO5_6];  // P2_6: R1.0 board mixer bypass
-#else
-constexpr GPIO gpio_mix_bypass = gpio[GPIO5_16];
-#endif
-constexpr GPIO gpio_not_mix_bypass = gpio[GPIO1_0];
-
-constexpr GPIO gpio_og_rx = gpio[GPIO5_5];
-constexpr GPIO gpio_og_tx = gpio[GPIO5_15];
-constexpr GPIO gpio_r9_rx = gpio[GPIO0_7];
-
-constexpr GPIO gpio_lp = gpio[GPIO2_10];
-constexpr GPIO gpio_hp = gpio[GPIO2_0];
-
-constexpr GPIO gpio_rx_amp = gpio[GPIO1_11];
-constexpr GPIO gpio_tx_amp = gpio[GPIO2_15];
-constexpr GPIO gpio_amp_bypass = gpio[GPIO0_14];
-constexpr GPIO gpio_not_tx_amp_pwr = gpio[GPIO3_5];
-
 #ifdef PRALINE
 // PRALINE: GPIO2[13] is SPI CS only, FPGA controls ENX/RESETX
 constexpr GPIO gpio_rffc5072_select = gpio[GPIO2_13];  // P5_4: SPI CS (ENX)
@@ -62,7 +40,6 @@ constexpr GPIO gpio_rffc5072_resetx = gpio[GPIO2_14];  // P5_5: LPC43xx controls
 #else
 constexpr GPIO gpio_rffc5072_select = gpio[GPIO2_13];
 constexpr GPIO gpio_rffc5072_resetx = gpio[GPIO2_14];
-constexpr GPIO gpio_not_rx_amp_pwr = gpio[GPIO1_12];
 #endif
 
 #ifdef PRALINE
@@ -106,14 +83,6 @@ constexpr GPIO gpio_max5864_select = gpio[GPIO2_7];
 constexpr GPIO gpio_q_invert = gpio[GPIO0_13];
 
 #ifdef PRALINE
-// PRALINE power control
-constexpr GPIO gpio_vaa_disable = gpio[GPIO4_1];  // VAA disable (P8_1)
-
-// PRALINE RF path control
-constexpr GPIO gpio_tx_enable = gpio[GPIO3_4];          // TX enable (P6_5)
-constexpr GPIO gpio_lpf_enable = gpio[GPIO4_8];         // LPF enable (PA_1)
-constexpr GPIO gpio_rf_amp_enable = gpio[GPIO4_9];      // RF amp enable (PA_2)
-constexpr GPIO gpio_ant_bias_disable = gpio[GPIO1_12];  // Antenna bias disable (P2_12)
 
 // constexpr GPIO gpio_pps_out = gpio[GPIO5_5];  // PPS output (P2_5)
 
@@ -135,7 +104,6 @@ constexpr GPIO gpio_cpld_tdi = gpio[GPIO3_1];
 constexpr GPIO gpio_r9_clkin_en = gpio[GPIO5_15];
 constexpr GPIO gpio_r9_clkout_en = gpio[GPIO0_9];
 constexpr GPIO gpio_r9_mcu_clk_en = gpio[GPIO0_8];
-constexpr GPIO gpio_r9_not_ant_pwr = gpio[GPIO2_4];
 
 } /* namespace one */
 } /* namespace hackrf */

--- a/firmware/common/hackrf_gpio.hpp
+++ b/firmware/common/hackrf_gpio.hpp
@@ -83,12 +83,6 @@ constexpr GPIO gpio_max5864_select = gpio[GPIO2_7];
 constexpr GPIO gpio_q_invert = gpio[GPIO0_13];
 
 #ifdef PRALINE
-
-// constexpr GPIO gpio_pps_out = gpio[GPIO5_5];  // PPS output (P2_5)
-
-#endif
-
-#ifdef PRALINE
 /* PRALINE has no HackRF CPLD. These pins are used for RFFC5072 and TX_EN instead.
  * Dummy assignments here allow cpld_update.cpp to compile; the functions
  * that use them are never called on PRALINE. */
@@ -100,10 +94,6 @@ constexpr GPIO gpio_cpld_tms = gpio[GPIO3_4];
 #endif
 constexpr GPIO gpio_cpld_tck = gpio[GPIO3_0];
 constexpr GPIO gpio_cpld_tdi = gpio[GPIO3_1];
-
-constexpr GPIO gpio_r9_clkin_en = gpio[GPIO5_15];
-constexpr GPIO gpio_r9_clkout_en = gpio[GPIO0_9];
-constexpr GPIO gpio_r9_mcu_clk_en = gpio[GPIO0_8];
 
 } /* namespace one */
 } /* namespace hackrf */


### PR DESCRIPTION
Refactor GPIO handling, unify RF path control, and simplify system architecture (Part 3)
Description:
This PR is the third part of the ongoing GPIO and hardware abstraction cleanup, focusing on unifying signal control and reducing architectural overhead.

Key changes:

Unified GPIO Control: Replaced legacy enable()/disable() methods with setActive() and setInactive() across all affected modules, ensuring consistent physical voltage level handling.

Antenna Bias & Clock Control: Integrated antenna bias and clock signal management into the standardized GPIO framework.

RF Path Refactoring: Simplified the RF path architecture by removing redundant structures and unnecessary abstractions, resulting in cleaner and more maintainable signal routing.

Radio Control Consolidation: Optimized radio control pin handling to reduce memory footprint and execution overhead.

Cleanup: Continued the removal of deprecated hardware-specific headers to promote a unified GPIO interface.

<img width="1190" height="893" alt="image" src="https://github.com/user-attachments/assets/d0b763e5-2ac5-4f03-bf48-c1bf4dae6304" />


## Checklist

- [x] Kept changes minimal and limited to necessary files
- [x] Verified functionality remains intact and code compiles
- [x] Attached proof that the code compiles successfully *(or marked N/A as a trusted contributor)*
- [x] Attached proof of testing on real PortaPack hardware *(or marked N/A as a trusted contributor)*
- [x] Attached proof of testing against a real emitter/receiver (if RF-related), or marked N/A with justification
- [x] I understand that by getting this PR merged, I am implicitly agreeing to create or update the corresponding wiki page (including a main-screen screenshot, description, controls, and limitations)
- [x] I own all rights to this code (i.e., all code contained in this PR), including compliant usage rights for third-party libraries, and I agree that this code is licensed under the license of this project (GPL-3.0). 
- [x] If any third-party libraries are used, I confirm that their licenses comply with the requirements for contributing to this repository.
- [x] Reviewed the [Contributing Guidelines](https://github.com/portapack-mayhem/mayhem-firmware/wiki/Contributing-Guidelines)
