### PR TITLE
Completely redesigned startup interface logic.

### DIFF
--- a/firmware/application/ui/ui_btngrid.cpp
+++ b/firmware/application/ui/ui_btngrid.cpp
@@ -28,6 +28,7 @@
 #include "rtc_time.hpp"
 #include "sd_card.hpp"
 #include <algorithm>
+#include <climits>
 
 namespace ui {
 
@@ -207,6 +208,9 @@ void BtnGridView::show_hide_arrows() {
 void BtnGridView::reload_items() {
     menu_items.clear();
     on_populate();
+    // Apply config.ini line order to this grid (home menu opts out to keep its fixed layout).
+    if (config_reorder_enabled())
+        reorder_menu_items();
     set_highlighted(highlighted_item, true);
     show_hide_arrows();
 
@@ -470,6 +474,58 @@ static Color app_color_from_config(const std::string& app_name) {
         case 'w': return Color::white();
         default:  return Color::grey();
     }
+}
+
+/* App menu ordering *************************************************/
+
+// Return the 0-based line index of app_name in config.ini, or -1 if not listed.
+// The line order in config.ini is what determines on-screen position, so the file
+// needs no explicit position numbers. app_colors_data starts with a '\n' sentinel
+// and separates records by '\n', so the count of newlines strictly before the match
+// is exactly the record's 0-based index.
+static int app_config_order(const std::string& app_name) {
+    if (app_colors_data.empty())
+        return -1;
+
+    const std::string key = "\n" + app_name + ",";
+    const auto pos = app_colors_data.find(key);
+    if (pos == std::string::npos)
+        return -1;
+
+    int index = 0;
+    for (size_t i = 0; i < pos; i++)
+        if (app_colors_data[i] == '\n')
+            index++;
+    return index;
+}
+
+// Non-app control tiles that must stay pinned to the front of a grid regardless of
+// config.ini. Matches the literals used to create these tiles in ui_navigation.cpp
+// (".." return icon, "ExtAppErr" no-SD/read-error notice).
+static bool is_pinned_tile(const std::string& text) {
+    return text == ".." || text == "ExtAppErr";
+}
+
+// Sort rank for a grid item: pinned tiles first, then config-listed apps by line
+// order, then unlisted apps last. Equal ranks keep original order via stable_sort.
+static int item_sort_rank(const GridItem& item) {
+    if (is_pinned_tile(item.text))
+        return INT_MIN;
+    const int order = app_config_order(item.text);
+    return (order >= 0) ? order : INT_MAX;
+}
+
+// Reposition items to: [pinned control tiles] [config-listed apps in file order]
+// [unlisted apps, original order]. Missing apps listed in config are ignored for
+// free -- they simply have no item here, so their line index is an unused gap.
+void BtnGridView::reorder_menu_items() {
+    if (menu_items.empty())
+        return;
+
+    std::stable_sort(menu_items.begin(), menu_items.end(),
+                     [](const GridItem& a, const GridItem& b) {
+                         return item_sort_rank(a) < item_sort_rank(b);
+                     });
 }
 
 void BtnGridView::page_up() {

--- a/firmware/application/ui/ui_btngrid.cpp
+++ b/firmware/application/ui/ui_btngrid.cpp
@@ -463,16 +463,26 @@ static Color app_color_from_config(const std::string& app_name) {
         return Color::grey();
 
     switch (app_colors_data[ci]) {
-        case 'r': return Color::red();
-        case 'g': return Color::green();
-        case 'b': return Color::blue();
-        case 'y': return Color::yellow();
-        case 'c': return Color::cyan();
-        case 'm': return Color::magenta();
-        case 'o': return Color::orange();
-        case 'p': return Color::purple();
-        case 'w': return Color::white();
-        default:  return Color::grey();
+        case 'r':
+            return Color::red();
+        case 'g':
+            return Color::green();
+        case 'b':
+            return Color::blue();
+        case 'y':
+            return Color::yellow();
+        case 'c':
+            return Color::cyan();
+        case 'm':
+            return Color::magenta();
+        case 'o':
+            return Color::orange();
+        case 'p':
+            return Color::purple();
+        case 'w':
+            return Color::white();
+        default:
+            return Color::grey();
     }
 }
 

--- a/firmware/application/ui/ui_btngrid.cpp
+++ b/firmware/application/ui/ui_btngrid.cpp
@@ -31,6 +31,9 @@
 
 namespace ui {
 
+// Maps an app display name to its config.ini icon color; grey if unlisted. Defined with the loader below.
+static Color app_color_from_config(const std::string& app_name);
+
 /* BtnGridView **************************************************************/
 
 BtnGridView::BtnGridView(
@@ -227,7 +230,8 @@ void BtnGridView::update_items() {
             item->hidden(false);
             item->set_text(menu_items[i + offset].text);
             item->set_bitmap(menu_items[i + offset].bitmap);
-            item->set_color(menu_items[i + offset].color);
+            item->set_color(app_color_from_config(menu_items[i + offset].text));  // icon color from config.ini
+            item->set_progress_color(menu_items[i + offset].color);               // progress block keeps original color
             item->set_bg_color(bg_color);
             item->on_select = menu_items[i + offset].on_select;
             item->set_dirty();
@@ -417,6 +421,55 @@ bool BtnGridView::blacklisted_app(GridItem new_item) {
         return false;
 
     return blacklist_data.find(app_name) != std::string::npos;
+}
+
+/* App icon color overrides ******************************************/
+
+std::string app_colors_data{};
+
+// Load config.ini into a buffer bracketed by '\n' so every record reads as "\nname,c".
+void load_app_colors() {
+    File f;
+    auto error = f.open(APP_COLORS);
+    if (error)
+        return;
+    // Resize to fit file + 2 newlines, prefilled with '\n' (first byte stays as the leading delimiter)
+    app_colors_data.assign(f.size() + 2, '\n');
+    if (f.read(app_colors_data.data() + 1, f.size())) {
+        // Normalize CR to '\n' so both LF and CRLF files parse the same
+        for (char& c : app_colors_data)
+            if (c == '\r') c = '\n';
+    } else {
+        app_colors_data.clear();  // Clear if read fails
+    }
+}
+
+// Find "\nname," and translate the following abbrev char to a color. Unlisted/undefined -> grey.
+static Color app_color_from_config(const std::string& app_name) {
+    if (app_colors_data.size() < app_name.size() + 3)
+        return Color::grey();
+
+    const std::string key = "\n" + app_name + ",";
+    const auto pos = app_colors_data.find(key);
+    if (pos == std::string::npos)
+        return Color::grey();
+
+    const size_t ci = pos + key.size();
+    if (ci >= app_colors_data.size())
+        return Color::grey();
+
+    switch (app_colors_data[ci]) {
+        case 'r': return Color::red();
+        case 'g': return Color::green();
+        case 'b': return Color::blue();
+        case 'y': return Color::yellow();
+        case 'c': return Color::cyan();
+        case 'm': return Color::magenta();
+        case 'o': return Color::orange();
+        case 'p': return Color::purple();
+        case 'w': return Color::white();
+        default:  return Color::grey();
+    }
 }
 
 void BtnGridView::page_up() {

--- a/firmware/application/ui/ui_btngrid.hpp
+++ b/firmware/application/ui/ui_btngrid.hpp
@@ -40,6 +40,9 @@
 // file used for listing apps to hide from menu
 #define BLACKLIST u"/SETTINGS/blacklist"
 
+// per-app icon color overrides, one "app_display_name,abbrev" per line (SD root)
+#define APP_COLORS u"/config.ini"
+
 namespace ui {
 
 struct GridItem {
@@ -52,6 +55,7 @@ struct GridItem {
 };
 
 void load_blacklist();
+void load_app_colors();
 
 class BtnGridView : public View {
    public:

--- a/firmware/application/ui/ui_btngrid.hpp
+++ b/firmware/application/ui/ui_btngrid.hpp
@@ -94,6 +94,7 @@ class BtnGridView : public View {
 
     void reload_items();
     void update_items();
+    void reorder_menu_items();  // Reorder items per config.ini line order; see .cpp.
     void set_btn_height_fixed(uint8_t h) {
         button_h = h;
     }
@@ -103,6 +104,9 @@ class BtnGridView : public View {
 
    protected:
     virtual void on_populate() = 0;
+    // Whether config.ini line order should reposition this grid's items.
+    // The home menu overrides this to false to preserve its fixed layout.
+    virtual bool config_reorder_enabled() const { return true; }
 
    private:
     int rows_{3};

--- a/firmware/application/ui_navigation.cpp
+++ b/firmware/application/ui_navigation.cpp
@@ -196,6 +196,7 @@ SystemStatusView::SystemStatusView(
     rtc_battery_workaround();
 
     ui::load_blacklist();
+    ui::load_app_colors();
 
     if (pmem::should_use_sdcard_for_pmem()) {
         pmem::load_persistent_settings_from_file();

--- a/firmware/application/ui_navigation.hpp
+++ b/firmware/application/ui_navigation.hpp
@@ -419,6 +419,7 @@ class SystemMenuView : public BtnGridView {
    private:
     NavigationView& nav_;
     void on_populate() override;
+    bool config_reorder_enabled() const override { return false; }  // Home menu keeps its fixed layout.
     void hackrf_mode(NavigationView& nav);
 };
 

--- a/firmware/common/ui_widget.cpp
+++ b/firmware/common/ui_widget.cpp
@@ -1456,10 +1456,11 @@ void NewButton::paint(Painter& painter) {
         }
     }
 
-    // Development-progress indicator: 4x4 block in the top-right corner, 1px from the edges (grid buttons only).
+    // Development-progress indicator: 6x6 block near the top-right corner (grid buttons only).
+    // Anchored to the former 4x4 top-right corner, then shifted 2px down and 3px left.
     if (has_progress_color_)
         painter.fill_rectangle(
-            {r.left() + r.width() - 5, r.top() + 1, 4, 4},
+            {r.left() + r.width() - 10, r.top() + 3, 6, 6},
             progress_color_);
 }
 

--- a/firmware/common/ui_widget.cpp
+++ b/firmware/common/ui_widget.cpp
@@ -1456,10 +1456,10 @@ void NewButton::paint(Painter& painter) {
         }
     }
 
-    // Development-progress indicator: 6x6 block in the bottom-left corner (grid buttons only).
+    // Development-progress indicator: 4x4 block in the top-right corner, 1px from the edges (grid buttons only).
     if (has_progress_color_)
         painter.fill_rectangle(
-            {r.left() + 2, r.top() + r.height() - 8, 6, 6},
+            {r.left() + r.width() - 5, r.top() + 1, 4, 4},
             progress_color_);
 }
 

--- a/firmware/common/ui_widget.cpp
+++ b/firmware/common/ui_widget.cpp
@@ -1364,6 +1364,12 @@ void NewButton::set_bg_color(Color color) {
     set_dirty();
 }
 
+void NewButton::set_progress_color(Color color) {
+    progress_color_ = color;
+    has_progress_color_ = true;
+    set_dirty();
+}
+
 void NewButton::set_vertical_center(bool value) {
     vertical_center_ = value;
     set_dirty();
@@ -1449,6 +1455,12 @@ void NewButton::paint(Painter& painter) {
             }
         }
     }
+
+    // Development-progress indicator: 6x6 block in the bottom-left corner (grid buttons only).
+    if (has_progress_color_)
+        painter.fill_rectangle(
+            {r.left() + 2, r.top() + r.height() - 8, 6, 6},
+            progress_color_);
 }
 
 Style NewButton::paint_style() {

--- a/firmware/common/ui_widget.hpp
+++ b/firmware/common/ui_widget.hpp
@@ -519,6 +519,7 @@ class NewButton : public Widget {
     void set_text(const std::string& value);
     void set_color(Color value);
     void set_bg_color(Color value);
+    void set_progress_color(Color value);
     void set_vertical_center(bool value);
     std::string text() const;
     const Bitmap* bitmap();
@@ -538,6 +539,8 @@ class NewButton : public Widget {
     virtual Style paint_style();
     Color color_;
     Color bg_color_{Theme::getInstance()->bg_medium->background};
+    Color progress_color_{};
+    bool has_progress_color_{false};  // only grid buttons draw the progress block
 
    private:
     std::string text_;


### PR DESCRIPTION


## Brief description of what you did

The newly designed development progress display logic sets it as a 6x6 color block in the upper right corner of the application, allowing users to customize the application icon color in "config.ini". This file also controls the display position of each application. Applications not defined in this file will be displayed in gray. If an application is not listed in this file, it will be placed last on the launch screen. (Home screen options are ignored and cannot be customized.)
The App NAME's relative positions—above or below one another—in the configuration file determine their order.
> [!NOTE]
> To recognize the App, it uses the App's display name.
> The color in the `config.ini` file use abbreviation

And here is compare list:
Abbrev | Color
-- | --
r | red
g | green
b | blue
y | yellow
c | cyan
m | magenta
o | orange
p | purple
w | white
(empty / unknown / not listed) | grey



---

## Proof that your changes work

### 🖥️ Proof it compiles
<!--
Attach a log snippet showing a successful build from the final firmware size/space summary in the build output. Example: `Space remaining in flash ROM: 19552 bytes ( 1.9 % )`.
Paste log below.
-->

<img width="1453" height="736" alt="截屏2026-07-01 20 51 45" src="https://github.com/user-attachments/assets/56b32785-ef8f-479b-b841-d20167a09fff" />




### 📱 Proof of testing on a real device

<img width="3024" height="4032" alt="IMG_0299" src="https://github.com/user-attachments/assets/55507299-da04-4b38-919f-a76d95dd1139" />

<img width="3024" height="4032" alt="IMG_0300" src="https://github.com/user-attachments/assets/06f7ae80-558d-4eb5-96a5-59100d15af44" />

<img width="3024" height="4032" alt="IMG_0301" src="https://github.com/user-attachments/assets/16f9c49a-f468-4b77-9402-e37b5a9e7af5" />

---

## 📚 Wiki documentation commitment
<!--
By submitting this PR, you acknowledge that once it is merged you are responsible for creating or updating the corresponding page on the project wiki(https://github.com/portapack-mayhem/mayhem-firmware/wiki).
Your wiki article should include:
- A screenshot of the main app screen (strongly recommended)
- A clear description of what the app does
- An explanation of the controls and UI elements
- Any known limitations, quirks, or caveats
- Anything else a user should know to use the app effectively (dependencies, required hardware, file formats, etc.)
- If you are modifying an existing app, make sure the wiki page reflects your changes.
-->


- [x] I will (or already) create(d) wiki document for my newly added feature


---

## Checklist

- [x] Kept changes minimal and limited to necessary files
- [x] Verified functionality remains intact and code compiles
- [x] Attached proof that the code compiles successfully *(or marked N/A as a trusted contributor)*
- [x] Attached proof of testing on real PortaPack hardware *(or marked N/A as a trusted contributor)*
- [ ] Attached proof of testing against a real emitter/receiver (if RF-related), or marked N/A with justification
- [x] I understand that by getting this PR merged, I am implicitly agreeing to create or update the corresponding wiki page (including a main-screen screenshot, description, controls, and limitations)
- [x] I own all rights to this code (i.e., all code contained in this PR), including compliant usage rights for third-party libraries, and I agree that this code is licensed under the license of this project (GPL-3.0). 
- [x] If any third-party libraries are used, I confirm that their licenses comply with the requirements for contributing to this repository.
- [x] Reviewed the [Contributing Guidelines](https://github.com/portapack-mayhem/mayhem-firmware/wiki/Contributing-Guidelines)
