### PR TITLE
remove fake brightness feature

### DIFF
--- a/firmware/application/apps/ui_settings.cpp
+++ b/firmware/application/apps/ui_settings.cpp
@@ -362,7 +362,6 @@ SetUIView::SetUIView(NavigationView& nav) {
                   &toggle_bias_tee,
                   &toggle_clock,
                   &toggle_mute,
-                  &toggle_fake_brightness,
                   &toggle_sd_card,
                   &button_save,
                   &button_cancel});
@@ -399,7 +398,6 @@ SetUIView::SetUIView(NavigationView& nav) {
     toggle_clock.set_value(!pmem::ui_hide_clock());
     toggle_speaker.set_value(!pmem::ui_hide_speaker());
     toggle_mute.set_value(!pmem::ui_hide_mute());
-    toggle_fake_brightness.set_value(!pmem::ui_hide_fake_brightness());
     toggle_battery_icon.set_value(!pmem::ui_hide_battery_icon());
     toggle_battery_text.set_value(!pmem::ui_hide_numeric_battery());
     toggle_sd_card.set_value(!pmem::ui_hide_sd_card());
@@ -427,7 +425,6 @@ SetUIView::SetUIView(NavigationView& nav) {
         pmem::set_ui_hide_clock(!toggle_clock.value());
         pmem::set_ui_hide_speaker(!toggle_speaker.value());
         pmem::set_ui_hide_mute(!toggle_mute.value());
-        pmem::set_ui_hide_fake_brightness(!toggle_fake_brightness.value());
         pmem::set_ui_hide_battery_icon(!toggle_battery_icon.value());
         pmem::set_ui_hide_numeric_battery(!toggle_battery_text.value());
         pmem::set_ui_hide_sd_card(!toggle_sd_card.value());
@@ -921,35 +918,21 @@ void SetConfigModeView::focus() {
 
 SetDisplayView::SetDisplayView(NavigationView& nav) {
     add_children({&labels,
-                  &field_fake_brightness,
                   &button_save,
-                  &button_cancel,
-                  &checkbox_brightness_switch});
+                  &button_cancel});
 
     if (portapack::device_type == portapack::DeviceType::DEV_PORTAPACK) {
         add_child(&checkbox_ips_screen_switch);
     }
 
-    field_fake_brightness.set_by_value(pmem::fake_brightness_level());
-    checkbox_brightness_switch.set_value(pmem::apply_fake_brightness());
     checkbox_ips_screen_switch.set_value(pmem::config_lcd_normally_black());
 
     button_save.on_select = [&nav, this](Button&) {
-        pmem::set_apply_fake_brightness(checkbox_brightness_switch.value());
-        pmem::set_fake_brightness_level(field_fake_brightness.selected_index_value());
         if (checkbox_ips_screen_switch.value() != pmem::config_lcd_normally_black()) {
             pmem::set_lcd_normally_black(checkbox_ips_screen_switch.value());
         }
         send_system_refresh();
         nav.pop();
-    };
-
-    // only enable invert OR fake brightness
-    checkbox_ips_screen_switch.on_select = [this](Checkbox&, bool v) {
-        if (v) checkbox_brightness_switch.set_value(false);
-    };
-    checkbox_brightness_switch.on_select = [this](Checkbox&, bool v) {
-        if (v) checkbox_ips_screen_switch.set_value(false);
     };
 
     button_cancel.on_select = [&nav, this](Button&) {

--- a/firmware/application/apps/ui_settings.hpp
+++ b/firmware/application/apps/ui_settings.hpp
@@ -404,12 +404,8 @@ class SetUIView : public View {
         {19 * 8, 12 * 16 + 2, 16, 16},
         &bitmap_icon_batt_text};
 
-    ImageToggle toggle_fake_brightness{
-        {21 * 8, 12 * 16 + 2, 16, 16},
-        &bitmap_icon_brightness};
-
     ImageToggle toggle_sd_card{
-        {23 * 8, 12 * 16 + 2, 16, 16},
+        {21 * 8, 12 * 16 + 2, 16, 16},
         &bitmap_sd_card_ok};
 
     Button button_save{
@@ -811,7 +807,6 @@ class SetConfigModeView : public View {
         "Cancel",
     };
 };
-using portapack::persistent_memory::fake_brightness_level_options;
 
 class SetDisplayView : public View {
    public:
@@ -823,25 +818,8 @@ class SetDisplayView : public View {
 
    private:
     Labels labels{
-        {{1 * 8, 1 * 16}, "Limits screen brightness", Theme::getInstance()->fg_light->foreground},
-        {{1 * 8, 2 * 16}, "(has a small performance", Theme::getInstance()->fg_light->foreground},
-        {{1 * 8, 3 * 16}, "impact when enabled).", Theme::getInstance()->fg_light->foreground},
-        {{2 * 8, 8 * 16}, "Brightness:", Theme::getInstance()->fg_light->foreground},
         {{2 * 8, 10 * 16}, "REBOOT TO APPLY SCREEN TYPE", Theme::getInstance()->fg_light->foreground},
-
     };
-
-    OptionsField field_fake_brightness{
-        {20 * 8, 8 * 16},
-        6,
-        {{"12.5%", fake_brightness_level_options::BRIGHTNESS_12p5},
-         {"25%", fake_brightness_level_options::BRIGHTNESS_25},
-         {"50%", fake_brightness_level_options::BRIGHTNESS_50}}};
-
-    Checkbox checkbox_brightness_switch{
-        {1 * 8, 5 * 16},
-        16,
-        "Enable brightness adjust"};
 
     Checkbox checkbox_ips_screen_switch{
         {1 * 8, 12 * 16},

--- a/firmware/application/external/debug_pmem/ui_debug_pmem.cpp
+++ b/firmware/application/external/debug_pmem/ui_debug_pmem.cpp
@@ -89,7 +89,6 @@ bool DebugDumpView::debug_dump_func() {
     pmem_dump_file.write_line("encoder_dial_direction: " + to_string_dec_uint(encoder_dial_direction()));  // 0 = normal, 1 = reverse
     pmem_dump_file.write_line("config_mode_storage: 0x" + to_string_hex(config_mode_storage_direct(), 8));
     pmem_dump_file.write_line("dst_config: 0x" + to_string_hex((uint32_t)config_dst().v, 8));
-    pmem_dump_file.write_line("fake_brightness_level: " + to_string_dec_uint(fake_brightness_level()));
     pmem_dump_file.write_line("menu_color: 0x" + to_string_hex(menu_color().v, 4));
     pmem_dump_file.write_line("touchscreen_threshold: " + to_string_dec_uint(touchscreen_threshold()));
 
@@ -105,7 +104,6 @@ bool DebugDumpView::debug_dump_func() {
     pmem_dump_file.write_line("ui_config hide_clock: " + to_string_dec_uint(hide_clock()));
     pmem_dump_file.write_line("ui_config clock_with_date: " + to_string_dec_uint(clock_with_date()));
     pmem_dump_file.write_line("ui_config clkout_enabled: " + to_string_dec_uint(clkout_enabled()));
-    pmem_dump_file.write_line("ui_config apply_fake_brightness: " + to_string_dec_uint(apply_fake_brightness()));
     pmem_dump_file.write_line("ui_config stealth_mode: " + to_string_dec_uint(stealth_mode()));
     pmem_dump_file.write_line("ui_config config_login: " + to_string_dec_uint(config_login()));
     pmem_dump_file.write_line("ui_config config_splash: " + to_string_dec_uint(config_splash()));
@@ -120,7 +118,6 @@ bool DebugDumpView::debug_dump_func() {
     pmem_dump_file.write_line("ui_config2 hide_clock: " + to_string_dec_uint(ui_hide_clock()));
     pmem_dump_file.write_line("ui_config2 hide_sd_card: " + to_string_dec_uint(ui_hide_sd_card()));
     pmem_dump_file.write_line("ui_config2 hide_mute: " + to_string_dec_uint(ui_hide_mute()));
-    pmem_dump_file.write_line("ui_config2 hide_fake_brightness: " + to_string_dec_uint(ui_hide_fake_brightness()));
     pmem_dump_file.write_line("ui_config2 hide_battery_icon: " + to_string_dec_uint(ui_hide_battery_icon()));
     pmem_dump_file.write_line("ui_config2 hide_numeric_battery: " + to_string_dec_uint(ui_hide_numeric_battery()));
     pmem_dump_file.write_line("ui_config2 theme_id: " + to_string_dec_uint(ui_theme_id()));

--- a/firmware/application/ui_navigation.cpp
+++ b/firmware/application/ui_navigation.cpp
@@ -359,15 +359,6 @@ SystemStatusView::SystemStatusView(
         this->on_bias_tee();
     };
 
-    button_fake_brightness.on_select = [this](ImageButton&) {
-        set_dirty();
-        pmem::toggle_fake_brightness_level();
-        refresh();
-        if (nullptr != parent()) {
-            parent()->set_dirty();  // The parent of NavigationView shal be the SystemView
-        }
-    };
-
     button_camera.on_select = [this](ImageButton&) {
         this->on_camera();
     };
@@ -460,7 +451,6 @@ void SystemStatusView::refresh() {
     // Display "Disable speaker" icon only if AK4951 Codec which has separate speaker/headphone control
     if (audio::speaker_disable_supported() && !pmem::ui_hide_speaker()) status_icons.add(&toggle_speaker);
 
-    if (!pmem::ui_hide_fake_brightness()) status_icons.add(&button_fake_brightness);
     if (battery::BatteryManagement::isDetected()) {
         batt_was_inited = true;
         if (!pmem::ui_hide_battery_icon()) {
@@ -492,9 +482,6 @@ void SystemStatusView::refresh() {
     // Converter
     button_converter.set_bitmap(pmem::config_updown_converter() ? &bitmap_icon_downconvert : &bitmap_icon_upconvert);
     button_converter.set_foreground(pmem::config_converter() ? Theme::getInstance()->fg_red->foreground : Theme::getInstance()->fg_light->foreground);
-
-    // Fake Brightness
-    button_fake_brightness.set_foreground(pmem::apply_fake_brightness() ? *Theme::getInstance()->status_active : Theme::getInstance()->fg_light->foreground);
 
     set_dirty();
 }

--- a/firmware/application/ui_navigation.hpp
+++ b/firmware/application/ui_navigation.hpp
@@ -307,12 +307,6 @@ class SystemStatusView : public View {
         Theme::getInstance()->fg_light->foreground,
         Theme::getInstance()->bg_dark->background};
 
-    ImageButton button_fake_brightness{
-        {0, 0, 2 * 8, 1 * 16},
-        &bitmap_icon_brightness,
-        *Theme::getInstance()->status_active,
-        Theme::getInstance()->bg_dark->background};
-
     SDCardStatusView sd_card_status_view{
         {0, UI_POS_Y(0), 2 * 8, 1 * 16}};
 

--- a/firmware/common/lcd_ili9341.cpp
+++ b/firmware/common/lcd_ili9341.cpp
@@ -294,7 +294,6 @@ void lcd_start_ram_write(
     lcd_caset(p.x(), p.x() + s.width() - 1);
     lcd_paset(p.y(), p.y() + s.height() - 1);
     lcd_ramwr_start();
-    io.update_cached_values();
 }
 
 void lcd_start_ram_read(

--- a/firmware/common/portapack_io.cpp
+++ b/firmware/common/portapack_io.cpp
@@ -111,24 +111,6 @@ void IO::reference_oscillator(const bool enable) {
     io_write(1, io_reg);
 }
 
-bool IO::get_dark_cover() {
-    return portapack::persistent_memory::apply_fake_brightness();
-}
-
-bool IO::get_is_normally_black() {
-    return portapack::persistent_memory::config_lcd_normally_black();
-}
-
-uint8_t IO::get_brightness() {
-    return portapack::persistent_memory::fake_brightness_level();
-}
-
-void IO::update_cached_values() {
-    lcd_normally_black = get_is_normally_black();
-    dark_cover_enabled = get_dark_cover();
-    brightness = get_brightness();
-}
-
 uint32_t IO::io_update(const TouchPinsConfig write_value) {
     /* Very touchy code to save context of PortaPack data bus while the
      * resistive touch pin drive is changed. Order of operations is

--- a/firmware/common/portapack_io.hpp
+++ b/firmware/common/portapack_io.hpp
@@ -37,21 +37,6 @@
 
 // #include "portapack_persistent_memory.hpp"
 
-// Darkened pixel bit mask for each possible shift value.
-static const uint16_t darken_mask[4] = {
-    0b1111111111111111,  // RrrrrGgggggBbbbb
-    0b0111101111101111,  // 0Rrrr0Ggggg0Bbbb
-    0b0011100111100111,  // 00Rrr00Gggg00Bbb
-    0b0001100011100011   // 000Rr000Ggg000Bb
-};
-
-// To darken, dividing each color level R/G/B by 2^shift.
-#define DARKENED_PIXEL(pixel, shift) ((pixel >> shift) & darken_mask[shift])
-
-// To un-darken, multiply each color level by 2^shift (might still be darker that before since some bits may have been lost above).
-// This function will only be called when the pixel has previously been darkened, so no masking is needed.
-#define UNDARKENED_PIXEL(pixel, shift) (pixel << shift)
-
 namespace portapack {
 
 enum DeviceType {
@@ -197,9 +182,6 @@ class IO {
     }
 
     void lcd_write_pixel(ui::Color pixel) {
-        if (dark_cover_enabled) {
-            pixel.v = DARKENED_PIXEL(pixel.v, brightness);
-        }
         lcd_write_data(pixel.v);
     }
 
@@ -208,18 +190,12 @@ class IO {
     }
 
     void lcd_write_pixels(ui::Color pixel, size_t n) {
-        if (dark_cover_enabled) {
-            pixel.v = DARKENED_PIXEL(pixel.v, brightness);
-        }
         while (n--) {
             lcd_write_data(pixel.v);
         }
     }
 
     void lcd_write_pixels_unrolled8(ui::Color pixel, size_t n) {
-        if (dark_cover_enabled) {
-            pixel.v = DARKENED_PIXEL(pixel.v, brightness);
-        }
         auto v = pixel.v;
         n >>= 3;
         while (n--) {
@@ -254,13 +230,6 @@ class IO {
 
         return switches_raw;
     }
-    bool lcd_normally_black = false;
-    bool dark_cover_enabled = false;
-    uint8_t brightness = 0;
-    bool get_is_normally_black();
-    bool get_dark_cover();
-    uint8_t get_brightness();
-    void update_cached_values();
 
     uint32_t io_update(const TouchPinsConfig write_value);
 
@@ -432,14 +401,6 @@ class IO {
             halPolledDelay(71);  // 90ns
             const auto value_low = data_read();
             uint32_t original_value = (value_high << 8) | value_low;
-
-            if (lcd_normally_black) return original_value;
-
-            if (dark_cover_enabled) {
-                // this is read data, so if the fake brightness is enabled AKA get_dark_cover() == true,
-                // then shift to back side AKA UNDARKENED_PIXEL, to prevent read shifted darkern info
-                original_value = UNDARKENED_PIXEL(original_value, brightness);
-            }
             return original_value;
         }
         const auto value_high = data_read();

--- a/firmware/common/portapack_persistent_memory.cpp
+++ b/firmware/common/portapack_persistent_memory.cpp
@@ -109,7 +109,7 @@ struct ui_config_t {
     bool hide_clock : 1;
     bool clock_show_date : 1;
     bool clkout_enabled : 1;
-    bool apply_fake_brightness : 1;  // Fake brightness level, which eventually could be something along the lines of apply_pwm_brightness
+    bool UNUSED_8 : 1;  // Deprecated: was apply_fake_brightness
     bool stealth_mode : 1;
     bool config_login : 1;
     bool config_splash : 1;
@@ -130,7 +130,7 @@ struct ui_config2_t {
     bool hide_sd_card : 1;
 
     bool hide_mute : 1;
-    bool hide_fake_brightness : 1;
+    bool UNUSED_9 : 1;  // Deprecated: was hide_fake_brightness
     bool hide_numeric_battery : 1;
     bool hide_battery_icon : 1;
     bool override_batt_calc : 1;
@@ -225,8 +225,7 @@ struct data_t {
     // Rotary encoder dial sensitivity (encoder.cpp/hpp)
     uint16_t encoder_dial_sensitivity : 4;
 
-    // fake brightness level (not switch, switch is in another place)
-    uint16_t fake_brightness_level : 4;
+    uint16_t UNUSED_5 : 4;  // Deprecated: was fake_brightness_level
 
     // Encoder rotation rate multiplier for larger increments when rotated rapidly
     uint16_t encoder_rate_multiplier : 4;
@@ -299,7 +298,7 @@ struct data_t {
           frequency_tx_correction(0),
 
           encoder_dial_sensitivity(DIAL_SENSITIVITY_NORMAL),
-          fake_brightness_level(BRIGHTNESS_50),
+          UNUSED_5(0),
           encoder_rate_multiplier(1),
           UNUSED(0),
 
@@ -476,7 +475,6 @@ void init() {
     set_config_mode_storage_direct(config_mode_backup);
 
     // Firmware upgrade handling - adjust newly defined fields where 0 is an invalid default
-    if (fake_brightness_level() == 0) set_fake_brightness_level(BRIGHTNESS_50);
     if (menu_color().v == 0) set_menu_color(Color::grey());
 }
 
@@ -671,10 +669,6 @@ bool stealth_mode() {
     return data->ui_config.stealth_mode;
 }
 
-bool apply_fake_brightness() {
-    return data->ui_config.apply_fake_brightness;
-}
-
 bool config_login() {
     return data->ui_config.config_login;
 }
@@ -792,10 +786,6 @@ void set_config_cpld(uint8_t i) {
 void set_config_backlight_timer(const backlight_config_t& new_value) {
     data->ui_config.backlight_timeout = static_cast<uint8_t>(new_value.timeout_enum());
     data->ui_config.enable_backlight_timeout = static_cast<uint8_t>(new_value.timeout_enabled());
-}
-
-void set_apply_fake_brightness(const bool v) {
-    data->ui_config.apply_fake_brightness = v;
 }
 
 uint32_t pocsag_last_address() {
@@ -987,9 +977,6 @@ bool ui_hide_clock() {
 bool ui_hide_sd_card() {
     return data->ui_config2.hide_sd_card;
 }
-bool ui_hide_fake_brightness() {
-    return data->ui_config2.hide_fake_brightness;
-}
 bool ui_hide_numeric_battery() {
     return data->ui_config2.hide_numeric_battery;
 }
@@ -1043,9 +1030,6 @@ void set_ui_hide_clock(bool v) {
 }
 void set_ui_hide_sd_card(bool v) {
     data->ui_config2.hide_sd_card = v;
-}
-void set_ui_hide_fake_brightness(bool v) {
-    data->ui_config2.hide_fake_brightness = v;
 }
 void set_ui_hide_numeric_battery(bool v) {
     data->ui_config2.hide_numeric_battery = v;
@@ -1181,25 +1165,6 @@ dst_config_t config_dst() {
 void set_config_dst(dst_config_t v) {
     data->dst_config = v;
     rtc_time::dst_init();
-}
-
-// Fake brightness level (switch is in another place)
-uint8_t fake_brightness_level() {
-    return data->fake_brightness_level;
-}
-void set_fake_brightness_level(uint8_t v) {
-    data->fake_brightness_level = v;
-}
-
-// Cycle through 4 brightness options: disabled -> enabled/50% -> enabled/25% -> enabled/12.5% -> disabled
-void toggle_fake_brightness_level() {
-    bool fbe = apply_fake_brightness();
-    if ((!fbe) || (data->fake_brightness_level >= BRIGHTNESS_12p5)) {
-        set_apply_fake_brightness(!fbe);
-        data->fake_brightness_level = BRIGHTNESS_50;
-    } else {
-        data->fake_brightness_level++;
-    }
 }
 
 // Menu Color Scheme

--- a/firmware/common/portapack_persistent_memory.hpp
+++ b/firmware/common/portapack_persistent_memory.hpp
@@ -139,12 +139,6 @@ typedef union {
 } dst_config_t;
 static_assert(sizeof(dst_config_t) == sizeof(uint32_t));
 
-enum fake_brightness_level_options {
-    BRIGHTNESS_50 = 1,
-    BRIGHTNESS_25 = 2,
-    BRIGHTNESS_12p5 = 3,  // 12p5 is 12.5
-};
-
 namespace cache {
 
 /* Set values in cache to sensible defaults. */
@@ -289,15 +283,6 @@ uint16_t clkout_freq();
 dst_config_t config_dst();
 void set_config_dst(dst_config_t v);
 
-/* Fake brightness */
-// switch (if do color change):
-bool apply_fake_brightness();
-void set_apply_fake_brightness(const bool v);
-// level (color change level):
-uint8_t fake_brightness_level();
-void set_fake_brightness_level(uint8_t v);
-void toggle_fake_brightness_level();
-
 /* Touchscreen threshold */
 uint16_t touchscreen_threshold();
 void set_touchscreen_threshold(uint16_t v);
@@ -351,7 +336,6 @@ bool ui_hide_camera();
 bool ui_hide_sleep();
 bool ui_hide_bias_tee();
 bool ui_hide_clock();
-bool ui_hide_fake_brightness();
 bool ui_hide_numeric_battery();
 bool ui_hide_battery_icon();
 bool ui_hide_sd_card();
@@ -370,7 +354,6 @@ void set_ui_hide_camera(bool v);
 void set_ui_hide_sleep(bool v);
 void set_ui_hide_bias_tee(bool v);
 void set_ui_hide_clock(bool v);
-void set_ui_hide_fake_brightness(bool v);
 void set_ui_hide_numeric_battery(bool v);
 void set_ui_hide_battery_icon(bool v);
 void set_ui_hide_sd_card(bool v);


### PR DESCRIPTION
TLDR:
- we have a weird lagging issue years ago, caused by fake brightness.
- it got "fixed" later by assuming the slow part seems from repetedly read from p.mem.
- the fixes worked for years.
- it's broken again now and the assume fix is probably wrong too.
- **we have to** remove it cuz in current SPI flash XIP structure it is too expensive to fix.