### PR TITLE
refactor: simplify audio volume handling in AudioVolumeField

### DIFF
--- a/firmware/application/ui/ui_receiver.cpp
+++ b/firmware/application/ui/ui_receiver.cpp
@@ -593,9 +593,8 @@ AudioVolumeField::AudioVolumeField(
     set_value(receiver_model.normalized_headphone_volume());
 
     on_change = [](int32_t vol) {
-        // don't call receiver model, because this widget should be able to handle volume settings from any app,
-        // regardless of the receiver model's enabled state. like the tx apps should be able to set volume too.
-        // this is identical to the receiver model's method.
+        // Don't call receiver_model here so volume can be adjusted even when ReceiverModel is disabled (e.g. TX apps/games).
+        // The dB mapping mirrors ReceiverModel::set_normalized_headphone_volume().
         uint8_t v = clip<uint8_t>(vol, 0, 99);
         auto new_volume = volume_t::decibel(v - 99) + audio::headphone::volume_range().max;
         persistent_memory::set_headphone_volume(new_volume);

--- a/firmware/application/ui/ui_receiver.cpp
+++ b/firmware/application/ui/ui_receiver.cpp
@@ -26,10 +26,7 @@
 #include "string_format.hpp"
 #include "ui_receiver.hpp"
 #include "ui_freqman.hpp"
-
-#ifndef PRALINE
 #include "audio.hpp"
-#endif
 
 using namespace portapack;
 
@@ -595,18 +592,14 @@ AudioVolumeField::AudioVolumeField(
           /* fill char */ ' '} {
     set_value(receiver_model.normalized_headphone_volume());
 
-#ifdef PRALINE
-    on_change = [](int32_t v) {
-        receiver_model.set_normalized_headphone_volume(v);
-#else
     on_change = [](int32_t vol) {
-        // don't call receiver model, because this widget shuld be able to handle volume settinsg from any app, regardless of the receiver model's enables state. like the tx apps should be able to set volume too.
-        // this is identical to the receiver model's method
+        // don't call receiver model, because this widget should be able to handle volume settings from any app,
+        // regardless of the receiver model's enabled state. like the tx apps should be able to set volume too.
+        // this is identical to the receiver model's method.
         uint8_t v = clip<uint8_t>(vol, 0, 99);
         auto new_volume = volume_t::decibel(v - 99) + audio::headphone::volume_range().max;
         persistent_memory::set_headphone_volume(new_volume);
         audio::headphone::set_volume(new_volume);
-#endif
     };
 }
 


### PR DESCRIPTION
## Overview
This PR introduces volume adjustment capabilities for TX applications and games when running on the Praline board.
* Verified functionality on the Praline board.
* Tested volume scaling during active transmission (TX) and gameplay.

<img width="819" height="286" alt="image" src="https://github.com/user-attachments/assets/568172f8-3a00-427f-b667-7258190245da" />

## Checklist

- [x] Kept changes minimal and limited to necessary files
- [x] Verified functionality remains intact and code compiles
- [x] Attached proof that the code compiles successfully *(or marked N/A as a trusted contributor)*
- [ ] Attached proof of testing on real PortaPack hardware *(or marked N/A as a trusted contributor)*
- [ ] Attached proof of testing against a real emitter/receiver (if RF-related), or marked N/A with justification
- [ ] I understand that by getting this PR merged, I am implicitly agreeing to create or update the corresponding wiki page (including a main-screen screenshot, description, controls, and limitations)
- [x] I own all rights to this code (i.e., all code contained in this PR), including compliant usage rights for third-party libraries, and I agree that this code is licensed under the license of this project (GPL-3.0). 
- [x] If any third-party libraries are used, I confirm that their licenses comply with the requirements for contributing to this repository.
- [x] Reviewed the [Contributing Guidelines](https://github.com/portapack-mayhem/mayhem-firmware/wiki/Contributing-Guidelines)
